### PR TITLE
Fix BIOS Info table searching.

### DIFF
--- a/osquery/tables/system/windows/wmi_bios_info.cpp
+++ b/osquery/tables/system/windows/wmi_bios_info.cpp
@@ -29,13 +29,13 @@ const std::vector<std::string> kDell = {"dell inc."};
 const std::map<std::string, std::pair<std::string, BSTR>> kQueryMap = {
     {"hp",
      {"select Name,Value from HP_BiosSetting",
-      (BSTR) "root\\hp\\instrumentedBIOS"}},
+      (BSTR)L"root\\hp\\instrumentedBIOS"}},
     {"lenovo",
-     {"select CurrentSetting from Lenovo_BiosSetting", (BSTR) "root\\wmi"}},
+     {"select CurrentSetting from Lenovo_BiosSetting", (BSTR)L"root\\wmi"}},
     {"dell",
      {"select AttributeName,CurrentValue,PossibleValues, "
       "PossibleValuesDescription from DCIM_BIOSEnumeration",
-      (BSTR) "root\\dcim\\sysman"}}};
+      (BSTR)L"root\\dcim\\sysman"}}};
 
 std::string getManufacturer(std::string manufacturer) {
   transform(manufacturer.begin(),

--- a/osquery/tables/system/windows/wmi_bios_info.cpp
+++ b/osquery/tables/system/windows/wmi_bios_info.cpp
@@ -26,16 +26,14 @@ const std::vector<std::string> kHP = {
     "hp", "hewlett-packard", "hewlett packard"};
 const std::vector<std::string> kLenovo = {"lenovo"};
 const std::vector<std::string> kDell = {"dell inc."};
-const std::map<std::string, std::pair<std::string, BSTR>> kQueryMap = {
+const std::map<std::string, std::pair<std::string, std::wstring>> kQueryMap = {
     {"hp",
-     {"select Name,Value from HP_BiosSetting",
-      (BSTR)L"root\\hp\\instrumentedBIOS"}},
-    {"lenovo",
-     {"select CurrentSetting from Lenovo_BiosSetting", (BSTR)L"root\\wmi"}},
+     {"select Name,Value from HP_BiosSetting", L"root\\hp\\instrumentedBIOS"}},
+    {"lenovo", {"select CurrentSetting from Lenovo_BiosSetting", L"root\\wmi"}},
     {"dell",
      {"select AttributeName,CurrentValue,PossibleValues, "
       "PossibleValuesDescription from DCIM_BIOSEnumeration",
-      (BSTR)L"root\\dcim\\sysman"}}};
+      L"root\\dcim\\sysman"}}};
 
 std::string getManufacturer(std::string manufacturer) {
   transform(manufacturer.begin(),
@@ -128,45 +126,43 @@ Row getDellBiosInfo(const WmiResultItem& item) {
 }
 
 QueryData genBiosInfo(QueryContext& context) {
-  QueryData results;
-  std::string manufacturer;
 
   const WmiRequest wmiComputerSystemReq(
       "select Manufacturer from Win32_ComputerSystem");
-  const std::vector<WmiResultItem>& wmiComputerSystemResults =
-      wmiComputerSystemReq.results();
-
-  if (!wmiComputerSystemResults.empty()) {
-    wmiComputerSystemResults[0].GetString("Manufacturer", manufacturer);
-    manufacturer = getManufacturer(manufacturer);
-  } else {
-    return results;
+  const auto& wmiComputerSystemResults = wmiComputerSystemReq.results();
+  if (wmiComputerSystemResults.empty()) {
+    return {};
   }
 
-  if (kQueryMap.find(manufacturer) != kQueryMap.end()) {
-    const WmiRequest wmiBiosReq(std::get<0>(kQueryMap.at(manufacturer)),
-                                (std::get<1>(kQueryMap.at(manufacturer))));
-    const std::vector<WmiResultItem>& wmiResults = wmiBiosReq.results();
+  std::string manufacturer;
+  wmiComputerSystemResults[0].GetString("Manufacturer", manufacturer);
+  manufacturer = getManufacturer(manufacturer);
 
-    for (unsigned int i = 0; i < wmiResults.size(); ++i) {
-      Row r;
-
-      if (manufacturer == "hp") {
-        r = getHPBiosInfo(wmiResults[i]);
-
-      } else if (manufacturer == "lenovo") {
-        r = getLenovoBiosInfo(wmiResults[i]);
-
-      } else if (manufacturer == "dell") {
-        r = getDellBiosInfo(wmiResults[i]);
-      }
-      if (!r.empty()) {
-        results.push_back(r);
-      }
-    }
-  } else {
+  auto it = kQueryMap.find(manufacturer);
+  if (it == kQueryMap.end()) {
     LOG(INFO) << "Vendor \"" << manufacturer << "\" is currently not supported";
+    return {};
   }
+
+  QueryData results;
+  const WmiRequest wmiBiosReq(std::get<0>(it->second), std::get<1>(it->second));
+  const auto& wmiResults = wmiBiosReq.results();
+  for (size_t i = 0; i < wmiResults.size(); ++i) {
+    Row r;
+    if (manufacturer == "hp") {
+      r = getHPBiosInfo(wmiResults[i]);
+
+    } else if (manufacturer == "lenovo") {
+      r = getLenovoBiosInfo(wmiResults[i]);
+
+    } else if (manufacturer == "dell") {
+      r = getDellBiosInfo(wmiResults[i]);
+    }
+    if (!r.empty()) {
+      results.push_back(r);
+    }
+  }
+
   return results;
 }
 } // namespace tables


### PR DESCRIPTION
https://github.com/facebook/osquery/issues/5244

Fixes blank results for wmi_bios_info table. In looking at other examples in the code base, you must use (BTSR)L"wmi\\namespace" instead of (BTSR) "wmi\\namespace", otherwise you get blank results.