### PR TITLE
fix http_client resolve

### DIFF
--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -88,7 +88,7 @@ void Client::createConnection() {
 
   boost_system::error_code rc;
   connect(sock_,
-          r_.resolve(boost_asio::ip::tcp::resolver::query{connect_host, port}),
+          r_.resolve(connect_host, port, boost::asio::ip::resolver_query_base::flags()),
           rc);
 
   if (rc) {


### PR DESCRIPTION
So as was written in https://github.com/facebook/osquery/issues/5557 : resolver is working not correctly in some cases:
```
osqueryi "select * from ec2_instance_metadata;"
terminating with uncaught exception of type boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >: resolve: Host not found (authoritative)
Aborted (core dumped)
``` 
the error above was seen a few times.

A fix was found here:
https://stackoverflow.com/questions/5971242/how-does-boost-asios-hostname-resolution-work-on-linux-is-it-possible-to-use-n
and then, after reading boost manuals, fix was updated even further by removing  a deprecated `query` type from a resolver.

Comments and suggestions are much appreciated.