### PR TITLE
Allow config to be an object or a string

### DIFF
--- a/osquery/config/plugins/tls_config.cpp
+++ b/osquery/config/plugins/tls_config.cpp
@@ -84,10 +84,19 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
 
       // Re-encode the config key into JSON.
       auto it = tree.doc().FindMember("config");
-      config["tls_plugin"] =
-          unescapeUnicode(it != tree.doc().MemberEnd() && it->value.IsString()
-                              ? it->value.GetString()
-                              : "");
+      if (it != tree.doc().MemberEnd() && it->value.IsString()) {
+        config["tls_plugin"] = unescapeUnicode(it->value.GetString());
+      } else if (it != tree.doc().MemberEnd() && it->value.IsObject()) {
+        auto doc = JSON::newFromValue(it->value);
+        std::string serialized{};
+
+        s = doc.toString(config["tls_plugin"]);
+      }
+      //config["tls_plugin"] =
+      //    unescapeUnicode(it != tree.doc().MemberEnd() && it->value.IsString()
+      //                        ? it->value.GetString()
+      //
+      //                        : "");
     } else {
       config["tls_plugin"] = json;
     }


### PR DESCRIPTION
Config is a sub-object that is serialized into a string. On one hand this makes sense because it get's put into a map where if it isn't a string it needs to be converted to one, but this makes the config endpoint messy if you're looking at it and slightly hacky to create one (because you take a json object, serialize it into a string then insert it into another json object instead of just adding a child).

This adds support for config to be either a config string, or an object so no backends need to change if you don't want to, it just seems like a reasonable thing to support.