### PR TITLE
aws logger hardening

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -7,20 +7,27 @@ The Kinesis Streams and Kinesis Firehose logger plugins are named `aws_kinesis` 
 Some configuration is shared between the two plugins:
 
 ```
---aws_access_key_id VALUE               AWS access key ID override
---aws_profile_name VALUE                AWS config profile to use for auth and region config
 --aws_region VALUE                      AWS region override
+--aws_access_key_id VALUE               AWS access key ID override
 --aws_secret_access_key VALUE           AWS secret access key override
+
+--aws_profile_name VALUE                AWS config profile to use for auth and region config
+
 --aws_sts_arn_role VALUE                AWS STS assume role ARN
 --aws_sts_region VALUE                  AWS STS assume role region
 --aws_sts_session_name VALUE            AWS STS session name
 --aws_sts_timeout VALUE                 AWS STS temporary credential timeout period in seconds (900-3600)
+--aws_session_token VALUE               AWS STS token
+
 --aws_enable_proxy VALUE                Enable proxying of HTTP/HTTPS requests in AWS client config (true or false)
 --aws_proxy_scheme VALUE                Proxy HTTP scheme for use in AWS client config (http or https)
 --aws_proxy_host VALUE                  Proxy host for use in AWS client config
 --aws_proxy_port VALUE                  Proxy port for use in AWS client config
 --aws_proxy_username VALUE              Proxy username for use in AWS client config
 --aws_proxy_password VALUE              Proxy password for use in AWS client config
+
+--aws_endpoint_override VALUE           Hostname to use instead of amazonaws.com
+
 ```
 
 When working with AWS, osquery will look for credentials and region configuration in the following order:
@@ -31,11 +38,37 @@ When working with AWS, osquery will look for credentials and region configuratio
 4. `default` profile in the AWS config files
 5. Profile from the EC2 Instance Metadata Service
 
