### PR TITLE
Add windows_optional_features virtual table.

### DIFF
--- a/osquery/tables/system/windows/tests/windows_optional_features_tests.cpp
+++ b/osquery/tables/system/windows/tests/windows_optional_features_tests.cpp
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+#include <string>
+
+#include <osquery/sql.h>
+
+#include "osquery/tests/test_util.h"
+
+namespace osquery {
+namespace tables {
+
+class WinOptFeaturesTablesTest : public testing::Test {};
+
+extern std::string getDismPackageFeatureStateName(uint32_t state);
+
+/*
+ * Basic sanity check on function that provides a name
+ * for InstallState.  We only know values 1 through 3.
+ * All other values should return Unknown.
+ */
+TEST_F(WinOptFeaturesTablesTest, get_state_name) {
+  EXPECT_EQ("Unknown", getDismPackageFeatureStateName(4));
+  EXPECT_EQ("Unknown", getDismPackageFeatureStateName(999998));
+  EXPECT_EQ("Unknown", getDismPackageFeatureStateName(0));
+  EXPECT_EQ("Enabled", getDismPackageFeatureStateName(1));
+  EXPECT_EQ("Disabled", getDismPackageFeatureStateName(2));
+  EXPECT_EQ("Absent", getDismPackageFeatureStateName(3));
+}
+
+}
+}

--- a/osquery/tables/system/windows/tests/windows_optional_features_tests.cpp
+++ b/osquery/tables/system/windows/tests/windows_optional_features_tests.cpp
@@ -37,6 +37,5 @@ TEST_F(WinOptFeaturesTablesTest, get_state_name) {
   EXPECT_EQ("Disabled", getDismPackageFeatureStateName(2));
   EXPECT_EQ("Absent", getDismPackageFeatureStateName(3));
 }
-
 }
 }

--- a/osquery/tables/system/windows/windows_optional_features.cpp
+++ b/osquery/tables/system/windows/windows_optional_features.cpp
@@ -1,0 +1,84 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <string>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+namespace tables {
+
+std::string getDismPackageFeatureStateName(uint32_t state);
+
+/**
+ * return collection of Windows Features installation states.
+ * On Window 10 Pro, returns about 140 rows.
+ */
+QueryData genWinOptionalFeatures(QueryContext& context) {
+  QueryData results;
+
+  const WmiRequest wmiReq(
+      "SELECT Caption,Name,InstallState FROM Win32_OptionalFeature");
+  const std::vector<WmiResultItem>& wmiResults = wmiReq.results();
+
+  if (wmiResults.empty()) {
+	return results;
+  }
+
+  for (unsigned int i = 0; i < wmiResults.size(); ++i) {
+	Row r;
+	wmiResults[i].GetString("Name", r["name"]);
+	wmiResults[i].GetString("Caption", r["caption"]);
+	uint32_t state = 99;
+	if (wmiResults[i].GetUnsignedInt32("InstallState", state).ok() == false) {
+		long i4;
+		if (wmiResults[i].GetLong("InstallState", i4).ok() == false) {
+			// no luck
+		}
+		else {
+			state = (uint32_t)i4;
+		}
+	}
+	r["state"] = INTEGER(state);
+	r["statename"] = getDismPackageFeatureStateName(atoi(r["state"].c_str()));
+	results.push_back(r);
+  }
+  return results;
+}
+
+/*
+https://docs.microsoft.com/en-us/windows/desktop/CIMWin32Prov/win32-optionalfeature
+Enabled (1)
+Disabled (2)
+Absent (3)
+Unknown (4)
+*/
+std::string getDismPackageFeatureStateName(uint32_t state)
+{
+	static std::vector<std::string> stateNames = {
+		"Unknown", "Enabled", "Disabled", "Absent"
+	};
+
+	if (state >= stateNames.size()) {
+		return "Unknown";
+	}
+
+	return stateNames[state];
+}
+
+} // namespace tables
+} // namespace osquery

--- a/specs/windows/windows_optional_features.table
+++ b/specs/windows/windows_optional_features.table
@@ -1,0 +1,13 @@
+table_name("windows_optional_features")
+description("Lists names and installation states of windows features. Maps to Win32_OptionalFeature WMI class.")
+schema([
+  Column("name", TEXT, "Name of the feature"),
+  Column("caption", TEXT, "Caption of feature in settings UI"),
+  Column("state", INTEGER, "Installation state value. 1 == Enabled, 2 == Disabled, 3 == Absent"),
+  Column("statename", TEXT, "Installation state name. 'Enabled','Disabled','Absent'"),
+])
+implementation("windows_optional_features@genWinOptionalFeatures")
+examples([
+  "select * from windows_optional_features",
+  "select * from windows_optional_features where name = 'SMB1Protocol' AND state = 1",
+])


### PR DESCRIPTION
This virtual table maps to Windows WMI class Win32_OptionalFeatures, and can be used to query which windows features are enabled or disabled.  For example, is SMB v1 enabled?


![screen shot 2018-10-15 at 7 13 13 pm](https://user-images.githubusercontent.com/20775507/46985152-74f68500-d0ae-11e8-9cd0-30f3d8386271.png)
