### PR TITLE
distributed query reliability

### DIFF
--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -18,10 +18,10 @@
 #include <osquery/status.h>
 
 // PENDING status is runtime only, never reported back to endpoint
-#define DQ_PENDING_STATUS -1
+const int DQ_PENDING_STATUS = -1;
 
 // INTERRUPTED status is when watcher kills resource intensive dist query
-#define DQ_INTERRUPTED_STATUS 9
+const int DQ_INTERRUPTED_STATUS = 9;
 
 namespace osquery {
 

--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -170,7 +170,7 @@ class Distributed {
 
   /// Serialize result data into a JSON string
   Status serializeResults(std::string& json,
-                          DistributedQueryResult* result = 0L);
+                          const DistributedQueryResult* result = 0L);
 
   /**
    * @brief Used to write a single result when

--- a/osquery/distributed/CMakeLists.txt
+++ b/osquery/distributed/CMakeLists.txt
@@ -17,4 +17,5 @@ ADD_OSQUERY_LIBRARY(FALSE osquery_distributed_plugins
 
 ADD_OSQUERY_TEST_ADDITIONAL(
   "${CMAKE_CURRENT_LIST_DIR}/tests/distributed_tests.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/tests/mock_distributed_plugin.cpp"
 )

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -205,9 +205,9 @@ Status Distributed::runQueries() {
 }
 
 Status Distributed::flushCompleted() {
-  Status status = Status(0, "OK");
+  Status status = Status(0);
 
-  if (results_.size() == 0) {
+  if (results_.empty()) {
     return status;
   }
 

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -18,6 +18,7 @@
 #include <osquery/registry_factory.h>
 #include <osquery/sql.h>
 
+#include "mock_distributed_plugin.h"
 #include "osquery/core/json.h"
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/tests/test_additional_util.h"
@@ -28,19 +29,13 @@ DECLARE_string(distributed_tls_write_endpoint);
 
 namespace osquery {
 
+DECLARE_bool(distributed_write_individually);
+DECLARE_uint64(distributed_intra_sleep);
+
 class DistributedTests : public testing::Test {
  protected:
   void TearDown() override {
-    if (server_started_) {
-      TLSServerRunner::stop();
-      TLSServerRunner::unsetClientConfig();
-      clearNodeKey();
-
-      Flag::updateValue("distributed_tls_read_endpoint",
-                        distributed_tls_read_endpoint_);
-      Flag::updateValue("distributed_tls_write_endpoint",
-                        distributed_tls_write_endpoint_);
-    }
+    stopServer();
   }
 
   void startServer() {
@@ -59,6 +54,18 @@ class DistributedTests : public testing::Test {
     Registry::get().setActive("distributed", "tls");
     server_started_ = true;
   }
+  void stopServer() {
+    if (server_started_) {
+      TLSServerRunner::stop();
+      TLSServerRunner::unsetClientConfig();
+      clearNodeKey();
+
+      Flag::updateValue("distributed_tls_read_endpoint",
+                        distributed_tls_read_endpoint_);
+      Flag::updateValue("distributed_tls_write_endpoint",
+                        distributed_tls_write_endpoint_);
+    }
+  }
 
  protected:
   std::string distributed_tls_read_endpoint_;
@@ -68,116 +75,6 @@ class DistributedTests : public testing::Test {
   bool server_started_{false};
 };
 
-TEST_F(DistributedTests, test_serialize_distributed_query_request) {
-  DistributedQueryRequest r;
-  r.query = "foo";
-  r.id = "bar";
-
-  auto doc = JSON::newObject();
-  auto s = serializeDistributedQueryRequest(r, doc, doc.doc());
-  EXPECT_TRUE(s.ok());
-  EXPECT_TRUE(doc.doc().HasMember("query") && doc.doc()["query"].IsString());
-  EXPECT_TRUE(doc.doc().HasMember("id") && doc.doc()["id"].IsString());
-  if (doc.doc().HasMember("query")) {
-    EXPECT_EQ(std::string(doc.doc()["query"].GetString()), "foo");
-  }
-  if (doc.doc().HasMember("id")) {
-    EXPECT_EQ(std::string(doc.doc()["id"].GetString()), "bar");
-  }
-}
-
-TEST_F(DistributedTests, test_deserialize_distributed_query_request) {
-  auto doc = JSON::newObject();
-  doc.addRef("query", "foo");
-  doc.addRef("id", "bar");
-
-  DistributedQueryRequest r;
-  auto s = deserializeDistributedQueryRequest(doc.doc(), r);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(r.query, "foo");
-  EXPECT_EQ(r.id, "bar");
-}
-
-TEST_F(DistributedTests, test_deserialize_distributed_query_request_json) {
-  std::string json = "{\"query\": \"foo\", \"id\": \"bar\"}";
-
-  DistributedQueryRequest r;
-  auto s = deserializeDistributedQueryRequestJSON(json, r);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(r.query, "foo");
-  EXPECT_EQ(r.id, "bar");
-}
-
-TEST_F(DistributedTests, test_serialize_distributed_query_result) {
-  DistributedQueryResult r;
-  r.request.query = "foo";
-  r.request.id = "bar";
-
-  Row r1;
-  r1["foo"] = "bar";
-  r.results = {r1};
-  r.columns = {"foo"};
-
-  //  rapidjson::Document d(rapidjson::kObjectType);
-  auto doc = JSON::newObject();
-  auto s = serializeDistributedQueryResult(r, doc, doc.doc());
-  EXPECT_TRUE(s.ok());
-  //  EXPECT_TRUE(doc.doc().IsObject());
-  EXPECT_EQ(doc.doc()["request"]["query"], "foo");
-  EXPECT_EQ(doc.doc()["request"]["id"], "bar");
-  EXPECT_TRUE(doc.doc()["results"].IsArray());
-  for (const auto& q : doc.doc()["results"].GetArray()) {
-    for (const auto& row : q.GetObject()) {
-      EXPECT_EQ(row.name, "foo");
-      EXPECT_EQ(q[row.name], "bar");
-    }
-  }
-}
-
-TEST_F(DistributedTests, test_deserialize_distributed_query_result) {
-  auto doc = JSON::newObject();
-  auto request_obj = doc.getObject();
-  doc.addRef("query", "bar", request_obj);
-  doc.addRef("id", "foo", request_obj);
-
-  auto row_obj = doc.getObject();
-  doc.addRef("foo", "bar", row_obj);
-
-  auto results_arr = doc.getArray();
-  doc.push(row_obj, results_arr);
-  doc.add("request", request_obj);
-  doc.add("results", results_arr);
-
-  DistributedQueryResult r;
-  auto s = deserializeDistributedQueryResult(doc.doc(), r);
-  EXPECT_EQ(r.request.id, "foo");
-  EXPECT_EQ(r.request.query, "bar");
-  EXPECT_EQ(r.results[0]["foo"], "bar");
-}
-
-TEST_F(DistributedTests, test_deserialize_distributed_query_result_json) {
-  auto json =
-      "{"
-      "  \"request\": {"
-      "    \"id\": \"foo\","
-      "    \"query\": \"bar\""
-      "  },"
-      "  \"results\": ["
-      "    {"
-      "      \"foo\": \"bar\""
-      "    }"
-      "  ]"
-      "}";
-
-  DistributedQueryResult r;
-  auto s = deserializeDistributedQueryResultJSON(json, r);
-  ASSERT_TRUE(s.ok());
-  EXPECT_EQ(r.request.id, "foo");
-  EXPECT_EQ(r.request.query, "bar");
-  ASSERT_EQ(r.results.size(), 1_sz);
-  EXPECT_EQ(r.results[0]["foo"], "bar");
-}
-
 TEST_F(DistributedTests, test_workflow) {
   startServer();
 
@@ -185,14 +82,397 @@ TEST_F(DistributedTests, test_workflow) {
   auto s = dist.pullUpdates();
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
+  EXPECT_EQ(0U, dist.numDistWrites());
 
   EXPECT_EQ(dist.getPendingQueryCount(), 2U);
-  EXPECT_EQ(dist.results_.size(), 0U);
+  EXPECT_EQ(dist.results_.size(), 2U);
   s = dist.runQueries();
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
 
   EXPECT_EQ(dist.getPendingQueryCount(), 0U);
   EXPECT_EQ(dist.results_.size(), 0U);
+
+  EXPECT_EQ(1U, dist.numDistWrites());
+  EXPECT_EQ(1U, dist.numDistReads());
 }
+
+/*
+ * At startup, Distributed should check 'distributed_work' key and
+ * report status interrupted (9) for all queries.  Here we make
+ * sure the 'distributed_work' value is removed after pullUpdates().
+ */
+TEST_F(DistributedTests, test_report_interrupted) {
+  static std::string strLastWork =
+      "{\"queries\":{\"99_1\":\"SELECT timestamp FROM time\",\"99_2\":\"SELECT "
+      "year FROM time\"}}";
+
+  startServer();
+
+  setDatabaseValue(kPersistentSettings, "distributed_work", strLastWork);
+
+  auto dist = Distributed();
+  auto s = dist.pullUpdates();
+  EXPECT_TRUE(s.ok());
+
+  EXPECT_EQ(1U, dist.numDistWrites());
+  EXPECT_EQ(1U, dist.numDistReads());
+
+  std::string strval;
+  getDatabaseValue(kPersistentSettings, "distributed_work", strval);
+
+  // should be replaced by server configured queries pullUpdates() received.
+  EXPECT_FALSE(strLastWork == strval);
+
+  // finish up so there isn't DB state left for other tests
+  dist.runQueries();
 }
+
+static bool EnableMockDistPlugin() {
+  auto& rf = RegistryFactory::get();
+  auto status = rf.setActive("distributed", "mock");
+  EXPECT_TRUE(status.ok());
+  return status.ok();
+}
+
+/*
+ * If a distributed query contains discovery queries:
+ *  - If all queries return more than zero rows, run 'queries'.  Otherwise,
+ * return empty results.
+ */
+TEST_F(DistributedTests, test_discovery) {
+  static const std::string strAlwaysDiscoveryQueriesJson =
+      "{\"discovery\":{\"dos\":\"SELECT * FROM time WHERE year > "
+      "1900\"},\"queries\":{\"1A\":\"SELECT year FROM time\",\"1B\":\"SELECT "
+      "timestamp FROM time\"}}";
+  static const std::string strNeverDiscoveryQueriesJson =
+      "{\"discovery\":{\"uno\":\"SELECT * FROM time WHERE "
+      "year=1902\",\"dos\":\"SELECT * FROM time WHERE year > "
+      "1900\"},\"queries\":{\"1A\":\"SELECT year FROM time\",\"1B\":\"SELECT "
+      "timestamp FROM time\"}}";
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  auto status = MockDistributedSetReadValue(strNeverDiscoveryQueriesJson);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(status.toString(), "OK");
+  EXPECT_EQ(1U, dist.numDistWrites());
+  EXPECT_EQ(1U, dist.numDistReads());
+
+  auto writes = std::vector<std::string>();
+
+  status = MockDistributedGetWrites(writes);
+  EXPECT_TRUE(status.ok());
+
+  // discovery should fail, so result should have zero rows
+
+  auto response_json1 = writes[0];
+
+  // This discovery should always pass, should have 1 row
+
+  status = MockDistributedSetReadValue(strAlwaysDiscoveryQueriesJson);
+
+  dist.pullUpdates();
+  dist.runQueries();
+
+  writes.clear();
+  status = MockDistributedGetWrites(writes);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(2, writes.size());
+
+  auto response_json2 = writes[1];
+
+  EXPECT_NE(response_json1, response_json2);
+}
+
+TEST_F(DistributedTests, test_write_endpoint_down) {
+  static std::string strQuery =
+      "{\"queries\":{\"C1\":\"SELECT year FROM time\",\"C2\":\"SELECT "
+      "timestamp FROM time\"}}";
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  auto status = MockDistributedSetReadValue(strQuery);
+  EXPECT_TRUE(status.ok());
+
+  MockDistributedWriteEndpointEnabled(false);
+
+  auto dist = Distributed();
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_FALSE(status.ok());
+
+  // NOTE : results get dropped
+
+  // Try again with empty read, and write endpoint back up
+
+  status = MockDistributedSetReadValue("{}");
+  MockDistributedWriteEndpointEnabled(false);
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries(); // no results to send, will not call write
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(2U, dist.numDistReads());
+  EXPECT_EQ(1U, dist.numDistWrites());
+
+  MockDistributedWriteEndpointEnabled(true);
+}
+
+/*
+ * Distributed work with many queries might want to be reported
+ * individually, rather than waiting on all to complete.  Especially
+ * if some queries have big result sets that would be kept in memory.
+ * This test will set FLAGS_distributed_write_individually = true
+ * and make sure each query is reported individually.
+ */
+TEST_F(DistributedTests, can_report_individually) {
+  static std::string strQuery =
+      "{\"queries\":{\"D1\":\"SELECT year FROM time\", \"D2\":\"SELECT day "
+      "FROM time\", \"D3\":\"SELECT timestamp FROM time\"}}";
+
+  startServer();
+
+  FLAGS_distributed_write_individually = true;
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  MockDistributedClearWrites();
+
+  auto status = MockDistributedSetReadValue(strQuery);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(1U, dist.numDistReads());
+  EXPECT_EQ(3U, dist.numDistWrites());
+
+  auto writes = std::vector<std::string>();
+
+  status = MockDistributedGetWrites(writes);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(3, writes.size());
+
+  // try again with flag off
+
+  FLAGS_distributed_write_individually = false;
+  MockDistributedClearWrites();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(2U, dist.numDistReads());
+  EXPECT_EQ(4U, dist.numDistWrites());
+
+  status = MockDistributedGetWrites(writes);
+  EXPECT_EQ(4, writes.size());
+}
+
+/*
+ * In this case, the first queries object is the one that gets used.
+ * the D3 query is never executed or reported.
+ */
+TEST_F(DistributedTests, queries_appears_twice) {
+  static const std::string strQuery =
+      "{\"queries\":{\"D1\":\"SELECT year FROM time\", \"D2\":\"SELECT day "
+      "FROM time\"},\"queries\":{\"D3\":\"SELECT timestamp FROM time\"}}";
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  FLAGS_distributed_write_individually = true;
+  MockDistributedClearWrites();
+  auto status = MockDistributedSetReadValue(strQuery);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(1U, dist.numDistReads());
+  EXPECT_EQ(2U, dist.numDistWrites());
+
+  auto writes = std::vector<std::string>();
+  status = MockDistributedGetWrites(writes);
+  EXPECT_EQ(2, writes.size());
+
+  FLAGS_distributed_write_individually = false;
+}
+
+TEST_F(DistributedTests, empty) {
+  static const std::string strQueryNoQueries = "{\"queries\":{}}";
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  auto status = MockDistributedSetReadValue(strQueryNoQueries);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(1U, dist.numDistReads());
+  EXPECT_EQ(0U, dist.numDistWrites());
+}
+
+TEST_F(DistributedTests, accelerate_for_minute) {
+  static const std::string strQueryAccel = "{\"accelerate\":60}";
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  std::string strExp1 = "";
+  getDatabaseValue(
+      kPersistentSettings, "distributed_accelerate_checkins_expire", strExp1);
+
+  auto status = MockDistributedSetReadValue(strQueryAccel);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_EQ(1U, dist.numDistReads());
+  EXPECT_EQ(0U, dist.numDistWrites());
+
+  std::string strExp2 = "";
+  getDatabaseValue(
+      kPersistentSettings, "distributed_accelerate_checkins_expire", strExp2);
+  EXPECT_NE(strExp1, strExp2);
+
+  deleteDatabaseValue(kPersistentSettings,
+                      "distributed_accelerate_checkins_expire");
+}
+
+TEST_F(DistributedTests, bad_docs) {
+  static const std::string strQueryEmpty = "";
+  static const std::string strQueryNotObject =
+      "{\"queries\":[\"SELECT * FROM time\"]}";
+  static const std::string strQueryIntId =
+      "{\"queries\":{2:\"SELECT * FROM time\"}}";
+  static const std::string strQueryNegativeAccel = "{\"accelerate\": -300 }";
+  static const std::string strQueryAccelLong = "{\"accelerate\": 5000 }";
+
+  static const std::string strDiscNotObject =
+      "{\"discovery\":[\"SELECT * FROM time\"]}";
+  static const std::string strDiscNoQuery =
+      "{\"discovery\":{\"X1\":\"SELECT * FROM time\"}}";
+
+  auto vec = std::vector<const std::string>({strQueryEmpty,
+                                             strQueryNotObject,
+                                             strQueryIntId,
+                                             strQueryNegativeAccel,
+                                             strQueryAccelLong,
+                                             strDiscNotObject,
+                                             strDiscNoQuery});
+
+  startServer();
+
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  for (auto& strQuery : vec) {
+    MockDistributedClearWrites();
+
+    auto status = MockDistributedSetReadValue(strQuery);
+    EXPECT_TRUE(status.ok());
+
+    auto dist = Distributed();
+
+    status = dist.pullUpdates();
+    // EXPECT_FALSE(status.ok()); // only invalid queries fails parse
+
+    status = dist.runQueries();
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(1U, dist.numDistReads());
+    EXPECT_EQ(0U, dist.numDistWrites());
+  }
+}
+
+TEST_F(DistributedTests, intra_sleep) {
+  static const std::string strQuery =
+      "{\"queries\":{\"D1\":\"SELECT year FROM time\", \"D2\":\"SELECT day "
+      "FROM time\", \"D3\":\"SELECT timestamp FROM time\"}}";
+  startServer();
+
+  FLAGS_distributed_intra_sleep = 1;
+  auto t1 = getUnixTime();
+  if (!EnableMockDistPlugin()) {
+    return;
+  }
+
+  auto status = MockDistributedSetReadValue(strQuery);
+  EXPECT_TRUE(status.ok());
+
+  auto dist = Distributed();
+
+  status = dist.pullUpdates();
+  EXPECT_TRUE(status.ok());
+
+  status = dist.runQueries();
+  EXPECT_TRUE(status.ok());
+
+  auto t2 = getUnixTime();
+
+  auto delta = t2 - t1;
+  EXPECT_TRUE(delta >= 2);
+
+  EXPECT_EQ(1U, dist.numDistReads());
+  EXPECT_EQ(1U, dist.numDistWrites());
+}
+
+} // namespace osquery

