### PR TITLE
Intel ME table refactor

### DIFF
--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -341,8 +341,6 @@ osquery::Status getDeviceInterfacePath(
   }
 
   dev_interface_path = std::move(path);
-  path.clear();
-
   return osquery::Status::success();
 }
 

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -15,8 +15,8 @@
 // clang-format off
 #include <osquery/utils/system/system.h>
 #include <SetupAPI.h>
-
 // clang-format on
+
 #include <initguid.h>
 #include <tchar.h>
 
@@ -67,6 +67,10 @@ const std::vector<std::uint8_t> kGetFirmareVersionCommandForInterfaceType2 = {
 const std::uint32_t kGetFirmareVersionCommandForInterfaceType2Reply =
     0x00000001U;
 
+// It is best to generate a report of your own system using the Intel
+// detection tool and then match the versions with the returned data.
+// The tool can be found here:
+// https://downloadcenter.intel.com/download/27150/INTEL-SA-00086-Detection-Tool
 struct IntelMEInformation final {
   struct HECIVersion final {
     std::uint8_t major{0U};

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <array>
+#include <chrono>
 #include <cstring>
 #include <memory>
 #include <unordered_set>

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -27,6 +27,9 @@
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/tables/system/intel_me.hpp>
 
+// The AMT documentation can be found at the following address:
+// https://software.intel.com/sites/manageability/AMT_Implementation_and_Reference_Guide/default.htm
+
 namespace osquery {
 namespace {
 DEFINE_GUID(HECI_INTERFACE_GUID,

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -279,7 +279,7 @@ osquery::Status getDeviceInformationSet(DeviceInformationSet& dev_info_set,
   }
 
   dev_info_set.reset(handle);
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status getDeviceInterfacePath(
@@ -341,7 +341,7 @@ osquery::Status getDeviceInterfacePath(
   dev_interface_path = std::move(path);
   path.clear();
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status enumerateHECIDeviceInterfacePaths(
@@ -398,7 +398,7 @@ osquery::Status enumerateHECIDeviceInterfacePaths(
   dev_path_list = std::move(path_list);
   path_list.clear();
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status openDeviceInterface(DeviceHandle& device_handle,
@@ -420,7 +420,7 @@ osquery::Status openDeviceInterface(DeviceHandle& device_handle,
   }
 
   device_handle.reset(device);
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status queryHECIVersion(IntelMEInformation& intel_me_info,
@@ -451,7 +451,7 @@ osquery::Status queryHECIVersion(IntelMEInformation& intel_me_info,
   intel_me_info.heci_version.hotfix = response.at(2);
 
   std::memcpy(&intel_me_info.heci_version.build, response.data() + 3U, 2U);
-  return Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status sendConnectDeviceCommand(
@@ -517,7 +517,7 @@ osquery::Status sendConnectDeviceCommand(
 
   std::memcpy(&protocol_information.version, base_ptr, 1U);
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status connectToHECIInterface(IntelMEInformation& intel_me_info,
@@ -553,7 +553,7 @@ osquery::Status createEvent(EventHandle& event) {
     event.reset(h);
   }
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status sendHECIMessage(HANDLE device,
@@ -595,7 +595,7 @@ osquery::Status sendHECIMessage(HANDLE device,
         "Not all the bytes in the message could be correctly transferred");
   }
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status receiveHECIMessage(std::vector<std::uint8_t>& buffer,
@@ -641,7 +641,7 @@ osquery::Status receiveHECIMessage(std::vector<std::uint8_t>& buffer,
   temp_buffer.resize(static_cast<std::size_t>(bytes_transferred));
   buffer = std::move(temp_buffer);
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status queryFirmwareVersionForInterfaceTypes0And1(
@@ -723,7 +723,7 @@ osquery::Status queryFirmwareVersionForInterfaceTypes0And1(
 
   intel_me_info.fw_version = fw_version;
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status queryFirmwareVersionForInterfaceType2(
@@ -799,7 +799,7 @@ osquery::Status queryFirmwareVersionForInterfaceType2(
   base_ptr += 2U;
 
   intel_me_info.fw_version = fw_version;
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 
 osquery::Status queryFirmwareVersion(IntelMEInformation& intel_me_info,
@@ -849,7 +849,7 @@ osquery::Status queryIntelMEDeviceInterface(
     return status;
   }
 
-  return osquery::Status(0);
+  return osquery::Status::success();
 }
 } // namespace
 

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -877,11 +877,13 @@ void getHECIDriverVersion(QueryData& results) {
       continue;
     }
 
+    // It useful to dump some information to the user in case something
+    // goes wrong with this table; it is of great help to developers when
+    // looking for a similar piece of hardware to reproduce the bug
     VLOG(1) << printIntelMEVersion(intel_me_info);
 
     // Do not dump the whole structures; just get the essential version
-    // information
-    // and ignore the rest
+    // information and ignore the rest
     std::string version = {};
 
     switch (intel_me_info.interface_type) {
@@ -913,7 +915,7 @@ void getHECIDriverVersion(QueryData& results) {
     }
 
     default: {
-      LOG(ERROR) << "Invalid interface type";
+      LOG(ERROR) << "Unrecognized Intel ME protocol/interface type";
       break;
     }
     }

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -363,7 +363,7 @@ osquery::Status enumerateHECIDeviceInterfacePaths(
   // for each device interface
   std::unordered_set<std::string> path_list;
 
-  for (DWORD member_index = 0U; true; member_index++) {
+  for (DWORD member_index = 0U;; member_index++) {
     SP_DEVICE_INTERFACE_DATA dev_interface = {};
     dev_interface.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 


### PR DESCRIPTION
This PR implements a more correct query protocol for communicating with the driver. Due to this, the patch will also fix compatibility issues with older Windows versions (< 10).

EDIT: I made a lot of guessing and many tests to get this to work. It is working fine on my machines, but it would be nice if someone could compile this patch and test it. Thanks!

EDIT 2: This should fix issue #3247 

# Tests

## Laptop computer running Windows 7 with the following Sandy Bridge processor: Intel Core i5-2410M

```
PS C:\Users\Claudio\Desktop> .\osqueryi.exe --verbose
I0227 19:31:33.643203  6752 init.cpp:416] osquery initialized [version=2.5.3-954-g3701ecae]
I0227 19:31:33.643203  6752 extensions.cpp:343] Could not autoload extensions: Failed reading: \ProgramData\osquery\extensions.load
I0227 19:31:33.653203  6752 database.cpp:563] Checking database version for migration
I0227 19:31:33.653203  6752 database.cpp:587] Performing migration: 0 -> 1
I0227 19:31:33.653203  6752 database.cpp:619] Migration 0 -> 1 successfully completed!
I0227 19:31:33.653203  6752 database.cpp:587] Performing migration: 1 -> 2
I0227 19:31:33.653203  6752 database.cpp:619] Migration 1 -> 2 successfully completed!
I0227 19:31:33.663203  6752 auto_constructed_tables.cpp:86] Removing stale ATC entries
I0227 19:31:33.663203  6752 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
I0227 19:31:33.663203  6752 init.cpp:688] Error reading config: config file does not exist: \ProgramData\osquery\osquery.conf
I0227 19:31:33.673203  6752 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
I0227 19:31:33.663203   372 interface.cpp:265] Extension manager service starting: \\.\pipe\shell.em
Using a â†[1mvirtual databaseâ†[0m. Need help, type '.help'
osquery> SELECT * FROM intel_me_info;
I0227 19:31:35.784206  6752 intel_me.cpp:875] HECI Version: 7.0.0.1144 Protocol Version: 1 Max Message Length: 1024 Interface type: Type0 VersionTypes0And1 { CODE { Major: 7 Minor: 0 Build number: 1197 Hotfix: 4 } NFTP { Major: 7 Minor: 0 Build number: 1197 Hotfix: 4 } }
+------------+
| version    |
+------------+
| 7.0.4.1197 |
+------------+
osquery> .q
```

## Desktop computer running Windows 10 with the following Skylake processor: Intel Core i5-6600K

```
PS C:\Users\alessandro> .\osqueryi.exe --verbose
I0227 20:27:17.047209  9224 init.cpp:416] osquery initialized [version=2.5.3-954-g3701ecae]
I0227 20:27:17.048568  9224 extensions.cpp:343] Could not autoload extensions: Failed reading: \ProgramData\osquery\extensions.load
I0227 20:27:17.048902  9224 database.cpp:563] Checking database version for migration
I0227 20:27:17.049029  9224 database.cpp:587] Performing migration: 0 -> 1
I0227 20:27:17.049158  9224 database.cpp:619] Migration 0 -> 1 successfully completed!
I0227 20:27:17.049296  9224 database.cpp:587] Performing migration: 1 -> 2
I0227 20:27:17.049419  9224 database.cpp:619] Migration 1 -> 2 successfully completed!
I0227 20:27:17.049551  6612 interface.cpp:265] Extension manager service starting: \\.\pipe\shell.em
I0227 20:27:17.049551  9224 auto_constructed_tables.cpp:86] Removing stale ATC entries
I0227 20:27:17.050549  9224 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
I0227 20:27:17.050549  9224 init.cpp:688] Error reading config: config file does not exist: \ProgramData\osquery\osquery.conf
I0227 20:27:17.050549  9224 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
Using a virtual database. Need help, type '.help'
osquery> SELECT * FROM intel_me_info;
I0227 20:27:22.622819  9224 intel_me.cpp:875] HECI Version: 11.7.0.1045 Protocol Version: 1 Max Message Length: 2048 Interface type: Type0 VersionTypes0And1 { CODE { Major: 11 Minor: 8 Build number: 3425 Hotfix: 50 } NFTP { Major: 11 Minor: 8 Build number: 3425 Hotfix: 50 } FITC { Major: 11 Minor: 8 Build number: 3425 Hotfix: 50 } }
+--------------+
| version      |
+--------------+
| 11.8.50.3425 |
+--------------+
osquery> .q
```

## Laptop computer running Windows 10 with the following Skylake processor: Intel Core i3-6006U

```
PS C:\Utenti\Alessandra> .\osqueryi.exe --verbose
I0227 19:54:10.544358 13716 init.cpp:416] osquery initialized [version=2.5.3-954-g3701ecae]
I0227 19:54:10.545768 13716 extensions.cpp:343] Could not autoload extensions: Failed reading: \ProgramData\osquery\extensions.load
I0227 19:54:10.545768 13716 database.cpp:563] Checking database version for migration
I0227 19:54:10.545768 13716 database.cpp:587] Performing migration: 0 -> 1
I0227 19:54:10.545768 13716 database.cpp:619] Migration 0 -> 1 successfully completed!
I0227 19:54:10.546770 13716 database.cpp:587] Performing migration: 1 -> 2
I0227 19:54:10.546849 13716 database.cpp:619] Migration 1 -> 2 successfully completed!
I0227 19:54:10.546849 13716 auto_constructed_tables.cpp:86] Removing stale ATC entries
I0227 19:54:10.546849 15028 interface.cpp:265] Extension manager service starting: \\.\pipe\shell.em
I0227 19:54:10.547894 13716 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
I0227 19:54:10.547894 13716 init.cpp:688] Error reading config: config file does not exist: \ProgramData\osquery\osquery.conf
I0227 19:54:10.547894 13716 killswitch.cpp:60] enum osquery::Killswitch::IsEnabledError 1 (Cannot call registry item: )
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> SELECT * FROM intel_me_info;
I0227 19:54:24.266716 13716 intel_me.cpp:875] HECI Version: 11.0.0.1181 Protocol Version: 1 Max Message Length: 2048 Interface type: Type0 VersionTypes0And1 { CODE { Major: 11 Minor: 0 Build number: 1001 Hotfix: 1 } NFTP { Major: 11 Minor: 0 Build number: 1001 Hotfix: 1 } FITC { Major: 11 Minor: 0 Build number: 1205 Hotfix: 0 } }
+-------------+
| version     |
+-------------+
| 11.0.1.1001 |
+-------------+
osquery> .q
```