### PR TITLE
mdls table implementation

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -113,6 +113,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/launchd.cpp
       darwin/managed_policies.cpp
       darwin/mdfind.mm
+      darwin/mdls.mm
       darwin/mounts.cpp
       darwin/nfs_shares.cpp
       darwin/nvram.cpp

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -65,34 +65,34 @@ std::string getStringOfValue(CFTypeRef value, int depth) {
 void genResults(const std::string& path, QueryData& results) {
   CFStringRef cs = CFStringCreateWithCString(
       kCFAllocatorDefault, path.c_str(), kCFStringEncodingASCII);
-  auto const cs_guard = scope_guard::create([cs]() { CFRelease(cs); });
   if (cs == nullptr) {
     return;
   }
+  auto const cs_guard = scope_guard::create([&cs]() { CFRelease(cs); });
 
   MDItemRef mdi = MDItemCreate(kCFAllocatorDefault, cs);
-  auto const mdi_guard = scope_guard::create([mdi]() { CFRelease(mdi); });
   if (mdi == nullptr) {
     return;
   }
+  auto const mdi_guard = scope_guard::create([&mdi]() { CFRelease(mdi); });
 
   CFTypeRef tr = MDItemCopyAttribute(mdi, CFSTR("kMDItemPath"));
-  auto const tr_guard = scope_guard::create([tr]() { CFRelease(tr); });
   if (tr == nullptr) {
     return;
   }
+  auto const tr_guard = scope_guard::create([&tr]() { CFRelease(tr); });
 
   CFArrayRef al = MDItemCopyAttributeNames(mdi);
-  auto const al_guard = scope_guard::create([al]() { CFRelease(al); });
   if (al == nullptr) {
     return;
   }
+  auto const al_guard = scope_guard::create([&al]() { CFRelease(al); });
 
   CFDictionaryRef d = MDItemCopyAttributes(mdi, al);
-  auto const d_guard = scope_guard::create([d]() { CFRelease(d); });
   if (d == nullptr) {
     return;
   }
+  auto const d_guard = scope_guard::create([&d]() { CFRelease(d); });
 
   for (int j = 0; j < CFArrayGetCount(al); ++j) {
     // Do not release key or value, they are released when the dict is released
@@ -105,11 +105,11 @@ void genResults(const std::string& path, QueryData& results) {
     }
 
     CFStringRef valuetype = CFCopyTypeIDDescription(CFGetTypeID(value));
-    auto const guard =
-        scope_guard::create([valuetype]() { CFRelease(valuetype); });
     if (valuetype == nullptr) {
       return;
     }
+    auto const guard =
+        scope_guard::create([&valuetype]() { CFRelease(valuetype); });
 
     rvalue = getStringOfValue(value, 0);
 

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -16,8 +16,8 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/darwin/cfdata.h>
-#include <osquery/utils/conversions/darwin/cfstring.h>
 #include <osquery/utils/conversions/darwin/cfnumber.h>
+#include <osquery/utils/conversions/darwin/cfstring.h>
 
 namespace osquery {
 namespace tables {
@@ -75,7 +75,7 @@ void genResults(const std::string& path, QueryData& results) {
   CFArrayRef al = MDItemCopyAttributeNames(mdi);
   CFDictionaryRef d = MDItemCopyAttributes(mdi, al);
   for (int j = 0; j < CFArrayGetCount(al); ++j) {
-    //Do not release key or value, they are released when the dict is released
+    // Do not release key or value, they are released when the dict is released
     CFTypeRef key = CFArrayGetValueAtIndex(al, j);
     CFTypeRef value = CFDictionaryGetValue(d, key);
     std::string rvalue{"null"};
@@ -101,7 +101,6 @@ void genResults(const std::string& path, QueryData& results) {
   CFRelease(cs);
 }
 
-//Some comment
 QueryData genMdlsResults(QueryContext& context) {
   QueryData results;
   // Resolve file paths for EQUALS and LIKE operations.

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -1,0 +1,131 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <CoreServices/CoreServices.h>
+
+#include <boost/filesystem.hpp>
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+std::string getStringOfValue(CFTypeRef value) {
+  std::string rvalue;
+
+  if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+    rvalue = stringFromCFNumber(static_cast<CFDataRef>(value));
+  } else if (CFGetTypeID(value) == CFDateGetTypeID()) {
+    auto unix_time = CFDateGetAbsoluteTime(static_cast<CFDateRef>(value)) +
+                     kCFAbsoluteTimeIntervalSince1970;
+    rvalue = INTEGER(std::llround(unix_time));
+  } else if (CFGetTypeID(value) == CFArrayGetTypeID()) {
+    for (int i = 0; i < CFArrayGetCount(static_cast<CFArrayRef>(value)); ++i) {
+      CFTypeRef b = CFArrayGetValueAtIndex(static_cast<CFArrayRef>(value), i);
+      if (i == 0) {
+        rvalue = getStringOfValue(b);
+      } else {
+        // beware of recursion....
+        rvalue = rvalue + "," + getStringOfValue(b);
+      }
+    }
+  } else if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
+    if (CFBooleanGetValue(static_cast<CFBooleanRef>(value))) {
+      rvalue = "true";
+    } else {
+      rvalue = "false";
+    }
+  } else if (CFGetTypeID(value) == CFStringGetTypeID()) {
+    // might be able to just stringFromCFString after #4778
+    CFDataRef df =
+        CFStringCreateExternalRepresentation(kCFAllocatorDefault,
+                                             static_cast<CFStringRef>(value),
+                                             kCFStringEncodingASCII,
+                                             '?');
+    rvalue = stringFromCFData(df);
+    CFRelease(df);
+  } else {
+    rvalue = "null";
+  }
+
+  return rvalue;
+}
+void genResults(const std::string& path, QueryData& results) {
+  CFStringRef cs = CFStringCreateWithCString(
+      kCFAllocatorDefault, path.c_str(), kCFStringEncodingASCII);
+  MDItemRef mdi = MDItemCreate(kCFAllocatorDefault, cs);
+  CFTypeRef tr = MDItemCopyAttribute(mdi, CFSTR("kMDItemPath"));
+  CFArrayRef al = MDItemCopyAttributeNames(mdi);
+  CFDictionaryRef d = MDItemCopyAttributes(mdi, al);
+  for (int j = 0; j < CFArrayGetCount(al); ++j) {
+    //Do not release key or value, they are released when the dict is released
+    CFTypeRef key = CFArrayGetValueAtIndex(al, j);
+    CFTypeRef value = CFDictionaryGetValue(d, key);
+    std::string rvalue{"null"};
+
+    if (tr == nullptr || key == nullptr || value == nullptr) {
+      continue;
+    }
+
+    Row r;
+
+    CFStringRef valuetype = CFCopyTypeIDDescription(CFGetTypeID(value));
+    rvalue = getStringOfValue(value);
+
+    r["path"] = stringFromCFString(static_cast<CFStringRef>(tr));
+    r["key"] = stringFromCFString(static_cast<CFStringRef>(key));
+    r["value"] = rvalue;
+    r["valuetype"] = stringFromCFString(static_cast<CFStringRef>(valuetype));
+    results.push_back(r);
+    CFRelease(valuetype);
+  }
+  CFRelease(tr);
+  CFRelease(al);
+  CFRelease(d);
+  CFRelease(cs);
+}
+
+QueryData genMdlsResults(QueryContext& context) {
+  QueryData results;
+  // Resolve file paths for EQUALS and LIKE operations.
+  auto paths = context.constraints["path"].getAll(EQUALS);
+  context.expandConstraints(
+      "path",
+      LIKE,
+      paths,
+      ([&](const std::string& pattern, std::set<std::string>& out) {
+        std::vector<std::string> patterns;
+        auto status =
+            resolveFilePattern(pattern, patterns, GLOB_ALL | GLOB_NO_CANON);
+        if (status.ok()) {
+          for (const auto& resolved : patterns) {
+            out.insert(resolved);
+          }
+        }
+        return status;
+      }));
+
+  for (const auto& path_string : paths) {
+    boost::filesystem::path path = path_string;
+    boost::system::error_code ec;
+    if (!(boost::filesystem::is_regular_file(path, ec) ||
+          boost::filesystem::is_directory(path, ec))) {
+      continue;
+    }
+    genResults(path.string(), results);
+  }
+  return results;
+}
+}
+}

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -12,11 +12,12 @@
 
 #include <boost/filesystem.hpp>
 #include <osquery/core.h>
-#include <osquery/filesystem.h>
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-
-#include "osquery/core/conversions.h"
+#include <osquery/utils/conversions/darwin/cfdata.h>
+#include <osquery/utils/conversions/darwin/cfstring.h>
+#include <osquery/utils/conversions/darwin/cfnumber.h>
 
 namespace osquery {
 namespace tables {
@@ -100,6 +101,7 @@ void genResults(const std::string& path, QueryData& results) {
   CFRelease(cs);
 }
 
+//Some comment
 QueryData genMdlsResults(QueryContext& context) {
   QueryData results;
   // Resolve file paths for EQUALS and LIKE operations.

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -67,6 +67,7 @@ void genResults(const std::string& path, QueryData& results) {
   CFTypeRef tr = MDItemCopyAttribute(mdi, CFSTR("kMDItemPath"));
   CFArrayRef al = MDItemCopyAttributeNames(mdi);
   CFDictionaryRef d = MDItemCopyAttributes(mdi, al);
+  CFRelease(mdi);
   for (int j = 0; j < CFArrayGetCount(al); ++j) {
     // Do not release key or value, they are released when the dict is released
     CFTypeRef key = CFArrayGetValueAtIndex(al, j);

--- a/osquery/tables/system/darwin/mdls.mm
+++ b/osquery/tables/system/darwin/mdls.mm
@@ -37,7 +37,7 @@ std::string getStringOfValue(CFTypeRef value, int depth) {
                      kCFAbsoluteTimeIntervalSince1970;
     rvalue = INTEGER(std::llround(unix_time));
   } else if (CFGetTypeID(value) == CFArrayGetTypeID()) {
-    for (int i = 0; i < CFArrayGetCount(static_cast<CFArrayRef>(value)); ++i) {
+    for (auto i = 0; i < CFArrayGetCount(static_cast<CFArrayRef>(value)); ++i) {
       CFTypeRef b = CFArrayGetValueAtIndex(static_cast<CFArrayRef>(value), i);
       if (i == 0) {
         rvalue = getStringOfValue(b, depth + 1);
@@ -53,14 +53,7 @@ std::string getStringOfValue(CFTypeRef value, int depth) {
       rvalue = "false";
     }
   } else if (CFGetTypeID(value) == CFStringGetTypeID()) {
-    // might be able to just stringFromCFString after #4778
-    CFDataRef df =
-        CFStringCreateExternalRepresentation(kCFAllocatorDefault,
-                                             static_cast<CFStringRef>(value),
-                                             kCFStringEncodingASCII,
-                                             '?');
-    rvalue = stringFromCFData(df);
-    CFRelease(df);
+    rvalue = stringFromCFString(static_cast<CFStringRef>(value));
   } else {
     rvalue = "null";
   }

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -103,6 +103,7 @@ function(generateNativeTables)
     "darwin/launchd_overrides.table:macos"
     "darwin/managed_policies.table:macos"
     "darwin/mdfind.table:macos"
+    "darwin/mdls.table:macos"
     "darwin/nfs_shares.table:macos"
     "darwin/nvram.table:macos"
     "darwin/package_bom.table:macos"

--- a/specs/darwin/mdls.table
+++ b/specs/darwin/mdls.table
@@ -4,7 +4,7 @@ schema([
     Column("path", TEXT, "Path of the file", required=True),
     Column("key", TEXT, "Name of the metadata key"),
     Column("value", TEXT, "Value stored in the metadata key"),
-    Column("valuetype", TEXT, "CoreFoundation Type of data stored in value", hidden=True),
+    Column("valuetype", TEXT, "CoreFoundation type of data stored in value", hidden=True),
 ])
 implementation("mdls@genMdlsResults")
 fuzz_paths([])

--- a/specs/darwin/mdls.table
+++ b/specs/darwin/mdls.table
@@ -1,0 +1,13 @@
+table_name("mdls")
+description("Query file metadata in the Spotlight database.")
+schema([
+    Column("path", TEXT, "Path of the file", required=True),
+    Column("key", TEXT, "Name of the metadata key"),
+    Column("value", TEXT, "Value stored in the metadata key"),
+    Column("valuetype", TEXT, "CoreFoundation Type of data stored in value", hidden=True),
+])
+implementation("mdls@genMdlsResults")
+fuzz_paths([])
+examples([
+	"select * from mdls where path = '/Users/testuser/Desktop/testfile';"
+])


### PR DESCRIPTION
Created mdls table which mimics the functionality of the mdls command in macOS. Table allows osquery to retrieve key/value pairs from spotlight metadata. 