### PR TITLE
macOS: Add a `bsd_flags` column to the `file` table

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -46,6 +46,7 @@ if(APPLE)
   target_sources(libosquery
     PRIVATE
       "${CMAKE_CURRENT_LIST_DIR}/darwin/conversions.cpp"
+      "${CMAKE_CURRENT_LIST_DIR}/darwin/bsd_file_flags.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/darwin/iokit.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/darwin/iokit.hpp"
   )
@@ -111,5 +112,11 @@ endif()
 if(LINUX)
   ADD_OSQUERY_TEST_CORE(
     "${CMAKE_CURRENT_LIST_DIR}/linux/tests/cpu_test.cpp"
+  )
+endif()
+
+if(APPLE)
+  ADD_OSQUERY_TEST_CORE(
+    "${CMAKE_CURRENT_LIST_DIR}/darwin/tests/bsd_file_flags_tests.cpp"
   )
 endif()

--- a/osquery/core/darwin/bsd_file_flags.cpp
+++ b/osquery/core/darwin/bsd_file_flags.cpp
@@ -32,9 +32,7 @@ std::uint32_t getBsdFlagMask() {
 }
 } // namespace
 
-/// Builds a list of the known BSD file flags specified by st_flags (see the
-/// stat structure). Foreign bits are added to the list as a hexadecimal number
-Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags) {
+bool describeBSDFileFlags(std::string& output, std::uint32_t st_flags) {
   output.clear();
 
   static const auto flag_mask = getBsdFlagMask();
@@ -50,21 +48,22 @@ Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags) {
     }
   }
 
-  auto foreign_bits = st_flags & (~flag_mask);
-  if (foreign_bits != 0U) {
+  // Get the bits that are not documented and show them as a hex number
+  auto undocumented_flags = st_flags & (~flag_mask);
+  if (undocumented_flags != 0U) {
     std::stringstream buffer;
     buffer << "0x" << std::setw(8) << std::setfill('0') << std::hex
-           << foreign_bits;
+           << undocumented_flags;
 
     label_list.push_back(buffer.str());
   }
 
   output = boost::algorithm::join(label_list, ", ");
 
-  if (foreign_bits != 0U) {
-    return Status::failure("Foreign bits were found in the st_flags field");
+  if (undocumented_flags != 0U) {
+    return false;
   }
 
-  return Status(0);
+  return true;
 }
 } // namespace osquery

--- a/osquery/core/darwin/bsd_file_flags.cpp
+++ b/osquery/core/darwin/bsd_file_flags.cpp
@@ -1,0 +1,70 @@
+#include <iomanip>
+#include <unordered_map>
+
+#include <boost/algorithm/string/join.hpp>
+
+#include <sys/stat.h>
+
+#include "osquery/core/utils.h"
+
+namespace osquery {
+namespace {
+/// The list of supported flags, as documented in `man 2 chflags`
+const std::unordered_map<std::uint32_t, std::string> kBsdFlagMap = {
+    {UF_NODUMP, "NODUMP"},
+    {UF_IMMUTABLE, "UF_IMMUTABLE"},
+    {UF_APPEND, "UF_APPEND"},
+    {UF_OPAQUE, "OPAQUE"},
+    {UF_HIDDEN, "HIDDEN"},
+    {SF_ARCHIVED, "ARCHIVED"},
+    {SF_IMMUTABLE, "SF_IMMUTABLE"},
+    {SF_APPEND, "SF_APPEND"}};
+
+std::uint32_t getBsdFlagMask() {
+  std::uint32_t result = 0U;
+
+  for (const auto& p : kBsdFlagMap) {
+    const auto& bit = p.first;
+    result |= bit;
+  }
+
+  return result;
+}
+} // namespace
+
+/// Builds a list of the known BSD file flags specified by st_flags (see the
+/// stat structure). Foreign bits are added to the list as a hexadecimal number
+Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags) {
+  output.clear();
+
+  static const auto flag_mask = getBsdFlagMask();
+
+  std::vector<std::string> label_list;
+
+  for (const auto& p : kBsdFlagMap) {
+    const auto& bit = p.first;
+    const auto& label = p.second;
+
+    if ((st_flags & bit) != 0U) {
+      label_list.push_back(label);
+    }
+  }
+
+  auto foreign_bits = st_flags & (~flag_mask);
+  if (foreign_bits != 0U) {
+    std::stringstream buffer;
+    buffer << "0x" << std::setw(8) << std::setfill('0') << std::hex
+           << foreign_bits;
+
+    label_list.push_back(buffer.str());
+  }
+
+  output = boost::algorithm::join(label_list, ", ");
+
+  if (foreign_bits != 0U) {
+    return Status::failure("Foreign bits were found in the st_flags field");
+  }
+
+  return Status(0);
+}
+} // namespace osquery

