### PR TITLE
add systemd security options

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -13,6 +13,12 @@ ExecStart=/usr/bin/osqueryd \
 Restart=on-failure
 KillMode=process
 KillSignal=SIGTERM
+NoNewPrivileges=yes
+PrivateTmp=true
+ProtectHome=read-only
+ProtectKernelTunables=true
+ProtectSystem=full
+RestrictRealtime=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This update default systemd config to include security options

https://www.freedesktop.org/software/systemd/man/systemd.exec.html
NoNewPrivileges=yes
PrivateTmp=true
ProtectHome=read-only
ProtectKernelTunables=true
ProtectSystem=full
RestrictRealtime=true

It will probably affect extensions which modifies system files or settings but should be fine for usual behavior of only reading/collecting data.
