### PR TITLE
core/windows/wmi: Add ability to exec methods on WMI results

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -96,6 +96,9 @@ function(generateOsqueryCore)
   add_test(NAME osquery_core_tests_querytests-test COMMAND osquery_core_tests_querytests-test)
   add_test(NAME osquery_core_tests_processtests-test COMMAND osquery_core_tests_processtests-test)
 
+  if(DEFINED PLATFORM_WINDOWS)
+    add_test(NAME osquery_core_tests_wmitests-test COMMAND osquery_core_tests_wmitests-test)
+  endif()
 endfunction()
 
 osqueryCoreMain()

--- a/osquery/core/tests/BUCK
+++ b/osquery/core/tests/BUCK
@@ -6,7 +6,7 @@
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
-load("//tools/build_defs/oss/osquery:platforms.bzl", "POSIX")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "POSIX", "WINDOWS")
 
 osquery_cxx_test(
     name = "flags_tests",
@@ -135,5 +135,26 @@ osquery_cxx_test(
         osquery_target("plugins/config:tls_config"),
         osquery_target("tests:helper"),
         osquery_target("specs:tables"),
+    ],
+)
+
+osquery_cxx_test(
+    name = "wmi_tests",
+    platform_srcs = [
+        (
+            WINDOWS,
+            [
+                "windows/wmi_tests.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/config/tests:test_utils"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/remote/enroll:tls_enroll"),
+        osquery_target("osquery/sql/tests:sql_test_utils"),
+        osquery_target("osquery/utils/info:info"),
+        osquery_target("tests:helper"),
     ],
 )

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ function(generateOsqueryCoreTestsWmitestsTest)
     osquery_sql_tests_sqltestutils
     osquery_utils_info
     tests_helper
+    thirdparty_googletest
   )
 endfunction()
 

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -11,6 +11,10 @@ function(osqueryCoreTestsMain)
   generateOsqueryCoreTestsWatcherpermissionstestsTest()
   generateOsqueryCoreTestsQuerytestsTest()
   generateOsqueryCoreTestsProcesstestsTest()
+
+  if(DEFINED PLATFORM_WINDOWS)
+    generateOsqueryCoreTestsWmitestsTest()
+  endif()
 endfunction()
 
 function(generateOsqueryCoreTestsFlagstestsTest)
@@ -136,6 +140,19 @@ function(generateOsqueryCoreTestsQuerytestsTest)
     plugins_config_tlsconfig
     specs_tables
     thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsqueryCoreTestsWmitestsTest)
+  add_osquery_executable(osquery_core_tests_wmitests-test windows/wmi_tests.cpp)
+
+  target_link_libraries(osquery_core_tests_wmitests-test PRIVATE
+    osquery_core
+    osquery_config_tests_testutils
+    osquery_remote_enroll_tlsenroll
+    osquery_sql_tests_sqltestutils
+    osquery_utils_info
+    tests_helper
   )
 endfunction()
 

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ function(generateOsqueryCoreTestsWmitestsTest)
   add_osquery_executable(osquery_core_tests_wmitests-test windows/wmi_tests.cpp)
 
   target_link_libraries(osquery_core_tests_wmitests-test PRIVATE
+    osquery_cxx_settings
     osquery_core
     osquery_config_tests_testutils
     osquery_remote_enroll_tlsenroll

--- a/osquery/core/tests/windows/wmi_tests.cpp
+++ b/osquery/core/tests/windows/wmi_tests.cpp
@@ -1,0 +1,121 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <sstream>
+
+#include <boost/algorithm/string.hpp>
+
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/system.h>
+#include <osquery/utils/system/env.h>
+#include <osquery/config/tests/test_utils.h>
+
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+
+class WmiTests : public testing::Test {
+protected:
+  void SetUp() {
+    Initializer::platformSetup();
+  }
+};
+
+TEST_F(WmiTests, test_methodcall_inparams) {
+  auto windir = getEnvVar("WINDIR");
+  EXPECT_TRUE(windir);
+
+  std::stringstream ss;
+  ss << "SELECT * FROM Win32_Directory WHERE Name = \"" << *windir << "\"";
+
+  auto query = ss.str();
+
+  // This is dirty, we need to escape the WINDIR path
+  boost::replace_all(query, "\\", "\\\\");
+
+  WmiRequest req(query);
+  const auto& wmiResults = req.results();
+
+  EXPECT_EQ(wmiResults.size(), 1);
+
+  WmiMethodArgs args;
+  WmiResultItem out;
+
+  // Setting in-parameter Permissions to 1 (FILE_LIST_DIRECTORY)
+  // The odd part here is that despite Permissions requiring a uint32 in
+  // MSDN documentation, this is actually a VT_BSTR...
+  args.Put<std::string>("Permissions", "1");
+
+  // Get the first item off the result vector since we should only have one.
+  auto &resultItem = wmiResults.front();
+  auto status = resultItem.ExecMethod("GetEffectivePermission", args, out);
+
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  bool retval = false;
+
+  // The reutnr value is stored in the ReturnValue key within the out-parameter object
+  status = out.GetBool("ReturnValue", retval);
+
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  // As both Administrator and normal user, we should be able to FILE_LIST_DIRECTORY on WINDIR
+  EXPECT_TRUE(retval);
+}
+
+TEST_F(WmiTests, test_methodcall_outparams) {
+  WmiRequest req("SELECT * FROM Win32_Process WHERE Name = \"wininit.exe\"");
+  const auto& wmiResults = req.results();
+
+  // We should expect only one wininit.exe instance?
+  EXPECT_EQ(wmiResults.size(), 1);
+
+  WmiMethodArgs args;
+  WmiResultItem out;
+
+  // Get the first item off the result vector since we should only have one.
+  auto &resultItem = wmiResults.front();
+  auto status = resultItem.ExecMethod("GetOwner", args, out);
+
+  // We use this check to make debugging errors faster
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  long retval;
+
+  // For some reason, this is a VT_I4
+  status = out.GetLong("ReturnValue", retval);
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  // Make sure the return value is successful
+  EXPECT_EQ(retval, 0);
+
+  std::string user_name;
+  std::string domain_name;
+
+  status = out.GetString("User", user_name);
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  status = out.GetString("Domain", domain_name);
+  EXPECT_EQ(status.getMessage(), "OK");
+  EXPECT_TRUE(status.ok());
+
+  // Only NT AUTHORITY\SYSTEM should be running wininit.exe
+  EXPECT_EQ(user_name, "SYSTEM");
+  EXPECT_EQ(domain_name, "NT AUTHORITY");
+}
+
+}