--- a/osquery/core/darwin/tests/bsd_file_flags_tests.cpp
+++ b/osquery/core/darwin/tests/bsd_file_flags_tests.cpp
@@ -1,0 +1,37 @@
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "osquery/core/utils.h"
+
+namespace osquery {
+namespace {
+class DarwinBsdFlags : public testing::Test {};
+
+TEST_F(DarwinBsdFlags, testAllFlags) {
+  auto flags = UF_NODUMP | UF_IMMUTABLE | UF_APPEND | UF_OPAQUE | UF_HIDDEN |
+               SF_ARCHIVED | SF_IMMUTABLE | SF_APPEND;
+
+  std::string expected_description =
+      "SF_APPEND, SF_IMMUTABLE, ARCHIVED, HIDDEN, OPAQUE, UF_APPEND, "
+      "UF_IMMUTABLE, NODUMP";
+
+  std::string description;
+  auto status = describeBSDFileFlags(description, flags);
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(description, expected_description);
+}
+
+TEST_F(DarwinBsdFlags, foreignFlags) {
+  auto flags = UF_NODUMP | 0xFF000000U;
+  std::string expected_description = "NODUMP, 0xff000000";
+
+  std::string description;
+  auto status = describeBSDFileFlags(description, flags);
+  EXPECT_FALSE(status.ok());
+
+  EXPECT_EQ(description, expected_description);
+}
+} // namespace
+} // namespace osquery

--- a/osquery/core/darwin/tests/bsd_file_flags_tests.cpp
+++ b/osquery/core/darwin/tests/bsd_file_flags_tests.cpp
@@ -16,9 +16,11 @@ TEST_F(DarwinBsdFlags, testAllFlags) {
       "SF_APPEND, SF_IMMUTABLE, ARCHIVED, HIDDEN, OPAQUE, UF_APPEND, "
       "UF_IMMUTABLE, NODUMP";
 
+  // The function should return true when there are no undocumented bits
+  // set inside the `flags` value
   std::string description;
-  auto status = describeBSDFileFlags(description, flags);
-  EXPECT_TRUE(status.ok());
+  auto s = describeBSDFileFlags(description, flags);
+  EXPECT_TRUE(s);
 
   EXPECT_EQ(description, expected_description);
 }
@@ -27,9 +29,11 @@ TEST_F(DarwinBsdFlags, foreignFlags) {
   auto flags = UF_NODUMP | 0xFF000000U;
   std::string expected_description = "NODUMP, 0xff000000";
 
+  // The function should return false when there are undocumented bits used
+  // in the `flags` value
   std::string description;
-  auto status = describeBSDFileFlags(description, flags);
-  EXPECT_FALSE(status.ok());
+  auto s = describeBSDFileFlags(description, flags);
+  EXPECT_FALSE(s);
 
   EXPECT_EQ(description, expected_description);
 }

--- a/osquery/core/utils.h
+++ b/osquery/core/utils.h
@@ -30,6 +30,10 @@ const std::string canonicalize_file_name(const char* name);
 #endif
 
 #ifdef __APPLE__
-Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags);
+/// Builds a list of the known BSD file flags specified by st_flags (see the
+/// stat structure). Foreign bits are added to the list as a hexadecimal number
+/// If undocumented bits are found inside the st_flags value, the function will
+/// include them in the output as a hexadecimal value and return false.
+bool describeBSDFileFlags(std::string& output, std::uint32_t st_flags);
 #endif
 }

--- a/osquery/core/utils.h
+++ b/osquery/core/utils.h
@@ -10,8 +10,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ctime>
 #include <string>
+
+#include <osquery/status.h>
 
 namespace osquery {
 
@@ -24,5 +27,9 @@ std::string platformStrerr(int errnum);
 #ifdef OSQUERY_POSIX
 /// Safer way to do realpath
 const std::string canonicalize_file_name(const char* name);
+#endif
+
+#ifdef __APPLE__
+Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags);
 #endif
 }

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -17,6 +17,7 @@
 #include <osquery/tables.h>
 
 #include "osquery/filesystem/fileops.h"
+#include "osquery/core/utils.h"
 
 namespace fs = boost::filesystem;
 
@@ -99,6 +100,17 @@ void genFileInfo(const fs::path& path,
   } else {
     r["type"] = "unknown";
   }
+
+#if defined(__APPLE__)
+  std::string bsd_file_attr;
+  auto s = describeBSDFileFlags(bsd_file_attr, file_stat.st_flags);
+  if (!s.ok()) {
+    LOG(WARNING) << "File \"" << path
+                 << "\" generated a warning: " << s.getMessage();
+  }
+
+  r["bsd_flags"] = bsd_file_attr;
+#endif
 
 #else
 

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -102,14 +102,14 @@ void genFileInfo(const fs::path& path,
   }
 
 #if defined(__APPLE__)
-  std::string bsd_file_attr;
-  auto s = describeBSDFileFlags(bsd_file_attr, file_stat.st_flags);
-  if (!s.ok()) {
-    LOG(WARNING) << "File \"" << path
-                 << "\" generated a warning: " << s.getMessage();
+  std::string bsd_file_flags_description;
+  if (!describeBSDFileFlags(bsd_file_flags_description, file_stat.st_flags)) {
+    LOG(WARNING)
+        << "The following file had undocumented BSD file flags (chflags) set: "
+        << path;
   }
 
-  r["bsd_flags"] = bsd_file_attr;
+  r["bsd_flags"] = bsd_file_flags_description;
 #endif
 
 #else

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -25,7 +25,7 @@ extended_schema(WINDOWS, [
     Column("file_id", TEXT, "file ID"),
 ])
 extended_schema(DARWIN, [
-    Column("bsd_flags", TEXT, "The BSD file flags")
+    Column("bsd_flags", TEXT, "The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND")
 ])
 attributes(utility=True)
 implementation("utility/file@genFile")

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -24,6 +24,9 @@ extended_schema(WINDOWS, [
     Column("volume_serial", TEXT, "Volume serial number"),
     Column("file_id", TEXT, "file ID"),
 ])
+extended_schema(DARWIN, [
+    Column("bsd_flags", TEXT, "The BSD file flags")
+])
 attributes(utility=True)
 implementation("utility/file@genFile")
 examples([


### PR DESCRIPTION
This PR implements support for the BSD flags on macOS as documented in issue https://github.com/facebook/osquery/issues/4189.

```sql
SELECT path, bsd_flags
FROM file
WHERE path = "/Volumes/Home/alessandro/Desktop/test_file";
```
```
+--------------------------------------------+------------------------------------------------------------------------------------+
| path                                       | bsd_flags                                                                          |
+--------------------------------------------+------------------------------------------------------------------------------------+
| /Volumes/Home/alessandro/Desktop/test_file | SF_APPEND, SF_IMMUTABLE, ARCHIVED, HIDDEN, OPAQUE, UF_APPEND, UF_IMMUTABLE, NODUMP |
+--------------------------------------------+------------------------------------------------------------------------------------+
```