### PR TITLE
tests: adding release tests for Windows

### DIFF
--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -64,6 +64,7 @@
     "mounts": {
       "query" : "select * from mounts;",
       "interval" : "86400",
+      "platform": "posix",
       "version" : "1.4.5",
       "description" : "Retrieves the current list of mounted drives in the target system.",
       "value" : "Verify if mounts are accessible to those who need it"
@@ -149,6 +150,7 @@
     "usb_devices": {
       "query" : "select * from usb_devices;",
       "interval" : "86400",
+      "platform": "posix",
       "version" : "1.4.5",
       "description" : "Retrieves the current list of USB devices in the target system.",
       "value" : "General security posture."

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -136,6 +136,11 @@ function Invoke-OsqueryMsbuild {
     }
   }
 
+  # Run the release tests on build hosts
+  if (Test-Path env:OSQUERY_BUILD_HOST) {
+    [Environment]::SetEnvironmentVariable("RUN_RELEASE_TESTS", "1", "Machine")
+  }
+
   # And finally, run the tests
   $ctest = (Get-Command 'ctest').Source
   $ctestArgs = @(

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -21,6 +21,7 @@ import subprocess
 import shutil
 import re
 
+
 def red(msg):
     return "\033[41m\033[1;30m %s \033[0m" % str(msg)
 
@@ -73,16 +74,20 @@ def platform():
         platform = "linux"
     if platform.find("freebsd") == 0:
         platform = "freebsd"
+    if platform.find("win") == 0:
+        platform = "windows"
     return platform
 
 
 def queries_from_config(config_path):
     config = {}
-    rmcomment = re.compile('\/\*[\*A-Za-z0-9\n\s\.\{\}\'\/\\\:]+\*\/|\s+\/\/.*|^\/\/.*|\x5c\x5c\x0a')
+    rmcomment = re.compile(
+        '\/\*[\*A-Za-z0-9\n\s\.\{\}\'\/\\\:]+\*\/|\s+\/\/.*|^\/\/.*|\x5c\x5c\x0a'
+    )
     try:
         with open(config_path, "r") as fh:
             configcontent = fh.read()
-            content = rmcomment.sub('',configcontent)
+            content = rmcomment.sub('', configcontent)
             config = json.loads(content)
     except Exception as e:
         print("Cannot open/parse config: %s" % str(e))
@@ -95,7 +100,7 @@ def queries_from_config(config_path):
         for name, details in config["schedule"].iteritems():
             queries[name] = details["query"]
     if "packs" in config:
-        for keys,values in config["packs"].iteritems():
+        for keys, values in config["packs"].iteritems():
             # Check if it is an internal pack definition
             if type(values) is dict:
                 for queryname, query in values["queries"].iteritems():
@@ -152,10 +157,8 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
     import psutil
     start_time = time.time()
     if proc is None:
-        proc = subprocess.Popen(cmd,
-                                shell=shell,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p = psutil.Process(pid=proc.pid)
 
     delay = 0


### PR DESCRIPTION
This is the first step towards adressing #2424 by porting the osquery release tests to function on Windows. The first stage is bringing tests for query packs using the Python extensions. The `avx` instruction test is currently failing on Windows, and simply needs some follow up on how we're compiling the binary, and lastly the shared libraries will need some consideration, as it seems our osquery release does have some DLL dependencies.

This PR will need to wait until a [modification to the osquery python](https://github.com/osquery/osquery-python/pull/53) libraries lands as our current logic for closing a pipe connection is incorrect.