### PR TITLE
(Windows) New table: default_environment

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -254,6 +254,7 @@ osquery_cxx_library(
                 "windows/certificates.cpp",
                 "windows/chocolatey_packages.cpp",
                 "windows/cpu_info.cpp",
+                "windows/default_environment.cpp",
                 "windows/disk_info.cpp",
                 "windows/drivers.cpp",
                 "windows/groups.cpp",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -165,6 +165,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/certificates.cpp
       windows/chocolatey_packages.cpp
       windows/cpu_info.cpp
+      windows/default_environment.cpp
       windows/disk_info.cpp
       windows/drivers.cpp
       windows/groups.cpp

--- a/osquery/tables/system/windows/default_environment.cpp
+++ b/osquery/tables/system/windows/default_environment.cpp
@@ -5,22 +5,24 @@
 
 namespace osquery {
 namespace tables {
-  static std::string kEnvironmentKey =
-    "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+static std::string kEnvironmentKey =
+    "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session "
+    "Manager\\Environment";
 
-  QueryData genEnvironment(QueryContext& context) {
-    QueryData results;
-    auto environment = SQL::selectAllFrom("registry", "key", EQUALS, kEnvironmentKey);
+QueryData genEnvironment(QueryContext& context) {
+  QueryData results;
+  auto environment =
+      SQL::selectAllFrom("registry", "key", EQUALS, kEnvironmentKey);
 
-    for (const auto& env : environment) {
-      Row r;
-      r["variable"] = env.at("name");
-      r["value"] = env.at("data");
-      r["expand"] = INTEGER(env.at("type") == "REG_EXPAND_SZ");
-      results.push_back(r);
-    }
-
-    return results;
+  for (const auto& env : environment) {
+    Row r;
+    r["variable"] = env.at("name");
+    r["value"] = env.at("data");
+    r["expand"] = INTEGER(env.at("type") == "REG_EXPAND_SZ");
+    results.push_back(r);
   }
+
+  return results;
 }
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/default_environment.cpp
+++ b/osquery/tables/system/windows/default_environment.cpp
@@ -9,7 +9,7 @@ static std::string kEnvironmentKey =
     "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session "
     "Manager\\Environment";
 
-QueryData genEnvironment(QueryContext& context) {
+QueryData genDefaultEnvironment(QueryContext& context) {
   QueryData results;
   auto environment =
       SQL::selectAllFrom("registry", "key", EQUALS, kEnvironmentKey);

--- a/osquery/tables/system/windows/default_environment.cpp
+++ b/osquery/tables/system/windows/default_environment.cpp
@@ -31,7 +31,7 @@ QueryData genDefaultEnvironment(QueryContext& context) {
     r["variable"] = env.at("name");
     r["value"] = env.at("data");
     r["expand"] = INTEGER(env.at("type") == "REG_EXPAND_SZ");
-    results.push_back(r);
+    results.push_back(std::move(r));
   }
 
   return results;

--- a/osquery/tables/system/windows/default_environment.cpp
+++ b/osquery/tables/system/windows/default_environment.cpp
@@ -16,10 +16,10 @@ QueryData genDefaultEnvironment(QueryContext& context) {
 
   for (const auto& env : environment) {
     Row r;
-    r["variable"] = env.at("name");
-    r["value"] = env.at("data");
+    r["variable"] = std::move(env.at("name"));
+    r["value"] = std::move(env.at("data"));
     r["expand"] = INTEGER(env.at("type") == "REG_EXPAND_SZ");
-    results.push_back(r);
+    results.push_back(std::move(r));
   }
 
   return results;

--- a/osquery/tables/system/windows/default_environment.cpp
+++ b/osquery/tables/system/windows/default_environment.cpp
@@ -1,0 +1,26 @@
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+  static std::string kEnvironmentKey =
+    "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+
+  QueryData genEnvironment(QueryContext& context) {
+    QueryData results;
+    auto environment = SQL::selectAllFrom("registry", "key", EQUALS, kEnvironmentKey);
+
+    for (const auto& env : environment) {
+      Row r;
+      r["variable"] = env.at("name");
+      r["value"] = env.at("data");
+      r["expand"] = INTEGER(env.at("type") == "REG_EXPAND_SZ");
+      results.push_back(r);
+    }
+
+    return results;
+  }
+}
+}

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -801,6 +801,10 @@ osquery_gentable_cxx_library(
             "windows",
         ),
         (
+            "windows/default_environment.table",
+            "windows",
+        ),
+        (
             "yara/yara_events.table",
             "linux,macos",
         ),

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -259,6 +259,7 @@ function(generateNativeTables)
     "windows/wmi_script_event_consumers.table:windows"
     "windows/physical_disk_performance.table:windows"
     "windows/autoexec.table:windows"
+    "windows/default_environment.table:windows"
     "windows/windows_security_products.table:windows"
     "windows/connectivity.table:windows"
     "yara/yara_events.table:linux,macos"

--- a/specs/windows/default_environment.table
+++ b/specs/windows/default_environment.table
@@ -1,0 +1,8 @@
+table_name("default_environment")
+description("Default environment variables and values.")
+schema([
+    Column("variable", TEXT, "Name of the environment variable"),
+    Column("value", TEXT, "Value of the environment variable"),
+    Column("expand", INTEGER, "1 if the variable needs expanding, 0 otherwise"),
+])
+implementation("system/windows/environment@genEnvironment")

--- a/specs/windows/default_environment.table
+++ b/specs/windows/default_environment.table
@@ -5,4 +5,4 @@ schema([
     Column("value", TEXT, "Value of the environment variable"),
     Column("expand", INTEGER, "1 if the variable needs expanding, 0 otherwise"),
 ])
-implementation("system/windows/environment@genEnvironment")
+implementation("system/windows/default_environment@genDefaultEnvironment")

--- a/tests/integration/tables/BUCK
+++ b/tests/integration/tables/BUCK
@@ -260,6 +260,7 @@ osquery_cxx_test(
                 "chocolatey_packages.cpp",
                 "connectivity.cpp",
                 "cpu_info.cpp",
+                "default_environment.cpp",
                 "disk_info.cpp",
                 "drivers.cpp",
                 "ie_extensions.cpp",

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -262,6 +262,7 @@ function(generateTestsIntegrationTablesTestsTest)
       connectivity.cpp
       chocolatey_packages.cpp
       cpu_info.cpp
+      default_environment.cpp
       disk_info.cpp
       drivers.cpp
       ie_extensions.cpp

--- a/tests/integration/tables/default_environment.cpp
+++ b/tests/integration/tables/default_environment.cpp
@@ -1,4 +1,3 @@
-
 /**
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.

--- a/tests/integration/tables/default_environment.cpp
+++ b/tests/integration/tables/default_environment.cpp
@@ -27,7 +27,7 @@ TEST_F(defaultEnvironment, test_sanity) {
 
   ASSERT_GE(data.size(), 0ul);
 
-  ValidatatioMap row_map = {
+  ValidationMap row_map = {
       {"variable", NonEmptyString},
       {"value", NormalType},
       {"expand", IntType},

--- a/tests/integration/tables/default_environment.cpp
+++ b/tests/integration/tables/default_environment.cpp
@@ -28,7 +28,7 @@ TEST_F(defaultEnvironment, test_sanity) {
   ASSERT_GE(data.size(), 0ul);
 
   ValidatatioMap row_map = {
-      {"variable", NormalType},
+      {"variable", NonEmptyString},
       {"value", NormalType},
       {"expand", IntType},
   };

--- a/tests/integration/tables/default_environment.cpp
+++ b/tests/integration/tables/default_environment.cpp
@@ -1,0 +1,40 @@
+
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+// Sanity check integration test for disk_info
+// Spec file: specs/windows/disk_info.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class diskInfo : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(diskInfo, test_sanity) {
+  auto const data = execute_query("select * from default_environment");
+
+  ASSERT_GE(data.size(), 0ul);
+
+  ValidatatioMap row_map = {
+      {"variable", NormalType},
+      {"value", NormalType},
+      {"expand", IntType},
+  };
+
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/default_environment.cpp
+++ b/tests/integration/tables/default_environment.cpp
@@ -7,22 +7,22 @@
  *  root directory of this source tree.
  */
 
-// Sanity check integration test for disk_info
-// Spec file: specs/windows/disk_info.table
+// Sanity check integration test for default_environment
+// Spec file: specs/windows/default_environment.table
 
 #include <osquery/tests/integration/tables/helper.h>
 
 namespace osquery {
 namespace table_tests {
 
-class diskInfo : public testing::Test {
+class defaultEnvironment : public testing::Test {
  protected:
   void SetUp() override {
     setUpEnvironment();
   }
 };
 
-TEST_F(diskInfo, test_sanity) {
+TEST_F(defaultEnvironment, test_sanity) {
   auto const data = execute_query("select * from default_environment");
 
   ASSERT_GE(data.size(), 0ul);


### PR DESCRIPTION
Adds the `default_environment` table, which contains rows of default environment variables added to each process on initialization by Windows.

This table proxies and extrapolates its contents from the `registry` table.