### PR TITLE
Forwarding events to tls logger, by-passing schedule query layer

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -268,7 +268,8 @@ Example:
     "read_max": 100000,
     "events_max": 100000,
     "enable_monitor": true,
-    "host_identifier": "uuid"
+    "host_identifier": "uuid",
+    "logger_tls_event_types": "file_events|socket_events|user_events|process_events"
   }
 }
 ```

--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -53,6 +53,34 @@ The two areas below that are relevant to FIM are the scheduled query against `fi
 }
 ```
 
+### Exmaple for by-passing schedule query layer
+
+```json
+{
+  "schedule": {
+    "crontab": {
+      "query": "SELECT * FROM crontab;",
+      "interval": 300
+    }
+  },
+  "file_paths": {
+    "homes": [
+      "/root/.ssh/%%",
+      "/home/%/.ssh/%%"
+    ],
+    "etc": [
+      "/etc/%%"
+    ],
+    "tmp": [
+      "/tmp/%%"
+    ]
+  },
+  "options": {
+    "logger_tls_event_types": "file_events"
+  }
+}
+```
+
 ## Sample Event Output
 
 As file changes happen, events will appear in the [**file_events**](https://osquery.io/docs/tables/#file_events) table.  During a file change event, the md5, sha1, and sha256 for the file will be calculated if possible. A sample event looks like this:

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -215,6 +215,12 @@ It is common for TLS/HTTPS servers to enforce a maximum request body size. The d
 
 Use this only in emergency situations as size violations are dropped. It is extremely uncommon for this to occur, as the `--value_max` for each column would need to be drastically larger, or the offending table would have to implement several hundred columns.
 
+`--logger_tls_event_types="file_events|socket_events|..."`
+
+Event types to be captured. This flag is introduced for forwarding the events to tls logger, by-passing the schedule query layer.
+One need not to specify 'select *' for any event table if this flag is set to capture that type of event.
+This flag can also be set by configuration file.
+
 `--logger_min_status=0`
 
 The minimum level for status log recording. Use the following values: `INFO = 0, WARNING = 1, ERROR = 2`. To disable all status messages use 3+. When using `--verbose` this value is ignored.

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -566,6 +566,10 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
 
   r["time"] = std::to_string(event_time);
   r["eid"] = eid;
+  // The field below is added for event forwarding to tls logger.
+  // Since this field is not part of any event table definition,
+  // so this does not exist for upper schedule query layer.
+  r["event_type"] = getName();
   // Serialize and store the row data, for query-time retrieval.
   std::string data;
   auto status = serializeRowJSON(r, data);

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -569,7 +569,7 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
   // The field below is added for event forwarding to tls logger.
   // Since this field is not part of any event table definition,
   // so this does not exist for upper schedule query layer.
-  r["event_type"] = getName();
+  r["_event_type"] = getName();
   // Serialize and store the row data, for query-time retrieval.
   std::string data;
   auto status = serializeRowJSON(r, data);

--- a/osquery/logger/plugins/tls_logger.cpp
+++ b/osquery/logger/plugins/tls_logger.cpp
@@ -75,8 +75,8 @@ Status TLSLoggerPlugin::logEvent(const std::string& s) {
     return Status(1, e.what());
   }
 
-  std::string event_type =
-      child.get<std::string>("event_type", "unknown_events");
+  auto event_type =
+      child.get<std::string>("_event_type", "unknown_events");
   if (capture_event_types.find(event_type) == std::string::npos) {
     return Status(0);
   }
@@ -87,7 +87,7 @@ Status TLSLoggerPlugin::logEvent(const std::string& s) {
   parent.put<std::string>("calendarTime", osquery::getAsciiTime());
   parent.put<size_t>("unixTime", osquery::getUnixTime());
   parent.put<uint64_t>("epoch", 0L);
-  child.erase("event_type");
+  child.erase("_event_type");
   parent.add_child("columns", child);
   parent.put("action", "added");
 

--- a/osquery/logger/plugins/tls_logger.h
+++ b/osquery/logger/plugins/tls_logger.h
@@ -60,12 +60,19 @@ class TLSLoggerPlugin : public LoggerPlugin {
     return true;
   }
 
+  bool usesLogEvent() override {
+    return true;
+  }
+
  protected:
   /// Log a result string. This is the basic catch-all for snapshots and events.
   Status logString(const std::string& s) override;
 
   /// Log a status (ERROR/WARNING/INFO) message.
   Status logStatus(const std::vector<StatusLogLine>& log) override;
+
+  /// Log a result string. bypassing schedule query layer.
+  Status logEvent(const std::string& s) override;
 
  private:
   /// Forwarder that buffers/sends logs. Runs in a Dispatcher thread.


### PR DESCRIPTION
This change enables the event subscribers to push the events to log/buffer forwarder, by-passing the expensive processing of schedule query layer.
Please see how to use this functionality in the updated docs of this patch.