-All of the STS configuration flags are optional.  However, if `aws_sts_arn_role` is set, you can utilize temporary credentials via assume role with the [AWS Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
+## Credential Considerations
+
+- **Never use the access keys for the root user for the AWS account.**  This would be like putting your AWS console username and password in your osquery config files.
+
+- **How would your environment invalid data or getting spammed with logs?**  Each device running osquery will have configuration containing AWS credentials to write to your AWS Kinesis or Firehose endpoints.  What if an agent had a bug and started sending 1000 messages per minute?  What if a malicious actor takes the credentials and crafts logs that are intended to break your server-side processing?  For these reasons, we need to consider how to mitigate those problems, revoke credentials, and how to control access to them.  There are a few different ways to configure AWS credentials for osquery to help manage those situations.
+
+- **Use tls configuration**  Consider using the TLS configuration, in which the osquery agents fetch the configuration periodically (e.g. 5 minutes) from a server.  This will help recover from changes to AWS credentials.
+- **Dropped messages** The AWS Kinesis logger is configured to retry (default 100 times) before dropping a message.
+
+## Credential Configuration Scenarios
+There are a few ways to provide osquery agents with the security credentials needed to write to AWS Kinesis or Firehose endpoints.
+
+**1. User security tokens**
+
+This is the simplest case, in which the 'Access Keys' for a user account are used (aws_access_key_id, aws_secret_access_key). You will want to create an IAM user with just the access needed:
+ - Kinesis / Firehose write access (e.g. PutRecord)
+ - no console access (default for new IAM users)
+
+You are unlikely to create IAM user accounts for each osquery endpoint device.  Therefore, if you need to revoke credentials, it will affect all osquery agents.
+
+**2. STS Tokens for IAM Role**
+
+In this scenario, configure the agents with Access Keys for an IAM user that has 'sts:AssumeRole' permission, along with a `aws_sts_arn_role` flag to specify a role to assume. See [AWS Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).  That role has restricted permissions to write to Kinesis or Firehose.  The osquery agent will try to assume the role and if successful will be given the new STS Access Keys, SessionToken, and Expiration Time.  When a token expires, osquery will do the assume role request again to reacquire credentials.
+
+**3. Server provided STS Token**
+
+In this scenario, a server provides Access Keys, along with `aws_session_token` in the configuration.  The periodic refresh of the TLS configuration provides means to update the AWS credentials as needed, with the ability to selectively deny AWS credentials to specific agents.  This is the most flexible, but also the most complicated, as it requires server management of STS tokens.
 
 ### Kinesis Streams
 
-When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period`.  
+When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period` (defaults to 10 seconds).  The number of retries before dropping a log record is configured using `aws_kinesis_max_retry`, which defaults to 100.
 
 Setting aws_kinesis_random_partition_key to true will use random partition keys when sending data to Kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Note that using this setting will result in the logs of each host distributed across shards, so do not use it if you need logs from each host to be processed by a consistent shard.  The default for this setting is "false".
 
@@ -44,6 +77,7 @@ Setting aws_kinesis_random_partition_key to true will use random partition keys 
 Similarly for Kinesis Firehose delivery streams, the stream name must be specified with `aws_firehose_stream`, and the period can be configured with `aws_firehose_period`.
 
 ### Sample Config File
+The following shows the configuration syntax.  Typically you will only have one AWS logger specified at a time (either firehose or kinesis).
 ```
 {
   "options": {

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -365,6 +365,7 @@ class Config : private boost::noncopyable {
   friend class FileEventsTableTests;
   friend class DecoratorsConfigParserPluginTests;
   friend class SchedulerTests;
+  friend class AwsLoggerIntegrationTests;
   FRIEND_TEST(ConfigTests, test_config_backup);
   FRIEND_TEST(ConfigTests, test_config_backup_integrate);
   FRIEND_TEST(ConfigTests, test_config_refresh);

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -484,6 +484,22 @@ if(NOT SKIP_TESTS)
               osquery_integration_tests
             COMMAND
               osquery_tables_tests ${TEST_ARGS})
+
+    # integration tests : aws_logger
+    if(POSIX AND NOT SKIP_AWS)
+      add_library(aws_logger_integration_tests_objs OBJECT)
+      SET_OSQUERY_COMPILE(aws_logger_integration_tests_objs "${GTEST_FLAGS}")
+
+      target_sources(aws_logger_integration_tests_objs
+        PRIVATE ""
+          "${CMAKE_CURRENT_LIST_DIR}/logger/plugins/tests/aws_logger_integration_tests.cpp"
+        )
+
+      add_executable(aws_logger_integration_tests main/tests.cpp $<TARGET_OBJECTS:aws_logger_integration_tests_objs>)
+      ADD_DEFAULT_LINKS(aws_logger_integration_tests TRUE)
+      target_link_libraries(aws_logger_integration_tests gtest gmock libosquery_testing)
+      SET_OSQUERY_COMPILE(aws_logger_integration_tests "${GTEST_FLAGS}")
+    endif()
   endif()
 
   # Build the example extension with the SDK.

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -68,6 +68,8 @@ class KinesisLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
+  void tearDown() override;
+
   bool usesLogStatus() override {
     return true;
   }
@@ -84,4 +86,4 @@ class KinesisLoggerPlugin : public LoggerPlugin {
  private:
   std::shared_ptr<KinesisLogForwarder> forwarder_{nullptr};
 };
-}
+} // namespace osquery

--- a/osquery/logger/plugins/tests/aws_logger_integration_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_logger_integration_tests.cpp
@@ -44,38 +44,38 @@ static bool haveCheckedDir = false;
 
 class AwsLoggerIntegrationTests : public testing::Test {
  public:
-   void SetUp() override {
-     Config::get().reset();
+  void SetUp() override {
+    Config::get().reset();
 
-     if (!haveCheckedDir) {
-       haveCheckedDir = true;
-       const char *env_var_name = "AWS_KINESIS_TEST_CFG";
-       const char *tmp = getenv(env_var_name);
-       if (nullptr == tmp) {
-         LOG(ERROR) << "ENV variable " << std::string(env_var_name) << " not set";
-         return;
-       }
-       aws_test_cfg_path = tmp;
-       if (!fs::exists(aws_test_cfg_path)) {
-         LOG(ERROR) << "aws_test_cfg_path does not exist:" << aws_test_cfg_path;
-         aws_test_cfg_path = "";
-       }
-     }
-   }
-   void TearDown() override {
-     Config::get().reset();
+    if (!haveCheckedDir) {
+      haveCheckedDir = true;
+      const char* env_var_name = "AWS_KINESIS_TEST_CFG";
+      const char* tmp = getenv(env_var_name);
+      if (nullptr == tmp) {
+        LOG(ERROR) << "ENV variable " << std::string(env_var_name)
+                   << " not set";
+        return;
+      }
+      aws_test_cfg_path = tmp;
+      if (!fs::exists(aws_test_cfg_path)) {
+        LOG(ERROR) << "aws_test_cfg_path does not exist:" << aws_test_cfg_path;
+        aws_test_cfg_path = "";
+      }
+    }
+  }
+  void TearDown() override {
+    Config::get().reset();
 
-     // if we don't do this cleanup, Dispatcher will segfault
-     PluginRef plugin = Registry::get().plugin("logger", "aws_kinesis");
-     if (plugin && (Registry::get().getActive("logger") == "aws_kinesis")) {
-       plugin->tearDown();
-       Dispatcher::joinServices();
-     }
-   }
+    // if we don't do this cleanup, Dispatcher will segfault
+    PluginRef plugin = Registry::get().plugin("logger", "aws_kinesis");
+    if (plugin && (Registry::get().getActive("logger") == "aws_kinesis")) {
+      plugin->tearDown();
+      Dispatcher::joinServices();
+    }
+  }
 };
 
-bool _loadConfig()
-{
+bool _loadConfig() {
   EXPECT_FALSE(aws_test_cfg_path.empty());
 
   if (aws_test_cfg_path.empty()) {
@@ -107,7 +107,8 @@ TEST_F(AwsLoggerIntegrationTests, log_one) {
 
   EXPECT_TRUE(Registry::get().setActive("logger", "aws_kinesis"));
 
-  auto status = logString("{ \"some\" : \"value\", \"zero\" : 0, \"vrai\" : true }", "added");
+  auto status = logString(
+      "{ \"some\" : \"value\", \"zero\" : 0, \"vrai\" : true }", "added");
 
   EXPECT_TRUE(status.ok());
   std::this_thread::sleep_for(std::chrono::seconds(2));

--- a/osquery/logger/plugins/tests/aws_logger_integration_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_logger_integration_tests.cpp
@@ -1,0 +1,116 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <aws/kinesis/KinesisClient.h>
+#include <aws/kinesis/model/PutRecordsRequestEntry.h>
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+#include "osquery/logger/plugins/aws_log_forwarder.h"
+#include "osquery/tests/test_util.h"
+
+/*
+ * A simple test that executes one logString() and exits.
+ *
+ * This is intended to be run by tools/tests/aws/aws-integration-tests.rb
+ * AWS_KINESIS_TEST_CFG environment variable needs to be set to
+ * path of config file to use.
+ */
+
+using namespace testing;
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+DECLARE_uint64(aws_kinesis_period);
+
+static std::string aws_test_cfg_path = "";
+static bool haveCheckedDir = false;
+
+class AwsLoggerIntegrationTests : public testing::Test {
+ public:
+   void SetUp() override {
+     Config::get().reset();
+
+     if (!haveCheckedDir) {
+       haveCheckedDir = true;
+       const char *env_var_name = "AWS_KINESIS_TEST_CFG";
+       const char *tmp = getenv(env_var_name);
+       if (nullptr == tmp) {
+         LOG(ERROR) << "ENV variable " << std::string(env_var_name) << " not set";
+         return;
+       }
+       aws_test_cfg_path = tmp;
+       if (!fs::exists(aws_test_cfg_path)) {
+         LOG(ERROR) << "aws_test_cfg_path does not exist:" << aws_test_cfg_path;
+         aws_test_cfg_path = "";
+       }
+     }
+   }
+   void TearDown() override {
+     Config::get().reset();
+
+     // if we don't do this cleanup, Dispatcher will segfault
+     PluginRef plugin = Registry::get().plugin("logger", "aws_kinesis");
+     if (plugin && (Registry::get().getActive("logger") == "aws_kinesis")) {
+       plugin->tearDown();
+       Dispatcher::joinServices();
+     }
+   }
+};
+
+bool _loadConfig()
+{
+  EXPECT_FALSE(aws_test_cfg_path.empty());
+
+  if (aws_test_cfg_path.empty()) {
+    return true;
+  }
+
+  std::string config_file_content = "";
+  std::map<std::string, std::string> config_data;
+
+  auto path = aws_test_cfg_path;
+  readFile(path, config_file_content);
+  if (config_file_content.empty()) {
+    LOG(ERROR) << "Unable to read config file:" << path;
+    EXPECT_TRUE(false);
+    return true;
+  }
+  config_data["testconfig"] = config_file_content;
+  Config::get().update(config_data);
+
+  LOG(WARNING) << "loaded config file:" << path;
+
+  return false;
+}
+
+TEST_F(AwsLoggerIntegrationTests, log_one) {
+  if (_loadConfig()) {
+    return;
+  }
+
+  EXPECT_TRUE(Registry::get().setActive("logger", "aws_kinesis"));
+
+  auto status = logString("{ \"some\" : \"value\", \"zero\" : 0, \"vrai\" : true }", "added");
+
+  EXPECT_TRUE(status.ok());
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+}
+
+} // namespace osquery

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -190,6 +190,11 @@ Status getAWSRegion(std::string& region, bool sts = false);
 void setAWSProxy(Aws::Client::ClientConfiguration& config);
 
 /**
+ * @return aws_endpoint_override FLAG value or empty string.
+ */
+std::string getAWSEndpointOverride();
+
+/**
  * @brief Instantiate an AWS client with the appropriate osquery configs,
  *
  * This will pull the region and authentication configs from the appropriate
@@ -218,6 +223,8 @@ Status makeAWSClient(std::shared_ptr<Client>& client,
     client_config.region = region;
   }
 
+  client_config.endpointOverride = getAWSEndpointOverride();
+
   // Setup any proxy options on the config if desired
   setAWSProxy(client_config);
 
@@ -237,4 +244,4 @@ Status makeAWSClient(std::shared_ptr<Client>& client,
  * @return 0 if successful, 1 if there were issues
  */
 Status appendLogTypeToJson(const std::string& log_type, std::string& log);
-}
+} // namespace osquery

--- a/tools/tests/aws/aws-integration-tests.rb
+++ b/tools/tests/aws/aws-integration-tests.rb
@@ -1,0 +1,229 @@
+require 'ostruct'
+require 'json'
+require 'optparse'
+
+TEST_NAMES=[
+  'local_user_creds',
+  'osquery_assume_role',
+  'provided_session_token',
+  'fail_user_creds_invalid',
+  'fail_invalid_sts_role'
+]
+
+class AwsIntegrationTestRunner
+
+  def initialize()
+    @exe="./build/darwin/osquery/aws_logger_integration_tests"
+  end
+
+  #---------------------------------------------------------
+  # use aws command-line to get region, access_key, secret_key
+  #---------------------------------------------------------
+  def get_aws_config
+    cmd_path = `which aws`.strip
+    unless cmd_path
+      puts "ERROR: 'aws' executable is not in your path"
+      exit 2
+    end
+
+    items = {}
+    items[:region] = `aws configure get region`.strip
+    items[:access_key] = `aws configure get aws_access_key_id`.strip
+    items[:secret_key] = `aws configure get aws_secret_access_key`.strip
+
+    unless items[:access_key]
+      puts "ERROR: access_key is not configured:#{items[:access_key]}"
+      exit 3
+    end
+    unless items[:secret_key]
+      puts "ERROR: secret_key is not configured:#{items[:secret_key]}"
+      exit 3
+    end
+
+    return items
+  end
+
+  #---------------------------------------------------------
+  # use aws command-line to assume role, return hashmap
+  # with access_key, secret_key, session_token
+  #---------------------------------------------------------
+  # {
+  #    "Credentials": {
+  #        "AccessKeyId": "ASI...K",
+  #        "SecretAccessKey": "Dc...5",
+  #        "SessionToken": "FJ...wU=",
+  #        "Expiration": "2018-11-15T22:43:40Z"
+  #    },
+  #    "AssumedRoleUser": {
+  #        "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:osquery-test1",
+  #        "Arn": "arn:aws:sts::123456789012:assumed-role/osquery-user/osquery-test1"
+  #    }
+  # }
+  def assume_role arn
+
+    json_response = `aws sts assume-role --role-arn "#{arn}" --role-session-name osquery-test1`
+    unless $?.success?
+      puts "ERROR: aws sts command-line failed"
+      exit 3
+    end
+    doc = JSON.parse(json_response, object_class: OpenStruct) rescue nil
+
+    #puts doc.inspect
+
+    retval = {}
+    return retval if doc.nil?
+
+    retval[:session_token] = doc.Credentials.SessionToken rescue nil
+    retval[:access_key] = doc.Credentials.AccessKeyId rescue nil
+    retval[:secret_key] = doc.Credentials.SecretAccessKey rescue nil
+
+    return retval
+  end
+
+  #---------------------------------------------------------
+  # run osquery test exe with specified config
+  #---------------------------------------------------------
+  def run_test(config_path)
+    output = `GLOG_v=1 GLOG_logtostderr=1 GLOG_stderrthreshold=1 AWS_KINESIS_TEST_CFG="#{config_path}" #{@exe} 2>&1`;
+    return output
+  end
+
+  #---------------------------------------------------------
+  # returns a hashmap matching names in osquery config 'options'
+  #---------------------------------------------------------
+  def get_config_hash(region, access_key_id="", secret_access_key="", logger_plugin="aws_kinesis")
+    options = OpenStruct.new(:aws_region => region, :aws_access_key_id => access_key_id,
+      :aws_secret_access_key => secret_access_key, :logger_plugin => logger_plugin,
+      :aws_session_token => "", :aws_endpoint_override => "",
+      :aws_kinesis_stream => "", :aws_kinesis_period => 1,
+      :aws_kinesis_max_retry => 2,
+      :disable_logging => false, :utc => true
+    )
+    return options
+  end
+
+  #---------------------------------------------------------
+  # alternative signature
+  #---------------------------------------------------------
+  def get_config_hash2(creds, options)
+    cfg = get_config_hash(creds[:region], creds[:access_key], creds[:secret_key])
+    cfg.aws_kinesis_stream = options.kinesis_stream_name
+    return cfg
+  end
+
+  #---------------------------------------------------------
+  # returns JSON string for options hashmap
+  #---------------------------------------------------------
+  def make_config_json(options)
+    doc = { "options" => options.to_h }
+    return doc.to_json
+  end
+
+end
+
+#### script execution starts here
+
+# defaults
+
+platform_name = `uname -s`.strip.downcase
+options = OpenStruct.new(
+  :kinesis_stream_name => 'osquery-kinesis-stream',
+  :role_arn => '',
+  :test_exe_path => "./build/#{platform_name}/osquery/aws_logger_integration_tests",
+  :test_names => TEST_NAMES
+)
+
+# parse arguments
+
+OptionParser.new do |opt|
+  opt.on('-s VALUE','--stream STREAM_NAME','e.g. "osquery-kinesis-stream"') { |value| options.kinesis_stream_name = value }
+  opt.on('-r VALUE','--role_arn ROLE_ARN_VALUE','e.g. "arn:aws:iam::123456789012:role/osquery-kinesis-streams"') { |value| options.role_arn = value }
+  opt.on('-p VALUE','--path_to_exe PATH','OPTIONAL e.g. ./build/darwin/osquery/aws_logger_integration_tests') { |value| options.test_exe_path = value }
+  opt.on('-f VALUE','--filter TEST_LIST', "OPTIONAL Comma-delimited list of test names to run.\n\t\tFull list: #{TEST_NAMES.join(',')}") { |value| options.test_names = value.split(',') }
+end.parse!
+
+osquery_configs = {}
+obj = AwsIntegrationTestRunner.new
+
+# get aws command-line config
+creds = obj.get_aws_config
+
+# build a hash map we can use to build JSON config
+
+cfg = obj.get_config_hash(creds[:region], creds[:access_key], creds[:secret_key])
+cfg.aws_kinesis_stream = options.kinesis_stream_name
+
+test_name = 'local_user_creds'
+if options.test_names.include?(test_name)
+  # this may or may not succeed, depending on AWS user settings
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
+# assume role
+
+test_name = 'osquery_assume_role'
+cfg = obj.get_config_hash2(creds,options)
+cfg.aws_sts_arn_role = options.role_arn
+if options.test_names.include?(test_name)
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
+# with role and session token
+
+test_name = 'provided_session_token'
+if options.test_names.include?(test_name)
+
+  result = obj.assume_role options.role_arn
+  if result.nil? || result[:session_token].nil?
+    puts "ERROR: assume role did not provide session token"
+    exit 3
+  end
+  cfg.aws_session_token = result[:session_token]
+  cfg.aws_sts_arn_role = ""
+  cfg.aws_access_key_id = result[:access_key]
+  cfg.aws_secret_access_key = result[:secret_key]
+
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+
+end
+
+# invalid secret
+
+test_name = 'fail_user_creds_invalid'
+if options.test_names.include?(test_name)
+  cfg = obj.get_config_hash2(creds,options)
+  cfg.aws_secret_access_key = 'xxxxxx'
+  # this may or may not succeed, depending on AWS user settings
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
+# invalid role
+
+test_name = 'fail_invalid_sts_role'
+if options.test_names.include?(test_name)
+  cfg = obj.get_config_hash2(creds,options)
+  cfg.aws_sts_arn_role = "#{options.role_arn}-nosuch"
+  # this may or may not succeed, depending on AWS user settings
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
+if osquery_configs.empty?
+  puts "ERROR: no configurations specified"
+  exit 4
+end
+
+# run them
+
+osquery_configs.each do |name, config_content|
+
+  path="/tmp/aws_int_test.conf"
+
+  File.open(path, "w") { |f| f.write(config_content) }
+  puts "-------------------------------------"
+  puts "Running '#{name}'"
+
+  output = obj.run_test path
+  puts output
+
+  File.unlink path
+end

--- a/tools/tests/aws/aws-integration-tests.rb
+++ b/tools/tests/aws/aws-integration-tests.rb
@@ -2,18 +2,47 @@ require 'ostruct'
 require 'json'
 require 'optparse'
 
+# Usage:
+#
+# $ ruby tools/tests/aws/aws-integration-tests.rb -s osquery-kinesis-stream -r "arn:aws:iam::123456789012:role/osquery-kinesis-streams"
+# -------------------------------------
+# Running 'local_user_creds'
+# :SUCCESS
+# -------------------------------------
+# Running 'osquery_assume_role'
+# :SUCCESS
+# -------------------------------------
+# Running 'provided_session_token'
+# :SUCCESS
+# -------------------------------------
+# :SKIPPING endpoint_override_provided_session (no local proxy)
+# -------------------------------------
+# :SKIPPING endpoint_override (no local proxy)
+# -------------------------------------
+# Running 'fail_user_creds_invalid'
+# :SUCCESS
+# -------------------------------------
+# Running 'fail_invalid_sts_role'
+# :SUCCESS
+
+
 TEST_NAMES=[
   'local_user_creds',
   'osquery_assume_role',
   'provided_session_token',
   'fail_user_creds_invalid',
-  'fail_invalid_sts_role'
+  'fail_invalid_sts_role',
+  'endpoint_override',
+  'endpoint_override_provided_session'
 ]
 
 class AwsIntegrationTestRunner
-
-  def initialize()
-    @exe="./build/darwin/osquery/aws_logger_integration_tests"
+  attr_reader :options, :creds, :have_local_proxy
+  def initialize(options)
+    @options = options
+    @exe = options.test_exe_path
+    @creds = get_aws_config
+    check_local_proxy
   end
 
   #---------------------------------------------------------
@@ -41,6 +70,16 @@ class AwsIntegrationTestRunner
     end
 
     return items
+  end
+
+  #---------------------------------------------------------
+  # In order to try the endpoint_override tests,
+  # need the local reverse proxy.  See nginx-proxy in
+  # https://github.com/packetzero/osquery_aws_notes
+  #---------------------------------------------------------
+  def check_local_proxy
+    tmp = `curl --head --insecure --stderr - -o - https://localhost:443/`
+    @have_local_proxy = tmp.include?("x-amzn-RequestId:")
   end
 
   #---------------------------------------------------------
@@ -91,24 +130,16 @@ class AwsIntegrationTestRunner
   #---------------------------------------------------------
   # returns a hashmap matching names in osquery config 'options'
   #---------------------------------------------------------
-  def get_config_hash(region, access_key_id="", secret_access_key="", logger_plugin="aws_kinesis")
-    options = OpenStruct.new(:aws_region => region, :aws_access_key_id => access_key_id,
-      :aws_secret_access_key => secret_access_key, :logger_plugin => logger_plugin,
+  def get_config_hash()
+    options = OpenStruct.new(:aws_region => @creds[:region], :aws_access_key_id => @creds[:access_key],
+      :aws_secret_access_key => @creds[:secret_key], :logger_plugin => "aws_kinesis",
       :aws_session_token => "", :aws_endpoint_override => "",
-      :aws_kinesis_stream => "", :aws_kinesis_period => 1,
+      :aws_kinesis_stream => @options.kinesis_stream_name,
+      :aws_kinesis_period => 1,
       :aws_kinesis_max_retry => 2,
       :disable_logging => false, :utc => true
     )
     return options
-  end
-
-  #---------------------------------------------------------
-  # alternative signature
-  #---------------------------------------------------------
-  def get_config_hash2(creds, options)
-    cfg = get_config_hash(creds[:region], creds[:access_key], creds[:secret_key])
-    cfg.aws_kinesis_stream = options.kinesis_stream_name
-    return cfg
   end
 
   #---------------------------------------------------------
@@ -119,9 +150,26 @@ class AwsIntegrationTestRunner
     return doc.to_json
   end
 
+  def was_successful output
+    was_sent = false
+    err_count = 0
+    output.lines.each do |line|
+      if line.start_with?("E")
+        err_count += 1
+      end
+      if line.include?("Successfully sent") && line.include?("aws_kinesis")
+        was_sent = true
+      end
+    end
+    return was_sent && err_count == 0
+  end
+
 end
 
 #### script execution starts here
+if ARGV.count == 0
+  ARGV.push "--help"
+end
 
 # defaults
 
@@ -130,7 +178,8 @@ options = OpenStruct.new(
   :kinesis_stream_name => 'osquery-kinesis-stream',
   :role_arn => '',
   :test_exe_path => "./build/#{platform_name}/osquery/aws_logger_integration_tests",
-  :test_names => TEST_NAMES
+  :test_names => TEST_NAMES,
+  :verbose => false
 )
 
 # parse arguments
@@ -139,19 +188,21 @@ OptionParser.new do |opt|
   opt.on('-s VALUE','--stream STREAM_NAME','e.g. "osquery-kinesis-stream"') { |value| options.kinesis_stream_name = value }
   opt.on('-r VALUE','--role_arn ROLE_ARN_VALUE','e.g. "arn:aws:iam::123456789012:role/osquery-kinesis-streams"') { |value| options.role_arn = value }
   opt.on('-p VALUE','--path_to_exe PATH','OPTIONAL e.g. ./build/darwin/osquery/aws_logger_integration_tests') { |value| options.test_exe_path = value }
+  opt.on('-v','--verbose','Write each test output and config to stdout') { |value| options.verbose = true }
   opt.on('-f VALUE','--filter TEST_LIST', "OPTIONAL Comma-delimited list of test names to run.\n\t\tFull list: #{TEST_NAMES.join(',')}") { |value| options.test_names = value.split(',') }
 end.parse!
 
+unless File.exists?(options.test_exe_path)
+  puts "ERROR: Test exe not found:#{options.test_exe_path}"
+  exit 2
+end
+
 osquery_configs = {}
-obj = AwsIntegrationTestRunner.new
+obj = AwsIntegrationTestRunner.new(options)
 
-# get aws command-line config
-creds = obj.get_aws_config
+# basic user creds test
 
-# build a hash map we can use to build JSON config
-
-cfg = obj.get_config_hash(creds[:region], creds[:access_key], creds[:secret_key])
-cfg.aws_kinesis_stream = options.kinesis_stream_name
+cfg = obj.get_config_hash()
 
 test_name = 'local_user_creds'
 if options.test_names.include?(test_name)
@@ -162,9 +213,9 @@ end
 # assume role
 
 test_name = 'osquery_assume_role'
-cfg = obj.get_config_hash2(creds,options)
-cfg.aws_sts_arn_role = options.role_arn
 if options.test_names.include?(test_name)
+  cfg = obj.get_config_hash()
+  cfg.aws_sts_arn_role = options.role_arn
   osquery_configs[test_name] = obj.make_config_json(cfg)
 end
 
@@ -172,6 +223,8 @@ end
 
 test_name = 'provided_session_token'
 if options.test_names.include?(test_name)
+
+  cfg = obj.get_config_hash()
 
   result = obj.assume_role options.role_arn
   if result.nil? || result[:session_token].nil?
@@ -187,11 +240,49 @@ if options.test_names.include?(test_name)
 
 end
 
+# endpoint override - with provided session
+
+test_name = 'endpoint_override_provided_session'
+if options.test_names.include?(test_name)
+
+  cfg = obj.get_config_hash()
+
+  result = obj.assume_role options.role_arn
+  if result.nil? || result[:session_token].nil?
+    puts "ERROR: assume role did not provide session token"
+    exit 3
+  end
+  cfg.aws_session_token = result[:session_token]
+  cfg.aws_sts_arn_role = options.role_arn
+  cfg.aws_access_key_id = result[:access_key]
+  cfg.aws_secret_access_key = result[:secret_key]
+  cfg.aws_endpoint_override = "localhost:443"
+
+  # get path to local server case
+  # assuming this ruby script lives in osquery/tools/tests/aws/
+  cfg.tls_server_certs = "#{File.dirname(__FILE__)}/../test_server_ca.pem"
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
+# endpoint override
+
+test_name = 'endpoint_override'
+if options.test_names.include?(test_name)
+  cfg = obj.get_config_hash()
+#  cfg.aws_sts_arn_role = options.role_arn
+
+  cfg.aws_endpoint_override = "localhost:443"
+  # get path to local server case
+  # assuming this ruby script lives in osquery/tools/tests/aws/
+  cfg.tls_server_certs = "#{File.dirname(__FILE__)}/../test_server_ca.pem"
+  osquery_configs[test_name] = obj.make_config_json(cfg)
+end
+
 # invalid secret
 
 test_name = 'fail_user_creds_invalid'
 if options.test_names.include?(test_name)
-  cfg = obj.get_config_hash2(creds,options)
+  cfg = obj.get_config_hash()
   cfg.aws_secret_access_key = 'xxxxxx'
   # this may or may not succeed, depending on AWS user settings
   osquery_configs[test_name] = obj.make_config_json(cfg)
@@ -201,7 +292,7 @@ end
 
 test_name = 'fail_invalid_sts_role'
 if options.test_names.include?(test_name)
-  cfg = obj.get_config_hash2(creds,options)
+  cfg = obj.get_config_hash()
   cfg.aws_sts_arn_role = "#{options.role_arn}-nosuch"
   # this may or may not succeed, depending on AWS user settings
   osquery_configs[test_name] = obj.make_config_json(cfg)
@@ -213,17 +304,30 @@ if osquery_configs.empty?
 end
 
 # run them
-
 osquery_configs.each do |name, config_content|
+
+  puts "-------------------------------------"
+  if name.start_with?("endpoint_override") && !obj.have_local_proxy
+    puts ":SKIPPING #{name} (no local proxy)"
+    next
+  end
 
   path="/tmp/aws_int_test.conf"
 
   File.open(path, "w") { |f| f.write(config_content) }
-  puts "-------------------------------------"
   puts "Running '#{name}'"
+  STDOUT.flush
+
+  puts "\n  Config:#{config_content}\n\n" if (options.verbose)
 
   output = obj.run_test path
-  puts output
+  if obj.was_successful(output) || name.start_with?("fail")
+    puts ":SUCCESS"
+    puts output if options.verbose
+  else
+    puts ":FAILED"
+    puts output
+  end
 
   File.unlink path
 end


### PR DESCRIPTION

- added aws_endpoint_override config flag
- added aws_session_token config flag to support server-supplied STS token
- fix KinesisLogger.tearDown() to interrupt forwarder for clean shutdown
- more detailed log messages in aws logger code path
- update aws logger doc page to provide more detail on credential usage
- build aws_logger_integration_tests exe target, which is used by tools/tests/aws/aws-integration-tests.rb to exercise the functionality.
