### PR TITLE
tables: Add iBridge details in macOS

### DIFF
--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -8,9 +8,9 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <osquery/core/map_take.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/core/map_take.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/core/darwin/iokit.hpp"
@@ -19,6 +19,7 @@ namespace osquery {
 namespace tables {
 
 #define kIODeviceEfiPath_ ":/efi/platform"
+#define kIODeviceChosenPath_ ":/chosen"
 #define kEmbeddedOSClass_ "AppleEmbeddedOSSupportHost"
 #define kAppleCoprocessorVersionKey_ "apple-coprocessor-version"
 
@@ -30,11 +31,32 @@ static const std::unordered_map<uint32_t, std::string> kCoprocessorVersions = {
     {0x00020000, "Apple T2 Chip"},
 };
 
+static inline void genBootUuid(Row& r) {
+  auto chosen = IORegistryEntryFromPath(
+      kIOMasterPortDefault, kIODeviceTreePlane kIODeviceChosenPath_);
+  if (chosen == MACH_PORT_NULL) {
+    return;
+  }
+
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      chosen, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(chosen);
+
+  if (kr != KERN_SUCCESS) {
+    LOG(WARNING) << "Cannot get EFI properties";
+    return;
+  }
+
+  r["boot_uuid"] = getIOKitProperty(properties, "boot-uuid");
+  CFRelease(properties);
+}
+
 static inline void genAppleCoprocessorVersion(Row& r) {
   auto asoc = IORegistryEntryFromPath(kIOMasterPortDefault,
                                       kIODeviceTreePlane kIODeviceEfiPath_);
   if (asoc == MACH_PORT_NULL) {
-    VLOG(1) << "Cannot open EFI Device Tree";
+    LOG(WARNING) << "Cannot open EFI Device Tree";
     return;
   }
 
@@ -44,7 +66,7 @@ static inline void genAppleCoprocessorVersion(Row& r) {
   IOObjectRelease(asoc);
 
   if (kr != KERN_SUCCESS) {
-    VLOG(1) << "Cannot get EFI properties";
+    LOG(WARNING) << "Cannot get EFI properties";
     return;
   }
 
@@ -53,22 +75,14 @@ static inline void genAppleCoprocessorVersion(Row& r) {
     auto version_data = (CFDataRef)CFDictionaryGetValue(
         properties, CFSTR(kAppleCoprocessorVersionKey_));
     auto range = CFRangeMake(0, CFDataGetLength(version_data));
-    auto buffer = (unsigned char*)malloc(range.length + 1);
 
-    if (buffer == nullptr) {
-      return;
-    }
-    memset(buffer, 0, range.length + 1);
-    CFDataGetBytes(version_data, range, buffer);
+    auto buffer = std::vector<unsigned char>(range.length + 1, 0);
+    CFDataGetBytes(version_data, range, &buffer[0]);
 
-    uint32_t version = {0};
-    memcpy(&version, buffer, 4);
-
-    //r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
-    //                               ? kCoprocessorVersions.at(version)
-    //                               : "unknown";
-    r["coprocessor_version"] = tryTakeCopy(kCoprocessorVersions, version).takeOr(std::string{"unknown"});
-    free(buffer);
+    uint32_t version = 0;
+    memcpy(&version, buffer.data(), 4);
+    r["coprocessor_version"] = tryTakeCopy(kCoprocessorVersions, version)
+                                   .takeOr(std::string{"unknown"});
   }
   CFRelease(properties);
 }
@@ -78,10 +92,11 @@ QueryData genIBridgeInfo(QueryContext& context) {
   Row r;
 
   genAppleCoprocessorVersion(r);
+  genBootUuid(r);
 
   auto eos = IOServiceNameMatching(kEmbeddedOSClass_);
   if (eos == nullptr) {
-    VLOG(1)
+    LOG(WARNING)
         << "EmbeddedOS class not found. Perhaps this mac doesn't have T* chip";
     return results;
   }
@@ -93,19 +108,18 @@ QueryData genIBridgeInfo(QueryContext& context) {
   IOObjectRelease(service);
 
   if (kr != KERN_SUCCESS) {
-    VLOG(1) << "Cannot get EmbeddedOS properties";
+    LOG(WARNING) << "Cannot get EmbeddedOS properties";
     IOObjectRelease(service);
     return results;
   }
 
   r["unique_chip_id"] = getIOKitProperty(properties, "DeviceUniqueChipID");
   r["firmware_version"] = getIOKitProperty(properties, "DeviceBuildVersion");
-  r["boot_uuid"] = getIOKitProperty(properties, "DeviceBootUUID");
 
   CFRelease(properties);
   IOObjectRelease(service);
 
-  results.push_back(r);
+  results.push_back(std::move(r));
   return results;
 }
 } // namespace tables

--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -10,6 +10,7 @@
 
 #include <osquery/logger.h>
 #include <osquery/tables.h>
+#include <osquery/core/map_take.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/core/darwin/iokit.hpp"
@@ -23,7 +24,7 @@ namespace tables {
 
 /// as defined in
 /// /System/Library/Frameworks/Kernel.framework/Headers/IOKit/IOPlatformExpert.h
-static const std::map<uint32_t, std::string> kCoprocessorVersions = {
+static const std::unordered_map<uint32_t, std::string> kCoprocessorVersions = {
     {0x00000000, ""},
     {0x00010000, "Apple T1 Chip"},
     {0x00020000, "Apple T2 Chip"},
@@ -63,9 +64,10 @@ static inline void genAppleCoprocessorVersion(Row& r) {
     uint32_t version = {0};
     memcpy(&version, buffer, 4);
 
-    r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
-                                   ? kCoprocessorVersions.at(version)
-                                   : "unknown";
+    //r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
+    //                               ? kCoprocessorVersions.at(version)
+    //                               : "unknown";
+    r["coprocessor_version"] = tryTakeCopy(kCoprocessorVersions, version).takeOr(std::string{"unknown"});
     free(buffer);
   }
   CFRelease(properties);

--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -1,0 +1,110 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/darwin/iokit.hpp"
+
+namespace osquery {
+namespace tables {
+
+#define kIODeviceEfiPath_ ":/efi/platform"
+#define kEmbeddedOSClass_ "AppleEmbeddedOSSupportHost"
+#define kAppleCoprocessorVersionKey_ "apple-coprocessor-version"
+
+/// as defined in
+/// /System/Library/Frameworks/Kernel.framework/Headers/IOKit/IOPlatformExpert.h
+static const std::map<uint32_t, std::string> kCoprocessorVersions = {
+    {0x00000000, ""},
+    {0x00010000, "Apple T1 Chip"},
+    {0x00020000, "Apple T2 Chip"},
+};
+
+static inline void genAppleCoprocessorVersion(Row& r) {
+  auto asoc = IORegistryEntryFromPath(kIOMasterPortDefault,
+                                      kIODeviceTreePlane kIODeviceEfiPath_);
+  if (asoc == MACH_PORT_NULL) {
+    VLOG(1) << "Cannot open EFI Device Tree";
+    return;
+  }
+
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      asoc, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(asoc);
+
+  if (kr != KERN_SUCCESS) {
+    VLOG(1) << "Cannot get EFI properties";
+    return;
+  }
+
+  if (CFDictionaryContainsKey(properties,
+                              CFSTR(kAppleCoprocessorVersionKey_))) {
+    auto version_data = (CFDataRef)CFDictionaryGetValue(
+        properties, CFSTR(kAppleCoprocessorVersionKey_));
+    auto range = CFRangeMake(0, CFDataGetLength(version_data));
+    auto buffer = (unsigned char*)malloc(range.length + 1);
+
+    if (buffer == nullptr) {
+      return;
+    }
+    memset(buffer, 0, range.length + 1);
+    CFDataGetBytes(version_data, range, buffer);
+
+    uint32_t version = {0};
+    memcpy(&version, buffer, 4);
+
+    r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
+                                   ? kCoprocessorVersions.at(version)
+                                   : "unknown";
+    free(buffer);
+  }
+  CFRelease(properties);
+}
+
+QueryData genIBridgeInfo(QueryContext& context) {
+  QueryData results;
+  Row r;
+
+  genAppleCoprocessorVersion(r);
+
+  auto eos = IOServiceNameMatching(kEmbeddedOSClass_);
+  if (eos == nullptr) {
+    VLOG(1)
+        << "EmbeddedOS class not found. Perhaps this mac doesn't have T* chip";
+    return results;
+  }
+
+  auto service = IOServiceGetMatchingService(kIOMasterPortDefault, eos);
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      service, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(service);
+
+  if (kr != KERN_SUCCESS) {
+    VLOG(1) << "Cannot get EmbeddedOS properties";
+    IOObjectRelease(service);
+    return results;
+  }
+
+  r["unique_chip_id"] = getIOKitProperty(properties, "DeviceUniqueChipID");
+  r["firmware_version"] = getIOKitProperty(properties, "DeviceBuildVersion");
+  r["boot_uuid"] = getIOKitProperty(properties, "DeviceBootUUID");
+
+  CFRelease(properties);
+  IOObjectRelease(service);
+
+  results.push_back(r);
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tests/integration/tables/CMakeLists.txt
+++ b/osquery/tests/integration/tables/CMakeLists.txt
@@ -236,6 +236,7 @@ if(APPLE)
       "${CMAKE_CURRENT_LIST_DIR}/gatekeeper.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/gatekeeper_approved_apps.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/homebrew_packages.cpp"
+      "${CMAKE_CURRENT_LIST_DIR}/ibridge.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/iokit_devicetree.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/iokit_registry.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/kernel_extensions.cpp"

--- a/osquery/tests/integration/tables/ibridge.cpp
+++ b/osquery/tests/integration/tables/ibridge.cpp
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+// Sanity check integration test for ibridge
+// Spec file: specs/darwin/ibridge.table
+
+#include <osquery/logger.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+
+class IBridgeTest : public IntegrationTableTest {};
+
+TEST_F(IBridgeTest, test_sanity) {
+  auto rows = execute_query("select * from ibridge");
+  if (rows.empty()) {
+    VLOG(1) << "Empty result for table: ibridge, skipping test";
+  } else {
+    ASSERT_EQ(rows.size(), 1ul);
+    ValidatatioMap validation_map = {
+        {"boot_uuid", NormalType},
+        {"coprocessor_version", NonEmptyString},
+        {"firmware_version", NonEmptyString},
+        {"unique_chip_id", NonEmptyString},
+    };
+    validate_rows(rows, validation_map);
+  }
+}
+} // namespace osquery

--- a/specs/darwin/ibridge.table
+++ b/specs/darwin/ibridge.table
@@ -1,0 +1,10 @@
+table_name("ibridge")
+description("Information about the Apple iBridge hardware controller.")
+schema([
+    Column("boot_uuid", TEXT, "Boot UUID of the iBridge controller"),
+    Column("coprocessor_version", TEXT, "The manufacturer and chip version"),
+    Column("firmware_version", TEXT, "The build version of the firmware"),
+    Column("unique_chip_id", TEXT, "unique id"),
+])
+attributes(cacheable=True)
+implementation("system/ibridge@genIBridgeInfo")


### PR DESCRIPTION
This is spearheaded by @terracatta, more background info in #5166 

This PR grabs T* chip details via IOKit


```
osquery> .all ibridge
+-----------+---------------------+------------------+-----------------+
| boot_uuid | coprocessor_version | firmware_version | unique_chip_id  |
+-----------+---------------------+------------------+-----------------+
|           | Apple T1 Chip       | 14Y664           | 854183246450470 |
+-----------+---------------------+------------------+-----------------+

➜  osquery git:(ibridge_iokit) ✗ python ./tools/analysis/profile.py --leaks --rounds 10 --query "select * ibridge"
Analyzing leaks in query: select * ibridge
  definitely: 0 leaks for 0 total leaked bytes.
```

I am currently guessing the IOKit key for the `boot_uuid` column, since it's a T2 chip only feature, which I don't have access to. If anyone with T2 SOC mac can help out by giving the outputs of ioreg below, it will be super helpful!
 
`ioreg -r -f -x -c "AppleEmbeddedOSSupportHost"`
`ioreg -d 1 -r -f -p IODeviceTree -n ASOC`
`ioreg -r -f -p IODeviceTree -k "boot-uuid" | grep "boot-uuid"`