--- a/osquery/distributed/tests/mock_distributed_plugin.cpp
+++ b/osquery/distributed/tests/mock_distributed_plugin.cpp
@@ -1,0 +1,122 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <sstream>
+#include <vector>
+
+#include <osquery/distributed.h>
+#include <osquery/enroll.h>
+#include <osquery/flags.h>
+#include <osquery/registry.h>
+
+#include "osquery/core/json.h"
+#include "osquery/remote/serializers/json.h"
+#include "osquery/remote/utility.h"
+
+namespace osquery {
+
+/**
+ * @brief A class that can be used in unit tests to mock up
+ * distributed read and write endpoints.  A test can set
+ * the query and read the result.
+ *
+ */
+class MockDistributedPlugin : public DistributedPlugin {
+ public:
+  MockDistributedPlugin()
+      : DistributedPlugin(),
+        read_value_(),
+        writes_(),
+        isReadEndpointEnabled_(true),
+        isWriteEndpointEnabled_(true) {}
+
+  Status setUp() override {
+    return Status();
+  }
+
+  Status getQueries(std::string& json) override {
+    if (!isReadEndpointEnabled_) {
+      VLOG(1) << "getQueries : emulating endpoint DOWN";
+      return Status(1, "Endpoint DOWN");
+    }
+    json = read_value_;
+    VLOG(1) << "getQueries " << json;
+    return Status();
+  }
+
+  Status writeResults(const std::string& json) override {
+    if (!isWriteEndpointEnabled_) {
+      VLOG(1) << "writeResults emulating endpoint DOWN";
+      return Status(1, "Endpoint down");
+    }
+    VLOG(1) << "writeResults " << json;
+    writes_.push_back(json);
+    return Status();
+  }
+
+  Status call(const PluginRequest& request, PluginResponse& response) override {
+    if (request.count("action") == 0) {
+      return Status(1,
+                    "Distributed plugins require an action in PluginRequest");
+    }
+
+    auto& action = request.at("action");
+
+    if (action == "getQueries") {
+      std::string queries;
+      getQueries(queries);
+      response.push_back({{"results", queries}});
+      return Status();
+
+    } else if (action == "writeResults") {
+      if (request.count("results") == 0) {
+        return Status(1, "Missing results field");
+      }
+      return writeResults(request.at("results"));
+
+    } else if (action == "getMockWrites") {
+      auto m = std::map<std::string, std::string>();
+      for (size_t i = 0; i < writes_.size(); i++) {
+        char idstr[32];
+        snprintf(idstr, sizeof(idstr), "W_%d", (int)i);
+        m[std::string(idstr)] = writes_[i];
+      }
+      response.push_back({m});
+      return Status();
+
+    } else if (action == "clearMockWrites") {
+      writes_.clear();
+      return Status();
+
+    } else if (action == "setMockReadStatus") {
+      isReadEndpointEnabled_ = (request.at("value") == "1");
+      return Status();
+
+    } else if (action == "setMockWriteStatus") {
+      isWriteEndpointEnabled_ = (request.at("value") == "1");
+      return Status();
+
+    } else if (action == "setMockReadValue") {
+      read_value_ = request.at("value");
+      return Status();
+    }
+
+    return Status(1, "Distributed plugin action unknown: " + action);
+  }
+
+  std::string read_value_;
+  std::vector<std::string> writes_;
+  bool isReadEndpointEnabled_;
+  bool isWriteEndpointEnabled_;
+};
+
+REGISTER(MockDistributedPlugin, "distributed", "mock");
+
+} // namespace osquery

