### PR TITLE
fix #4810 syslog pipe hang

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -80,6 +80,7 @@ elseif(LINUX)
     "${CMAKE_CURRENT_LIST_DIR}/linux/tests/inotify_tests.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/linux/tests/process_file_events_tests.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/linux/tests/syslog_tests.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/linux/tests/pipe_liner_tests.cpp"
   )
 elseif(WINDOWS)
   ADD_OSQUERY_TEST_ADDITIONAL(

--- a/osquery/events/linux/pipe_liner.h
+++ b/osquery/events/linux/pipe_liner.h
@@ -1,0 +1,198 @@
+#ifndef _PIPE_LINER_H_
+#define _PIPE_LINER_H_
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+// default max syslog line is 1024, but can be configured as high as 8192
+
+#define LINE_BUF_MAX 16384
+
+struct PipeLinerListener {
+  virtual void onLine(std::string line) = 0;
+  virtual ~PipeLinerListener() {}
+};
+
+/**
+ * A non-blocking buffered line reader that uses select()
+ */
+struct PipeLiner {
+  PipeLiner(PipeLinerListener* listener, uint32_t chunksize = 4096)
+      : chunksize_(chunksize),
+        path_(),
+        fd_(0),
+        buf_(),
+        listener_(listener),
+        tmpbuf_(chunksize) {
+    buf_.reserve(chunksize_ * 2);
+  }
+  ~PipeLiner() {}
+
+  /**
+   * Open the pipe file read-only and non-blocking.
+   * @returns true on error, false on success
+   */
+  bool open(std::string pipe_file_path) {
+    if (path_.size() > 0) {
+      return true;
+    }
+    path_ = pipe_file_path;
+    fd_ = ::open(path_.c_str(), O_RDONLY | O_NONBLOCK);
+
+    return (fd_ <= 0);
+  }
+
+  /**
+   * reads data and calls listener_.onLine() with any new lines.
+   * @returns -1 if select() error, 0 timeout waiting for data, 1 if data read.
+   */
+  int update() {
+    fd_set set;
+    struct timeval timeout = {timeout_sec_, (int)timeout_usec_};
+
+    FD_ZERO(&set); /* clear the set */
+    FD_SET(fd_, &set); /* add our file descriptor to the set */
+
+    // is data available?
+
+    int rv = select(fd_ + 1, &set, NULL, NULL, &timeout);
+    if (rv == -1) {
+      return rv; // error
+    } else if (rv == 0) {
+      return rv; // timeout waiting for data
+    }
+
+    // Only iterate N times, rather than getting stuck when lots of data.
+    // If chunksize is 4096, but line is 8192 bytes, it will take a couple of
+    // reads to get it all.
+
+    for (int i = 0; i < read_loop_count_; i++) {
+      // setup a pointer to end of existing data in buffer
+
+      ssize_t avail = read(fd_, tmpbuf_.data(), tmpbuf_.size() - 1);
+      if (avail > 0) {
+        tmpbuf_[avail] = 0; // add null terminator
+
+        _onBuffer(tmpbuf_.data(), avail);
+      }
+
+      // if read less than size of buffer, no need to loop
+
+      if (avail < (ssize_t)(tmpbuf_.size() - 1))
+        break;
+    }
+
+    return 1;
+  }
+
+  /*
+   * close file if opened
+   */
+  void close() {
+    if (fd_ <= 0) {
+      return;
+    }
+
+    ::close(fd_);
+    fd_ = 0;
+  }
+
+  /*
+   * Process a chunk of data from pipe.
+   * It may or may not include a full line.
+   */
+  void _onBuffer(const char* tmpbuf, ssize_t avail) {
+    const char* ptr = tmpbuf;
+    size_t remaining = (size_t)avail;
+
+    // check for existing partial line in buf_
+
+    if (buf_.size() > 0) {
+      auto existingSize = buf_.size();
+
+      if ((existingSize + avail) > LINE_BUF_MAX) {
+        // drop existing data
+        buf_.resize(0);
+
+      } else {
+        // append
+        buf_.resize(existingSize + avail);
+        memcpy(buf_.data() + existingSize, tmpbuf, avail);
+
+        // overwrite local tracking vars to use _buf
+        ptr = buf_.data();
+        remaining = buf_.size();
+      }
+    }
+
+    // process lines in buffer
+
+    while (remaining > 0) {
+      // find end of line
+
+      auto end = ptr + remaining;
+      auto pos = ptr;
+      while (pos < end && *pos != '\n') {
+        pos++;
+      }
+
+      if (pos == end) {
+        // no end of line
+        _stash((char*)ptr, remaining);
+        return;
+      }
+
+      // send to listener
+
+      auto line = std::string(ptr, pos - ptr);
+      auto len = line.size();
+      if (listener_ != 0L) {
+        listener_->onLine(line);
+      }
+
+      ptr += len + 1;
+      remaining -= len + 1;
+    }
+
+    // We were able to read entire buffer - shrink buf_
+
+    if (buf_.size() > 0) {
+      buf_.resize(0);
+    }
+  }
+
+  /*
+   * have a partial line, store in buf_ for now
+   */
+  void _stash(char* ptr, size_t len) {
+    // copy to a temp vector
+
+    auto tmp = std::vector<char>(len);
+    memcpy(tmp.data(), ptr, len);
+
+    // add more capacity if needed for next read
+
+    if ((buf_.capacity() - len) < chunksize_) {
+      buf_.reserve(buf_.size() * 2);
+    }
+
+    // copy to buf_
+
+    buf_.resize(len);
+    memcpy(buf_.data(), tmp.data(), len);
+  }
+
+  uint32_t chunksize_;
+  std::string path_;
+  int fd_;
+  std::vector<char> buf_; // used if partial lines remain from last read
+  PipeLinerListener* listener_;
+  uint32_t timeout_sec_{0};
+  uint32_t timeout_usec_{500000}; // 500ms
+  int read_loop_count_{3};
+  std::vector<char> tmpbuf_; // buffer filled with read()
+};
+
+#endif // _PIPE_LINER_H_

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -17,6 +17,8 @@
 
 #include <osquery/events.h>
 
+#include "pipe_liner.h"
+
 namespace osquery {
 
 /**
@@ -55,7 +57,8 @@ using SyslogSubscriptionContextRef = std::shared_ptr<SyslogSubscriptionContext>;
  * publisher will read from.
  */
 class SyslogEventPublisher
-    : public EventPublisher<SyslogSubscriptionContext, SyslogEventContext> {
+    : public EventPublisher<SyslogSubscriptionContext, SyslogEventContext>,
+      public PipeLinerListener {
   DECLARE_PUBLISHER("syslog");
 
  public:
@@ -68,7 +71,11 @@ class SyslogEventPublisher
   Status run() override;
 
  public:
-  SyslogEventPublisher() : EventPublisher(), errorCount_(0), lockFd_(-1) {}
+  SyslogEventPublisher()
+      : EventPublisher(), pipeReader_(this), errorCount_(0), lockFd_(-1) {}
+
+ public:
+  virtual void onLine(std::string line) override;
 
  private:
   /// Apply normal subscription to event matching logic.
@@ -115,7 +122,7 @@ class SyslogEventPublisher
   /**
    * @brief Input stream for reading from the pipe.
    */
-  std::fstream readStream_;
+  PipeLiner pipeReader_;
 
   /**
    * @brief Counter used to shut down thread when too many errors occur.
@@ -203,4 +210,4 @@ class RsyslogCsvSeparator {
  private:
   bool last_;
 };
-}
+} // namespace osquery

--- a/osquery/events/linux/tests/pipe_liner_tests.cpp
+++ b/osquery/events/linux/tests/pipe_liner_tests.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+#include "../pipe_liner.h"
+
+class PipeLinerTest : public ::testing::Test {
+protected:
+  virtual void SetUp() {
+
+  }
+};
+
+struct MyListener : public PipeLinerListener {
+  virtual void onLine(std::string line) override {
+    lines_.push_back(line);
+  }
+  std::vector<std::string> lines_;
+};
+
+const std::string TEST1 = "one\ntwo\nthree\n";
+const std::string TEST2 = "abcdef0123456789";
+
+TEST_F(PipeLinerTest, basic) {
+  auto listener = MyListener();
+  auto reader = PipeLiner(&listener);
+  reader._onBuffer(TEST1.c_str(), TEST1.size());
+  ASSERT_EQ(3, listener.lines_.size());
+}
+
+TEST_F(PipeLinerTest, no_line_ending) {
+  auto listener = MyListener();
+  auto reader = PipeLiner(&listener);
+  reader._onBuffer(TEST1.c_str(), 2); // only present 2 chars of entire string
+  ASSERT_EQ(0, listener.lines_.size());
+}
+
+TEST_F(PipeLinerTest, append) {
+  auto listener = MyListener();
+  auto reader = PipeLiner(&listener);
+  reader._onBuffer(TEST1.c_str(), 2); // only present 2 chars of entire string
+  reader._onBuffer(TEST1.c_str() + 2, TEST1.size()-2); // give rest of string
+  ASSERT_EQ(3, listener.lines_.size());
+}
+
+TEST_F(PipeLinerTest, append_past_capacity) {
+  auto listener = MyListener();
+  auto reader = PipeLiner(&listener, (uint32_t)TEST2.size());
+
+  reader._onBuffer(TEST2.c_str(), TEST2.size());
+  ASSERT_EQ(0, listener.lines_.size());
+  reader._onBuffer(TEST2.c_str(), TEST2.size());
+  reader._onBuffer(TEST2.c_str(), TEST2.size());
+  reader._onBuffer("\n", 1);
+  ASSERT_EQ(1, listener.lines_.size());
+  ASSERT_EQ(16+16+16, listener.lines_[0].size());
+  auto tmp = TEST2 + TEST2 + TEST2;
+  ASSERT_EQ(tmp, listener.lines_[0]);
+}


### PR DESCRIPTION
Fix for syslog issue in V3 branches .  This implementation opens pipe using NONBLOCK and uses select and buffered read of lines, rather than waiting on gets() or getline() like existing code.
https://github.com/facebook/osquery/issues/4810
