### PR TITLE
Add osquery_platform table

### DIFF
--- a/osquery/tables/system/tests/darwin/platform_tests.cpp
+++ b/osquery/tables/system/tests/darwin/platform_tests.cpp
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/config/tests/test_utils.h>
+#include <osquery/core/sql/query_data.h>
+
+namespace osquery {
+  namespace tables {
+
+    class PlatformTableTest : public testing::Test {};
+
+    TEST_F(PlatformTableTest, test_platform_table) {
+      SQL results("select * from osquery_platform");
+      ASSERT_EQ(results.rows().size(), 1U);
+      EXPECT_EQ(rows[0].at("posix"), 1);
+      EXPECT_EQ(rows[0].at("windows"), 0);
+      EXPECT_EQ(rows[0].at("bsd"), 1);
+      EXPECT_EQ(rows[0].at("linux"), 0);
+      EXPECT_EQ(rows[0].at("osx"), 1);
+      EXPECT_EQ(rows[0].at("is_freebsd"), 0);
+    }
+  } // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/darwin/platform_tests.cpp
+++ b/osquery/tables/system/tests/darwin/platform_tests.cpp
@@ -12,19 +12,19 @@
 #include <osquery/core/sql/query_data.h>
 
 namespace osquery {
-  namespace tables {
+namespace tables {
 
-    class PlatformTableTest : public testing::Test {};
+class PlatformTableTest : public testing::Test {};
 
-    TEST_F(PlatformTableTest, test_platform_table) {
-      SQL results("select * from osquery_platform");
-      ASSERT_EQ(results.rows().size(), 1U);
-      EXPECT_EQ(rows[0].at("posix"), 1);
-      EXPECT_EQ(rows[0].at("windows"), 0);
-      EXPECT_EQ(rows[0].at("bsd"), 1);
-      EXPECT_EQ(rows[0].at("linux"), 0);
-      EXPECT_EQ(rows[0].at("osx"), 1);
-      EXPECT_EQ(rows[0].at("is_freebsd"), 0);
-    }
-  } // namespace tables
+TEST_F(PlatformTableTest, test_platform_table) {
+  SQL results("select * from osquery_platform");
+  ASSERT_EQ(results.rows().size(), 1U);
+  EXPECT_EQ(rows[0].at("posix"), 1);
+  EXPECT_EQ(rows[0].at("windows"), 0);
+  EXPECT_EQ(rows[0].at("bsd"), 1);
+  EXPECT_EQ(rows[0].at("linux"), 0);
+  EXPECT_EQ(rows[0].at("osx"), 1);
+  EXPECT_EQ(rows[0].at("is_freebsd"), 0);
+}
+} // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/linux/platform_tests.cpp
+++ b/osquery/tables/system/tests/linux/platform_tests.cpp
@@ -12,19 +12,19 @@
 #include <osquery/core/sql/query_data.h>
 
 namespace osquery {
-  namespace tables {
+namespace tables {
 
-    class PlatformTableTest : public testing::Test {};
+class PlatformTableTest : public testing::Test {};
 
-    TEST_F(PlatformTableTest, test_platform_table) {
-      SQL results("select * from osquery_platform");
-      ASSERT_EQ(results.rows().size(), 1U);
-      EXPECT_EQ(rows[0].at("posix"), 1);
-      EXPECT_EQ(rows[0].at("windows"), 0);
-      EXPECT_EQ(rows[0].at("bsd"), 0);
-      EXPECT_EQ(rows[0].at("linux"), 1);
-      EXPECT_EQ(rows[0].at("osx"), 0);
-      EXPECT_EQ(rows[0].at("freebsd"), 0);
-    }
-  } // namespace tables
+TEST_F(PlatformTableTest, test_platform_table) {
+  SQL results("select * from osquery_platform");
+  ASSERT_EQ(results.rows().size(), 1U);
+  EXPECT_EQ(rows[0].at("posix"), 1);
+  EXPECT_EQ(rows[0].at("windows"), 0);
+  EXPECT_EQ(rows[0].at("bsd"), 0);
+  EXPECT_EQ(rows[0].at("linux"), 1);
+  EXPECT_EQ(rows[0].at("osx"), 0);
+  EXPECT_EQ(rows[0].at("freebsd"), 0);
+}
+} // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/linux/platform_tests.cpp
+++ b/osquery/tables/system/tests/linux/platform_tests.cpp
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/config/tests/test_utils.h>
+#include <osquery/core/sql/query_data.h>
+
+namespace osquery {
+  namespace tables {
+
+    class PlatformTableTest : public testing::Test {};
+
+    TEST_F(PlatformTableTest, test_platform_table) {
+      SQL results("select * from osquery_platform");
+      ASSERT_EQ(results.rows().size(), 1U);
+      EXPECT_EQ(rows[0].at("posix"), 1);
+      EXPECT_EQ(rows[0].at("windows"), 0);
+      EXPECT_EQ(rows[0].at("bsd"), 0);
+      EXPECT_EQ(rows[0].at("linux"), 1);
+      EXPECT_EQ(rows[0].at("osx"), 0);
+      EXPECT_EQ(rows[0].at("freebsd"), 0);
+    }
+  } // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/posix/platform_tests.cpp
+++ b/osquery/tables/system/tests/posix/platform_tests.cpp
@@ -1,0 +1,26 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/config/tests/test_utils.h>
+#include <osquery/core/sql/query_data.h>
+
+namespace osquery {
+  namespace tables {
+
+    class PlatformTableTest : public testing::Test {};
+
+    TEST_F(PlatformTableTest, test_platform_table) {
+      SQL results("select * from osquery_platform");
+      ASSERT_EQ(results.rows().size(), 1U);
+      EXPECT_EQ(rows[0].at("posix"), 1);
+      EXPECT_EQ(rows[0].at("windows"), 0);
+    }
+  } // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/posix/platform_tests.cpp
+++ b/osquery/tables/system/tests/posix/platform_tests.cpp
@@ -12,15 +12,15 @@
 #include <osquery/core/sql/query_data.h>
 
 namespace osquery {
-  namespace tables {
+namespace tables {
 
-    class PlatformTableTest : public testing::Test {};
+class PlatformTableTest : public testing::Test {};
 
-    TEST_F(PlatformTableTest, test_platform_table) {
-      SQL results("select * from osquery_platform");
-      ASSERT_EQ(results.rows().size(), 1U);
-      EXPECT_EQ(rows[0].at("posix"), 1);
-      EXPECT_EQ(rows[0].at("windows"), 0);
-    }
-  } // namespace tables
+TEST_F(PlatformTableTest, test_platform_table) {
+  SQL results("select * from osquery_platform");
+  ASSERT_EQ(results.rows().size(), 1U);
+  EXPECT_EQ(rows[0].at("posix"), 1);
+  EXPECT_EQ(rows[0].at("windows"), 0);
+}
+} // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -353,5 +353,12 @@ TEST_F(HashTableTest, test_cache_updates) {
   EXPECT_NE(rows[0].at("md5"), contentMd5);
   EXPECT_EQ(rows[0].at("md5"), badContentMd5);
 }
+
+class PlatformTableTest : public testing::Test {};
+
+TEST_F(PlatformTableTest, test_platform_table) {
+  SQL results("select * from osquery_platform");
+  ASSERT_EQ(results.rows().size(), 1U);
+}
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -20,6 +20,7 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 #include <osquery/utils/info/version.h>
+#include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/macros/macros.h>
 
 namespace osquery {
@@ -221,6 +222,24 @@ QueryData genOsqueryInfo(QueryContext& context) {
 
   std::string instance;
   r["instance_id"] = (getInstanceUUID(instance)) ? instance : "";
+
+  results.push_back(r);
+  return results;
+}
+
+QueryData genOsqueryPlatform(QueryContext& context) {
+  QueryData results;
+
+  Row r;
+
+  r["platform_bitmask"] = INTEGER(static_cast<uint64_t>(kPlatformType));
+
+  r["posix"] = INTEGER(isPlatform(PlatformType::TYPE_POSIX));
+  r["windows"] = INTEGER(isPlatform(PlatformType::TYPE_WINDOWS));
+  r["bsd"] = INTEGER(isPlatform(PlatformType::TYPE_BSD));
+  r["linux"] = INTEGER(isPlatform(PlatformType::TYPE_LINUX));
+  r["osx"] = INTEGER(isPlatform(PlatformType::TYPE_OSX));
+  r["freebsd"] = INTEGER(isPlatform(PlatformType::TYPE_FREEBSD));
 
   results.push_back(r);
   return results;

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -19,8 +19,8 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
-#include <osquery/utils/info/version.h>
 #include <osquery/utils/info/platform_type.h>
+#include <osquery/utils/info/version.h>
 #include <osquery/utils/macros/macros.h>
 
 namespace osquery {

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -34,7 +34,8 @@ enum class PlatformType {
 };
 
 /// The build-defined set of platform types.
-constexpr PlatformType kPlatformType = static_cast<PlatformType>(0u
+constexpr PlatformType kPlatformType = static_cast<PlatformType>(
+    0u
 #ifdef POSIX
     | static_cast<unsigned>(PlatformType::TYPE_POSIX)
 #endif

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -20,6 +20,9 @@ namespace osquery {
  *
  * CMake, or the build tooling, will generate a OSQUERY_PLATFORM_MASK and pass
  * it to the library compile only.
+ *
+ * This infomation can be queried through the osquery_platform
+ * table. Please update than when new PlatformTypes are added.
  */
 enum class PlatformType {
   TYPE_POSIX = 0x01,

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -837,6 +837,7 @@ osquery_gentable_cxx_library(
         "utility/osquery_flags.table",
         "utility/osquery_info.table",
         "utility/osquery_packs.table",
+        "utility/osquery_platform.table",
         "utility/osquery_registry.table",
         "utility/osquery_schedule.table",
         "utility/time.table",

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -59,6 +59,7 @@ function(generateNativeTables)
     utility/osquery_flags.table
     utility/osquery_info.table
     utility/osquery_packs.table
+    utility/osquery_platform.table
     utility/osquery_registry.table
     utility/osquery_schedule.table
     utility/time.table

--- a/specs/utility/osquery_platform.table
+++ b/specs/utility/osquery_platform.table
@@ -1,0 +1,13 @@
+table_name("osquery_platform")
+description("Platform information about osquery. See platform_type.h for definitions.")
+schema([
+    Column("platform_bitmask", INTEGER, "The osquery platform bitmask"),
+    Column("posix", INTEGER, "Is this posix compatible"),
+    Column("windows", INTEGER, "Is this windows compatible"),
+    Column("bsd", INTEGER, "Is this BSD compatible"),
+    Column("linux", INTEGER, "Is this linux compatible"),
+    Column("osx", INTEGER, "Is this osx compatible"),
+    Column("freebsd", INTEGER, "Is this freebsd compatible")
+])
+attributes(utility=True)
+implementation("osquery@genOsqueryPlatform")


### PR DESCRIPTION
This adds an osquery_platform table. This exposes the existing PlatformType bit mask, as well as boolean columns for the existing `isPlatform` types.