### PR TITLE
detect encryption of ed25519 ssh keys

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -35,6 +35,7 @@ osquery_cxx_library(
                 "posix/apt_sources.h",
                 "posix/known_hosts.h",
                 "posix/shell_history.h",
+                "posix/ssh_keys.h",
                 "posix/sudoers.h",
                 "posix/sysctl_utils.h",
                 "posix/last.h",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -280,6 +280,7 @@ function(generateOsqueryTablesSystemSystemtable)
       posix/apt_sources.h
       posix/known_hosts.h
       posix/shell_history.h
+      posix/ssh_keys.h
       posix/sudoers.h
       posix/sysctl_utils.h
       posix/last.h
@@ -319,6 +320,11 @@ function(generateOsqueryTablesSystemSystemtable)
 
   if(DEFINED PLATFORM_POSIX)
     add_test(NAME osquery_tables_system_posix_tests-test COMMAND osquery_tables_system_posix_tests-test)
+    add_test(NAME osquery_tables_system_tests_knownhoststests-test COMMAND osquery_tables_system_tests_knownhoststests-test)
+    add_test(NAME osquery_tables_system_tests_shellhistorytests-test COMMAND osquery_tables_system_tests_shellhistorytests-test)
+    add_test(NAME osquery_tables_system_tests_sshkeystests-test COMMAND osquery_tables_system_tests_sshkeystests-test)
+    add_test(NAME osquery_tables_system_tests_sudoerstests-test COMMAND osquery_tables_system_tests_sudoerstests-test)
+    add_test(NAME osquery_tables_system_tests_yumsourcestests-test COMMAND osquery_tables_system_tests_yumsourcestests-test)
     add_test(NAME osquery_tables_system_tests_augeastests-test COMMAND osquery_tables_system_tests_augeastests-test)
     set_tests_properties(
       osquery_tables_system_tests_augeastests-test

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -320,11 +320,6 @@ function(generateOsqueryTablesSystemSystemtable)
 
   if(DEFINED PLATFORM_POSIX)
     add_test(NAME osquery_tables_system_posix_tests-test COMMAND osquery_tables_system_posix_tests-test)
-    add_test(NAME osquery_tables_system_tests_knownhoststests-test COMMAND osquery_tables_system_tests_knownhoststests-test)
-    add_test(NAME osquery_tables_system_tests_shellhistorytests-test COMMAND osquery_tables_system_tests_shellhistorytests-test)
-    add_test(NAME osquery_tables_system_tests_sshkeystests-test COMMAND osquery_tables_system_tests_sshkeystests-test)
-    add_test(NAME osquery_tables_system_tests_sudoerstests-test COMMAND osquery_tables_system_tests_sudoerstests-test)
-    add_test(NAME osquery_tables_system_tests_yumsourcestests-test COMMAND osquery_tables_system_tests_yumsourcestests-test)
     add_test(NAME osquery_tables_system_tests_augeastests-test COMMAND osquery_tables_system_tests_augeastests-test)
     set_tests_properties(
       osquery_tables_system_tests_augeastests-test

--- a/osquery/tables/system/posix/ssh_keys.h
+++ b/osquery/tables/system/posix/ssh_keys.h
@@ -1,0 +1,32 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/query.h>
+#include <osquery/tables.h>
+
+#include <string>
+
+namespace osquery {
+namespace tables {
+
+const std::string kSSHUserKeysDir = ".ssh/";
+
+void genSSHkeyForHosts(const std::string& uid,
+                       const std::string& gid,
+                       const std::string& directory,
+                       QueryData& results);
+
+QueryData getUserSshKeys(QueryContext& context);
+
+} // namespace tables
+} // namespace osquery
+
+// TODOS
+// - Copyright header still Facebook?
+// - Include tests in buck build?
+// - Would like a third-party ssh key parser

--- a/osquery/tables/system/posix/ssh_keys.h
+++ b/osquery/tables/system/posix/ssh_keys.h
@@ -25,8 +25,3 @@ QueryData getUserSshKeys(QueryContext& context);
 
 } // namespace tables
 } // namespace osquery
-
-// TODOS
-// - Copyright header still Facebook?
-// - Include tests in buck build?
-// - Would like a third-party ssh key parser

--- a/osquery/tables/system/posix/ssh_keys.h
+++ b/osquery/tables/system/posix/ssh_keys.h
@@ -14,7 +14,7 @@
 namespace osquery {
 namespace tables {
 
-const std::string kSSHUserKeysDir = ".ssh/";
+extern const std::string kSSHUserKeysDir;
 
 void genSSHkeyForHosts(const std::string& uid,
                        const std::string& gid,

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -26,6 +26,8 @@
 namespace osquery {
 namespace tables {
 
+const std::string kSSHUserKeysDir = ".ssh";
+
 // parsePrivateKey returns true iff the key is valid
 bool parsePrivateKey(std::string& keys_content,
                      int* key_type,
@@ -45,8 +47,7 @@ bool parsePrivateKey(std::string& keys_content,
     return -1; // let openssl know that the passwordCallback failed
   };
 
-  EVP_PKEY* pkey;
-  pkey =
+  auto pkey =
       PEM_read_bio_PrivateKey(bio_stream, nullptr, passwordCallback, nullptr);
   *is_encrypted = encrypted;
   scope_guard::create([=]() {

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -47,7 +47,6 @@ bool isOpenSSHKey(std::string& keys_content) {
 bool isOpenSSHKeyEncrypted(std::string& keys_content) {
   const std::string prefix = keys_content.substr(
       kOpenSshHeader.size() + 1, kOpenSshUnencryptedPrefix.size());
-  printf("%s\n", prefix.c_str());
   return prefix != kOpenSshUnencryptedPrefix;
 }
 

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -39,7 +39,7 @@ bool isEncrypted(std::string& keys_content) {
         kEd25519Header.size(), kEd25519UnencryptedPrefix.size());
     return prefix != kEd25519UnencryptedPrefix;
   }
-  return (keys_content.find("ENCRYPTED") != std::string::npos) ? true : false;
+  return keys_content.find("ENCRYPTED") != std::string::npos;
 }
 
 void genSSHkeyForHosts(const std::string& uid,

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -16,10 +16,31 @@
 #include <osquery/tables/system/system_utils.h>
 #include <osquery/utils/system/system.h>
 
+#include <boost/algorithm/string.hpp>
+
 namespace osquery {
 namespace tables {
 
 const std::string kSSHUserKeysDir = ".ssh/";
+const std::string kEd25519Header = "-----BEGIN OPENSSH PRIVATE KEY-----";
+
+// The first bytes of an OpenSSH key are |key type|length of cipher name|cipher
+// name| so all unencrypted ed25519 keys should start with the value below
+// (encoded in base64) This magic string is
+//  6f 70 65 6e 73 73 68 2d 6b 65 79 2d 76 31 00 00 00 00 04 6e 6f 6e 65
+// |--------------------------------------------|-----------|----------|
+// | o  p  e  n  s  s  h  -  k  e  y  -  v  1 \0|          4| n  o  n e|
+//
+const std::string kEd25519UnencryptedPrefix = "b3BlbnNzaC1rZXktdjEAAAAABG5vbmU";
+
+bool isEncrypted(std::string keys_content) {
+  if (boost::starts_with(keys_content, kEd25519Header)) {
+    const std::string prefix = keys_content.substr(
+        kEd25519Header.size() + 1, kEd25519UnencryptedPrefix.size());
+    return prefix != kEd25519UnencryptedPrefix;
+  }
+  return (keys_content.find("ENCRYPTED") != std::string::npos) ? true : false;
+}
 
 void genSSHkeyForHosts(const std::string& uid,
                        const std::string& gid,
@@ -47,8 +68,7 @@ void genSSHkeyForHosts(const std::string& uid,
       Row r;
       r["uid"] = uid;
       r["path"] = kfile;
-      r["encrypted"] =
-          (keys_content.find("ENCRYPTED") != std::string::npos) ? "1" : "0";
+      r["encrypted"] = isEncrypted(keys_content) ? "1" : "0";
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -13,33 +13,83 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
+#include <osquery/tables/system/posix/ssh_keys.h>
 #include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/scope_guard.h>
 #include <osquery/utils/system/system.h>
 
 #include <boost/algorithm/string.hpp>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
 
 namespace osquery {
 namespace tables {
 
-const std::string kSSHUserKeysDir = ".ssh/";
-const std::string kEd25519Header = "-----BEGIN OPENSSH PRIVATE KEY-----\n";
-
-// The first bytes of an OpenSSH key are |key type|length of cipher name|cipher
-// name| so all unencrypted ed25519 keys should start with the value below
-// (encoded in base64) This magic string is
-//  6f 70 65 6e 73 73 68 2d 6b 65 79 2d 76 31 00 00 00 00 04 6e 6f 6e 65
-// |--------------------------------------------|-----------|----------|
-// | o  p  e  n  s  s  h  -  k  e  y  -  v  1 \0|          4| n  o  n e|
-//
-const std::string kEd25519UnencryptedPrefix = "b3BlbnNzaC1rZXktdjEAAAAABG5vbmU";
-
-bool isEncrypted(std::string& keys_content) {
-  if (boost::starts_with(keys_content, kEd25519Header)) {
-    const std::string prefix = keys_content.substr(
-        kEd25519Header.size(), kEd25519UnencryptedPrefix.size());
-    return prefix != kEd25519UnencryptedPrefix;
+// parsePrivateKey returns true iff the key is valid
+bool parsePrivateKey(std::string& keys_content,
+                     int* key_type,
+                     bool* is_encrypted) {
+  BIO* bio_stream = BIO_new(BIO_s_mem());
+  BIO_write(bio_stream, keys_content.c_str(), keys_content.size());
+  if (bio_stream == nullptr) {
+    return false;
   }
-  return keys_content.find("ENCRYPTED") != std::string::npos;
+
+  // PEM_read_bio_PrivateKey calls passwordCallback
+  // if the private key is encrypted. We don't care what the key is;
+  // only whether or not it's encrypted.
+  static bool encrypted = false;
+  auto passwordCallback = [](char*, int, int, void*) {
+    encrypted = true;
+    return -1; // let openssl know that the passwordCallback failed
+  };
+
+  EVP_PKEY* pkey;
+  pkey =
+      PEM_read_bio_PrivateKey(bio_stream, nullptr, passwordCallback, nullptr);
+  *is_encrypted = encrypted;
+  scope_guard::create([=]() {
+    BIO_free(bio_stream);
+    EVP_PKEY_free(pkey);
+  });
+
+  if (pkey == nullptr) {
+    if (encrypted) {
+      *key_type = EVP_PKEY_NONE;
+      encrypted = false;
+      return true;
+    }
+    return false;
+  }
+
+  *key_type = EVP_PKEY_base_id(pkey);
+  return true;
+}
+
+std::string keyTypeAsString(int key_type) {
+  switch (key_type) {
+  case EVP_PKEY_RSA:
+  case EVP_PKEY_RSA2:
+    return "rsa";
+  case EVP_PKEY_DSA:
+  case EVP_PKEY_DSA1:
+  case EVP_PKEY_DSA2:
+  case EVP_PKEY_DSA3:
+  case EVP_PKEY_DSA4:
+    return "dsa";
+  case EVP_PKEY_DH:
+  case EVP_PKEY_DHX:
+    return "dh";
+  case EVP_PKEY_EC:
+    return "ec";
+  case EVP_PKEY_HMAC:
+    return "hmac";
+  case EVP_PKEY_CMAC:
+    return "cmac";
+  default:
+    return "";
+  }
 }
 
 void genSSHkeyForHosts(const std::string& uid,
@@ -62,13 +112,15 @@ void genSSHkeyForHosts(const std::string& uid,
       // Cannot read a specific keys file.
       continue;
     }
-
-    if (keys_content.find("PRIVATE KEY") != std::string::npos) {
-      // File is private key, create record for it
+    int key_type;
+    bool encrypted;
+    bool parsed = parsePrivateKey(keys_content, &key_type, &encrypted);
+    if (parsed) {
       Row r;
       r["uid"] = uid;
       r["path"] = kfile;
-      r["encrypted"] = isEncrypted(keys_content) ? "1" : "0";
+      r["encrypted"] = encrypted ? "1" : "0";
+      r["key_type"] = keyTypeAsString(key_type);
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -22,7 +22,7 @@ namespace osquery {
 namespace tables {
 
 const std::string kSSHUserKeysDir = ".ssh/";
-const std::string kEd25519Header = "-----BEGIN OPENSSH PRIVATE KEY-----";
+const std::string kEd25519Header = "-----BEGIN OPENSSH PRIVATE KEY-----\n";
 
 // The first bytes of an OpenSSH key are |key type|length of cipher name|cipher
 // name| so all unencrypted ed25519 keys should start with the value below
@@ -33,10 +33,10 @@ const std::string kEd25519Header = "-----BEGIN OPENSSH PRIVATE KEY-----";
 //
 const std::string kEd25519UnencryptedPrefix = "b3BlbnNzaC1rZXktdjEAAAAABG5vbmU";
 
-bool isEncrypted(std::string keys_content) {
+bool isEncrypted(std::string& keys_content) {
   if (boost::starts_with(keys_content, kEd25519Header)) {
     const std::string prefix = keys_content.substr(
-        kEd25519Header.size() + 1, kEd25519UnencryptedPrefix.size());
+        kEd25519Header.size(), kEd25519UnencryptedPrefix.size());
     return prefix != kEd25519UnencryptedPrefix;
   }
   return (keys_content.find("ENCRYPTED") != std::string::npos) ? true : false;

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -12,7 +12,6 @@ function(osqueryTablesSystemTestsMain)
 
   if(DEFINED PLATFORM_POSIX)
     generateOsqueryTablesSystemPosixTests()
-    generateOsqueryTablesSystemTestsSshkeystestsTest()
     generateOsqueryTablesSystemTestsAugeasTestsTest()
   endif()
 
@@ -52,29 +51,12 @@ function(generateOsqueryTablesSystemLinuxTests)
   )
 endfunction()
 
-function(generateOsqueryTablesSystemTestsSshkeystestsTest)
-  add_osquery_executable(osquery_tables_system_tests_sshkeystests-test posix/ssh_keys_tests.cpp)
-
-  target_link_libraries(osquery_tables_system_tests_sshkeystests-test PRIVATE
-    osquery_config_tests_testutils
-    osquery_core
-    osquery_core_sql
-    osquery_database
-    osquery_filesystem
-    osquery_remote_tests_remotetestutils
-    osquery_tables_system_systemtable
-    osquery_utils
-    osquery_utils_conversions
-    plugins_database_ephemeral
-    thirdparty_googletest
-  )
-endfunction()
-
 function(generateOsqueryTablesSystemPosixTests)
   add_osquery_executable(osquery_tables_system_posix_tests-test
     posix/apt_sources_tests.cpp
     posix/known_hosts_tests.cpp
     posix/shell_history_tests.cpp
+    posix/ssh_keys_tests.cpp
     posix/sudoers_tests.cpp
     posix/yum_sources_tests.cpp
     posix/last_tests.cpp

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -12,11 +12,7 @@ function(osqueryTablesSystemTestsMain)
 
   if(DEFINED PLATFORM_POSIX)
     generateOsqueryTablesSystemPosixTests()
-    generateOsqueryTablesSystemTestsKnownhoststestsTest()
-    generateOsqueryTablesSystemTestsShellhistorytestsTest()
     generateOsqueryTablesSystemTestsSshkeystestsTest()
-    generateOsqueryTablesSystemTestsSudoerstestsTest()
-    generateOsqueryTablesSystemTestsYumsourcestestsTest()
     generateOsqueryTablesSystemTestsAugeasTestsTest()
   endif()
 
@@ -60,7 +56,6 @@ function(generateOsqueryTablesSystemTestsSshkeystestsTest)
   add_osquery_executable(osquery_tables_system_tests_sshkeystests-test posix/ssh_keys_tests.cpp)
 
   target_link_libraries(osquery_tables_system_tests_sshkeystests-test PRIVATE
-    global_cxx_settings
     osquery_config_tests_testutils
     osquery_core
     osquery_core_sql

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -12,6 +12,11 @@ function(osqueryTablesSystemTestsMain)
 
   if(DEFINED PLATFORM_POSIX)
     generateOsqueryTablesSystemPosixTests()
+    generateOsqueryTablesSystemTestsKnownhoststestsTest()
+    generateOsqueryTablesSystemTestsShellhistorytestsTest()
+    generateOsqueryTablesSystemTestsSshkeystestsTest()
+    generateOsqueryTablesSystemTestsSudoerstestsTest()
+    generateOsqueryTablesSystemTestsYumsourcestestsTest()
     generateOsqueryTablesSystemTestsAugeasTestsTest()
   endif()
 
@@ -37,6 +42,25 @@ function(generateOsqueryTablesSystemLinuxTests)
 
   target_link_libraries(osquery_tables_system_linux_tests-test PRIVATE
     osquery_cxx_settings
+    osquery_config_tests_testutils
+    osquery_core
+    osquery_core_sql
+    osquery_database
+    osquery_filesystem
+    osquery_remote_tests_remotetestutils
+    osquery_tables_system_systemtable
+    osquery_utils
+    osquery_utils_conversions
+    plugins_database_ephemeral
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsqueryTablesSystemTestsSshkeystestsTest)
+  add_osquery_executable(osquery_tables_system_tests_sshkeystests-test posix/ssh_keys_tests.cpp)
+
+  target_link_libraries(osquery_tables_system_tests_sshkeystests-test PRIVATE
+    global_cxx_settings
     osquery_config_tests_testutils
     osquery_core
     osquery_core_sql

--- a/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
+++ b/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
@@ -1,0 +1,283 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+#include <osquery/sql.h>
+#include <osquery/tables/system/posix/ssh_keys.h>
+
+#include <osquery/utils/scope_guard.h>
+
+namespace fs = boost::filesystem;
+
+// ssh-keygen -t rsa -b 1024 -N ''
+const std::string kRsaUnencrypted = R"(-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQC9MV4sOpwCeYi/Cp5jrd/CFWRAFPXAj4431v0fjzhjCEPqggEO
+Aofpyqjh+mM5ToQLGo0baPiF3dNA9o0MHZFyfAfD/Jok0G1F7ByqwpS+/S9SQ2kG
+23PjD+8DZJA8LF496t4lr6SBPguCquw5MyEhv2WeOTrYYPvohQa1iA9I8QIDAQAB
+AoGAXuF6TA4cnXUb6ktGAdF6TRhzTVv1n1ufREvSZ9hou+myPdJy+vaz+MDFD4eF
+6YCB4huvtpZfRKtpvcOoGvJdNUJKLjv3LoHQWzhWUiP9O3XbLG3b2Hr/RKI4yQFQ
+bvEK4tvDvvimAnp4K2wNWHM0Kg1pL0N0oVOfjKu1qxHPtd0CQQDynOZaKc+2xjsZ
+CUjAt7jVkCLjSjRNmOjHUXCehcFc44n7SuQwKdvL6PyYqHUcxxsLmPi9GFhl3FKU
+2dmC496rAkEAx6HeC9P9E73jFmw2WQLf+vhzwymrfGL90uXIeE+4vqAVOQc8UrFS
+5wTTQh83WhplZ2dCjV9hVFLXtMoc1hRG0wJBAOrZluKQttFm8q45noNvVSzmad87
+ZYX4Dt1iqHHLaHJSkK8AwAMfgfTRhDMCXtuMoVGIsr/ZYTi5HfeZKkTZ8CECQDbJ
+g6j3WuNKH8KNnDS9hz7XZN3Q19FhUYvJqETsjCU0xd5K0BFZvQjN2DSzYHuH9wBz
+5F3sKUf9HFnvhg5yriUCQGYtoBvMGPcAzaZQ6rtmfXxUBSHfFU3wX+1Z4i1Gonb9
+tLRdtCx5SLsaVpdWslTCD0izLC4YEgYOrlWDrPSbiQU=
+-----END RSA PRIVATE KEY-----
+)";
+
+// ssh-keygen -t rsa -b 1024 -N 'osquery'
+const std::string kRsaEncrypted =
+    R"(-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-128-CBC,5F2D5A76540C4C9366061E04B8AD5382
+
+yYYTbNWNwzRaxGRbwqoHJR5ery8ZWJF4SwuYgrio+fucfYpmTTk0s0CHAqKHRZXe
+z8mygti52juDYRJmpG33pElm3LfkmhPO86D5DeVYSsLNKu61PgsZqURR0WhAdqts
+oniK/rkBXCB+Vk7DcENCPIiMoxaoyK4332qlbtz4X8e47F3ga0AmQm+etV5eO++S
+w34lyylOTPHg93Ao3Jc7Jso5151vGLr4CjoeHfmQPAObjd4hteiFhRfsgRQZqAIv
+O+HLAoqMmx0mFkfA3wlo9SDUmZuWcgxOdSBQEhLJ+lNNo9tmY3ZdvBq/qQL4htme
+C/9EpSuwRJoMKdW55sgVuRkif9+yvnqbkxJZw1ONezOr+03r66YYrks98nBgCKTY
+Pc7NOFFTvmjX0VV6bL+v2Yk/UaqZ6qnMH//dEVMPXIXMKpDLvmH+2dHn39cuAHWn
+dNEKdB21EzvepjbtC/+MgQFb+yBYZx6FOzaJQZkUmDin3VUwGoVL29dvSFZ4do4u
+AJOziYrsUOnZORUNkCHPqnSflIzudgLPVUAeBNC7/0VwnuFucJvIdAgYatAcvdYp
+M4JInkgDpQYkHh1ZN30eIclguspLs+dHFfJco5VZg6OhTm+dpsI837229J+CZThV
+3gMbj9QItqoB+RdYtAaCxC6/8MDG7rUOnaNyXv+Z7F3PJ37lficxaHBHoyA0CYli
+RPp1ENrwmNqR2Hfl4JQCbACh7syyC0F9qq9BWVzeOwY+WSTK1+Tdqp+esi749VW0
+OmavH/dSTJTM6bQuzYBNw97xGhUzkvPotkLm/LY4EMi4hf9RJzXwzYcbSy8N+N28
+-----END RSA PRIVATE KEY-----
+)";
+
+// ssh-keygen -t ed25519 -b 1024 -N ''
+const std::string kEd25519Unencrypted = R"(-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACAxBdSIEpSo2GCI+XFNJVMMMtMFqCM2PtxU15kJod968gAAAKAl+A8pJfgP
+KQAAAAtzc2gtZWQyNTUxOQAAACAxBdSIEpSo2GCI+XFNJVMMMtMFqCM2PtxU15kJod968g
+AAAECElvYf6Uw04m5FzC6pK2F9m654mgKLsTi7mOHCuSzN/DEF1IgSlKjYYIj5cU0lUwwy
+0wWoIzY+3FTXmQmh33ryAAAAGnJvYmJpZUBIZXBoYWVzdHVzLUlJLmxvY2FsAQID
+-----END OPENSSH PRIVATE KEY-----
+)";
+
+// ssh-keygen -t ed25519 -b 1024 -N 'osquery'
+const std::string kEd25519Encrypted = R"(-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABBtHgT9BK
+xU2YnYX1Kmhd2+AAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAINuzCGrt5ycXx5zy
+Qmg9LgQK0AfqJjrMc5hY2okjK7GxAAAAoPtS99mcHbCChhVBtyrPiZp7lteeZT5fj2kj19
+kgjZXM0IjDqUY3yHeBdSOJq6xV+5jPYd8GzWxCjdWPlRQpaJbqQYeZIMes+xFE+dQYBcIb
+HViYhoiqtoA7rjzFZVReI2tgytE0cyJHIPAqpUaGFiMrNrGoZqwvNL3eHfY654UfYqGbLN
+lr3nvK/353Djovxgm6WxHe82aPpQvBlDbEiR0=
+-----END OPENSSH PRIVATE KEY-----
+)";
+
+// ssh-keygen -t dsa -b 1024 -N ''
+const std::string kDsaUnencrypted = R"(-----BEGIN DSA PRIVATE KEY-----
+MIIBugIBAAKBgQCfH5N5h6a/9t9V0RnHUjsdTTE7vi6C4uMMbDRdnX1U/Or6eoY6
+3qFKDOto8UmSeVNgmYf7yUfcO3P89m2BckzHPJbabHRm5cHjsKl8h1+MFHoXzNBY
+QnUzZJRokGrnHc2p8W6Yz3ABAJDy/VarTIuJOA9mhLya7wVgwLORk5dAcQIVAKdD
+GwYrdxW3TldRSgQemq91RnIvAoGAftjV5PtN0bCS9BXBzYnU80pNLLDSXZxa0aIj
+b1Lafi4yD3zNPHexIZcKJff+9wi+eeKKRBAmcO9xCCGRrLsFqvK7BYLX6mf+B/d5
+cYOlyhJ6vb8tmmfwq3m1/fDaYj+Jcr+gMj6fCMcuAHLT+Qbd9+vLNOFbjGb/HvrI
+iA2sMEcCgYAzoSqFkgLS2NUVlaOTG3sbHEYQgMAYVi5qmgFIB6Co6qO8cSHFziuc
+U7PU/WINSt/m9QpAl5sl5gJvDO7s+5XbXbDmdvyjvBuUo1MUm2YsOATM6dLX1fl2
+b9uYdciS8xDZGUe7BvFR5iZW2P0WLU+j2nm1lZ6yHDXnSawFrGd/8wIUfv/G+GZQ
+UQ2bWX3iqGz7GKbKvVI=
+-----END DSA PRIVATE KEY-----
+)";
+
+// ssh-keygen -t dsa -b 1024 -N 'osquery'
+const std::string kDsaEncrypted =
+    R"(-----BEGIN DSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-128-CBC,4776535AE68A52C8C65C3EF8375C71A3
+
+priHoiSJGZSp8Qg1ncE8UvZp2HX3IvtLvsycVlr2H7yeuKIbXDZN4zF7wV3wN19t
+h27UTXZ4AYnPlIHAWOUt1dPF18tY1naCEsJQsm/+wNWN2Oq3ZbKEurB/ZpejsuS7
+JJ9nZDRqmHkc9GQsIFZ3DFo9VTC6SjGoTU/yipRGn5T8JAme9I1D9NrpmfSfHiwS
+JGyjUn2QpZui7hCh5MYWv/OiR+3Qaap5m7wvrPshkTCG6NilhfCg2D/vmauthgYQ
+QSYv7W3odFWfy0dpRFBmeI4Rfbm1Grp4+3iR1S+BQKSusiucoufPHD6tRA9Kqv+e
+S9EzAe9igP1E7CuYmUilloB9uu/bldljV5rsK84gQCysB7aFyjbSDA3c0n9Qtn1s
+MjWRb/GTHjMXz+kRveUAErIC+G27QJMB/fq/q3k8Hc5B5H8djXg9Pg02MnRItbjL
+sOPSbcdl7/4UF3erCwfqDVTc60wTZwNyQ0hMWNcIHwFTdP8dTBtJhuTpJxoCldNa
+jN1jCIAhAAttxOoNVSNEzqko7KrdIte+lSwhPb4nnsRCt3GVx8NNFHEKJjM17xx6
+BIQxZ7GBy1EHTqNWP7UhZg==
+-----END DSA PRIVATE KEY-----
+)";
+
+namespace osquery {
+namespace tables {
+
+class SshKeysTests : public testing::Test {
+ protected:
+  void SetUp() override {
+    directory = fs::temp_directory_path() /
+                fs::unique_path("osquery.ssh_keys_impl_tests.%%%%-%%%%");
+
+    ASSERT_TRUE(fs::create_directories(directory));
+
+    ssh_directory = directory / fs::path(kSSHUserKeysDir);
+
+    ASSERT_TRUE(fs::create_directories(ssh_directory));
+  }
+  void TearDown() override {
+    fs::remove_all(directory);
+  }
+  fs::path directory;
+  fs::path ssh_directory;
+};
+
+TEST_F(SshKeysTests, invalid_key) {
+  auto results = QueryData{};
+
+  {
+    auto filepath = ssh_directory / fs::path("invalid");
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << "this is an invalid key" << '\n';
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 0u);
+}
+
+TEST_F(SshKeysTests, rsa_key_unencrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("rsa_unencrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kRsaUnencrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "0");
+  EXPECT_EQ(row.at("key_type"), "rsa");
+}
+
+TEST_F(SshKeysTests, rsa_key_encrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("rsa_unencrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kRsaEncrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "1");
+  EXPECT_EQ(row.at("key_type"), "");
+}
+
+TEST_F(SshKeysTests, dsa_unencrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("dsa_unencrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kDsaUnencrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "0");
+  EXPECT_EQ(row.at("key_type"), "dsa");
+}
+
+TEST_F(SshKeysTests, dsa_encrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("dsa_encrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kDsaEncrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "1");
+  EXPECT_EQ(row.at("key_type"), "");
+}
+
+TEST_F(SshKeysTests, ed25519_unencrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("ed25519_unencrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kEd25519Unencrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "0");
+  EXPECT_EQ(row.at("key_type"), "ed25519");
+}
+
+TEST_F(SshKeysTests, ed25519_encrypted) {
+  auto results = QueryData{};
+
+  auto filepath = ssh_directory / fs::path("ed25519_encrypted");
+  {
+    auto fout =
+        std::ofstream(filepath.native(), std::ios::out | std::ios::binary);
+    fout << kEd25519Encrypted;
+  }
+  auto const uid = std::to_string(geteuid());
+  genSSHkeyForHosts(
+      uid, std::to_string(getegid()), directory.native(), results);
+  ASSERT_EQ(results.size(), 1u);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("uid"), uid);
+  EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
+  EXPECT_EQ(row.at("encrypted"), "1");
+  EXPECT_EQ(row.at("key_type"), "");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
+++ b/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
@@ -255,7 +255,7 @@ TEST_F(SshKeysTests, ed25519_unencrypted) {
   EXPECT_EQ(row.at("uid"), uid);
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "0");
-  EXPECT_EQ(row.at("key_type"), "ed25519");
+  EXPECT_EQ(row.at("key_type"), "");
 }
 
 TEST_F(SshKeysTests, ed25519_encrypted) {

--- a/specs/user_ssh_keys.table
+++ b/specs/user_ssh_keys.table
@@ -5,6 +5,7 @@ schema([
       additional=True),
     Column("path", TEXT, "Path to key file", index=True),
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
+    Column("key_type", TEXT, "The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string."),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True, no_pkey=True)


### PR DESCRIPTION
Newer versions of OpenSSH use ed25519 keys, which don't include the text "ENCRYPTED" in their body. This patch ~checks to see if the first few bytes of the key line up with what we would expect from an unencrypted key.~ tries to parse the keys using openssl to support arbitrary key types.

Fixes #4826 
Fixes #5253. 
Fixes #4886

~I haven't added tests as I haven't seen any for the SSH table yet, but I'm happy to look into that if helpful.~ Also added a bunch of tests for the user_ssh_keys table.