### PR TITLE
use async so we honor timeout

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -97,9 +97,9 @@ void Client::createConnection() {
   }
 
   boost_system::error_code rc;
-  connect(sock_,
-          r_.resolve(boost_asio::ip::tcp::resolver::query{connect_host, port}),
-          rc);
+  boost::asio::async_connect(sock_,
+                             r_.resolve(boost_asio::ip::tcp::resolver::query{connect_host, port}),
+          std::bind(&Client::timeoutHandler, this, std::placeholders::_1));
 
   if (rc) {
     std::string error("Failed to connect to ");

--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -98,7 +98,7 @@ void Client::createConnection() {
 
   boost_system::error_code rc;
   boost::asio::async_connect(sock_,
-                             r_.resolve(boost_asio::ip::tcp::resolver::query{connect_host, port}),
+          r_.resolve(boost_asio::ip::tcp::resolver::query{connect_host, port}),
           std::bind(&Client::timeoutHandler, this, std::placeholders::_1));
 
   if (rc) {


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

The current createConnection code blocks on the connect call, this, in turn, prevents the code from honouring the timeout value, and thus causes inconsistent behaviour.

A simple test can be done, on a Linux distro (non-ec2) execute the following plugin "select * from ec2_instance_metadata" and issue a timeout of 3 seconds. You will see that the timeout actually happening is in excess of 30s, while we expect it to be ~3s.

The networking code on the experimental branch is unchanged from the networking code in 3.3.3 (where we tested this).

Let me know if you have any questions.

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.
