### PR TITLE
Add schema_stubs config to stub out unknown tables at runtime

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -365,6 +365,7 @@ class Config : private boost::noncopyable {
   friend class FileEventsTableTests;
   friend class DecoratorsConfigParserPluginTests;
   friend class SchedulerTests;
+  friend class SchemaStubsConfigParserPluginTests;
   FRIEND_TEST(ConfigTests, test_config_backup);
   FRIEND_TEST(ConfigTests, test_config_backup_integrate);
   FRIEND_TEST(ConfigTests, test_config_refresh);

--- a/osquery/config/CMakeLists.txt
+++ b/osquery/config/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(libosquery
     "${CMAKE_CURRENT_LIST_DIR}/parsers/prometheus_targets.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/parsers/prometheus_targets.h"
     "${CMAKE_CURRENT_LIST_DIR}/parsers/views.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/parsers/schema_stubs.cpp"
 )
 
 ADD_OSQUERY_LIBRARY(FALSE osquery_config_plugins
@@ -58,4 +59,5 @@ ADD_OSQUERY_TEST_ADDITIONAL(
   "${CMAKE_CURRENT_LIST_DIR}/parsers/tests/decorators_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/parsers/tests/events_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/plugins/tests/tls_config_tests.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/parsers/tests/schema_stubs_tests.cpp"
 )

--- a/osquery/config/parsers/schema_stubs.cpp
+++ b/osquery/config/parsers/schema_stubs.cpp
@@ -1,0 +1,251 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/config.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/registry_factory.h>
+#include <osquery/sql.h>
+
+#include <osquery/core/conversions.h>
+
+#include "schema_stubs.h"
+
+//   "package_receipts|packages":[
+//     "package_id/Ti","package_filename/Tih","version","location",
+//     "install_time/D","installer_name","path/a"
+//   ],
+
+namespace osquery {
+
+class EmptyTablePlugin : public TablePlugin {
+ public:
+  EmptyTablePlugin(std::string name,
+                   TableColumns columnDefs,
+                   std::vector<std::string> aliases)
+      : TablePlugin(), name_(name), cols_(columnDefs), aliases_(aliases) {}
+
+ private:
+  TableColumns columns() const override {
+    return cols_;
+  }
+
+  QueryData generate(QueryContext& request) override {
+    return QueryData();
+  }
+
+  std::vector<std::string> aliases() const override {
+    return aliases_;
+  }
+
+  std::string name_;
+  TableColumns cols_;
+  std::vector<std::string> aliases_;
+};
+
+/**
+ * @brief A simple ConfigParserPlugin for an "schema_stubs" dictionary key.
+ * A typical osquery agent deployment may have older agents that have not
+ * yet been updated.  Running a query for a recently defined virtual table
+ * across your entire fleet will result in 'no such table' errors on older
+ * agents.  Adding some 'schema_stubs' definitions in the config for all
+ * agents (e.g. using tls_config) will allow these queries to return empty
+ * results, rather than errors.
+ *
+ * Example format of config:
+ *
+ * "schema_stubs": {
+ *   "some_table_name|optional_table_alias":[
+ *     "package_id/Ti","package_filename/Tih","version","location",
+ *     "install_time/D","installer_name","path/a"
+ *   ],
+ *   "table_created_after_compile":[ "col1", "int_col1/I"]
+ * }
+ *
+ * By default, columns are TEXT_TYPE.  Column names can be appended with a
+ * slash '/' followed by type and option characters defined here:
+ *
+ * T  TEXT_TYPE
+ * I  INTEGER_TYPE
+ * D  DOUBLE_TYPE
+ *
+ * i  INDEX
+ * h  HIDDEN
+ * r  REQUIRED
+ * a  ADDITIONAL
+ *
+ * Generate using tools/codegen/genschemastub.py <path to .spec file>
+ */
+class SchemaStubsConfigParserPlugin : public ConfigParserPlugin {
+ public:
+  virtual ~SchemaStubsConfigParserPlugin() = default;
+
+  std::vector<std::string> keys() const override {
+    return {"schema_stubs"};
+  }
+
+  Status setUp() override;
+
+  Status update(const std::string& source, const ParserConfig& config) override;
+
+  void updateTypeAndOptions(std::string str,
+                            ColumnType& columnType,
+                            ColumnOptions& opts);
+
+ private:
+};
+
+Status SchemaStubsConfigParserPlugin::setUp() {
+  auto paths_obj = data_.getObject();
+  data_.add("schema_stubs", paths_obj);
+
+  return Status();
+}
+
+void SchemaStubsParseTypeAndOptions(std::string str,
+                                    ColumnType& columnType,
+                                    ColumnOptions& opts) {
+  for (auto c : str) {
+    switch (c) {
+    case 'T':
+      columnType = TEXT_TYPE;
+      break;
+    case 'D':
+      columnType = DOUBLE_TYPE;
+      break;
+    case 'I':
+      columnType = INTEGER_TYPE;
+      break;
+    case 'L':
+      columnType = BIGINT_TYPE;
+      break;
+    case 'U':
+      columnType = UNSIGNED_BIGINT_TYPE;
+      break;
+    case 'B':
+      columnType = BLOB_TYPE;
+      break;
+    case 'i':
+      opts = (ColumnOptions)((int)opts | (int)ColumnOptions::INDEX);
+      break;
+    case 'a':
+      opts = (ColumnOptions)((int)opts | (int)ColumnOptions::ADDITIONAL);
+      break;
+    case 'h':
+      opts = (ColumnOptions)((int)opts | (int)ColumnOptions::HIDDEN);
+      break;
+    case 'r':
+      opts = (ColumnOptions)((int)opts | (int)ColumnOptions::REQUIRED);
+      break;
+    case 'o':
+      opts = (ColumnOptions)((int)opts | (int)ColumnOptions::OPTIMIZED);
+      break;
+    default:
+      LOG(WARNING) << "invalid column type or option:" << c;
+    }
+  }
+}
+std::string SchemaStubsParseTableName(std::string str,
+                                      std::vector<std::string>& aliases) {
+  auto tableNameAndAliases = split(str, SCHEMA_STUBS_ALIAS_DELIMITER);
+  std::string tableName = tableNameAndAliases[0];
+
+  for (size_t i = 1; i < tableNameAndAliases.size(); i++) {
+    // basic sanity check on alias
+    if (tableNameAndAliases[i].size() == 0 ||
+        tableNameAndAliases[i] == tableName) {
+      continue;
+    }
+    aliases.push_back(tableNameAndAliases[i]);
+  }
+  return tableName;
+}
+
+std::string SchemaStubsParseColumnName(std::string str,
+                                       ColumnType& columnType,
+                                       ColumnOptions& opts) {
+  auto parts = split(str, SCHEMA_STUBS_COLUMN_DETAIL_DELIMITER);
+
+  std::string columnName = parts[0];
+  columnType = TEXT_TYPE;
+  opts = ColumnOptions::DEFAULT;
+
+  if (parts.size() > 1) {
+    SchemaStubsParseTypeAndOptions(parts[1], columnType, opts);
+  }
+
+  return columnName;
+}
+
+Status SchemaStubsConfigParserPlugin::update(const std::string& source,
+                                             const ParserConfig& config) {
+  if (config.count("schema_stubs") == 0) {
+    return Status();
+  }
+
+  auto tables = RegistryFactory::get().registry("table");
+
+  if (config.count("schema_stubs") > 0) {
+    // We know this top-level is an Object.
+    const auto& stubs_defs = config.at("schema_stubs").doc();
+    if (stubs_defs.IsObject()) {
+      for (const auto& tableNode : stubs_defs.GetObject()) {
+        if (tableNode.value.IsArray()) {
+          TableColumns columns;
+
+          std::vector<std::string> tableAliases;
+          auto tableName = SchemaStubsParseTableName(tableNode.name.GetString(),
+                                                     tableAliases);
+
+          if (tableName.size() == 0 || tables->exists(tableName)) {
+            continue;
+          }
+
+          for (const auto& columnStrNode : tableNode.value.GetArray()) {
+            std::string columnStr = columnStrNode.GetString();
+            if (columnStr.empty()) {
+              continue;
+            }
+
+            ColumnType columnType;
+            ColumnOptions opts;
+            std::string columnName =
+                SchemaStubsParseColumnName(columnStr, columnType, opts);
+
+            columns.push_back(make_tuple(columnName, columnType, opts));
+          }
+
+          Status s = tables->add(tableName,
+                                 std::make_shared<EmptyTablePlugin>(
+                                     tableName, columns, tableAliases),
+                                 true);
+
+          if (!s.ok()) {
+            LOG(WARNING) << s.getMessage();
+            continue;
+          }
+
+          PluginResponse resp;
+          Registry::call(
+              "sql", "sql", {{"action", "attach"}, {"table", tableName}}, resp);
+          LOG(INFO) << "Registered SchemaStub table: " << tableName;
+        }
+      }
+    }
+  }
+
+  return Status();
+}
+
+REGISTER_INTERNAL(SchemaStubsConfigParserPlugin,
+                  "config_parser",
+                  "schema_stubs");
+
+} // namespace osquery

--- a/osquery/config/parsers/schema_stubs.h
+++ b/osquery/config/parsers/schema_stubs.h
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <osquery/config.h>
+#include <osquery/sql.h>
+
+#define SCHEMA_STUBS_ALIAS_DELIMITER "|"
+#define SCHEMA_STUBS_COLUMN_DETAIL_DELIMITER "/"
+
+namespace osquery {
+
+void SchemaStubsParseTypeAndOptions(std::string str,
+                                    ColumnType& columnType,
+                                    ColumnOptions& opts);
+
+std::string SchemaStubsParseColumnName(std::string str,
+                                       ColumnType& columnType,
+                                       ColumnOptions& opts);
+
+std::string SchemaStubsParseTableName(std::string str,
+                                      std::vector<std::string>& aliases);
+
+} // namespace osquery

--- a/osquery/config/parsers/tests/schema_stubs_tests.cpp
+++ b/osquery/config/parsers/tests/schema_stubs_tests.cpp
@@ -1,0 +1,151 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/config.h>
+#include <osquery/registry.h>
+#include <osquery/sql.h>
+
+#include "../schema_stubs.h"
+#include "osquery/tests/test_util.h"
+
+namespace osquery {
+
+class SchemaStubsConfigParserPluginTests : public testing::Test {
+ public:
+  void SetUp() override {
+    // Read config content manually.
+    readFile(kTestDataPath + "test_parse_schema_stubs.conf", content_);
+
+    // Construct a config map, the typical output from `Config::genConfig`.
+    config_data_["schema_stubs_test"] = content_;
+    Config::get().reset();
+  }
+
+  void TearDown() override {
+    Config::get().reset();
+  }
+
+ protected:
+  std::string content_;
+  std::map<std::string, std::string> config_data_;
+};
+
+//     "some_table": [ "text_column1", "int_column1/I", "text_column2/T",
+//     "hidden_text_column1/Th", "indexed_int_column1/Ii" ]
+
+TEST_F(SchemaStubsConfigParserPluginTests, test_table_query) {
+  std::string query = "SELECT * FROM some_table";
+  auto results = SQL(query);
+
+  EXPECT_NE(0, results.getStatus().getCode()); // "no such table: some_table"
+
+  Config::get().update(config_data_);
+
+  results = SQL(query);
+
+  EXPECT_EQ(0, results.getStatus().getCode());
+  EXPECT_EQ(0, results.rows().size());
+  EXPECT_EQ(4, results.columns().size()); // 1 is hidden
+
+  results =
+      SQL("SELECT text_column1, int_column1, text_column2, indexed_int_column1 "
+          "FROM some_table WHERE int_column1 > 0");
+
+  EXPECT_EQ(0, results.getStatus().getCode());
+  EXPECT_EQ(0, results.rows().size());
+}
+
+TEST_F(SchemaStubsConfigParserPluginTests, table_names) {
+  auto aliases = std::vector<std::string>();
+
+  EXPECT_EQ("nemo/dd", SchemaStubsParseTableName("nemo/dd", aliases));
+  EXPECT_EQ(0, aliases.size());
+
+  // aliases same as table name
+  EXPECT_EQ("nemo", SchemaStubsParseTableName("nemo|nemo", aliases));
+  EXPECT_EQ(0, aliases.size());
+
+  EXPECT_EQ("nemo", SchemaStubsParseTableName("nemo|omen", aliases));
+  EXPECT_EQ(1, aliases.size());
+  if (aliases.size() > 0) {
+    EXPECT_EQ("omen", aliases[0]);
+  }
+  aliases.clear();
+
+  EXPECT_EQ("a", SchemaStubsParseTableName("a|one||two|three|four", aliases));
+  EXPECT_EQ(4, aliases.size());
+  if (aliases.size() == 4) {
+    EXPECT_EQ("one", aliases[0]);
+    EXPECT_EQ("four", aliases[3]);
+  }
+  aliases.clear();
+}
+
+TEST_F(SchemaStubsConfigParserPluginTests, column_names) {
+  ColumnType columnType = TEXT_TYPE;
+  ColumnOptions opts = ColumnOptions::DEFAULT;
+
+  EXPECT_EQ("column_name",
+            SchemaStubsParseColumnName("column_name////Z", columnType, opts));
+  EXPECT_EQ(TEXT_TYPE, columnType);
+  EXPECT_EQ(ColumnOptions::DEFAULT, opts);
+
+  EXPECT_EQ("c", SchemaStubsParseColumnName("c", columnType, opts));
+  EXPECT_EQ(TEXT_TYPE, columnType);
+  EXPECT_EQ(ColumnOptions::DEFAULT, opts);
+
+  EXPECT_EQ("", SchemaStubsParseColumnName("/", columnType, opts));
+  EXPECT_EQ(TEXT_TYPE, columnType);
+  EXPECT_EQ(ColumnOptions::DEFAULT, opts);
+}
+
+TEST_F(SchemaStubsConfigParserPluginTests, types_and_options) {
+  ColumnType columnType = TEXT_TYPE;
+  ColumnOptions opts = ColumnOptions::DEFAULT;
+
+  SchemaStubsParseTypeAndOptions("", columnType, opts);
+
+  EXPECT_EQ(TEXT_TYPE, columnType);
+  EXPECT_EQ(ColumnOptions::DEFAULT, opts);
+
+  SchemaStubsParseTypeAndOptions("zkjltBILUT.;?", columnType, opts);
+
+  EXPECT_EQ(TEXT_TYPE, columnType);
+  EXPECT_EQ(ColumnOptions::DEFAULT, opts);
+
+  SchemaStubsParseTypeAndOptions("Uahir", columnType, opts);
+
+  EXPECT_EQ(UNSIGNED_BIGINT_TYPE, columnType);
+  int val = (int)opts;
+  EXPECT_TRUE((val & (int)ColumnOptions::ADDITIONAL));
+  EXPECT_TRUE((val & (int)ColumnOptions::HIDDEN));
+  EXPECT_TRUE((val & (int)ColumnOptions::INDEX));
+  EXPECT_TRUE((val & (int)ColumnOptions::REQUIRED));
+
+  SchemaStubsParseTypeAndOptions("I", columnType, opts);
+  
+  EXPECT_EQ(INTEGER_TYPE, columnType);
+
+  SchemaStubsParseTypeAndOptions("B", columnType, opts);
+  
+  EXPECT_EQ(BLOB_TYPE, columnType);
+
+  SchemaStubsParseTypeAndOptions("L", columnType, opts);
+  
+  EXPECT_EQ(BIGINT_TYPE, columnType);
+
+  SchemaStubsParseTypeAndOptions("D", columnType, opts);
+  
+  EXPECT_EQ(DOUBLE_TYPE, columnType);
+}
+
+} // namespace osquery

--- a/tools/codegen/genschemastub.py
+++ b/tools/codegen/genschemastub.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import ast
+import fnmatch
+import jinja2
+import logging
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(SCRIPT_DIR + "/../tests")
+
+from utils import platform
+
+# the log format for the logging module
+LOG_FORMAT = "%(levelname)s [Line %(lineno)d]: %(message)s"
+
+# Read all implementation templates
+TEMPLATES = {}
+
+# Temporary reserved column names
+RESERVED = ["n", "index"]
+
+# Set the platform in osquery-language
+PLATFORM = platform()
+
+# Supported SQL types for spec
+class DataType(object):
+    def __init__(self, affinity, cpp_type="std::string"):
+        '''A column datatype is a pair of a SQL affinity to C++ type.'''
+        self.affinity = affinity
+        self.type = cpp_type
+
+    def __repr__(self):
+        return self.affinity
+
+# Define column-type MACROs for the table specs
+TEXT = DataType("TEXT_TYPE")
+DATE = DataType("TEXT_TYPE")
+DATETIME = DataType("TEXT_TYPE")
+INTEGER = DataType("INTEGER_TYPE", "int")
+BIGINT = DataType("BIGINT_TYPE", "long long int")
+UNSIGNED_BIGINT = DataType("UNSIGNED_BIGINT_TYPE", "long long unsigned int")
+DOUBLE = DataType("DOUBLE_TYPE", "double")
+BLOB = DataType("BLOB_TYPE", "Blob")
+
+# Define table-category MACROS from the table specs
+UNKNOWN = "UNKNOWN"
+UTILITY = "UTILITY"
+SYSTEM = "SYSTEM"
+NETWORK = "NETWORK"
+EVENTS = "EVENTS"
+APPLICATION = "APPLICATION"
+
+# This should mimic the C++ enumeration ColumnOptions in table.h
+COLUMN_OPTIONS = {
+    "index": "INDEX",
+    "additional": "ADDITIONAL",
+    "required": "REQUIRED",
+    "optimized": "OPTIMIZED",
+    "hidden": "HIDDEN",
+}
+
+# Column options that render tables uncacheable.
+NON_CACHEABLE = [
+    "REQUIRED",
+    "ADDITIONAL",
+    "OPTIMIZED",
+]
+
+TABLE_ATTRIBUTES = {
+    "event_subscriber": "EVENT_BASED",
+    "user_data": "USER_BASED",
+    "cacheable": "CACHEABLE",
+    "utility": "UTILITY",
+    "kernel_required": "KERNEL_REQUIRED",
+}
+
+TYPE_CHARS = {
+"TEXT_TYPE" : "",
+"INTEGER_TYPE" : "I",
+"DOUBLE_TYPE" : "D",
+"BIGINT_TYPE" : "L",
+"UNSIGNED_BIGINT_TYPE" : "U",
+"BLOB" : "B"
+}
+
+OPT_CHARS = {
+    "index": "i",
+    "additional": "a",
+    "required": "r",
+    "optimized": "o",
+    "hidden": "h"
+}
+
+def WINDOWS():
+    return PLATFORM in ['windows', 'win32', 'cygwin']
+
+
+def LINUX():
+    return PLATFORM in ['linux']
+
+
+def POSIX():
+    return PLATFORM in ['linux', 'darwin', 'freebsd']
+
+
+def DARWIN():
+    return PLATFORM in ['darwin']
+
+
+def FREEBSD():
+    return PLATFORM in ['freebsd']
+
+
+def to_camel_case(snake_case):
+    """ convert a snake_case string to camelCase """
+    components = snake_case.split('_')
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def lightred(msg):
+    return "\033[1;31m %s \033[0m" % str(msg)
+
+
+def is_blacklisted(table_name, path=None, blacklist=None):
+    """Allow blacklisting by tablename."""
+    if blacklist is None:
+        specs_path = os.path.dirname(path)
+        if os.path.basename(specs_path) != "specs":
+            specs_path = os.path.dirname(specs_path)
+        blacklist_path = os.path.join(specs_path, "blacklist")
+        if not os.path.exists(blacklist_path):
+            return False
+        try:
+            with open(blacklist_path, "r") as fh:
+                blacklist = [
+                    line.strip() for line in fh.read().split("\n")
+                    if len(line.strip()) > 0 and line.strip()[0] != "#"
+                ]
+        except:
+            # Blacklist is not readable.
+            return False
+    if not blacklist:
+        return False
+
+    # table_name based blacklisting!
+    for item in blacklist:
+        item = item.split(":")
+        # If this item is restricted to a platform and the platform
+        # and table name match
+        if len(item) > 1 and PLATFORM == item[0] and table_name == item[1]:
+            return True
+        elif len(item) == 1 and table_name == item[0]:
+            return True
+    return False
+
+
+def setup_templates(templates_path):
+    if not os.path.exists(templates_path):
+        templates_path = os.path.join(
+            os.path.dirname(tables_path), "templates")
+        if not os.path.exists(templates_path):
+            print("Cannot read templates path: %s" % (templates_path))
+            exit(1)
+    templates = (f for f in os.listdir(templates_path) if fnmatch.fnmatch(f, "*.in"))
+    for template in templates:
+        template_name = template.split(".", 1)[0]
+        with open(os.path.join(templates_path, template), "r") as fh:
+            TEMPLATES[template_name] = fh.read().replace("\\\n", "")
+
+
+class Singleton(object):
+
+    """
+    Make sure that anything that subclasses Singleton can only be instantiated
+    once
+    """
+
+    _instance = None
+
+    def __new__(self, *args, **kwargs):
+        if not self._instance:
+            self._instance = super(Singleton, self).__new__(
+                self, *args, **kwargs)
+        return self._instance
+
+
+class TableState(Singleton):
+
+    """
+    Maintain the state of of the table commands during the execution of
+    the config file
+    """
+
+    def __init__(self):
+        self.table_name = ""
+        self.schema = []
+        self.header = ""
+        self.impl = ""
+        self.function = ""
+        self.class_name = ""
+        self.description = ""
+        self.attributes = {}
+        self.examples = []
+        self.aliases = []
+        self.fuzz_paths = []
+        self.has_options = False
+        self.has_column_aliases = False
+        self.generator = False
+
+    def columns(self):
+        return [i for i in self.schema if isinstance(i, Column)]
+
+    def foreign_keys(self):
+        return [i for i in self.schema if isinstance(i, ForeignKey)]
+
+    def generate(self, path, template="default"):
+        """Generate the virtual table files"""
+        logging.debug("TableState.generate")
+
+        all_options = []
+        # Create a list of column options from the kwargs passed to the column.
+        for column in self.columns():
+            column_options = []
+            for option in column.options:
+                # Only allow explicitly-defined options.
+                if option in COLUMN_OPTIONS:
+                    column_options.append("ColumnOptions::" + COLUMN_OPTIONS[option])
+                    all_options.append(COLUMN_OPTIONS[option])
+                else:
+                    print(yellow(
+                        "Table %s column %s contains an unknown option: %s" % (
+                            self.table_name, column.name, option)))
+            column.options_set = " | ".join(column_options)
+            if len(column.aliases) > 0:
+                self.has_column_aliases = True
+        if len(all_options) > 0:
+            self.has_options = True
+        if "event_subscriber" in self.attributes:
+            self.generator = True
+        if "cacheable" in self.attributes:
+            if self.generator:
+                print(lightred(
+                    "Table cannot use a generator and be marked cacheable: %s" % (path)))
+                exit(1)
+        if self.table_name == "" or self.function == "":
+            print(lightred("Invalid table spec: %s" % (path)))
+            exit(1)
+
+        # Check for reserved column names
+        for column in self.columns():
+            if column.name in RESERVED:
+                print(lightred(("Cannot use column name: %s in table: %s "
+                                "(the column name is reserved)" % (
+                                    column.name, self.table_name))))
+                exit(1)
+
+        if "ADDITIONAL" in all_options and "INDEX" not in all_options:
+            if "no_pkey" not in self.attributes:
+                print(lightred(
+                    "Table cannot have 'additional' columns without an index: %s" %(
+                    path)))
+                exit(1)
+
+        path_bits = path.split("/")
+        for i in range(1, len(path_bits)):
+            dir_path = ""
+            for j in range(i):
+                dir_path += "%s/" % path_bits[j]
+            if not os.path.exists(dir_path):
+                try:
+                    os.mkdir(dir_path)
+                except:
+                    # May encounter a race when using a make jobserver.
+                    pass
+        logging.debug("generating %s" % path)
+        self.impl_content = jinja2.Template(TEMPLATES[template]).render(
+            table_name=self.table_name,
+            table_name_cc=to_camel_case(self.table_name),
+            schema=self.columns(),
+            header=self.header,
+            impl=self.impl,
+            function=self.function,
+            class_name=self.class_name,
+            attributes=self.attributes,
+            examples=self.examples,
+            aliases=self.aliases,
+            has_options=self.has_options,
+            has_column_aliases=self.has_column_aliases,
+            generator=self.generator,
+            attribute_set=[TABLE_ATTRIBUTES[attr] for attr in self.attributes if attr in TABLE_ATTRIBUTES],
+        )
+
+        with open(path, "w+") as file_h:
+            file_h.write(self.impl_content)
+
+    def blacklist(self, path):
+        print(lightred("Blacklisting generated %s" % path))
+        logging.debug("blacklisting %s" % path)
+        self.generate(path, template="blacklist")
+
+table = TableState()
+
+
+class Column(object):
+
+    """
+    Part of an osquery table schema.
+    Define a column by name and type with an optional description to assist
+    documentation generation and reference.
+    """
+
+    def __init__(self, name, col_type, description="", aliases=[], **kwargs):
+        self.name = name
+        self.type = col_type
+        self.description = description
+        self.aliases = aliases
+        self.options = kwargs
+
+
+class ForeignKey(object):
+
+    """
+    Part of an osquery table schema.
+    Loosely define a column in a table spec as a Foreign key in another table.
+    """
+
+    def __init__(self, **kwargs):
+        self.column = kwargs.get("column", "")
+        self.table = kwargs.get("table", "")
+
+
+def table_name(name, aliases=[]):
+    """define the virtual table name"""
+    s = name
+    for a in aliases:
+        s += "|" + a
+    sys.stdout.write("\"%s\" : [" % s)
+    logging.debug("- table_name")
+    logging.debug("  - called with: %s" % name)
+    table.table_name = name
+    table.description = ""
+    table.attributes = {}
+    table.examples = []
+    table.aliases = aliases
+
+def get_opts(it):
+    s = TYPE_CHARS[it.type.affinity]
+    for opt in it.options:
+        s += OPT_CHARS[opt]
+    return s
+
+def schema(schema_list):
+    """
+    define a list of Column object which represent the columns of your virtual
+    table
+    """
+    logging.debug("- schema")
+    i=-1
+    for it in schema_list:
+        if isinstance(it, Column):
+            i += 1
+            opts = get_opts(it)
+            s = it.name
+            if opts:
+                s += "/" + opts
+            if i > 0 :
+                sys.stdout.write(",")
+            sys.stdout.write("\"%s\"" % s)
+            logging.debug("  - column: %s (%s)" % (it.name, it.type))
+        if isinstance(it, ForeignKey):
+            logging.debug("  - foreign_key: %s (%s)" % (it.column, it.table))
+    table.schema = schema_list
+
+
+def extended_schema(check, schema_list):
+    """
+    define a comparator and a list of Columns objects.
+    """
+    logging.debug("- extended schema")
+    for it in schema_list:
+        if isinstance(it, Column):
+            logging.debug("  - column: %s (%s)" % (it.name, it.type))
+            if not check():
+                it.options['hidden'] = True
+            table.schema.append(it)
+
+
+def description(text):
+    if text[-1:] != '.':
+        print(lightred("Table description must end with a period!"))
+        exit(1)
+    table.description = text
+
+
+def select_all(name=None):
+    if name is None:
+        name = table.table_name
+    return "select count(*) from %s;" % (name)
+
+
+def examples(example_queries):
+    table.examples = example_queries
+
+
+def attributes(**kwargs):
+    for attr in kwargs:
+        table.attributes[attr] = kwargs[attr]
+
+
+def fuzz_paths(paths):
+    table.fuzz_paths = paths
+
+
+def implementation(impl_string, generator=False):
+    """
+    define the path to the implementation file and the function which
+    implements the virtual table. You should use the following format:
+
+      # the path is "osquery/table/implementations/foo.cpp"
+      # the function is "QueryData genFoo();"
+      implementation("foo@genFoo")
+    """
+    logging.debug("- implementation")
+    filename, function = impl_string.split("@")
+    class_parts = function.split("::")[::-1]
+    function = class_parts[0]
+    class_name = class_parts[1] if len(class_parts) > 1 else ""
+    impl = "%s.cpp" % filename
+    logging.debug("  - impl => %s" % impl)
+    logging.debug("  - function => %s" % function)
+    logging.debug("  - class_name => %s" % class_name)
+    table.impl = impl
+    table.function = function
+    table.class_name = class_name
+    table.generator = generator
+
+def main(argc, argv):
+    parser = argparse.ArgumentParser(
+        "Generate schema_stub config from specfile.")
+    parser.add_argument("spec_file", help="Path to input .table spec file")
+    args = parser.parse_args()
+
+    if False: #args.debug:
+        logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG)
+    else:
+        logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
+
+    filename = args.spec_file
+    #output = args.output
+    if filename.endswith(".table"):
+        # Adding a 3rd parameter will enable the blacklist
+
+        #setup_templates(args.templates)
+        with open(filename, "rU") as file_handle:
+            tree = ast.parse(file_handle.read())
+            exec(compile(tree, "<string>", "exec"))
+
+            sys.stdout.write("]")
+            print()
+
+if __name__ == "__main__":
+    SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+    main(len(sys.argv), sys.argv)

--- a/tools/tests/test_parse_schema_stubs.conf
+++ b/tools/tests/test_parse_schema_stubs.conf
@@ -1,0 +1,8 @@
+{
+  "schema_stubs": {
+    "package_receipts|packages":[
+      "package_id/Ti","package_filename/Tih","version","location","install_time/D","installer_name","path/a"
+    ],
+    "some_table": [ "text_column1", "int_column1/I", "text_column2/T", "hidden_text_column1/Th", "indexed_int_column1/Ii" ]
+  }
+}


### PR DESCRIPTION
Running a query for a recently defined virtual table across your entire fleet will result in 'no such table' errors on older agents.  Adding some 'schema_stubs' definitions in the config for all agents (e.g. using tls_config) will allow these queries to return empty results, rather than errors.  The stub table plugins are only loaded if the table plugin does not exist.  All types, aliases, and options are supported.

A script (tools/codegen/genschemastub.py) is provided to generate the right format based on table spec.  Here is an example configuration for agents to return empty results for the recent specs/windows/ntdomains.table if not present in the osquery binary:

```
"schema_stubs" : {
  "ntdomains" : ["name","client_site_name","dc_site_name","dns_forest_name","domain_controller_address","domain_controller_name","domain_name","status"]
}
```