### PR TITLE
Initial codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Osquery Codeowners
+# Documented at https://help.github.com/en/articles/about-code-owners
+#
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# General write access
+* @osquery/osquery-committers, @osquery/facebook-osquery-write
+
+# As CODEOWNERS is last match oriented, we restrict slightly more
+# sensitive files here.
+CODEOWNERS		@osquery/foundation-committers
+azure-pipelines.yml	@osquery/foundation-committers


### PR DESCRIPTION
This adds a codeowners file. The intent here, is to provide a route to opening up more people to vet and approve commits. Committers should be added to the [osquery/osquery-committers](https://github.com/orgs/osquery/teams/osquery-committers) team. This will grant them write permissions, and cause them to be notified on PRs.

We will need to _additionally_ toggle the codeowners button in master branch protections.

This does _not_ provided a clearly visible audit trail for who has been added to `osquery-committers` or a process for doing that.

Fixes: https://github.com/osquery/foundation/issues/1
