### PR TITLE
Add version_less SQL function

### DIFF
--- a/docs/wiki/introduction/sql.md
+++ b/docs/wiki/introduction/sql.md
@@ -76,7 +76,7 @@ osquery> SELECT * FROM osquery_info;
           uuid = 4892E1C6-F800-5F8E-92B1-BC2216C29D4F
    instance_id = 94c004b0-49e5-4ece-93e6-96c1939c0f83
        version = 2.4.6
-   config_hash = 
+   config_hash =
   config_valid = 0
     extensions = active
 build_platform = darwin
@@ -260,6 +260,8 @@ The following trig functions: `sin`, `cos`, `tan`, `cot`, `asin`, `acos`, `atan`
 </details>
 
 **String functions**
+
+- `version_less(VERSION1, VERSION2)`: returns an integer representing `VERSION1 < VERSION2` when they are interpreted as version strings (eg. '1.2.3.4'). Combined with the normal `==` string comparison, any desired comparison on version strings is possible.
 
 String parsing functions are always helpful, some help within subqueries so they make sense as local-additions:
 

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -166,6 +166,58 @@ TEST_F(SQLTests, test_sql_sha256) {
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 }
 
+TEST_F(SQLTests, test_sql_version_less) {
+  QueryData d;
+  query("select version_less('1.1.1.1', '1.1.1.1') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('1.1.1.1', '1.2.1.1') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  query("select version_less('2.1.1.1', '1.2.1.1') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('2.1.1.1', '2.1.0.1') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('2.1.0.0', '2.1.0.1') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  query("select version_less('321.123.0.0', '32.1.2.3') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('321.123.0.0', '32.1.2.3') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('0.22.0.0', '0.22.0.3') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  query("select version_less('22.22.0.0', '0.22.0.3') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+  query("select version_less('0.5.5-19-ga7b9229', '0.5.5-22-g85b16ae') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  query("select version_less('0.5.5-19-ga7b9229', '0.5.6') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  query("select version_less('0.5.5-22-g85b16ae', '0.5.5-19-ga7b9229') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+
+}
+
 #ifdef OSQUERY_POSIX
 TEST_F(SQLTests, test_sql_ssdeep_compare) {
   QueryData d;


### PR DESCRIPTION
A combination of this function and the normal string comparison (==) allows the
full range of comparison functions to be performed on version strings.

Closes #5196
