### PR TITLE
travis: Add homebrew update true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ matrix:
       <<: *os-common-macos
 
 script:
-  - buck build @mode/${OSQUERY_PLATFORM}/${OSQUERY_BUILD_MODE} -c color.ui=never osquery:osqueryd
+  - travis_wait 30 buck build @mode/${OSQUERY_PLATFORM}/${OSQUERY_BUILD_MODE} -c color.ui=never osquery:osqueryd
   - buck test @mode/${OSQUERY_PLATFORM}/${OSQUERY_BUILD_MODE} -c color.ui=never osquery/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ os-common:
   macos: &os-common-macos
     addons:
       homebrew:
+        update: true
         taps:
           - facebook/fb
           - homebrew/cask-versions
         casks:
-          - java8
+          - adoptopenjdk8
         packages:
           - buck
           - watchman

--- a/tools/buckconfigs/freebsd-x86_64/type/debug.bcfg
+++ b/tools/buckconfigs/freebsd-x86_64/type/debug.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/debug"
+  buck_out = buck-out/debug
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/freebsd-x86_64/type/release.bcfg
+++ b/tools/buckconfigs/freebsd-x86_64/type/release.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/release"
+  buck_out = buck-out/release
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/linux-x86_64/type/debug.bcfg
+++ b/tools/buckconfigs/linux-x86_64/type/debug.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/debug"
+  buck_out = buck-out/debug
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/linux-x86_64/type/release.bcfg
+++ b/tools/buckconfigs/linux-x86_64/type/release.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/release"
+  buck_out = buck-out/release
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/macos-x86_64/type/debug.bcfg
+++ b/tools/buckconfigs/macos-x86_64/type/debug.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/debug"
+  buck_out = buck-out/debug
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/macos-x86_64/type/release.bcfg
+++ b/tools/buckconfigs/macos-x86_64/type/release.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/release"
+  buck_out = buck-out/release
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/windows-x86_64/type/debug.bcfg
+++ b/tools/buckconfigs/windows-x86_64/type/debug.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/debug"
+  buck_out = buck-out/debug
 
 [cxx_type]
   cppflags = \

--- a/tools/buckconfigs/windows-x86_64/type/release.bcfg
+++ b/tools/buckconfigs/windows-x86_64/type/release.bcfg
@@ -1,5 +1,5 @@
 [project]
-  buck_out = "buck-out/release"
+  buck_out = buck-out/release
 
 [cxx_type]
   cppflags = \


### PR DESCRIPTION
It seems the base homebrew on TravisCI is not working (this may have started on June 11th). The error is `Error: Your Homebrew is outdated. Please run brew update.` 

This may add time to the build but should fix it.