### PR TITLE
Reimplement queryInternal with a new inner method

### DIFF
--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -16,6 +16,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/variant.hpp>
+
 #include <osquery/core.h>
 
 #include "osquery/core/json.h"
@@ -24,9 +26,14 @@ namespace osquery {
 
 class Status;
 /**
- * @brief A variant type for the SQLite type affinities.
+ * @brief Alias for string.
  */
 using RowData = std::string;
+
+/**
+ * @brief A variant type for the SQLite type affinities.
+ */
+using RowDataTyped = boost::variant<int64_t, double, std::string>;
 
 /**
  * @brief A single row from a database query
@@ -35,6 +42,14 @@ using RowData = std::string;
  * the Row's respective value
  */
 using Row = std::map<std::string, RowData>;
+
+/**
+ * @brief A single row from a database query
+ *
+ * Row is a simple map where individual column names are keys, which map to
+ * the Row's respective typed value
+ */
+using RowTyped = std::map<std::string, RowDataTyped>;
 
 /**
  * @brief A vector of column names associated with a query
@@ -95,6 +110,14 @@ Status deserializeRowJSON(const std::string& json, Row& r);
  * osquery. It's just a vector of Rows.
  */
 using QueryData = std::vector<Row>;
+
+/**
+ * @brief The result set returned from a osquery SQL query
+ *
+ * QueryData is the canonical way to represent the results of SQL queries in
+ * osquery. It's just a vector of RowTypeds.
+ */
+using QueryDataTyped = std::vector<RowTyped>;
 
 /**
  * @brief Set representation result returned from a osquery SQL query

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -318,6 +318,23 @@ Status queryInternal(const std::string& q,
                      const SQLiteDBInstanceRef& instance);
 
 /**
+ * @brief SQLite Internal: Execute a query on a specific database
+ *
+ * If you need to use a different database, other than the osquery default,
+ * use this method and pass along a pointer to a SQLite3 database. This is
+ * useful for testing.
+ *
+ * @param q the query to execute
+ * @param results The QueryDataTyped vector to emit rows on query success.
+ * @param db the SQLite3 database to execute query q against
+ *
+ * @return A status indicating SQL query results.
+ */
+Status queryInternal(const std::string& q,
+                     QueryDataTyped& results,
+                     const SQLiteDBInstanceRef& instance);
+
+/**
  * @brief SQLite Intern: Analyze a query, providing information about the
  * result columns
  *

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -92,22 +92,22 @@ TEST_F(SQLiteUtilTests, test_direct_query_execution) {
   EXPECT_EQ(results, getTestDBExpectedResults());
 }
 
-TEST_F(SQLiteUtilTests, test_passing_callback_no_data_param) {
-  char* err = nullptr;
-  auto dbc = getTestDBC();
-  sqlite3_exec(dbc->db(), kTestQuery.c_str(), queryDataCallback, nullptr, &err);
-  EXPECT_TRUE(err != nullptr);
-  if (err != nullptr) {
-    sqlite3_free(err);
-  }
-}
-
 TEST_F(SQLiteUtilTests, test_aggregate_query) {
   auto dbc = getTestDBC();
   QueryData results;
   auto status = queryInternal(kTestQuery, results, dbc);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(results, getTestDBExpectedResults());
+}
+
+TEST_F(SQLiteUtilTests, test_no_results_query) {
+  auto dbc = getTestDBC();
+  QueryData results;
+  auto status = queryInternal(
+      "select * from test_table where username=\"A_NON_EXISTENT_NAME\"",
+      results,
+      dbc);
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(SQLiteUtilTests, test_get_test_db_result_stream) {


### PR DESCRIPTION
Reimplement queryInternal with a new method, wrapped by the older one, that obtains column type info (in preparation for further changes for https://github.com/facebook/osquery/issues/4799 ).

This is a partial replacement for (and part of the breaking up of) this [larger pull request](https://github.com/facebook/osquery/pull/4827).

I've incorporated the suggestions made in that pull request, for the relevant parts of the code.