### PR TITLE
macos: Add hack for boost asio string_view detection

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -6,6 +6,12 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
+// TODO(5591) Remove this when addressed by Boost's ASIO config.
+// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
+// Standard library support for std::string_view.
+#define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
+
 // clang-format off
 // Keep it on top of all other includes to fix double include WinSock.h header file
 // which is windows specific boost build problem

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -19,6 +19,12 @@
 #define OPENSSL_NO_MD5 1
 #define OPENSSL_NO_DEPRECATED 1
 
+// TODO(5591) Remove this when addressed by Boost's ASIO config.
+// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
+// Standard library support for std::string_view.
+#define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
+
 // clang-format off
 // Keep it on top of all other includes to fix double include WinSock.h header file
 // which is windows specific boost build problem

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -16,6 +16,12 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+// TODO(5591) Remove this when addressed by Boost's ASIO config.
+// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
+// Standard library support for std::string_view.
+#define BOOST_ASIO_HAS_STD_STRING_VIEW 1
+#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
+
 #include <boost/asio.hpp>
 #include <boost/foreach.hpp>
 


### PR DESCRIPTION
See issue #5591.

Boost ASIO does not detect the availability of `std::string_view` on newer LLVM/C++ installations. This is fixed in later versions of ASIO and #5591 should track the removal of this hack. 