--- a/osquery/core/tests/windows/wmi_tests.cpp
+++ b/osquery/core/tests/windows/wmi_tests.cpp
@@ -14,17 +14,17 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/config/tests/test_utils.h>
 #include <osquery/core.h>
 #include <osquery/system.h>
 #include <osquery/utils/system/env.h>
-#include <osquery/config/tests/test_utils.h>
 
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
 
 class WmiTests : public testing::Test {
-protected:
+ protected:
   void SetUp() {
     Initializer::platformSetup();
   }
@@ -56,7 +56,7 @@ TEST_F(WmiTests, test_methodcall_inparams) {
   args.Put<std::string>("Permissions", "1");
 
   // Get the first item off the result vector since we should only have one.
-  auto &resultItem = wmiResults.front();
+  auto& resultItem = wmiResults.front();
   auto status = resultItem.ExecMethod("GetEffectivePermission", args, out);
 
   EXPECT_EQ(status.getMessage(), "OK");
@@ -64,13 +64,15 @@ TEST_F(WmiTests, test_methodcall_inparams) {
 
   bool retval = false;
 
-  // The reutnr value is stored in the ReturnValue key within the out-parameter object
+  // The reutnr value is stored in the ReturnValue key within the out-parameter
+  // object
   status = out.GetBool("ReturnValue", retval);
 
   EXPECT_EQ(status.getMessage(), "OK");
   EXPECT_TRUE(status.ok());
 
-  // As both Administrator and normal user, we should be able to FILE_LIST_DIRECTORY on WINDIR
+  // As both Administrator and normal user, we should be able to
+  // FILE_LIST_DIRECTORY on WINDIR
   EXPECT_TRUE(retval);
 }
 
@@ -85,7 +87,7 @@ TEST_F(WmiTests, test_methodcall_outparams) {
   WmiResultItem out;
 
   // Get the first item off the result vector since we should only have one.
-  auto &resultItem = wmiResults.front();
+  auto& resultItem = wmiResults.front();
   auto status = resultItem.ExecMethod("GetOwner", args, out);
 
   // We use this check to make debugging errors faster
@@ -118,4 +120,4 @@ TEST_F(WmiTests, test_methodcall_outparams) {
   EXPECT_EQ(domain_name, "NT AUTHORITY");
 }
 
-}
+} // namespace osquery

--- a/osquery/core/tests/windows/wmi_tests.cpp
+++ b/osquery/core/tests/windows/wmi_tests.cpp
@@ -64,7 +64,7 @@ TEST_F(WmiTests, test_methodcall_inparams) {
 
   bool retval = false;
 
-  // The reutnr value is stored in the ReturnValue key within the out-parameter
+  // The return value is stored in the ReturnValue key within the out-parameter
   // object
   status = out.GetBool("ReturnValue", retval);
 

--- a/osquery/core/tests/windows/wmi_tests.cpp
+++ b/osquery/core/tests/windows/wmi_tests.cpp
@@ -57,7 +57,7 @@ TEST_F(WmiTests, test_methodcall_inparams) {
 
   // Get the first item off the result vector since we should only have one.
   auto& resultItem = wmiResults.front();
-  auto status = resultItem.ExecMethod("GetEffectivePermission", args, out);
+  auto status = req.ExecMethod(resultItem, "GetEffectivePermission", args, out);
 
   EXPECT_EQ(status.getMessage(), "OK");
   EXPECT_TRUE(status.ok());
@@ -88,7 +88,7 @@ TEST_F(WmiTests, test_methodcall_outparams) {
 
   // Get the first item off the result vector since we should only have one.
   auto& resultItem = wmiResults.front();
-  auto status = resultItem.ExecMethod("GetOwner", args, out);
+  auto status = req.ExecMethod(resultItem, "GetOwner", args, out);
 
   // We use this check to make debugging errors faster
   EXPECT_EQ(status.getMessage(), "OK");

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -39,7 +39,7 @@ Status WmiMethodArgs::Put<unsigned int>(const std::string& name,
   var.ulVal = value;
 
   arguments.insert(std::pair<std::string, VARIANT>(name, var));
-  return Status(0);
+  return Status::success();
 }
 
 template <>
@@ -55,7 +55,7 @@ Status WmiMethodArgs::Put<std::string>(const std::string& name,
   }
 
   arguments.insert(std::pair<std::string, VARIANT>(name, var));
-  return Status(0);
+  return Status::success();
 }
 
 /// Utility function to help turn a property value into BSTR
@@ -102,7 +102,7 @@ Status WmiResultItem::GetBool(const std::string& name, bool& ret) const {
   }
   ret = value.boolVal == VARIANT_TRUE ? true : false;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetDateTime(const std::string& name,
@@ -153,7 +153,7 @@ Status WmiResultItem::GetDateTime(const std::string& name,
   SysFreeString(filetime_str);
   dt->Release();
 
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetUChar(const std::string& name,
@@ -170,7 +170,7 @@ Status WmiResultItem::GetUChar(const std::string& name,
   }
   ret = value.bVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetUnsignedShort(const std::string& name,
@@ -188,7 +188,7 @@ Status WmiResultItem::GetUnsignedShort(const std::string& name,
   }
   ret = value.uiVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetUnsignedInt32(const std::string& name,
@@ -206,7 +206,7 @@ Status WmiResultItem::GetUnsignedInt32(const std::string& name,
   }
   ret = value.uiVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetLong(const std::string& name, long& ret) const {
@@ -222,7 +222,7 @@ Status WmiResultItem::GetLong(const std::string& name, long& ret) const {
   }
   ret = value.lVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetUnsignedLong(const std::string& name,
@@ -239,7 +239,7 @@ Status WmiResultItem::GetUnsignedLong(const std::string& name,
   }
   ret = value.lVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetLongLong(const std::string& name,
@@ -256,7 +256,7 @@ Status WmiResultItem::GetLongLong(const std::string& name,
   }
   ret = value.lVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetUnsignedLongLong(const std::string& name,
@@ -273,7 +273,7 @@ Status WmiResultItem::GetUnsignedLongLong(const std::string& name,
   }
   ret = value.lVal;
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetString(const std::string& name,
@@ -292,7 +292,7 @@ Status WmiResultItem::GetString(const std::string& name,
   }
   ret = bstrToString(value.bstrVal);
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::GetVectorOfStrings(const std::string& name,
@@ -320,7 +320,7 @@ Status WmiResultItem::GetVectorOfStrings(const std::string& name,
   }
   SafeArrayUnaccessData(value.parray);
   VariantClear(&value);
-  return Status(0);
+  return Status::success();
 }
 
 Status WmiResultItem::ExecMethod(const std::string& method,
@@ -421,7 +421,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   out_result.result_.reset(out_params);
   out_result.services_ = services_;
 
-  return Status(0);
+  return Status::success();
 }
 
 WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -478,7 +478,7 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
 
     hr = enum_->Next(WBEM_INFINITE, 1, &result, &result_count);
     if (SUCCEEDED(hr) && result_count > 0) {
-      results_.emplace_back(WmiResultItem(result, locator_, services_));
+      results_.emplace_back(result, locator_, services_);
     }
   }
 

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -94,11 +94,11 @@ Status WmiResultItem::GetBool(const std::string& name, bool& ret) const {
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
 
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_BOOL) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.boolVal == VARIANT_TRUE ? true : false;
   VariantClear(&value);
@@ -113,12 +113,12 @@ Status WmiResultItem::GetDateTime(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving datetime from WMI query result.");
+    return Status::failure("Error retrieving datetime from WMI query result.");
   }
 
   if (value.vt != VT_BSTR) {
     VariantClear(&value);
-    return Status(-1, "Expected VT_BSTR, got something else.");
+    return Status::failure("Expected VT_BSTR, got something else.");
   }
 
   ISWbemDateTime* dt = nullptr;
@@ -126,7 +126,7 @@ Status WmiResultItem::GetDateTime(const std::string& name,
       CLSID_SWbemDateTime, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dt));
   if (!SUCCEEDED(hr)) {
     VariantClear(&value);
-    return Status(-1, "Failed to create SWbemDateTime object.");
+    return Status::failure("Failed to create SWbemDateTime object.");
   }
 
   hr = dt->put_Value(value.bstrVal);
@@ -134,14 +134,14 @@ Status WmiResultItem::GetDateTime(const std::string& name,
 
   if (!SUCCEEDED(hr)) {
     dt->Release();
-    return Status(-1, "Failed to set SWbemDateTime value.");
+    return Status::failure("Failed to set SWbemDateTime value.");
   }
 
   BSTR filetime_str = {0};
   hr = dt->GetFileTime(is_local ? VARIANT_TRUE : VARIANT_FALSE, &filetime_str);
   if (!SUCCEEDED(hr)) {
     dt->Release();
-    return Status(-1, "GetFileTime failed.");
+    return Status::failure("GetFileTime failed.");
   }
 
   ULARGE_INTEGER ui = {};
@@ -162,11 +162,11 @@ Status WmiResultItem::GetUChar(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_UI1) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.bVal;
   VariantClear(&value);
@@ -180,11 +180,11 @@ Status WmiResultItem::GetUnsignedShort(const std::string& name,
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
 
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_UI2) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.uiVal;
   VariantClear(&value);
@@ -198,11 +198,11 @@ Status WmiResultItem::GetUnsignedInt32(const std::string& name,
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
 
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_UINT) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.uiVal;
   VariantClear(&value);
@@ -214,11 +214,11 @@ Status WmiResultItem::GetLong(const std::string& name, long& ret) const {
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_I4) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.lVal;
   VariantClear(&value);
@@ -231,11 +231,11 @@ Status WmiResultItem::GetUnsignedLong(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_UI4) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.lVal;
   VariantClear(&value);
@@ -248,11 +248,11 @@ Status WmiResultItem::GetLongLong(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_I8) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.lVal;
   VariantClear(&value);
@@ -265,11 +265,11 @@ Status WmiResultItem::GetUnsignedLongLong(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_UI8) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = value.lVal;
   VariantClear(&value);
@@ -283,12 +283,12 @@ Status WmiResultItem::GetString(const std::string& name,
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
     ret = "";
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_BSTR) {
     ret = "";
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   ret = bstrToString(value.bstrVal);
   VariantClear(&value);
@@ -301,11 +301,11 @@ Status WmiResultItem::GetVectorOfStrings(const std::string& name,
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    return Status(-1, "Error retrieving data from WMI query.");
+    return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != (VT_BSTR | VT_ARRAY)) {
     VariantClear(&value);
-    return Status(-1, "Invalid data type returned.");
+    return Status::failure("Invalid data type returned.");
   }
   long lbound, ubound;
   SafeArrayGetLBound(value.parray, 1, &lbound);
@@ -337,7 +337,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
 
   BSTR wmi_class_name = WbemClassObjectPropToBSTR(*this, "__CLASS");
   if (wmi_class_name == nullptr) {
-    return Status(-1, "Class name out of memory");
+    return Status::failure("Class name out of memory");
   }
 
   // GetObject obtains a CIM Class definition object
@@ -345,7 +345,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   SysFreeString(wmi_class_name);
 
   if (FAILED(hr)) {
-    return Status(-1, "Failed to GetObject");
+    return Status::failure("Failed to GetObject");
   }
 
   class_obj.reset(raw);
@@ -355,7 +355,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   // we don't use result_
   hr = class_obj->GetMethod(property_name.c_str(), 0, &raw, nullptr);
   if (FAILED(hr)) {
-    return Status(-1, "Failed to GetMethod");
+    return Status::failure("Failed to GetMethod");
   }
 
   in_def.reset(raw);
@@ -368,7 +368,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   if (in_def != nullptr) {
     hr = in_def->SpawnInstance(0, &raw);
     if (FAILED(hr)) {
-      return Status(-1, "Failed to SpawnInstance");
+      return Status::failure("Failed to SpawnInstance");
     }
     args_inst.reset(raw);
 
@@ -381,7 +381,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
 
       hr = args_inst->Put(args_name.c_str(), 0, &pVal, 0);
       if (FAILED(hr)) {
-        return Status(-1, "Failed to Put arguments");
+        return Status::failure("Failed to Put arguments");
       }
     }
   }
@@ -392,13 +392,13 @@ Status WmiResultItem::ExecMethod(const std::string& method,
 
   auto wmi_meth_name = SysAllocString(property_name.c_str());
   if (wmi_meth_name == nullptr) {
-    return Status(-1, "Out of memory");
+    return Status::failure("Out of memory");
   }
 
   auto wmi_obj_path = WbemClassObjectPropToBSTR(*this, "__PATH");
   if (wmi_obj_path == nullptr) {
     SysFreeString(wmi_meth_name);
-    return Status(-1, "Out of memory");
+    return Status::failure("Out of memory");
   }
 
   // Execute the WMI method, the return value and out-params all exist in
@@ -415,7 +415,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   SysFreeString(wmi_obj_path);
 
   if (FAILED(hr)) {
-    return Status(-1, "Failed to ExecMethod");
+    return Status::failure("Failed to ExecMethod");
   }
 
   out_result.result_.reset(out_params);

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -419,7 +419,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   }
 
   out_result.result_.reset(out_params);
-  out_result.services_.reset(services_);
+  out_result.services_ = services_;
 
   return Status::success();
 }

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -485,8 +485,4 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
 
   status_ = Status(0);
 }
-
-WmiRequest::~WmiRequest() {
-  results_.clear();
-}
 } // namespace osquery

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -448,7 +448,6 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
   if (hr != S_OK) {
     return;
   }
-
   locator_.reset(locator);
 
   IWbemServices* services = nullptr;
@@ -457,7 +456,6 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
   if (hr != S_OK) {
     return;
   }
-
   services_.reset(services);
 
   IEnumWbemClassObject* wbem_enum = nullptr;
@@ -480,7 +478,7 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
 
     hr = enum_->Next(WBEM_INFINITE, 1, &result, &result_count);
     if (SUCCEEDED(hr) && result_count > 0) {
-      results_.push_back(WmiResultItem(result, locator_, services_));
+      results_.emplace_back(WmiResultItem(result, locator_, services_));
     }
   }
 

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -419,6 +419,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   }
 
   out_result.result_.reset(out_params);
+  out_result.locator_ = locator_;
   out_result.services_ = services_;
 
   return Status::success();
@@ -479,7 +480,7 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
 
     hr = enum_->Next(WBEM_INFINITE, 1, &result, &result_count);
     if (SUCCEEDED(hr) && result_count > 0) {
-      results_.push_back(WmiResultItem(result, services_));
+      results_.push_back(WmiResultItem(result, locator_, services_));
     }
   }
 

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -419,7 +419,7 @@ Status WmiResultItem::ExecMethod(const std::string& method,
   }
 
   out_result.result_.reset(out_params);
-  out_result.services_ = services_;
+  out_result.services_.reset(services_);
 
   return Status::success();
 }

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -15,6 +15,60 @@
 
 namespace osquery {
 
+WmiMethodArgs::WmiMethodArgs(WmiMethodArgs&& src) {
+  std::swap(arguments, src.arguments);
+}
+
+WmiMethodArgs::~WmiMethodArgs() {
+  for (const auto &p : arguments) {
+    auto var = p.second;
+
+    // BSTR variant types have a raw pointer we need to clean up
+    if (var.vt == VT_BSTR && var.bstrVal != nullptr) {
+      SysFreeString(var.bstrVal);
+      var.bstrVal = nullptr;
+    }
+  }
+}
+
+template <>
+Status WmiMethodArgs::Put<unsigned int>(const std::string& name, const unsigned int& value) {
+  VARIANT var;
+  var.vt = VT_UI4;
+  var.ulVal = value;
+
+  arguments.insert(std::pair<std::string, VARIANT>(name, var));
+  return Status(0);
+}
+
+template <>
+Status WmiMethodArgs::Put<std::string>(const std::string& name, const std::string& value) {
+  auto wide_value = stringToWstring(value);
+
+  VARIANT var;
+  var.vt = VT_BSTR;
+  var.bstrVal = SysAllocString(wide_value.c_str());
+  if (var.bstrVal == nullptr) {
+    return Status::failure("Out of memory");
+  }
+
+  arguments.insert(std::pair<std::string, VARIANT>(name, var));
+  return Status(0);
+}
+
+/// Utility function to help turn a property value into BSTR
+inline BSTR WbemClassObjectPropToBSTR(const WmiResultItem& item,
+                                      const std::string& property) {
+  std::string value;
+  auto status = item.GetString(property, value);
+  if (!status.ok()) {
+    return nullptr;
+  }
+
+  auto wstr_value = stringToWstring(value);
+  return SysAllocString(wstr_value.c_str());
+}
+
 void WmiResultItem::PrintType(const std::string& name) const {
   std::wstring property_name = stringToWstring(name);
   VARIANT value;
@@ -267,6 +321,94 @@ Status WmiResultItem::GetVectorOfStrings(const std::string& name,
   return Status(0);
 }
 
+Status WmiResultItem::ExecMethod(const std::string& method, const WmiMethodArgs& args, WmiResultItem& out_result) const {
+  std::wstring property_name = stringToWstring(method);
+
+  IWbemClassObject *raw = nullptr;
+
+  std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> in_def{nullptr, impl::wmiObjectDeleter};
+  std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> class_obj{nullptr, impl::wmiObjectDeleter};
+
+  BSTR wmi_class_name = WbemClassObjectPropToBSTR(*this, "__CLASS");
+  if (wmi_class_name == nullptr) {
+    return Status(-1, "Class name out of memory");
+  }
+
+  // GetObject obtains a CIM Class definition object
+  HRESULT hr = services_->GetObject(wmi_class_name, 0, nullptr, &raw, nullptr);
+  SysFreeString(wmi_class_name);
+
+  if (FAILED(hr)) {
+    return Status(-1, "Failed to GetObject");
+  }
+
+  class_obj.reset(raw);
+  raw = nullptr;
+
+  // GetMethod only works on CIM class definition objects. This is why
+  // we don't use result_
+  hr = class_obj->GetMethod(property_name.c_str(), 0, &raw, nullptr);
+  if (FAILED(hr)) {
+    return Status(-1, "Failed to GetMethod");
+  }
+
+  in_def.reset(raw);
+  raw = nullptr;
+
+  std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> args_inst{nullptr, impl::wmiObjectDeleter};
+
+  // in_def can be nullptr if the chosen method has no in-parameters
+  if (in_def != nullptr) {
+    hr = in_def->SpawnInstance(0, &raw);
+    if (FAILED(hr)) {
+      return Status(-1, "Failed to SpawnInstance");
+    }
+    args_inst.reset(raw);
+
+    // Build up the WMI method call arguments
+    for (const auto &p : args.GetArguments()) {
+      const auto &name = p.first;
+      auto pVal = p.second;
+
+      auto args_name = stringToWstring(name);
+
+      hr = args_inst->Put(args_name.c_str(), 0, &pVal, 0);
+      if (FAILED(hr)) {
+        return Status(-1, "Failed to Put arguments");
+      }
+    }
+  }
+
+  // In order to execute a WMI method, we need to know the specific object name and method name
+  IWbemClassObject *out_params = nullptr;
+
+  auto wmi_meth_name = SysAllocString(property_name.c_str());
+  if (wmi_meth_name == nullptr) {
+    return Status(-1, "Out of memory");
+  }
+
+  auto wmi_obj_path = WbemClassObjectPropToBSTR(*this, "__PATH");
+  if (wmi_obj_path == nullptr) {
+    SysFreeString(wmi_meth_name);
+    return Status(-1, "Out of memory");
+  }
+
+  // Execute the WMI method, the return value and out-params all exist in out_params
+  hr = services_->ExecMethod(wmi_obj_path, wmi_meth_name, 0, nullptr, args_inst.get(), &out_params, nullptr);
+
+  SysFreeString(wmi_meth_name);
+  SysFreeString(wmi_obj_path);
+
+  if (FAILED(hr)) {
+    return Status(-1, "Failed to ExecMethod");
+  }
+
+  out_result.result_.reset(out_params);
+  out_result.services_ = services_;
+
+  return Status(0);
+}
+
 WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
   std::wstring wql = stringToWstring(query);
 
@@ -319,7 +461,7 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
 
     hr = enum_->Next(WBEM_INFINITE, 1, &result, &result_count);
     if (SUCCEEDED(hr) && result_count > 0) {
-      results_.push_back(WmiResultItem(result));
+      results_.push_back(WmiResultItem(result, services_));
     }
   }
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -216,7 +216,6 @@ class WmiRequest {
   explicit WmiRequest(const std::string& query,
                       BSTR nspace = (BSTR)L"ROOT\\CIMV2");
   WmiRequest(WmiRequest&& src) = default;
-  ~WmiRequest();
 
   const std::vector<WmiResultItem>& results() const {
     return results_;

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -29,7 +29,6 @@ namespace impl {
 const auto wmiObjectDeleter = [](auto* ptr) {
   if (ptr != nullptr) {
     ptr->Release();
-    delete ptr;
   }
 };
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -83,9 +83,10 @@ class WmiResultItem {
 
   explicit WmiResultItem(IWbemClassObject* result,
                          std::shared_ptr<IWbemLocator> locator,
-                         std::shared_ptr<IWbemServices> services)
-      : locator_(locator), services_(services) {
+                         std::shared_ptr<IWbemServices> services) {
     result_.reset(result);
+    locator_ = locator;
+    services_ = services;
   }
 
   WmiResultItem(WmiResultItem&& src) = default;

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -83,10 +83,9 @@ class WmiResultItem {
 
   explicit WmiResultItem(IWbemClassObject* result,
                          std::shared_ptr<IWbemLocator> locator,
-                         std::shared_ptr<IWbemServices> services) {
+                         std::shared_ptr<IWbemServices> services)
+      : locator_(locator), services_(services) {
     result_.reset(result);
-    locator_ = locator;
-    services_ = services;
   }
 
   WmiResultItem(WmiResultItem&& src) = default;

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -203,8 +203,7 @@ class WmiResultItem {
  private:
   std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> result_{
       nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
-                                           impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{nullptr, impl::wmiObjectDeleter};
 };
 
 /**
@@ -240,7 +239,6 @@ class WmiRequest {
       nullptr, impl::wmiObjectDeleter};
   std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{
       nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
-                                           impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{nullptr, impl::wmiObjectDeleter};
 };
 } // namespace osquery

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -24,21 +24,18 @@ namespace osquery {
 
 using WmiMethodArgsMap = std::unordered_map<std::string, VARIANT>;
 
-namespace impl{
+namespace impl {
 
-const auto wmiObjectDeleter = [](auto *ptr) {
-  ptr->Release();
-};
+const auto wmiObjectDeleter = [](auto* ptr) { ptr->Release(); };
 
 } // namespace impl
 
-
 /**
-* @brief Helper class to construct and hold the arguments of a WMI method call
-*
-* This class is used somewhat exclusively with WmiResultItem::ExecMethod. It
-* simplifies the construction of a WMI method argument
-*/
+ * @brief Helper class to construct and hold the arguments of a WMI method call
+ *
+ * This class is used somewhat exclusively with WmiResultItem::ExecMethod. It
+ * simplifies the construction of a WMI method argument
+ */
 class WmiMethodArgs {
  public:
   WmiMethodArgs() {}
@@ -49,19 +46,19 @@ class WmiMethodArgs {
   ~WmiMethodArgs();
 
   /**
-  * @brief Helper function to add items to the arguments of a WMI method call
-  * 
-  * @returns Status indicating the success of the query
-  */ 
-  template <typename T> Status Put(const std::string& name, const T& value);
+   * @brief Helper function to add items to the arguments of a WMI method call
+   *
+   * @returns Status indicating the success of the query
+   */
+  template <typename T>
+  Status Put(const std::string& name, const T& value);
 
   /**
-  * @brief Getter method for argument dictionary
-  *
-  * @returns Map containing name, value pairs of the arguments
-  */
-  const WmiMethodArgsMap &GetArguments() const
-  {
+   * @brief Getter method for argument dictionary
+   *
+   * @returns Map containing name, value pairs of the arguments
+   */
+  const WmiMethodArgsMap& GetArguments() const {
     return arguments;
   }
 
@@ -70,12 +67,12 @@ class WmiMethodArgs {
 };
 
 /**
-* @brief Helper class to hold 1 result object from a WMI request
-*
-* This class is used to return to the user just the base type
-* and value requested from WMI. The class is largely used by
-* the WmiRequest class defined below
-*/
+ * @brief Helper class to hold 1 result object from a WMI request
+ *
+ * This class is used to return to the user just the base type
+ * and value requested from WMI. The class is largely used by
+ * the WmiRequest class defined below
+ */
 class WmiResultItem {
  public:
   explicit WmiResultItem() {}
@@ -89,18 +86,19 @@ class WmiResultItem {
   WmiResultItem(WmiResultItem&& src) = default;
 
   /**
-  * @brief Windows WMI Helper function to print the type associated with results
-  *
-  * @returns None.
-  */
+   * @brief Windows WMI Helper function to print the type associated with
+   * results
+   *
+   * @returns None.
+   */
   void PrintType(const std::string& name) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a bool result from a WMI
-  * query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a bool result from a WMI
+   * query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetBool(const std::string& name, bool& ret) const;
 
   /**
@@ -122,94 +120,95 @@ class WmiResultItem {
   Status GetUChar(const std::string& name, unsigned char& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve an unsigned Short from WMI
-  * query
-  *
-  * @returns Status indiciating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve an unsigned Short from WMI
+   * query
+   *
+   * @returns Status indiciating the success of the query
+   */
   Status GetUnsignedShort(const std::string& name, unsigned short& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve an unsigned 32 bit integer
-  * from a WMI query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve an unsigned 32 bit integer
+   * from a WMI query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetUnsignedInt32(const std::string& name, unsigned int& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a Long result from a WMI
-  * query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a Long result from a WMI
+   * query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetLong(const std::string& name, long& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve an unsigned Long result from
-  * a WMI query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve an unsigned Long result from
+   * a WMI query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetUnsignedLong(const std::string& name, unsigned long& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a Long Long result from a WMI
-  * query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a Long Long result from a
+   * WMI query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetLongLong(const std::string& name, long long& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve an Unsigned Long Long result
-  * from a WMI query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve an Unsigned Long Long result
+   * from a WMI query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetUnsignedLongLong(const std::string& name,
                              unsigned long long& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a String result from a WMI
-  * query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a String result from a WMI
+   * query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetString(const std::string& name, std::string& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a vector of String result
-  * from
-  * a WMI query
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a vector of String result
+   * from
+   * a WMI query
+   *
+   * @returns Status indicating the success of the query
+   */
   Status GetVectorOfStrings(const std::string& name,
                             std::vector<std::string>& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to execute a WMI method call from the
-  * resultant object
-  *
-  * @returns Status indicating the success of the query
-  */
+   * @brief Windows WMI Helper function to execute a WMI method call from the
+   * resultant object
+   *
+   * @returns Status indicating the success of the query
+   */
   Status ExecMethod(const std::string& method,
                     const WmiMethodArgs& args,
                     WmiResultItem& out_result) const;
 
  private:
-
-  std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> result_{nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr), impl::wmiObjectDeleter};
+  std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> result_{
+      nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
+                                           impl::wmiObjectDeleter};
 };
 
 /**
-* @brief Windows wrapper class for querying WMI
-*
-* This class abstracts away the WMI querying logic and
-* will return WMI results given a query string.
-*/
+ * @brief Windows wrapper class for querying WMI
+ *
+ * This class abstracts away the WMI querying logic and
+ * will return WMI results given a query string.
+ */
 class WmiRequest {
  public:
   explicit WmiRequest(const std::string& query,
@@ -222,10 +221,10 @@ class WmiRequest {
   }
 
   /**
-  * @brief Getter for retrieving the status of a WMI Request
-  *
-  * @returns the status of the WMI request.
-  */
+   * @brief Getter for retrieving the status of a WMI Request
+   *
+   * @returns the status of the WMI request.
+   */
   Status getStatus() const {
     return status_;
   }
@@ -234,8 +233,11 @@ class WmiRequest {
   Status status_;
   std::vector<WmiResultItem> results_;
 
-  std::unique_ptr<IWbemLocator, decltype(impl::wmiObjectDeleter)> locator_{nullptr, impl::wmiObjectDeleter};
-  std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr), impl::wmiObjectDeleter};
+  std::unique_ptr<IWbemLocator, decltype(impl::wmiObjectDeleter)> locator_{
+      nullptr, impl::wmiObjectDeleter};
+  std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{
+      nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
+                                           impl::wmiObjectDeleter};
 };
-}
+} // namespace osquery

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -26,7 +26,11 @@ using WmiMethodArgsMap = std::unordered_map<std::string, VARIANT>;
 
 namespace impl {
 
-const auto wmiObjectDeleter = [](auto* ptr) { ptr->Release(); };
+const auto wmiObjectDeleter = [](auto* ptr) {
+  if (ptr != nullptr) {
+    ptr->Release();
+  }
+};
 
 } // namespace impl
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -82,8 +82,9 @@ class WmiResultItem {
   explicit WmiResultItem() {}
 
   explicit WmiResultItem(IWbemClassObject* result,
+                         std::shared_ptr<IWbemLocator> locator,
                          std::shared_ptr<IWbemServices> services)
-      : services_(services) {
+      : locator_(locator), services_(services) {
     result_.reset(result);
   }
 
@@ -203,6 +204,8 @@ class WmiResultItem {
  private:
   std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> result_{
       nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemLocator> locator_{static_cast<IWbemLocator*>(nullptr),
+                                         impl::wmiObjectDeleter};
   std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
                                            impl::wmiObjectDeleter};
 };
@@ -236,10 +239,10 @@ class WmiRequest {
   Status status_;
   std::vector<WmiResultItem> results_;
 
-  std::unique_ptr<IWbemLocator, decltype(impl::wmiObjectDeleter)> locator_{
-      nullptr, impl::wmiObjectDeleter};
   std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{
       nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemLocator> locator_{static_cast<IWbemLocator*>(nullptr),
+                                         impl::wmiObjectDeleter};
   std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
                                            impl::wmiObjectDeleter};
 };

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -29,6 +29,7 @@ namespace impl {
 const auto wmiObjectDeleter = [](auto* ptr) {
   if (ptr != nullptr) {
     ptr->Release();
+    delete ptr;
   }
 };
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -203,7 +203,8 @@ class WmiResultItem {
  private:
   std::unique_ptr<IWbemClassObject, decltype(impl::wmiObjectDeleter)> result_{
       nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
+                                           impl::wmiObjectDeleter};
 };
 
 /**
@@ -239,6 +240,7 @@ class WmiRequest {
       nullptr, impl::wmiObjectDeleter};
   std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{
       nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{nullptr, impl::wmiObjectDeleter};
+  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr),
+                                           impl::wmiObjectDeleter};
 };
 } // namespace osquery

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -79,8 +79,6 @@ class WmiMethodArgs {
  */
 class WmiResultItem {
  public:
-  explicit WmiResultItem() {}
-
   explicit WmiResultItem(IWbemClassObject* result,
                          std::shared_ptr<IWbemServices> services)
       : services_(services) {

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -79,6 +79,8 @@ class WmiMethodArgs {
  */
 class WmiResultItem {
  public:
+  explicit WmiResultItem() {}
+
   explicit WmiResultItem(IWbemClassObject* result,
                          std::shared_ptr<IWbemServices> services)
       : services_(services) {


### PR DESCRIPTION
Hi, this PR adds the ability to execute methods on WMI results for Windows.

An example use case for this would be extending the `bitlocker_info` table to also include the Bitlocker version. This is done by executing the `GetVersion` method of the `Win32_EncryptableVolume` class, which this PR provides the foundation for doing.

At a high level, the main thing this PR does is add the `ExecMethod` method onto the `WmiResultItem` class. This is the interface for executing methods on WMI results. Adding this method required adding a secondary helper class: `WmiMethodArgs`. This helper class is used to hold the arguments to be provided to the result item method.

The `services_` member of `WmiRequest` has been converted to a shared pointer, since it is now being shared with `WmiResultItem`, since it is needed in `WmiResultItem::ExecMethod`.

To see how this infrastructure might be used for the `bitlocker_info` use case, you can take a look at this PR: https://github.com/trailofbits/osquery-pr/pull/9/files#diff-d8c657956b1466ab36306601810495b6

Thank you!

this is a follow on from: https://github.com/osquery/osquery/pull/5492