--- a/osquery/distributed/tests/mock_distributed_plugin.h
+++ b/osquery/distributed/tests/mock_distributed_plugin.h
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+#pragma once
+
+#include <osquery/core.h>
+#include <osquery/distributed.h>
+#include <osquery/enroll.h>
+#include <osquery/registry_factory.h>
+#include <osquery/sql.h>
+
+namespace osquery {
+
+Status MockDistributedSetReadValue(const std::string value) {
+  PluginResponse response;
+  Status status =
+      Registry::call("distributed",
+                     {{"action", "setMockReadValue"}, {"value", value}},
+                     response);
+  return status;
+}
+
+Status MockDistributedGetWrites(std::vector<std::string>& dest) {
+  PluginResponse response = PluginResponse();
+  Status status =
+      Registry::call("distributed", {{"action", "getMockWrites"}}, response);
+  if (status.ok() == false) {
+    return status;
+  }
+
+  for (auto it = response[0].begin(); it != response[0].end(); it++) {
+    auto key = it->first;
+    if (key.size() > 2 && key[0] == 'W' && key[1] == '_') {
+      dest.push_back(it->second);
+    }
+  }
+
+  return status;
+}
+
+Status MockDistributedClearWrites() {
+  PluginResponse response = PluginResponse();
+  Status status =
+      Registry::call("distributed", {{"action", "clearMockWrites"}}, response);
+  return status;
+}
+
+Status MockDistributedWriteEndpointEnabled(bool isEnabled) {
+  PluginResponse response = PluginResponse();
+  Status status = Registry::call(
+      "distributed",
+      {{"action", "setMockWriteStatus"}, {"value", (isEnabled ? "1" : "0")}},
+      response);
+  return status;
+}
+
+Status MockDistributedReadEndpointEnabled(bool isEnabled) {
+  PluginResponse response = PluginResponse();
+  Status status = Registry::call(
+      "distributed",
+      {{"action", "setMockReadStatus"}, {"value", (isEnabled ? "1" : "0")}},
+      response);
+  return status;
+}
+
+} // namespace osquery


### PR DESCRIPTION
These changes are to make distributed queries more flexible and more reliable.
 - If watcher kills distributed worker, it will be detected and results reported to distributed_write with status 9.
 - Fixes #5260 where discovery queries have no effect.
 - Add **distributed_write_individually** boolean flag, false by default.  If true, results are reported to distributed_write endpoint after each query, rather than accumulating all results in memory and waiting for them all to finish.
 - Add **distributed_intra_sleep** uint64 flag, 0 by default.  If greater than zero, it's the number of seconds to sleep between distributed queries in the same work set.  This help spread out CPU load when running several queries in the same distributed request. Maximum is 30 seconds.
 - Removed a bunch of needless serialization/deserialization and related gtests.
 - Added several tests, as well as a mock distributed plugin to help test.
- Validate _accelerate_ value, should be greater than zero, less than 1 hour.
- Add logging of discovery queries and when results are dropped due to distributed_write endpoint down.
 