### PR TITLE
add acl to pipes table

### DIFF
--- a/osquery/tables/system/windows/pipes.cpp
+++ b/osquery/tables/system/windows/pipes.cpp
@@ -157,3 +157,4 @@ QueryData genPipes(QueryContext& context) {
 }
 }
 }
+

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -6,8 +6,8 @@ schema([
     Column("instances", INTEGER, "Number of instances of the named pipe"),
     Column("max_instances", INTEGER, "The maximum number of instances creatable for this pipe"),
     Column("flags", TEXT, "The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes"),
-  Column("type", TEXT, "Type of access mode for the access control entry."),
-  Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),
+    Column("type", TEXT, "Type of access mode for the access control entry."),
+    Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),
 ])
 implementation("pipes@genPipes")
 examples([

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -6,6 +6,8 @@ schema([
     Column("instances", INTEGER, "Number of instances of the named pipe"),
     Column("max_instances", INTEGER, "The maximum number of instances creatable for this pipe"),
     Column("flags", TEXT, "The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes"),
+  Column("type", TEXT, "Type of access mode for the access control entry."),
+  Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),
 ])
 implementation("pipes@genPipes")
 examples([


### PR DESCRIPTION
Attempt to get ACL informations for pipes too.
Mirroring code of ntfs_acl_permissions (probably want to split it somewhere, getting Windows acl is probably useful in many place)

not tested, pending upstream CI.