### PR TITLE
(Windows) New table: connectivity

### DIFF
--- a/osquery/tables/networking/BUCK
+++ b/osquery/tables/networking/BUCK
@@ -99,6 +99,7 @@ osquery_cxx_library(
             WINDOWS,
             [
                 "windows/arp_cache.cpp",
+                "windows/connectivity.cpp",
                 "windows/interfaces.cpp",
                 "windows/process_open_sockets.cpp",
                 "windows/routes.cpp",

--- a/osquery/tables/networking/CMakeLists.txt
+++ b/osquery/tables/networking/CMakeLists.txt
@@ -22,7 +22,7 @@ function(generateOsqueryTablesNetworking)
     etc_services.cpp
     listening_ports.cpp
   )
-  
+
   if(DEFINED PLATFORM_POSIX)
     list(APPEND source_files
       posix/dns_resolvers.cpp
@@ -61,6 +61,7 @@ function(generateOsqueryTablesNetworking)
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND source_files
       windows/arp_cache.cpp
+      windows/connectivity.cpp
       windows/interfaces.cpp
       windows/process_open_sockets.cpp
       windows/routes.cpp

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -58,6 +58,7 @@ QueryData genConnectivity(QueryContext& context) {
 
   mgr->Release();
   results.push_back(std::move(r));
+  return results;
 }
 
 } // namespace tables

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -49,6 +49,7 @@ QueryData genConnectivity(QueryContext& context) {
   r["ipv6_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCAL_NETWORK);
   r["ipv6_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
 
+  mgr->Release();
   results.push_back(std::move(r));
 }
 

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -1,0 +1,56 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <string>
+
+#include <windows.h>
+#include <netlistmgr.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+
+namespace osquery {
+namespace tables {
+
+QueryData genConnectivity(QueryContext& context) {
+  QueryData results;
+  Row r;
+
+  INetworkListManager *mgr = nullptr;
+  HRESULT res = CoCreateInstance(CLSID_NetworkListManager, NULL, CLSCTX_ALL, IID_NetworkListManager, &mgr);
+
+  if (res != S_OK) {
+    TLOG << "Failed to instantiate INetworkListManager";
+    return results;
+  }
+
+  NLM_CONNECTIVITY connectivity = 0;
+  res = mgr->GetConnectivity(&connectivity);
+
+  if (res != S_OK) {
+    TLOG << "GetConnectivity() failed";
+    return results;
+  }
+
+  r["disconnected"] = INTEGER(connectivity & NLM_CONNECTIVITY_DISCONNECTED);
+  r["ipv4_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
+  r["ipv6_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
+  r["ipv4_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
+  r["ipv4_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCAL_NETWORK);
+  r["ipv4_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
+  r["ipv6_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
+  r["ipv6_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCAL_NETWORK);
+  r["ipv6_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+
+  results.push_back(std::move(r));
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -20,7 +20,6 @@ namespace tables {
 
 QueryData genConnectivity(QueryContext& context) {
   QueryData results;
-  Row r;
 
   INetworkListManager* mgr = nullptr;
   HRESULT res = CoCreateInstance(CLSID_NetworkListManager,
@@ -39,9 +38,11 @@ QueryData genConnectivity(QueryContext& context) {
 
   if (res != S_OK) {
     TLOG << "GetConnectivity() failed";
+    mgr->Release();
     return results;
   }
 
+  Row r;
   r["disconnected"] =
       INTEGER(bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
   r["ipv4_no_traffic"] =

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -42,17 +42,17 @@ QueryData genConnectivity(QueryContext& context) {
     return results;
   }
 
-  r["disconnected"] = bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED);
-  r["ipv4_no_traffic"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
-  r["ipv6_no_traffic"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
-  r["ipv4_subnet"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
+  r["disconnected"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
+  r["ipv4_no_traffic"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC));
+  r["ipv6_no_traffic"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC));
+  r["ipv4_subnet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET));
   r["ipv4_local_network"] =
-      bool(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
-  r["ipv4_internet"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
-  r["ipv6_subnet"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK));
+  r["ipv4_internet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET));
+  r["ipv6_subnet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET));
   r["ipv6_local_network"] =
-      bool(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
-  r["ipv6_internet"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK));
+  r["ipv6_internet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET));
 
   mgr->Release();
   results.push_back(std::move(r));

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -42,19 +42,21 @@ QueryData genConnectivity(QueryContext& context) {
     return results;
   }
 
-  r["disconnected"] = INTEGER(connectivity & NLM_CONNECTIVITY_DISCONNECTED);
+  r["disconnected"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
   r["ipv4_no_traffic"] =
-      INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC));
   r["ipv6_no_traffic"] =
-      INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
-  r["ipv4_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC));
+  r["ipv4_subnet"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET));
   r["ipv4_local_network"] =
-      INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
-  r["ipv4_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
-  r["ipv6_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK));
+  r["ipv4_internet"] =
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET));
+  r["ipv6_subnet"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET));
   r["ipv6_local_network"] =
-      INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
-  r["ipv6_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK));
+  r["ipv6_internet"] =
+      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET));
 
   mgr->Release();
   results.push_back(std::move(r));

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -8,13 +8,12 @@
 
 #include <string>
 
-#include <windows.h>
 #include <netlistmgr.h>
+#include <windows.h>
 
 #include <osquery/core.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-
 
 namespace osquery {
 namespace tables {
@@ -23,8 +22,12 @@ QueryData genConnectivity(QueryContext& context) {
   QueryData results;
   Row r;
 
-  INetworkListManager *mgr = nullptr;
-  HRESULT res = CoCreateInstance(CLSID_NetworkListManager, NULL, CLSCTX_ALL, IID_INetworkListManager, &mgr);
+  INetworkListManager* mgr = nullptr;
+  HRESULT res = CoCreateInstance(CLSID_NetworkListManager,
+                                 NULL,
+                                 CLSCTX_ALL,
+                                 IID_INetworkListManager,
+                                 reinterpret_cast<void*>(&mgr));
 
   if (res != S_OK) {
     TLOG << "Failed to instantiate INetworkListManager";
@@ -40,13 +43,17 @@ QueryData genConnectivity(QueryContext& context) {
   }
 
   r["disconnected"] = INTEGER(connectivity & NLM_CONNECTIVITY_DISCONNECTED);
-  r["ipv4_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
-  r["ipv6_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
+  r["ipv4_no_traffic"] =
+      INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
+  r["ipv6_no_traffic"] =
+      INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
   r["ipv4_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
-  r["ipv4_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
+  r["ipv4_local_network"] =
+      INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
   r["ipv4_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
   r["ipv6_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
-  r["ipv6_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
+  r["ipv6_local_network"] =
+      INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
   r["ipv6_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
 
   mgr->Release();

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -42,17 +42,22 @@ QueryData genConnectivity(QueryContext& context) {
     return results;
   }
 
-  r["disconnected"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
-  r["ipv4_no_traffic"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC));
-  r["ipv6_no_traffic"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC));
+  r["disconnected"] =
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
+  r["ipv4_no_traffic"] =
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC));
+  r["ipv6_no_traffic"] =
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC));
   r["ipv4_subnet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET));
   r["ipv4_local_network"] =
       INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK));
-  r["ipv4_internet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET));
+  r["ipv4_internet"] =
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET));
   r["ipv6_subnet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET));
   r["ipv6_local_network"] =
       INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK));
-  r["ipv6_internet"] = INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET));
+  r["ipv6_internet"] =
+      INTEGER(bool(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET));
 
   mgr->Release();
   results.push_back(std::move(r));

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -42,21 +42,17 @@ QueryData genConnectivity(QueryContext& context) {
     return results;
   }
 
-  r["disconnected"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_DISCONNECTED));
-  r["ipv4_no_traffic"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC));
-  r["ipv6_no_traffic"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC));
-  r["ipv4_subnet"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET));
+  r["disconnected"] = bool(connectivity & NLM_CONNECTIVITY_DISCONNECTED);
+  r["ipv4_no_traffic"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
+  r["ipv6_no_traffic"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
+  r["ipv4_subnet"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
   r["ipv4_local_network"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK));
-  r["ipv4_internet"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET));
-  r["ipv6_subnet"] = INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET));
+      bool(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
+  r["ipv4_internet"] = bool(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
+  r["ipv6_subnet"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
   r["ipv6_local_network"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK));
-  r["ipv6_internet"] =
-      INTEGER(!!(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET));
+      bool(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
+  r["ipv6_internet"] = bool(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
 
   mgr->Release();
   results.push_back(std::move(r));

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -27,14 +27,14 @@ QueryData genConnectivity(QueryContext& context) {
                                  NULL,
                                  CLSCTX_ALL,
                                  IID_INetworkListManager,
-                                 reinterpret_cast<void*>(&mgr));
+                                 reinterpret_cast<void**>(&mgr));
 
   if (res != S_OK) {
     TLOG << "Failed to instantiate INetworkListManager";
     return results;
   }
 
-  NLM_CONNECTIVITY connectivity = 0;
+  NLM_CONNECTIVITY connectivity;
   res = mgr->GetConnectivity(&connectivity);
 
   if (res != S_OK) {

--- a/osquery/tables/networking/windows/connectivity.cpp
+++ b/osquery/tables/networking/windows/connectivity.cpp
@@ -24,7 +24,7 @@ QueryData genConnectivity(QueryContext& context) {
   Row r;
 
   INetworkListManager *mgr = nullptr;
-  HRESULT res = CoCreateInstance(CLSID_NetworkListManager, NULL, CLSCTX_ALL, IID_NetworkListManager, &mgr);
+  HRESULT res = CoCreateInstance(CLSID_NetworkListManager, NULL, CLSCTX_ALL, IID_INetworkListManager, &mgr);
 
   if (res != S_OK) {
     TLOG << "Failed to instantiate INetworkListManager";
@@ -43,10 +43,10 @@ QueryData genConnectivity(QueryContext& context) {
   r["ipv4_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_NOTRAFFIC);
   r["ipv6_no_traffic"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_NOTRAFFIC);
   r["ipv4_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_SUBNET);
-  r["ipv4_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCAL_NETWORK);
+  r["ipv4_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_LOCALNETWORK);
   r["ipv4_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV4_INTERNET);
   r["ipv6_subnet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_SUBNET);
-  r["ipv6_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCAL_NETWORK);
+  r["ipv6_local_network"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_LOCALNETWORK);
   r["ipv6_internet"] = INTEGER(connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
 
   mgr->Release();

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -737,6 +737,10 @@ osquery_gentable_cxx_library(
             "windows",
         ),
         (
+            "windows/connectivity.table",
+            "windows",
+        ),
+        (
             "windows/logical_drives.table",
             "windows",
         ),

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -261,6 +261,7 @@ function(generateNativeTables)
     "windows/physical_disk_performance.table:windows"
     "windows/autoexec.table:windows"
     "windows/windows_security_products.table:windows"
+    "windows/connectivity.table:windows"
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,freebsd"
   )

--- a/specs/windows/connectivity.table
+++ b/specs/windows/connectivity.table
@@ -1,0 +1,18 @@
+table_name("connectivity")
+description("Provides the overall system's network state.")
+schema([
+    Column("disconnected", INTEGER, "True if the all interfaces are not connected to any network"),
+    Column("ipv4_no_traffic", INTEGER, "True if any interface is connected via IPv4, but has seen no traffic"),
+    Column("ipv6_no_traffic", INTEGER, "True if any interface is connected via IPv6, but has seen no traffic"),
+    Column("ipv4_subnet", INTEGER, "True if any interface is connected to the local subnet via IPv4"),
+    Column("ipv4_local_network", INTEGER, "True if any interface is connected to a routed network via IPv4"),
+    Column("ipv4_internet", INTEGER, "True if any interface is connected to the Internet via IPv4"),
+    Column("ipv6_subnet", INTEGER, "True if any interface is connected to the local subnet via IPv6"),
+    Column("ipv6_local_network", INTEGER, "True if any interface is connected to a routed network via IPv6"),
+    Column("ipv6_internet", INTEGER, "True if any interface is connected to the Internet via IPv6"),
+])
+implementation("connectivity@genConnectivity")
+examples([
+    "select * from connectivity",
+    "select ipv4_internet from connectivity",
+])

--- a/tests/integration/tables/BUCK
+++ b/tests/integration/tables/BUCK
@@ -258,6 +258,7 @@ osquery_cxx_test(
                 "autoexec.cpp",
                 "certificates.cpp",
                 "chocolatey_packages.cpp",
+                "connectivity.cpp",
                 "cpu_info.cpp",
                 "disk_info.cpp",
                 "drivers.cpp",

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -259,6 +259,7 @@ function(generateTestsIntegrationTablesTestsTest)
       authenticode.cpp
       autoexec.cpp
       certificates.cpp
+      connectivity.cpp
       chocolatey_packages.cpp
       cpu_info.cpp
       disk_info.cpp

--- a/tests/integration/tables/connectivity.cpp
+++ b/tests/integration/tables/connectivity.cpp
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+// Sanity check integration test for connectivity
+// Spec file: specs/windows/connectivity.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class connectivity : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(connectivity, test_sanity) {
+  auto const data = execute_query("select * from connectivity");
+
+  ASSERT_EQ(data.size(), 1ul);
+
+  ValidatatioMap row_map = {
+      {"disconnected", IntType},
+      {"ipv4_no_traffic", IntType},
+      {"ipv6_no_traffic", IntType},
+      {"ipv4_subnet", IntType},
+      {"ipv4_local_network", IntType},
+      {"ipv4_internet", IntType},
+      {"ipv6_subnet", IntType},
+      {"ipv6_local_network", IntType},
+      {"ipv6_internet", IntType},
+  };
+
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/connectivity.cpp
+++ b/tests/integration/tables/connectivity.cpp
@@ -26,7 +26,7 @@ TEST_F(connectivity, test_sanity) {
 
   ASSERT_EQ(data.size(), 1ul);
 
-  ValidatatioMap row_map = {
+  ValidatationMap row_map = {
       {"disconnected", IntType},
       {"ipv4_no_traffic", IntType},
       {"ipv6_no_traffic", IntType},

--- a/tests/integration/tables/connectivity.cpp
+++ b/tests/integration/tables/connectivity.cpp
@@ -26,7 +26,7 @@ TEST_F(connectivity, test_sanity) {
 
   ASSERT_EQ(data.size(), 1ul);
 
-  ValidatationMap row_map = {
+  ValidationMap row_map = {
       {"disconnected", IntType},
       {"ipv4_no_traffic", IntType},
       {"ipv6_no_traffic", IntType},


### PR DESCRIPTION
Introduces the `connectivity` table, which contains the current system-wide (i.e., all interface) network state:

```
osquery> select * from connectivity;
+--------------+-----------------+-----------------+-------------+--------------------+---------------+-------------+--------------------+---------------+
| disconnected | ipv4_no_traffic | ipv6_no_traffic | ipv4_subnet | ipv4_local_network | ipv4_internet | ipv6_subnet | ipv6_local_network | ipv6_internet |
+--------------+-----------------+-----------------+-------------+--------------------+---------------+-------------+--------------------+---------------+
| 0            | 0               | 1               | 0           | 0                  | 1             | 0           | 0                  | 0             |
+--------------+-----------------+-----------------+-------------+--------------------+---------------+-------------+--------------------+---------------+
```

Each column corresponds to an `NLM_CONNECTIVITY` flag: https://docs.microsoft.com/en-us/windows/desktop/api/netlistmgr/ne-netlistmgr-nlm_connectivity