### PR TITLE
build: Use a submodule for prebuilds instead of fetching and extracting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ build/
 # Run Artifacts
 *.log
 *.orig
-*.patch
 *.rej
 
 # Vagrant Artifacts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third-party-prebuilt"]
+	path = third-party-prebuilt
+	url = https://github.com/theopolis/osquery-third-party-prebuilt

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,7 @@
 # Building osquery
 
-## With CMake
+## Using CMake
+
 osquery supports Linux (Ubuntu 18.04/18.10), macOS, and Windows.
 
 git, CMake (>= 3.13.3), clang 6.0, Python 2, and Python 3 are required to build. The rest of the dependencies are downloaded by CMake.
@@ -13,7 +14,7 @@ The build type is chosen when building on Windows, not during the configure phas
 
 The root folder is assumed to be `/home/<user>`
 
-#### Ubuntu 18.04
+**Ubuntu 18.04**
 
 ```
 # Install the prerequisites
@@ -25,14 +26,13 @@ sudo tar xvf cmake-3.14.5-Linux-x86_64.tar.gz -C /usr/local --strip 1
 # Verify that `/usr/local/bin` is in the `PATH` and comes before `/usr/bin`
 
 # Download and build osquery
-cd $HOME; mkdir osquery; cd osquery
-git clone https://github.com/osquery/osquery.git -b master src
+git clone https://github.com/osquery/osquery
 mkdir build; cd build
-cmake ../src -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-cmake --build . -j # // where # is the number of parallel build jobs
+cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
+cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 
-#### Ubuntu 18.10
+**Ubuntu 18.10**
 
 ```
 # Install the prerequisites
@@ -44,41 +44,39 @@ sudo tar xvf cmake-3.14.5-Linux-x86_64.tar.gz -C /usr/local --strip 1
 # Verify that `/usr/local/bin` is in the `PATH` and comes before `/usr/bin`
 
 # Download and build osquery
-cd $HOME; mkdir osquery; cd osquery
-git clone https://github.com/osquery/osquery.git -b master src
+git clone https://github.com/osquery/osquery
 mkdir build; cd build
-cmake ../src -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 (-DBUILD_TESTING=ON for tests)
-cmake --build . -j # // where # is the number of parallel build jobs
+cmake -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 ..
+cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 
 ### Windows
 
 The root folder is assumed to be `C:\Users\<user>`
 
-#### Step 1: Install the prerequisites
-- [CMake](https://cmake.org/) (>= 3.14.4): be sure to put it into the PATH
+**Step 1: Install the prerequisites**
+
+- [CMake](https://cmake.org/) (>= 3.14.4): be sure to put it into the `PATH`
 - [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16): from the installer choose the C++ build tools workload, then on the right, under Installation details, also check MSVC v141
 - [Git for Windows](https://github.com/git-for-windows/git/releases/latest) (or equivalent)
 - [Python 2](https://www.python.org/downloads/windows/)
 - [Python 3](https://www.python.org/downloads/windows/)
 
-#### Step 2: Download and build osquery
+**Step 2: Download and build**
 
 ```
 # Download using a PowerShell console
-mkdir osquery; cd osquery
-git clone https://github.com/osquery/osquery.git -b master src
+git clone https://github.com/osquery/osquery
 
 # Configure
 mkdir build; cd build
-cmake ../src -G "Visual Studio 16 2019" -A x64 -T v141
+cmake -G "Visual Studio 16 2019" -A x64 -T v141 ..
 
 # Build
-cmake --build . --config RelWithDebInfo -j # // Number of projects to build in parallel
-
+cmake --build . --config RelWithDebInfo -j10 # Number of projects to build in parallel
 ```
 
-### macOS
+### MacOS
 
 Please ensure [homebrew](https://brew.sh/) has been installed. The root folder is assumed to be `/Users/<user>`
 
@@ -86,27 +84,28 @@ Please ensure [homebrew](https://brew.sh/) has been installed. The root folder i
 # Install prerequisites
 brew install git cmake python@2 python
 
-# Download and build osquery
-mkdir osquery; cd osquery
-git clone https://github.com/osquery/osquery.git -b master src
+# Download and build
+git clone https://github.com/osquery/osquery
 
 # Configure
 mkdir build; cd build
-cmake ../src
+cmake ..
 
 # Build
-cmake --build . -j # // where # is the number of parallel build jobs
-
+cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 
 ### Tests
+
 To build with tests active, add `-DBUILD_TESTING=ON` to the osquery configure phase, then build the project. CTest will be used to run the tests and give a report.
 
-#### Run tests on Windows
+**Run tests on Windows**
+
 To run the tests and get just a summary report:\
 `cmake --build . --config <RelWithDebInfo|Release|Debug> --target run_tests`
 
 To get more information when a test fails using powershell:
+
 ```
 $Env:CTEST_OUTPUT_ON_FAILURE=1
 cmake --build . --config <RelWithDebInfo|Release|Debug> --target run_tests
@@ -115,7 +114,8 @@ cmake --build . --config <RelWithDebInfo|Release|Debug> --target run_tests
 To run a single test, in verbose mode:\
 `ctest -R <test name> -C <RelWithDebInfo|Release|Debug> -V`
 
-#### Run tests on Linux/macOS
+**Run tests on Linux/MacOS**
+
 To run the tests and get just a summary report:\
 `cmake --build . --target test`
 
@@ -125,16 +125,34 @@ To get more information when a test fails:\
 To run a single test, in verbose mode:\
 `ctest -R <test name> -V`
 
-## With Buck
+## Using Buck
 
-## Provisioning
+Building and testing is the same on all platforms. Each platform section below describes how to install the required tools and dependencies.
 
-Start by provisioning your machine following the steps bellow according to your
-operating system.
+### Ubuntu 18.04 and 18.10
 
-### macOS
+Install required tools
 
-*Install tools*
+```
+sudo apt install openjdk-8-jre clang libc++1 libc++-dev libc++abi1 libc++abi-dev python python3 python3-distutils
+```
+
+Install library dependencies
+
+```
+sudo apt install liblzma-dev
+```
+
+Install `buck`
+
+```
+wget 'https://github.com/facebook/buck/releases/download/v2018.10.29.01/buck.2018.10.29.01_all.deb'
+sudo apt install ./buck.2018.10.29.01_all.deb
+```
+
+### MacOS
+
+Install required tools using Homebrew
 
 ```
 xcode-select --install
@@ -144,52 +162,29 @@ brew tap caskroom/versions
 brew cask install java8
 ```
 
-*Install Buck and Watchman*
-
-Watchman isn't mandatory but will make builds faster.
+Install `buck` and `watchman`. Watchman isn't mandatory but will make builds faster.
 
 ```
 brew tap facebook/fb
 brew install buck watchman
 ```
 
-### Ubuntu 18.04 / 18.10
-
-*Install tools*
-
-```
-sudo apt install openjdk-8-jre clang libc++1 libc++-dev libc++abi1 libc++abi-dev python python3 python3-distutils
-```
-
-*Install dependencies*
-
-```
-sudo apt install liblzma-dev
-```
-
-*Install Buck*
-
-```
-wget 'https://github.com/facebook/buck/releases/download/v2018.10.29.01/buck.2018.10.29.01_all.deb'
-sudo apt install ./buck.2018.10.29.01_all.deb
-```
-
 ### FreeBSD 11.2
 
-*Install tools*
+Install required tools
 
 ```
 sudo pkg install openjdk8 python3 python2 clang35
 ```
 
-*Install Buck*
+Install `buck`
 
 ```
 sudo curl --output /usr/local/bin/buck 'https://jitpack.io/com/github/facebook/buck/v2018.10.29.01/buck-v2018.10.29.01.pex'
 sudo chmod +x /usr/local/bin/buck
 ```
 
-*Install dependencies*
+Install library dependencies
 
 ```
 sudo pkg install glog thrift thrift-cpp boost-libs magic rocksdb-lite rapidjson zstd linenoise-ng augeas ssdeep sleuthkit yara aws-sdk-cpp lldpd libxml++-2 smartmontools lldpd
@@ -206,7 +201,7 @@ You'll need to have the following software installed before you can build osquer
 
 Once you've installed the above requirements, run `.\tools\generate_buck_config.ps1 -VsInstall '' -VcToolsVersion '' -SdkInstall '' -SdkVersion '' -Python3Path '' -BuckConfigRoot .\tools\buckconfigs\` to generate the buckconfig for building.
 
-## Build & Test
+### Build & Test
 
 To build simply run the following command replacing `<platform>` and `<mode>`
 appropriately:
@@ -236,3 +231,58 @@ Supported modes:
 
 * `release`
 * `debug`
+
+## Building prebuilt dependencies
+
+"Prebuilt" versions of the dependency libraries are provided for Linux, MacOS, and Windows. This means you only need to install the required tooling.
+
+"Prebuilt" or "prebuilds" are versions of library dependencies pre-built using our logic in CMake within the third-party folder. We use CMake's `ExternalProject` and a custom `PREFIX`, or install location, set to the `third-party-prebuilt` submodule. These configurations should be supported on MacOS, Linux, and Windows.
+
+An individual library can be built using:
+
+```
+mkdir -p build/deps && cd build/deps
+cmake ../..
+cmake --build . --config Release --target thirdparty_build_LIBRARY
+```
+
+Or all libraries can be built using
+
+```
+cmake --build . --config Release --target thirdparty_prebuilt
+```
+
+### MacOS
+
+Prebuilt libraries use the system toolchain and operating system version support flags set to `10.13` (subject to change).
+
+Use the prebuilt building helper script. It optionally uses a `STATIC_ENFORCE` environent variable to enforce that the location of the osquery clone and the location of the toolchain are well-known. This is required for reproducible building.
+
+```
+./tools/build_prebuilt.sh
+```
+
+### Linux
+
+**Portable toolchain**
+
+Since there are many Linux distributions we use a static toolchain for building dependencies. This helps achieve a reproducible build and makes debugging easier. You may use any toolchain you like.
+
+Pay attention to the portability aspect of the toolchain. What runtime/dynamic linking requirements does it impose on the output executables.
+
+```
+sudo apt-get install automake pkg-config libtool autopoint bison flex xsltproc texinfo
+wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz
+sudo tar xvf cmake-3.14.5-Linux-x86_64.tar.gz -C /usr/local --strip 1
+
+mkdir ~/toolchains; cd ~/toolchains
+wget https://github.com/theopolis/build-anywhere/releases/download/v5/x86_64-anywhere-linux-gnu-v5.tar.xz
+tar xf x86_64-anywhere-linux-gnu-v5.tar.xz
+source ./x86_64-anywhere-linux-gnu/scripts/anywhere-setup.sh
+```
+
+Use the prebuilt building helper script. It optionally uses a `STATIC_ENFORCE` environent variable to enforce that the location of the osquery clone and the location of the toolchain are well-known. This is required for reproducible building.
+
+```
+./tools/build_prebuilt.sh
+```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,14 +246,12 @@ jobs:
       vmImage: vs2017-win2016
 
     steps:
-    - checkout: self
-      submodules: recursive
-      displayName: "Update submodules"
-
     - powershell: |
         git config --global core.autocrlf false
 
     - checkout: self
+      submodules: recursive
+      displayName: "Update submodules"
 
     - powershell: |
         mkdir $(Build.BinariesDirectory)\build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,10 @@ jobs:
       options: --privileged
 
     steps:
+    - checkout: self
+      submodules: recursive
+      displayName: "Update submodules"
+
     - script: mkdir $(Build.BinariesDirectory)/build
       displayName: "Create build folder"
 
@@ -145,6 +149,10 @@ jobs:
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20
 
+    - checkout: self
+      submodules: recursive
+      displayName: "Update submodules"
+
     - script: mkdir $(Build.BinariesDirectory)/build
       displayName: "Create build folder"
 
@@ -238,6 +246,10 @@ jobs:
       vmImage: vs2017-win2016
 
     steps:
+    - checkout: self
+      submodules: recursive
+      displayName: "Update submodules"
+
     - powershell: |
         git config --global core.autocrlf false
 

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -58,3 +58,7 @@ set(PACKAGING_SYSTEM "" CACHE STRING "Packaging system to generate when building
 if(DEFINED PLATFORM_WINDOWS)
   set(WIX_ROOT_FOLDER_PATH "" CACHE STRING "Root folder of the WIX installation")
 endif()
+
+# Prebuilt variables
+set(_ep_keywords_definePrebuiltProject "^(URL|SHA256|DEPENDS|PATCHES|CONFIGURE|BUILD|INSTALL|BUILD_IN_SOURCE)$")
+set(REPLACE_CMD "${CMAKE_SOURCE_DIR}/tools/replace.py")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -24,9 +24,9 @@ option(BUILD_TESTING "Whether to enable and build tests or not")
 # This is the default S3 storage used by Facebook to store 3rd party dependencies; it
 # is provided here as a configuration option
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")
-  set(THIRD_PARTY_REPOSITORY_URL "https://s3.amazonaws.com/osquery-packages")
+  set(THIRD_PARTY_REPOSITORY_URL "https://s3.amazonaws.com/osquery-packages" CACHE STRING "")
 endif()
 
 if("${THIRD_PARTY_PREBUILT_PATH}" STREQUAL "")
-  set(THIRD_PARTY_PREBUILT_PATH "${CMAKE_SOURCE_DIR}/third-party-prebuilt")
+  set(THIRD_PARTY_PREBUILT_PATH "${CMAKE_SOURCE_DIR}/third-party-prebuilt" CACHE STRING "Path to prebuilt platform prefixes")
 endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -26,3 +26,7 @@ option(BUILD_TESTING "Whether to enable and build tests or not")
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")
   set(THIRD_PARTY_REPOSITORY_URL "https://s3.amazonaws.com/osquery-packages")
 endif()
+
+if("${THIRD_PARTY_PREBUILT_PATH}" STREQUAL "")
+  set(THIRD_PARTY_PREBUILT_PATH "${CMAKE_SOURCE_DIR}/third-party-prebuilt")
+endif()

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -36,11 +36,6 @@ function(generateOsqueryTablesTableimplementations)
       osquery_tables_cloud
       osquery_tables_smart
     )
-
-  elseif(DEFINED PLATFORM_WINDOWS)
-    target_link_libraries(osquery_tables_tableimplementations INTERFACE
-      osquery_tables_cloud
-    )
   endif()
 
   target_link_libraries(osquery_tables_tableimplementations INTERFACE

--- a/osquery/tables/cloud/CMakeLists.txt
+++ b/osquery/tables/cloud/CMakeLists.txt
@@ -5,7 +5,9 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(osqueryTablesCloudMain)
-  generateOsqueryTablesCloud()
+  if(NOT DEFINED PLATFORM_WINDOWS)
+    generateOsqueryTablesCloud()
+  endif()
 endfunction()
 
 function(generateOsqueryTablesCloud)

--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -22,6 +22,14 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
+// librpm may be configured and compiled with glibc < 2.17.
+#if defined(__GLIBC__) && __GLIBC_MINOR__ > 17
+extern "C" char* __secure_getenv(const char* _s) __attribute__((weak));
+extern "C" char* __secure_getenv(const char* _s) {
+  return secure_getenv(_s);
+}
+#endif
+
 namespace osquery {
 namespace tables {
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -222,7 +222,7 @@ function(importThirdPartyBinaryLibrary name anchor_file_name)
     set_target_properties("${identifier}" PROPERTIES IMPORTED_LOCATION "${base_path}/${relative_anchor_path}")
   endif()
 
-  #execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${base_folder}/include")
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${base_folder}/include")
   target_include_directories("${identifier}" INTERFACE "${base_path}/include")
 
   set(importThirdPartyBinaryLibrary_baseFolderPath "${base_path}" PARENT_SCOPE)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -19,7 +19,7 @@ function(osqueryThirdpartyMain)
   add_subdirectory("sqlite")
   add_subdirectory("googletest")
 
-  # Ordered recorsive dependencies
+  # Ordered recursive dependencies
   add_subdirectory("zlib")
   add_subdirectory("bzip2")
   add_subdirectory("libxml2")
@@ -66,6 +66,10 @@ endfunction()
 
 function(definePrebuiltProject name)
   set(identifier "thirdparty_build_${name}")
+  if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    # Ninja build will error with "$(MAKE)" output
+    return()
+  endif()
 
   # Create a target to hold the arguments from the function call.
   set(props "${identifier}_props")
@@ -222,18 +226,29 @@ function(importThirdPartyBinaryLibrary name anchor_file_name)
     set_target_properties("${identifier}" PROPERTIES IMPORTED_LOCATION "${base_path}/${relative_anchor_path}")
   endif()
 
-  execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${base_folder}/include")
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${base_path}/include")
   target_include_directories("${identifier}" INTERFACE "${base_path}/include")
 
   set(importThirdPartyBinaryLibrary_baseFolderPath "${base_path}" PARENT_SCOPE)
 endfunction()
 
 function(importThirdPartyHeaderOnlyLibrary library_type name anchor_file include_folder)
+  if(DEFINED PLATFORM_LINUX)
+    set(platform_name "linux")
+  elseif(DEFINED PLATFORM_MACOS)
+    set(platform_name "macos")
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(platform_name "windows")
+  else()
+    message(FATAL_ERROR "Unrecognized system")
+    return()
+  endif()
+
   set(identifier "thirdparty_${name}")
   set(base_path "${THIRD_PARTY_PREBUILT_PATH}/${platform_name}-x86_64")
 
   add_osquery_library("${identifier}" INTERFACE)
-  target_include_directories("${identifier}" INTERFACE "${base_folder}/${include_folder}")
+  target_include_directories("${identifier}" INTERFACE "${base_path}/${include_folder}")
 endfunction()
 
 # Generates a empty imported or interface library named thirdparty_name that will depends on the targets

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -4,50 +4,122 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 
+include(ExternalProject)
+
 function(osqueryThirdpartyMain)
   initializePythonPathFolder()
+  osqueryThirdpartyBuildMain()
 
+  # Python modules
+  add_subdirectory("jinja2")
+  add_subdirectory("markupsafe")
+
+  # Placeholder or build-from-source
+  add_subdirectory("glibc")
+  add_subdirectory("sqlite")
+  add_subdirectory("googletest")
+
+  # Ordered recorsive dependencies
+  add_subdirectory("zlib")
+  add_subdirectory("bzip2")
+  add_subdirectory("libxml2")
+  add_subdirectory("lzma")
+  add_subdirectory("openssl")
+  add_subdirectory("gflags")
+  add_subdirectory("glog")
+  add_subdirectory("boost")
+  add_subdirectory("libgpg-error")
+  add_subdirectory("libgcrypt")
+  add_subdirectory("ncurses")
+  add_subdirectory("util-linux")
+  add_subdirectory("popt")
+  add_subdirectory("rapidjson")
   add_subdirectory("augeas")
   add_subdirectory("aws-sdk-cpp")
   add_subdirectory("berkeley-db")
-  add_subdirectory("boost")
-  add_subdirectory("bzip2")
-  add_subdirectory("gflags")
-  add_subdirectory("glibc")
-  add_subdirectory("glog")
-  add_subdirectory("googletest")
-  add_subdirectory("jinja2")
   add_subdirectory("libarchive")
   add_subdirectory("libaudit")
-  add_subdirectory("libcryptsetup")
   add_subdirectory("libdevmapper")
-  add_subdirectory("libdpkg")
+  add_subdirectory("libcryptsetup")
   add_subdirectory("libelfin")
-  add_subdirectory("libgcrypt")
-  add_subdirectory("libgpg-error")
   add_subdirectory("libiptables")
   add_subdirectory("libmagic")
-  add_subdirectory("librdkafka")
   add_subdirectory("librpm")
   add_subdirectory("libudev")
-  add_subdirectory("libxml2")
   add_subdirectory("linenoise-ng")
   add_subdirectory("lldpd")
-  add_subdirectory("lzma")
-  add_subdirectory("markupsafe")
-  add_subdirectory("openssl")
-  add_subdirectory("popt")
-  add_subdirectory("rapidjson")
+  add_subdirectory("libdpkg")
+  add_subdirectory("librdkafka")
   add_subdirectory("rocksdb")
   add_subdirectory("sleuthkit")
   add_subdirectory("smartmontools")
-  add_subdirectory("sqlite")
   add_subdirectory("ssdeep-cpp")
   add_subdirectory("thrift")
-  add_subdirectory("util-linux")
   add_subdirectory("yara")
-  add_subdirectory("zlib")
   add_subdirectory("zstd")
+endfunction()
+
+function(osqueryThirdpartyBuildMain)
+  # For our custom ExternalProject wrapper we define argument groups.
+  add_custom_target(thirdparty_prebuilt)
+endfunction()
+
+function(definePrebuiltProject name)
+  set(identifier "thirdparty_build_${name}")
+
+  # Create a target to hold the arguments from the function call.
+  set(props "${identifier}_props")
+  add_custom_target(${props})
+  _ep_parse_arguments(definePrebuiltProject ${props} _CEP_ "${ARGN}")
+
+  # Access arguments as propertoes.
+  get_property(depends_list TARGET ${props} PROPERTY _CEP_DEPENDS)
+  foreach(depends ${depends_list})
+    list(APPEND depends_targets "thirdparty_build_${depends}")
+  endforeach()
+
+  get_property(url TARGET ${props} PROPERTY _CEP_URL)
+  get_property(hash TARGET ${props} PROPERTY _CEP_SHA256)
+  get_property(patches TARGET ${props} PROPERTY _CEP_PATCHES)
+  get_property(configure_command TARGET ${props} PROPERTY _CEP_CONFIGURE)
+  get_property(build_command TARGET ${props} PROPERTY _CEP_BUILD)
+  get_property(install_command TARGET ${props} PROPERTY _CEP_INSTALL)
+  get_property(build_in_source TARGET ${props} PROPERTY _CEP_BUILD_IN_SOURCE)
+
+  set(patch_glue)
+  foreach(patch ${patches})
+    list(APPEND patch_command ${patch_glue}
+      patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/${patch})
+    set(patch_glue &&)
+  endforeach()
+
+  if(DEFINED PLATFORM_LINUX)
+    set(platform_name "linux")
+  elseif(DEFINED PLATFORM_MACOS)
+    set(platform_name "macos")
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(platform_name "windows")
+  else()
+    message(FATAL_ERROR "Unrecognized system")
+    return()
+  endif()
+
+  set(install_prefix "${THIRD_PARTY_PREBUILT_PATH}/${platform_name}-x86_64")
+
+  # 'Forward' them to ExternalProject
+  ExternalProject_Add(${identifier}
+    URL ${url}
+    URL_HASH SHA256=${hash}
+    INSTALL_DIR "${install_prefix}"
+    DEPENDS ${depends_targets}
+    PATCH_COMMAND ${patch_command}
+    CONFIGURE_COMMAND ${configure_command}
+    BUILD_COMMAND ${build_command}
+    INSTALL_COMMAND ${install_command}
+    EXCLUDE_FROM_ALL ON
+    BUILD_IN_SOURCE ${build_in_source}
+  )
+  add_dependencies(thirdparty_prebuilt "${identifier}")
 endfunction()
 
 # Generates a target named identifier_downloader that will acquire the remote file while also verifying
@@ -108,9 +180,65 @@ function(extractLocalArchive identifier anchor_file archive_path working_directo
   add_custom_target("${identifier}_extractor" DEPENDS "${absolute_anchor_path}" ${additional_anchor_file_paths})
 endfunction()
 
+function(importThirdPartyBinaryLibrary name anchor_file_name)
+  if(DEFINED PLATFORM_LINUX)
+    set(platform_name "linux")
+  elseif(DEFINED PLATFORM_MACOS)
+    set(platform_name "macos")
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(platform_name "windows")
+  else()
+    message(FATAL_ERROR "Unrecognized system")
+    return()
+  endif()
+
+  set(identifier "thirdparty_${name}")
+  set(base_path "${THIRD_PARTY_PREBUILT_PATH}/${platform_name}-x86_64")
+
+  # Just the name of the file
+  set(relative_anchor_path "${anchor_file_name}")
+
+  if(${ARGC} GREATER 2)
+    foreach(additional_anchor ${ARGN})
+      list(APPEND additional_anchor_rel_paths "${additional_anchor}")
+    endforeach()
+  endif()
+
+  if(additional_anchor_rel_paths)
+    add_osquery_library("${identifier}" INTERFACE IMPORTED GLOBAL)
+    set_target_properties("${identifier}" PROPERTIES INTERFACE_BINARY_DIR "${base_path}")
+
+    list(APPEND libraries "${relative_anchor_path}")
+    list(APPEND libraries "${additional_anchor_rel_paths}")
+
+    foreach(library ${libraries})
+      get_filename_component(library_name "${library}" NAME_WE)
+      add_osquery_library("${identifier}_${library_name}" STATIC IMPORTED GLOBAL)
+      set_target_properties("${identifier}_${library_name}" PROPERTIES IMPORTED_LOCATION "${base_path}/${library}")
+      target_link_libraries("${identifier}" INTERFACE "${identifier}_${library_name}")
+    endforeach()
+  else()
+    add_osquery_library("${identifier}" STATIC IMPORTED GLOBAL)
+    set_target_properties("${identifier}" PROPERTIES IMPORTED_LOCATION "${base_path}/${relative_anchor_path}")
+  endif()
+
+  #execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${base_folder}/include")
+  target_include_directories("${identifier}" INTERFACE "${base_path}/include")
+
+  set(importThirdPartyBinaryLibrary_baseFolderPath "${base_path}" PARENT_SCOPE)
+endfunction()
+
+function(importThirdPartyHeaderOnlyLibrary library_type name anchor_file include_folder)
+  set(identifier "thirdparty_${name}")
+  set(base_path "${THIRD_PARTY_PREBUILT_PATH}/${platform_name}-x86_64")
+
+  add_osquery_library("${identifier}" INTERFACE)
+  target_include_directories("${identifier}" INTERFACE "${base_folder}/${include_folder}")
+endfunction()
+
 # Generates a empty imported or interface library named thirdparty_name that will depends on the targets
 # that will download and extract the remote tarball
-function(importThirdPartyBinaryLibrary name version hash anchor_file_name)
+function(importThirdPartyBinaryLibrary_DEPRECATED name version hash anchor_file_name)
   if(DEFINED PLATFORM_LINUX)
     set(platform_name "linux")
   elseif(DEFINED PLATFORM_MACOS)
@@ -170,7 +298,7 @@ endfunction()
 
 # Generates an interface library named thirdparty_name that automatically includes the specified
 # include folder. This library will depend on the downloader and extractor targets
-function(importThirdPartyHeaderOnlyLibrary library_type name version hash anchor_file include_folder)
+function(importThirdPartyHeaderOnlyLibrary_DEPRECATED library_type name version hash anchor_file include_folder)
 
   if("${library_type}" STREQUAL "SOURCE")
     set(base_url "${THIRD_PARTY_REPOSITORY_URL}/third-party/src")
@@ -208,7 +336,7 @@ function(importThirdPartyHeaderOnlyLibrary library_type name version hash anchor
 endfunction()
 
 # Initializes the PYTHONPATH folder in the binary directory, used to run the codegen scripts
-function(initializePythonPathFolder)  
+function(initializePythonPathFolder)
   add_custom_command(
     OUTPUT "${PYTHON_PATH}"
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${PYTHON_PATH}"

--- a/third-party/augeas/CMakeLists.txt
+++ b/third-party/augeas/CMakeLists.txt
@@ -6,13 +6,8 @@
 
 function(augeasMain)
   set(name "augeas")
-  set(version "1.9.0")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "ff21a672ec7d6ae313eabe32a458d2d4528ad086559a24e9d70638da10983b37")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "7330e0fcfbcea6f58d199916238c47078f3ea2ba85ac4ed2fa74fcb63e034b1c")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     add_osquery_library(thirdparty_augeas INTERFACE)
     return()
   endif()
@@ -23,7 +18,30 @@ function(augeasMain)
     "lib/libfa.a"
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_library})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_library})
+
+  set(dependencies libxml2)
+  definePrebuiltProject(${name}
+    URL http://download.augeas.net/augeas-1.12.0.tar.gz
+    SHA256 321942c9cc32185e2e9cb72d0a70eea106635b50269075aca6714e3ec282cb87
+    DEPENDS ${dependencies}
+    PATCHES libaugeas-1.12.0-1.patch
+    CONFIGURE
+      autoreconf &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --enable-shared=no
+        --without-selinux
+    BUILD
+      cd <SOURCE_DIR>/gnulib/lib && $(MAKE) &&
+      cd <SOURCE_DIR>/src &&
+        $(MAKE) datadir.h &&
+        $(MAKE) install-libLTLIBRARIES &&
+        $(MAKE) install-data-am
+    INSTALL
+      $(MAKE) install-data-am
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 augeasMain()

--- a/third-party/augeas/libaugeas-1.12.0-1.patch
+++ b/third-party/augeas/libaugeas-1.12.0-1.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 5230efe..d639e14 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -91,7 +91,7 @@ AUGEAS_COMPILE_WARNINGS(maximum)
+ AUGEAS_CFLAGS=-std=gnu99
+ AC_SUBST(AUGEAS_CFLAGS)
+
+-AUGEAS_CHECK_READLINE
++# AUGEAS_CHECK_READLINE
+ AC_CHECK_FUNCS([open_memstream uselocale])
+
+ AC_MSG_CHECKING([how to pass version script to the linker ($LD)])

--- a/third-party/aws-sdk-cpp/CMakeLists.txt
+++ b/third-party/aws-sdk-cpp/CMakeLists.txt
@@ -6,37 +6,65 @@
 
 function(awsSdkCppMain)
   set(name "aws-sdk-cpp")
-  set(version "1.4.55")
-
-  set(anchor_file "lib/libtesting-resources.a")
+  set(anchor_file lib/libaws-cpp-sdk-ec2.a)
 
   set(additional_libraries
-    lib/libaws-cpp-sdk-ec2.a
     lib/libaws-cpp-sdk-firehose.a
     lib/libaws-cpp-sdk-kinesis.a
     lib/libaws-cpp-sdk-sts.a
     lib/libaws-cpp-sdk-core.a
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "38d8ab7feccc25ba89adb49ffbcbe8c9b274191f2eb9172371c94f2ceb5a1159")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "1d1974a6bb22dbe40ebd98547e775364357e65e81cda52b6fb2485250fdd15ba")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "71b575fc0ade0ae22239c4bdb2ba2f09a90d67c44425196aaffc96a14cb9a4fc")
-    set(anchor_file "lib/aws-cpp-sdk-core.lib")
-
+  if(DEFINED PLATFORM_WINDOWS)
+    set(anchor_file "lib/aws-cpp-sdk-firehose.lib")
     set(additional_libraries
-      lib/aws-cpp-sdk-ec2.lib
-      lib/aws-cpp-sdk-firehose.lib
       lib/aws-cpp-sdk-kinesis.lib
       lib/aws-cpp-sdk-sts.lib
+      lib/aws-cpp-sdk-core.lib
     )
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
+
+  # Might want to skip EC2 on Windows (remove cloud tables).
+  if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
+    set(configure_options
+      -DCMAKE_LIBRARY_PATH=<INSTALL_DIR>/lib
+      -DZLIB_INCLUDE_DIR=<INSTALL_DIR>/include
+      -DOPENSSL_INCLUDE_DIR=<INSTALL_DIR>/include
+      -DOPENSSL_SSL_LIBRARY=<INSTALL_DIR>/lib/libssl.a
+      -DOPENSSL_CRYPTO_LIBRARY=<INSTALL_DIR>/lib/libcrypto.a
+      -DBUILD_ONLY=firehose$<SEMICOLON>kinesis$<SEMICOLON>sts$<SEMICOLON>ec2
+    )
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(configure_options
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=/MT\ /O2\ /Ob2\ /DNDEBUG
+      -DFORCE_SHARED_CRT=OFF
+      -DBUILD_ONLY=firehose$<SEMICOLON>kinesis$<SEMICOLON>sts
+    )
+  endif()
+
+  set(dependencies zlib openssl boost)
+  definePrebuiltProject(${name}
+    URL https://github.com/aws/aws-sdk-cpp/archive/1.6.53.tar.gz
+    SHA256 80cb2e1d7012897832dee5d2465ac85b8ad052b520ba4d9bf03aa92e57f7406d
+    DEPENDS ${dependencies}
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DSTATIC_LINKING=1
+        -DNO_HTTP_CLIENT=1
+        -DMINIMIZE_SIZE=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DENABLE_TESTING=OFF
+        -DAUTORUN_UNIT_TESTS=OFF
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 awsSdkCppMain()

--- a/third-party/berkeley-db/CMakeLists.txt
+++ b/third-party/berkeley-db/CMakeLists.txt
@@ -10,8 +10,6 @@ function(berkeleydbMain)
   endif()
 
   set(name "berkeley-db")
-  set(version "5.3.28")
-  set(hash "793ab1515833c680ef3054f6a16781fa766699395ffbb6810635d36f2e8f6cb0")
   set(anchor_file "lib/libdb.a")
 
   set(additional_libraries
@@ -20,8 +18,28 @@ function(berkeleydbMain)
     lib/libdb_cxx.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
 
+  set(dependencies libxml2)
+  definePrebuiltProject(${name}
+    URL http://pkgs.fedoraproject.org/repo/pkgs/libdb/db-5.3.28.tar.gz/b99454564d5b4479750567031d66fe24/db-5.3.28.tar.gz
+    SHA256 e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628
+    DEPENDS ${dependencies}
+    PATCHES berkeley-db-5.3.28-1.patch
+    CONFIGURE
+      cd build_unix && ../dist/configure
+        --disable-debug
+        --prefix=<INSTALL_DIR>
+        --enable-cxx
+        --enable-compat185
+        --disable-shared
+        --enable-static
+    BUILD
+      cd build_unix && $(MAKE)
+    INSTALL
+      cd build_unix && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 berkeleydbMain()

--- a/third-party/berkeley-db/berkeley-db-5.3.28-1.patch
+++ b/third-party/berkeley-db/berkeley-db-5.3.28-1.patch
@@ -1,0 +1,128 @@
+diff --git a/src/dbinc/atomic.h b/src/dbinc/atomic.h
+index 6a858f7..9f338dc 100644
+--- a/src/dbinc/atomic.h
++++ b/src/dbinc/atomic.h
+@@ -70,7 +70,7 @@ typedef struct {
+  * These have no memory barriers; the caller must include them when necessary.
+  */
+ #define	atomic_read(p)		((p)->value)
+-#define	atomic_init(p, val)	((p)->value = (val))
++#define	atomic_init_db(p, val)	((p)->value = (val))
+ 
+ #ifdef HAVE_ATOMIC_SUPPORT
+ 
+@@ -144,7 +144,7 @@ typedef LONG volatile *interlocked_val;
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@ static inline int __atomic_dec(db_atomic_t *p)
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;
+@@ -206,7 +206,7 @@ static inline int __atomic_compare_exchange(
+ #define	atomic_dec(env, p)	(--(p)->value)
+ #define	atomic_compare_exchange(env, p, oldval, newval)		\
+ 	(DB_ASSERT(env, atomic_read(p) == (oldval)),		\
+-	atomic_init(p, (newval)), 1)
++	atomic_init_db(p, (newval)), 1)
+ #else
+ #define atomic_inc(env, p)	__atomic_inc(env, p)
+ #define atomic_dec(env, p)	__atomic_dec(env, p)
+diff --git a/src/mp/mp_fget.c b/src/mp/mp_fget.c
+index 16de695..d0dcc29 100644
+--- a/src/mp/mp_fget.c
++++ b/src/mp/mp_fget.c
+@@ -649,7 +649,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 
+ 		/* Initialize enough so we can call __memp_bhfree. */
+ 		alloc_bhp->flags = 0;
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ #ifdef DIAGNOSTIC
+ 		if ((uintptr_t)alloc_bhp->buf & (sizeof(size_t) - 1)) {
+ 			__db_errx(env, DB_STR("3025",
+@@ -955,7 +955,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 			MVCC_MPROTECT(bhp->buf, mfp->pagesize,
+ 			    PROT_READ);
+ 
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+ 		alloc_bhp->priority = bhp->priority;
+ 		alloc_bhp->pgno = bhp->pgno;
+diff --git a/src/mp/mp_mvcc.c b/src/mp/mp_mvcc.c
+index 770bad8..e28cce0 100644
+--- a/src/mp/mp_mvcc.c
++++ b/src/mp/mp_mvcc.c
+@@ -276,7 +276,7 @@ __memp_bh_freeze(dbmp, infop, hp, bhp, need_frozenp)
+ #else
+ 	memcpy(frozen_bhp, bhp, SSZA(BH, buf));
+ #endif
+-	atomic_init(&frozen_bhp->ref, 0);
++	atomic_init_db(&frozen_bhp->ref, 0);
+ 	if (mutex != MUTEX_INVALID)
+ 		frozen_bhp->mtx_buf = mutex;
+ 	else if ((ret = __mutex_alloc(env, MTX_MPOOL_BH,
+@@ -428,7 +428,7 @@ __memp_bh_thaw(dbmp, infop, hp, frozen_bhp, alloc_bhp)
+ #endif
+ 		alloc_bhp->mtx_buf = mutex;
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		F_CLR(alloc_bhp, BH_FROZEN);
+ 	}
+ 
+diff --git a/src/mp/mp_region.c b/src/mp/mp_region.c
+index 4952030..47645f8 100644
+--- a/src/mp/mp_region.c
++++ b/src/mp/mp_region.c
+@@ -245,7 +245,7 @@ __memp_init(env, dbmp, reginfo_off, htab_buckets, max_nreg)
+ 			     MTX_MPOOL_FILE_BUCKET, 0, &htab[i].mtx_hash)) != 0)
+ 				return (ret);
+ 			SH_TAILQ_INIT(&htab[i].hash_bucket);
+-			atomic_init(&htab[i].hash_page_dirty, 0);
++			atomic_init_db(&htab[i].hash_page_dirty, 0);
+ 		}
+ 
+ 		/*
+@@ -302,7 +302,7 @@ no_prealloc:
+ 		} else
+ 			hp->mtx_hash = mtx_base + (i % dbenv->mp_mtxcount);
+ 		SH_TAILQ_INIT(&hp->hash_bucket);
+-		atomic_init(&hp->hash_page_dirty, 0);
++		atomic_init_db(&hp->hash_page_dirty, 0);
+ #ifdef HAVE_STATISTICS
+ 		hp->hash_io_wait = 0;
+ 		hp->hash_frozen = hp->hash_thawed = hp->hash_frozen_freed = 0;
+diff --git a/src/mutex/mut_tas.c b/src/mutex/mut_tas.c
+index 106b161..fc4de9d 100644
+--- a/src/mutex/mut_tas.c
++++ b/src/mutex/mut_tas.c
+@@ -47,7 +47,7 @@ __db_tas_mutex_init(env, mutex, flags)
+ 
+ #ifdef HAVE_SHARED_LATCHES
+ 	if (F_ISSET(mutexp, DB_MUTEX_SHARED))
+-		atomic_init(&mutexp->sharecount, 0);
++		atomic_init_db(&mutexp->sharecount, 0);
+ 	else
+ #endif
+ 	if (MUTEX_INIT(&mutexp->tas)) {
+@@ -536,7 +536,7 @@ __db_tas_mutex_unlock(env, mutex)
+ 			F_CLR(mutexp, DB_MUTEX_LOCKED);
+ 			/* Flush flag update before zeroing count */
+ 			MEMBAR_EXIT();
+-			atomic_init(&mutexp->sharecount, 0);
++			atomic_init_db(&mutexp->sharecount, 0);
+ 		} else {
+ 			DB_ASSERT(env, sharecount > 0);
+ 			MEMBAR_EXIT();

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 function(boostMain)
   set(name "boost")
-  set(version "1.66.0")
-
   set(anchor_file "lib/libboost_chrono-mt.a")
 
   set(additional_libraries
@@ -19,12 +17,7 @@ function(boostMain)
     lib/libboost_system-mt.a
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "3a24d65730beb3a718ee443eaedac40033d349582eeb83664ea2529080c812ba")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "69c884d27838a11f9a45b78e03eb12a425d554dac4ad8c6ef19f91e63e945286")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "5530174b75b67c3c8e59f2ae62c3e18fea1b5e55c795ff19b40fb75cf93dfb51")
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/libboost_chrono-mt-s.lib")
 
     set(additional_libraries
@@ -35,11 +28,74 @@ function(boostMain)
       lib/libboost_thread-mt-s.lib
       lib/libboost_system-mt-s.lib
     )
-  else()
-    message(SEND_ERROR "Unsupported platform")
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
+
+  set(dependencies zlib)
+
+  if(DEFINED PLATFORM_MACOS)
+    set(platform_toolchain darwin)
+    set(boost_toolchain clang)
+    set(configure_command
+      CC=clang ./bootstrap.sh
+        --prefix=<INSTALL_DIR>
+        --libdir=<INSTALL_DIR>/lib
+        --with-toolset=cc &&
+      ${REPLACE_CMD} "cc ;" "${platform_toolchain} ;" project-config.jam
+    )
+    set(cxx_flags "cxxflags=-std=c++11 -fvisibility=hidden -fvisibility-inlines-hidden $ENV{CXXFLAGS}")
+    set(link_flags optimization=space "linkflags=$ENV{LDFLAGS}")
+  elseif(DEFINED PLATFORM_LINUX)
+    list(APPEND dependencies bzip2)
+    set(platform_toolchain clang)
+    set(boost_toolchain clang)
+    set(configure_command
+      CC=clang ./bootstrap.sh
+        --prefix=<INSTALL_DIR>
+        --libdir=<INSTALL_DIR>/lib
+        --with-toolset=cc &&
+      ${REPLACE_CMD} "cc ;" "${platform_toolchain} ;" project-config.jam
+    )
+    set(cxx_flags "cxxflags=-std=c++11 -fvisibility=hidden -fvisibility-inlines-hidden $ENV{CXXFLAGS}")
+    set(link_flags optimization=space "linkflags=$ENV{LDFLAGS}")
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(boost_toolchain msvc-14.1)
+    set(configure_command bootstrap.bat)
+    set(link_flags runtime-link=static)
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.bz2
+    SHA256 5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ${configure_command}
+    BUILD true
+    INSTALL
+      ./b2 install
+        --prefix=<INSTALL_DIR>
+        --libdir=<INSTALL_DIR>/lib
+        -d2
+        --layout=tagged
+        --ignore-site-config
+        --disable-icu
+        --with-filesystem
+        --with-regex
+        --with-system
+        --with-thread
+        --with-coroutine
+        --with-context
+        threading=multi
+        link=static
+        variant=release
+        toolset=${boost_toolchain}
+        address-model=64
+        include=<INSTALL_DIR>/include
+        ${link_flags}
+        ${cxx_flags}
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 boostMain()

--- a/third-party/bzip2/CMakeLists.txt
+++ b/third-party/bzip2/CMakeLists.txt
@@ -6,27 +6,31 @@
 
 function(bzip2Main)
   set(name "bzip2")
-  set(version "1.0.6")
-
   set(anchor_file "lib/libbz2.a")
 
   if(DEFINED PLATFORM_MACOS)
     add_osquery_library(thirdparty_bzip2 INTERFACE)
     target_link_libraries(thirdparty_bzip2 INTERFACE "bz2")
-
     return()
-
-  elseif(DEFINED PLATFORM_LINUX)
-    set(hash "1cc3eaf8fe78f19fcae9f71065b04bd2dedb4862081f1d1c96e0668f3df864c8")
-
   elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "11001b5e353bc255a755284b9ed8baed01b6d9fe2a63e5e325124e8b998d48c2")
-    set(anchor_file "lib/libbz2.lib")
-  else()
+    add_osquery_library(thirdparty_bzip2 INTERFACE)
     return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://src.fedoraproject.org/lookaside/pkgs/bzip2/bzip2-1.0.6.tar.gz/00b516f4704d4a7cb50a1d97e6e8e15b/bzip2-1.0.6.tar.gz
+    SHA256 a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ${REPLACE_CMD} "CFLAGS=" "CFLAGS=$ENV{CFLAGS} " Makefile &&
+      ${REPLACE_CMD} "CC=gcc" "CC=$ENV{CC}" Makefile
+    BUILD true
+    INSTALL
+      $(MAKE) install PREFIX=<INSTALL_DIR>
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 bzip2Main()

--- a/third-party/gflags/CMakeLists.txt
+++ b/third-party/gflags/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 function(gflagsMain)
   set(name "gflags")
-  set(version "2.2.1")
 
   set(anchor_file "lib/libgflags.a")
 
@@ -14,21 +13,37 @@ function(gflagsMain)
     lib/libgflags_nothreads.a
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "5e0813ea29d5ba739c089ae21dccf5b7d4ec6f7a7d9550da0834476fade2b60c")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "217fd2573443981bc8e521fcf4d8201ba4d3c29cace1b9a537f94be08df7ebb6")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "a7bb0676d7ac0338cfa71f48f5e0d83332470e1fcd0223aa697f1a0fd2e0789a")
-
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/gflags_static.lib")
     set(additional_library "")
-
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_library})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_library})
+
+  if(DEFINED PLATFORM_WINDOWS)
+    set(configure_options
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=/MT\ /O2\ /Ob2\ /DNDEBUG
+    )
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://github.com/gflags/gflags/archive/v2.2.1.tar.gz
+    SHA256 ae27cdbcd6a2f935baa78e4f21f675649271634c092b1be01469440495609d0e
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DBUILD_SHARED_LIBS=OFF
+        -DGFLAGS_BUILD_STATIC_LIBS=ON
+        -DGFLAGS_BUILD_SHARED_LIBS=OFF
+        -DGFLAGS_BUILD_gflags_LIB=ON
+        -DGFLAGS_INSTALL_STATIC_LIBS=ON
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 gflagsMain()

--- a/third-party/glog/CMakeLists.txt
+++ b/third-party/glog/CMakeLists.txt
@@ -6,25 +6,39 @@
 
 function(glogMain)
   set(name "glog")
-  set(version "0.3.5")
-
   set(anchor_file "lib/libglog.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "1291104355f4373f22294d86eeb2e612d03ea1adbf7cbaef2083ca730e9df60c")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "91ccd947175a029da61447cc2f871798dc3756bc3adfc178cc782e4714e5a712")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "7c25024502db7e5ffaa0d7e851450946b9193fb093b815692763b619b4d55723")
-
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/glog.lib")
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_gflags)
+
+  if(DEFINED PLATFORM_WINDOWS)
+    set(configure_options
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=/MT\ /O2\ /Ob2\ /DNDEBUG
+    )
+  endif()
+
+  set(dependencies gflags)
+  definePrebuiltProject(${name}
+    URL https://github.com/google/glog/archive/v0.3.5.tar.gz
+    SHA256 7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0
+    DEPENDS ${dependencies}
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_TESTING=OFF
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 glogMain()

--- a/third-party/libarchive/CMakeLists.txt
+++ b/third-party/libarchive/CMakeLists.txt
@@ -6,23 +6,38 @@
 
 function(archiveMain)
   set(name "libarchive")
-  set(version "3.3.2")
-
   set(anchor_file "lib/libarchive.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "6818c2d6c8067918365cb81992f7853b100ef3244b8767bf2d182a1974f225a3")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "a3ec7af1618116fca2008838ef18d2028148b34e215c748da3f25e4053bfe6e8")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "cb1fc7e7ed1c652d7c322f629145749a60586eb8ec033a76025a04f4a42117a5")
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/archive_static.lib")
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
+  set(dependencies zlib)
+  if(DEFINED PLATFORM_LINUX)
+    list(APPEND dependencies bzip2 lzma)
+  endif()
+
+  definePrebuiltProject(${name}
+    URL http://www.libarchive.org/downloads/libarchive-3.3.2.tar.gz
+    SHA256 ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure --prefix=<INSTALL_DIR>
+        --without-lzo2
+        --without-nettle
+        --without-xml2
+        --without-openssl
+        --with-expat
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 archiveMain()

--- a/third-party/libaudit/CMakeLists.txt
+++ b/third-party/libaudit/CMakeLists.txt
@@ -10,12 +10,26 @@ function(libauditMain)
   endif()
 
   set(name "libaudit")
-  set(version "2.4.2")
-  set(hash "4e87a234f68eb8686ab3fa9096ffd664a899efc8e7839c767abd60ac956f6688")
   set(anchor_file "lib/libaudit.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
+  definePrebuiltProject(${name}
+    URL https://github.com/Distrotech/libaudit/archive/audit-2.4.2.tar.gz
+    SHA256 63020c88b0f37a93438894e67e63ccede23d658277ecc6afb9d40e4043147d3f
+    CONFIGURE
+      touch INSTALL.tmp &&
+      ./autogen.sh &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      cd lib && $(MAKE)
+    INSTALL
+      cd lib && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libauditMain()

--- a/third-party/libcryptsetup/CMakeLists.txt
+++ b/third-party/libcryptsetup/CMakeLists.txt
@@ -10,14 +10,34 @@ function(libcryptsetupMain)
   endif()
 
   set(name "libcryptsetup")
-  set(version "1.7.5")
-  set(hash "ebb53650592212d67ea8c0e49b48891eec64ef370743678881985490c09adeac")
   set(anchor_file "lib/libcryptsetup.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_libgcrypt)
 
+  set(dependencies util-linux libdevmapper popt libgcrypt)
+  definePrebuiltProject(${name}
+    URL https://gitlab.com/cryptsetup/cryptsetup/repository/v1_7_5/archive.tar.gz
+    SHA256 6dead2f1420ab1c84a7e82f0ee197861f4a52e4c3284a0bfef824a90c392e077
+    DEPENDS ${dependencies}
+    CONFIGURE
+    ./autogen.sh
+      --prefix=<INSTALL_DIR>
+      --with-libgcrypt-prefix=<INSTALL_DIR>
+      --disable-selinux
+      --disable-udev
+      --disable-veritysetup
+      --disable-nls
+      --disable-kernel_crypto
+      --disable-shared
+      --enable-static
+    BUILD
+      cd lib && $(MAKE)
+    INSTALL
+      cd lib && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libcryptsetupMain()

--- a/third-party/libdevmapper/CMakeLists.txt
+++ b/third-party/libdevmapper/CMakeLists.txt
@@ -10,8 +10,6 @@ function(libdevmapperMain)
   endif()
 
   set(name "libdevmapper")
-  set(version "2.2.02.173")
-  set(hash "54fc7a991f42e3693fa3aa9cafe39f0b65a6fe29620f3146fd05f1a1f1bf1eae")
   set(anchor_file "lib/liblvm2app.a")
 
   set(additional_libraries
@@ -20,7 +18,32 @@ function(libdevmapperMain)
     lib/libdaemonclient.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
+
+  set(dependencies util-linux)
+  definePrebuiltProject(${name}
+    URL https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2/old/LVM2.2.02.173.tgz
+    SHA256 ceb9168c7e009ef487f96a1fe969b23cbb07d920ffb71769affdbdf30fea8d64
+    DEPENDS ${dependencies}
+    CONFIGURE
+      export VALGRIND_CFLAGS=-fPIC\ -I/usr/include/valgrind &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --with-lvm1=none
+        --disable-selinux
+        --disable-readline
+        --enable-static_link
+    BUILD
+      $(MAKE) libdm.device-mapper &&
+      cd <SOURCE_DIR>/libdm && $(MAKE) install &&
+      cd <SOURCE_DIR>/lib && $(MAKE) &&
+      cd <SOURCE_DIR>/libdaemon && $(MAKE) &&
+      cd <SOURCE_DIR>/liblvm && $(MAKE) install
+    INSTALL
+      cp <SOURCE_DIR>/lib/liblvm-internal.a <INSTALL_DIR>/lib &&
+      cp <SOURCE_DIR>/libdaemon/client/libdaemonclient.a <INSTALL_DIR>/lib
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libdevmapperMain()

--- a/third-party/libdpkg/CMakeLists.txt
+++ b/third-party/libdpkg/CMakeLists.txt
@@ -10,13 +10,28 @@ function(libdpkgMain)
   endif()
 
   set(name "libdpkg")
-  set(version "1.19.0.5")
-  set(hash "9bd06978cf7caaa68bd607ac817c2fd0f436659a9620f6e8bf0281c4f3106799")
   set(anchor_file "lib/libdpkg.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_zlib)
+
+  set(dependencies zlib bzip2 lzma)
+  definePrebuiltProject(${name}
+    URL https://launchpad.net/debian/+archive/primary/+sourcefiles/dpkg/1.19.0.5/dpkg_1.19.0.5.tar.xz
+    SHA256 818046927a7f77c1bcbbad7d8dbc04cdf0f3e6ec4e1a4f9d313378ecc69d85b5
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-dselect
+        --disable-start-stop-daemon
+    BUILD
+      cd lib && $(MAKE)
+    INSTALL
+      cd lib && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libdpkgMain()

--- a/third-party/libelfin/CMakeLists.txt
+++ b/third-party/libelfin/CMakeLists.txt
@@ -10,15 +10,25 @@ function(libelfinMain)
   endif()
 
   set(name "libelfin")
-  set(version "0.3")
-  set(hash "d3f6611493558a38796072a5464e0c261e6651b5630b51459d9d98dec7d052c9")
   set(anchor_file "lib/libdwarf++.a")
 
   set(additional_lib
     lib/libelf++.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_lib})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_lib})
+
+  definePrebuiltProject(${name}
+    URL https://github.com/aclements/libelfin/archive/v0.3.tar.gz
+    SHA256 c338942b967582922b3514b54b93175ca9051a9668db92dd8ef619824d443ac7
+    CONFIGURE true
+    BUILD
+      export CXXFLAGS=-Wno-unused-command-line-argument\ $ENV{CXXFLAGS} &&
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libelfinMain()

--- a/third-party/libgcrypt/CMakeLists.txt
+++ b/third-party/libgcrypt/CMakeLists.txt
@@ -10,13 +10,43 @@ function(libgcryptMain)
   endif()
 
   set(name "libgcrypt")
-  set(version "1.8.1")
-  set(hash "338bb77bac1565319f69a210db5b50e0410046628b05f9c5ed3521607cbbf711")
   set(anchor_file "lib/libgcrypt.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_libgpg-error)
+
+  set(dependencies libgpg-error)
+  definePrebuiltProject(${name}
+    URL https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2
+    SHA256 7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+        --disable-avx-support
+        --disable-avx2-support
+        --disable-drng-support
+        --disable-pclmul-support
+        --disable-sse41-support
+        --disable-optimization
+        --disable-asm
+        --disable-jent-support
+        --with-libgpg-error-prefix=<INSTALL_DIR>
+        --with-gpg-error-prefix=<INSTALL_DIR> &&
+      ed -s - config.h < ${CMAKE_CURRENT_SOURCE_DIR}/libgcrypt-1.8.1-1-config.h.ed
+    BUILD
+      cd <SOURCE_DIR>/cipher && $(MAKE) &&
+      cd <SOURCE_DIR>/random && $(MAKE) &&
+      cd <SOURCE_DIR>/mpi && $(MAKE) &&
+      cd <SOURCE_DIR>/compat && $(MAKE) &&
+      cd <SOURCE_DIR>/src && $(MAKE)
+    INSTALL
+      cd src && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libgcryptMain()

--- a/third-party/libgcrypt/libgcrypt-1.8.1-1-config.h.ed
+++ b/third-party/libgcrypt/libgcrypt-1.8.1-1-config.h.ed
@@ -1,0 +1,8 @@
+/#define SIZEOF_UNSIGNED_LONG/c
+#ifdef __LP64__
+#define SIZEOF_UNSIGNED_LONG 8
+#else
+#define SIZEOF_UNSIGNED_LONG 4
+#endif
+.
+w

--- a/third-party/libgpg-error/CMakeLists.txt
+++ b/third-party/libgpg-error/CMakeLists.txt
@@ -10,11 +10,24 @@ function(libgpgerrorMain)
   endif()
 
   set(name "libgpg-error")
-  set(version "1.27")
-  set(hash "6976db62b22844015e934f7225b236c8c4851c515815efa9967575eadd6dabf5")
   set(anchor_file "lib/libgpg-error.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2
+    SHA256 4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libgpgerrorMain()

--- a/third-party/libiptables/CMakeLists.txt
+++ b/third-party/libiptables/CMakeLists.txt
@@ -10,8 +10,6 @@ function(libiptablesMain)
   endif()
 
   set(name "libiptables")
-  set(version "1.8.0")
-  set(hash "f32841cca13b8273f767d859b6c98f6fe7fea05cfc835ff192c794a5d417ba26")
   set(anchor_file "lib/libip4tc.a")
 
   set(additional_libraries
@@ -19,7 +17,24 @@ function(libiptablesMain)
     lib/libiptc.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
+
+  definePrebuiltProject(${name}
+    URL https://ftp.osuosl.org/pub/blfs/conglomeration/iptables/iptables-1.8.3.tar.bz2
+    SHA256 a23cac034181206b4545f4e7e730e76e08b5f3dd78771ba9645a6756de9cdd80
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-nftables
+        --disable-shared
+    BUILD
+      cd libiptc && $(MAKE)
+    INSTALL
+      cd <SOURCE_DIR>/libiptc && $(MAKE) install &&
+      cd <SOURCE_DIR>/include && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libiptablesMain()

--- a/third-party/libmagic/CMakeLists.txt
+++ b/third-party/libmagic/CMakeLists.txt
@@ -6,22 +6,35 @@
 
 function(libmagicMain)
   set(name "libmagic")
-  set(version "5.32")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "e6c7144360b29d672db7a98cdfe55dc80812c2100b4a111d65f98e78404835aa")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "66efdaf945b8d04751aa337ef0529ded53fcd7e3b85fb8dfd9e4c40a562ffa6d")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     add_osquery_library(thirdparty_libmagic INTERFACE)
     return()
   endif()
 
   set(anchor_file "lib/libmagic.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_zlib)
+
+  set(dependencies zlib)
+  definePrebuiltProject(${name}
+    URL https://distfiles.macports.org/file/file-5.32.tar.gz
+    SHA256 8639dc4d1b21e232285cd483604afc4a6ee810710e00e579dbe9591681722b50
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --enable-fsect-man5
+        --enable-static
+        --disable-shared
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libmagicMain()

--- a/third-party/librdkafka/CMakeLists.txt
+++ b/third-party/librdkafka/CMakeLists.txt
@@ -6,23 +6,42 @@
 
 function(librdkafkaMain)
   set(name "librdkafka")
-  set(version "0.11.3")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "a8cece2c04522243ee53fd85130c4c6e2874ba27261bef554e74afed7425641b")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "61790b76923d0005734db6209d99cd2c262cf2227500261244c208918e8b79b7")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
   set(anchor_file "lib/librdkafka.a")
 
-  set(additional_lib
-    lib/librdkafka++.a
-  )
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_lib})
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_lib})
+  target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_openssl)
+
+  set(dependencies zlib openssl rapidjson)
+  if(DEFINED PLATFORM_LINUX)
+    list(APPEND dependencies bzip2)
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://github.com/edenhill/librdkafka/archive/v1.0.1.tar.gz
+    SHA256 b2a2defa77c0ef8c508739022a197886e0644bd7bf6179de1b68bdffb02b3550
+    DEPENDS ${dependencies}
+    PATCHES librdkafka-1.0.1-1.patch
+    CONFIGURE
+      export LDFLAGS=-L<INSTALL_DIR>/lib &&
+      export LIBS=-lcrypto &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-sasl
+        --disable-gssapi
+        --disable-lz4-ext
+        --enable-static
+    BUILD
+      cd src && $(MAKE)
+    INSTALL
+      cd src && $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 librdkafkaMain()

--- a/third-party/librdkafka/librdkafka-1.0.1-1.patch
+++ b/third-party/librdkafka/librdkafka-1.0.1-1.patch
@@ -1,0 +1,22 @@
+diff --git a/src/tinycthread.c b/src/tinycthread.c
+index 0049db3..9b186a3 100644
+--- a/src/tinycthread.c
++++ b/src/tinycthread.c
+@@ -921,7 +921,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
+ {
+ #if defined(_TTHREAD_WIN32_)
+   struct _timeb tb;
+-#elif !defined(CLOCK_REALTIME)
++#elif !defined(CLOCK_REALTIME) || defined(__APPLE__)
+   struct timeval tv;
+ #endif
+
+@@ -934,7 +934,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
+   _ftime_s(&tb);
+   ts->tv_sec = (time_t)tb.time;
+   ts->tv_nsec = 1000000L * (long)tb.millitm;
+-#elif defined(CLOCK_REALTIME)
++#elif defined(CLOCK_REALTIME) && !defined(__APPLE__)
+   base = (clock_gettime(CLOCK_REALTIME, ts) == 0) ? base : 0;
+ #else
+   gettimeofday(&tv, NULL);

--- a/third-party/librpm/CMakeLists.txt
+++ b/third-party/librpm/CMakeLists.txt
@@ -10,8 +10,6 @@ function(librpmMain)
   endif()
 
   set(name "librpm")
-  set(version "4.14.1")
-  set(hash "5aca71879ab793c1029684dfa59baec462584ba3f4e3f6444c374b160b5afde8")
   set(anchor_file "lib/librpm.a")
 
   set(additional_libraries
@@ -20,7 +18,7 @@ function(librpmMain)
     lib/librpmsign.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
 
   target_link_libraries("thirdparty_${name}" INTERFACE
     thirdparty_berkeley-db
@@ -36,6 +34,44 @@ function(librpmMain)
   )
 
   target_link_libraries("thirdparty_${name}_librpmio" INTERFACE thirdparty_zlib)
+  target_link_libraries("thirdparty_${name}_librpmio" INTERFACE thirdparty_bzip2)
+
+  if(DEFINED PLATFORM_MACOS)
+    set(extra_libs "-lz -liconv")
+    set(extra_patches librpm-4.14.1-1-darwin.patch)
+  endif()
+
+  set(dependencies openssl popt berkeley-db libmagic)
+  definePrebuiltProject(${name}
+    URL http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.1.tar.bz2
+    SHA256 43f40e2ccc3ca65bd3238f8c9f8399d4957be0878c2e83cba2746d2d0d96793b
+    DEPENDS ${dependencies}
+    PATCHES
+      librpm-4.14.1-1.patch
+      ${extra_patches}
+    CONFIGURE
+      export LIBS=${extra_libs} &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --with-external-db
+        --without-selinux
+        --without-lua
+        --without-cap
+        --without-archive
+        --disable-nls
+        --disable-rpath
+        --disable-plugins
+        --disable-python
+        --enable-zstd=no
+        --with-crypto=openssl
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 librpmMain()

--- a/third-party/librpm/librpm-4.14.1-1-darwin.patch
+++ b/third-party/librpm/librpm-4.14.1-1-darwin.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile.in b/Makefile.in
+index a62c841..a92187a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -172,7 +172,7 @@ rpm_DEPENDENCIES = libcliutils.la lib/librpm.la rpmio/librpmio.la
+ am_rpm2archive_OBJECTS = rpm2archive.$(OBJEXT)
+ rpm2archive_OBJECTS = $(am_rpm2archive_OBJECTS)
+ rpm2archive_DEPENDENCIES = lib/librpm.la rpmio/librpmio.la
+-am_rpm2cpio_OBJECTS = rpm2cpio.$(OBJEXT)
++am_rpm2cpio_OBJECTS = rpm2cpio.$(OBJEXT) lib/poptALL.$(OBJEXT) lib/poptQV.$(OBJEXT)
+ rpm2cpio_OBJECTS = $(am_rpm2cpio_OBJECTS)
+ rpm2cpio_DEPENDENCIES = lib/librpm.la rpmio/librpmio.la
+ am_rpmbuild_OBJECTS = rpmbuild-rpmbuild.$(OBJEXT)
+@@ -196,7 +196,7 @@ am_rpmsign_OBJECTS = rpmsign-rpmsign.$(OBJEXT)
+ rpmsign_OBJECTS = $(am_rpmsign_OBJECTS)
+ rpmsign_DEPENDENCIES = libcliutils.la sign/librpmsign.la lib/librpm.la \
+ 	rpmio/librpmio.la
+-am_rpmspec_OBJECTS = rpmspec-rpmspec.$(OBJEXT)
++am_rpmspec_OBJECTS = rpmspec-rpmspec.$(OBJEXT) lib/poptQV.$(OBJEXT)
+ rpmspec_OBJECTS = $(am_rpmspec_OBJECTS)
+ rpmspec_DEPENDENCIES = libcliutils.la build/librpmbuild.la \
+ 	lib/librpm.la rpmio/librpmio.la

--- a/third-party/librpm/librpm-4.14.1-1.patch
+++ b/third-party/librpm/librpm-4.14.1-1.patch
@@ -1,0 +1,26 @@
+diff --git a/rpmio/digest_openssl.c b/rpmio/digest_openssl.c
+index 18e52a7..07647f2 100644
+--- a/rpmio/digest_openssl.c
++++ b/rpmio/digest_openssl.c
+@@ -175,9 +175,6 @@ static const EVP_MD *getEVPMD(int hashalgo)
+     case PGPHASHALGO_RIPEMD160:
+         return EVP_ripemd160();
+ 
+-    case PGPHASHALGO_MD2:
+-        return EVP_md2();
+-
+     case PGPHASHALGO_SHA256:
+         return EVP_sha256();
+
+diff --git a/rpmio/rpmio.c b/rpmio/rpmio.c
+index c7cbc32..425d982 100644
+--- a/rpmio/rpmio.c
++++ b/rpmio/rpmio.c
+@@ -725,7 +725,6 @@ static const FDIO_t bzdio = &bzdio_s ;
+ #include <lzma.h>
+ /* Multithreading support in stable API since xz 5.2.0 */
+ #if LZMA_VERSION >= 50020002
+-#define HAVE_LZMA_MT
+ #endif
+ 
+ #define kBufferSize (1 << 15)

--- a/third-party/libudev/CMakeLists.txt
+++ b/third-party/libudev/CMakeLists.txt
@@ -5,8 +5,7 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(libudevMain)
-
-  if (DEFINED PLATFORM_WINDOWS OR DEFINED PLATFORM_MACOS)
+  if(NOT DEFINED PLATFORM_LINUX)
     add_osquery_library(thirdparty_libudev INTERFACE)
     return()
   endif()
@@ -16,8 +15,31 @@ function(libudevMain)
   set(hash "fc1483fa27cb92876661e453bceef0c5752e4dbe83074a1653928ce44078aa34")
   set(anchor_file "lib/libudev.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
+  definePrebuiltProject(${name}
+    URL http://pkgs.fedoraproject.org/repo/pkgs/udev/udev-173.tar.bz2/91a88a359b60bbd074b024883cc0dbde/udev-173.tar.bz2
+    SHA256 70a18315a12f8fc1131f7da5b4dae3606988b69d5c08f96f443b84b8486caaaf
+    CONFIGURE
+      ./configure --prefix=<INSTALL_DIR>
+        --disable-logging
+        --disable-rule_generator
+        --disable-introspection
+        --disable-gudev
+        --disable-keymap
+        --disable-mtd-probe
+        --disable-hwdb
+        --disable-shared
+        --enable-static
+        --enable-gtk-doc-html=no
+        --with-systemdsystemunitdir=<INSTALL_DIR>/share
+    BUILD
+      $(MAKE) libudev/libudev.la
+    INSTALL
+      $(MAKE) install-exec &&
+      $(MAKE) install-includeHEADERS
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libudevMain()

--- a/third-party/libxml2/CMakeLists.txt
+++ b/third-party/libxml2/CMakeLists.txt
@@ -6,22 +6,38 @@
 
 function(libxml2Main)
   set(name "libxml2")
-  set(version "2.9.7")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "40f341caf6442347a130e614f7d1be3193656b7c5ad86a644a87f3b15282f7bf")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "15c240f914a430036847d19f18be54b86d0c78d54eff601f9b036b63481b420e")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     add_osquery_library(thirdparty_libxml2 INTERFACE)
     return()
   endif()
 
   set(anchor_file "lib/libxml2.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_zlib)
+
+  set(dependencies zlib)
+  definePrebuiltProject(${name}
+    URL http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz
+    SHA256 f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --without-python
+        --without-lzma
+        --with-zlib=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install &&
+      ln -sf libxml2/libxml <INSTALL_DIR>/include
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 libxml2Main()

--- a/third-party/linenoise-ng/CMakeLists.txt
+++ b/third-party/linenoise-ng/CMakeLists.txt
@@ -6,23 +6,29 @@
 
 function(linenoisengMain)
   set(name "linenoise-ng")
-  set(version "1.0.1")
-  set(hash "")
 
   set(anchor_file "lib/liblinenoise.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "604e50db04ab61ef592bcb96941bb30b67e976ac5487f904eab6927d96b9f5e9")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "78030ddb7041e86cfdd8db60bf446a147fb4c82959319597b09dcf0877337cf9")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "6dbc0acd2c2c02a93136c5a673f87463e3f619ee07fa6b20c5806a2d5bef7c05")
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/linenoise.lib")
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://github.com/arangodb/linenoise-ng/archive/master.zip
+    SHA256 35f8fa471328dd534da111f46c1814fb7efdf0feafb1b71c5a6b4b98d5fd67e8
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SHARED_LIBS=OFF
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 linenoisengMain()

--- a/third-party/lldpd/CMakeLists.txt
+++ b/third-party/lldpd/CMakeLists.txt
@@ -6,19 +6,45 @@
 
 function(lldpdMain)
   set(name "lldpd")
-  set(version "0.9.6")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "27c0b6e6faf1863db025b95e8217e715cffc51b960b1d09e8fe9235b5ef203d8")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "f9d5d5c0c2514e7d51914ffc747a068b8a82602ca62e44b65f02857f015e0d3f")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
   set(anchor_file "lib/liblldpctl.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  set(dependencies zlib)
+  if(DEFINED PLATFORM_LINUX)
+    list(APPEND dependencies bzip2)
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://media.luffy.cx/files/lldpd/lldpd-0.9.6.tar.gz
+    SHA256 e74e2dd7e2a233ca1ff385c925ddae2a916d302819d1433741407d2f8fb0ddd8
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./autogen.sh &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --with-systemdsystemunitdir=<INSTALL_DIR>/share
+        --with-sysusersdir=<INSTALL_DIR>/share
+        --with-privsep-chroot=/var/empty
+        --with-privsep-user=nobody
+        --with-privsep-group=nogroup
+        --with-launchddaemonsdir=no
+        --with-xml=no
+        --with-json=no
+        --with-readline=no
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 lldpdMain()

--- a/third-party/lzma/CMakeLists.txt
+++ b/third-party/lzma/CMakeLists.txt
@@ -5,15 +5,30 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(lzmaMain)
-  add_osquery_library(thirdparty_lzma INTERFACE)
-
-  if(DEFINED PLATFORM_LINUX)
-    set(library_name "liblzma.a")
-  else()
-    set(library_name "lzma")
+  if(NOT DEFINED PLATFORM_LINUX)
+    return()
   endif()
 
-  target_link_libraries(thirdparty_lzma INTERFACE "${library_name}")
+  set(name "lzma")
+
+  set(anchor_file lib/liblzma.a)
+
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://tukaani.org/xz/xz-5.2.4.tar.gz
+    SHA256 b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145
+    CONFIGURE
+      ./autogen.sh &&
+      ./configure --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 lzmaMain()

--- a/third-party/ncurses/CMakeLists.txt
+++ b/third-party/ncurses/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(libncursesMain)
+  if(NOT DEFINED PLATFORM_LINUX)
+    return()
+  endif()
+
+  set(name "ncurses")
+
+  definePrebuiltProject(${name}
+    URL http://ftpmirror.gnu.org/ncurses/ncurses-6.0.tar.gz
+    SHA256 f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --enable-symlinks
+        --without-shared
+        --without-manpages
+        --with-gmp=no
+        --with-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install &&
+      ln -sf ncurses/curses.h <INSTALL_DIR>/include/curses.h &&
+      ln -sf ncurses/term.h <INSTALL_DIR>/include/term.h
+    BUILD_IN_SOURCE ON
+  )
+endfunction()
+
+libncursesMain()

--- a/third-party/openssl/CMakeLists.txt
+++ b/third-party/openssl/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 function(opensslMain)
   set(name "openssl")
-  set(version "1.0.2o")
 
   set(anchor_file "lib/libssl.a")
 
@@ -14,22 +13,79 @@ function(opensslMain)
     lib/libcrypto.a
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "73472b9cf2d050b3cdda404144d28244b52d89b538b82de95acaaa98e282a1ea")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "39c59c34a497b365af0895de2b3e65e89c03f14c846084902ad3a77f943c3457")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "71144e5754cb19c32bad2ba298a3cf24e3fde4a012334c622c84e9a8cdc91ef8")
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/libeay32.lib")
 
     set(additional_lib
       lib/ssleay32.lib
     )
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_lib})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_lib})
+
+  if(DEFINED PLATFORM_MACOS)
+    set(configure_targets
+      darwin64-x86_64-cc
+      enable-ec_nistp_64_gcc_128
+    )
+    set(build_command
+      mkdir -p <INSTALL_DIR>/etc/openssl &&
+      $(MAKE) depend &&
+      $(MAKE)
+    )
+    set(install_command
+      $(MAKE) install
+    )
+  elseif(DEFINED PLATFORM_LINUX)
+    set(configure_targets
+      linux-x86_64
+    )
+    set(build_command
+      mkdir -p <INSTALL_DIR>/etc/openssl &&
+      $(MAKE) depend &&
+      $(MAKE)
+    )
+    set(install_command
+      $(MAKE) install
+    )
+  elseif(DEFINED PLATFORM_WINDOWS)
+    set(configure_targets
+      VC-WIN64A
+    )
+    set(build_command
+      ms/do_win64a.bat &&
+      nmake -f ms/nt.mak
+    )
+    set(install_command
+      cp out32/ssleay32.lib <INSTALL_DIR>/lib &&
+      cp out32/libeay32.lib <INSTALL_DIR>/lib &&
+      cp -R inc32/openssl <INSTALL_DIR>/include
+    )
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://www.openssl.org/source/openssl-1.0.2o.tar.gz
+    SHA256 ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+    CONFIGURE
+      perl ./Configure --prefix=<INSTALL_DIR>
+        --openssldir=<INSTALL_DIR>/etc/openssl
+        no-ssl2
+        no-ssl3
+        no-asm
+        no-shared
+        no-weak-ssl-ciphers
+        zlib-dynamic
+        enable-cms
+        --with-zlib-include=<INSTALL_DIR>/include
+        --with-zlib-lib=<INSTALL_DIR>/lib
+        "$ENV{CFLAGS}"
+        ${configure_targets}
+    BUILD
+      ${build_command}
+    INSTALL
+      ${install_command}
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 opensslMain()

--- a/third-party/popt/CMakeLists.txt
+++ b/third-party/popt/CMakeLists.txt
@@ -6,19 +6,30 @@
 
 function(poptMain)
   set(name "popt")
-  set(version "1.16")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "3a328038dc908d8912983100b675333207780f6239a10433a78e365f80e8d3bf")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "09ef8458657814af24d60968af57800af7f2896175a235c9b2776772be9171e9")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
   set(anchor_file "lib/libpopt.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://fossies.org/linux/misc/popt-1.16.tar.gz
+    SHA256 e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-debug
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 poptMain()

--- a/third-party/rapidjson/CMakeLists.txt
+++ b/third-party/rapidjson/CMakeLists.txt
@@ -6,21 +6,31 @@
 
 function(rapidjsonMain)
   set(name "rapidjson")
-  set(version "1.1.0")
-
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "f9a3d4e71cb72f00372696fb6c2c14094cec30519a692982de5b893a3562f244")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "ab8c220677cc03424d0683e36542a9dcd4eac1ff99ceae70007ce6e2462da9fa")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "62d59198edd5851d2c990d0e68edf7fbb633bb2816ed22adbdede03e688b0b67")
-  else()
-    return()
-  endif()
-
   set(anchor_file "include/rapidjson/rapidjson.h")
 
-  importThirdPartyHeaderOnlyLibrary("PREBUILT" "${name}" "${version}" "${hash}" "${anchor_file}" "include")
+  importThirdPartyHeaderOnlyLibrary("PREBUILT" "${name}" "${anchor_file}" "include")
+
+  set(additional_flags "$ENV{CXXFLAGS}")
+  if(NOT DEFINED PLATFORM_WINDOWS)
+    set(additional_flags "-Wno-unknown-warning-option -Wno-extra-semi-stmt -Wno-zero-as-null-pointer-constant -Wno-shadow ${additional_flags}")
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz
+    SHA256 bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
+    PATCHES librapidjson-1.1.0-1.patch
+    CONFIGURE
+      cmake
+        -DCMAKE_CXX_FLAGS_RELEASE=${additional_flags}
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DRAPIDJSON_BUILD_DOC=OFF
+        -DCMAKE_BUILD_TYPE=Release
+      <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 rapidjsonMain()

--- a/third-party/rapidjson/librapidjson-1.1.0-1.patch
+++ b/third-party/rapidjson/librapidjson-1.1.0-1.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ceda71b..9fc5273 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,7 +50,7 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -73,7 +73,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror -Wno-missing-field-initializers")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-missing-field-initializers")
+     if (RAPIDJSON_BUILD_CXX11)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     endif()

--- a/third-party/rocksdb/CMakeLists.txt
+++ b/third-party/rocksdb/CMakeLists.txt
@@ -6,26 +6,53 @@
 
 function(rocksdbMain)
   set(name "rocksdb")
-  set(version "5.7.2")
 
   set(anchor_file "lib/librocksdb_lite.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "12c8abadd96ae8ac38327e8b30c195c18f30001025f400efcac82053057d9834")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "95b161e7d3def2d4f9241c57061ea1cab4f64e51f0015db490ef99eff890354d")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "2c6d47cbc32063e420965c4949832d1c5f253da282949f81d9de4d1faeb00fa8")
-    set(anchor_file "lib/rocksdb.lib")
-  else()
-    return()
+  if(DEFINED PLATFORM_WINDOWS)
+    set(anchor_file "lib/rocksdb_lite.lib")
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_bzip2)
   target_compile_definitions("thirdparty_${name}" INTERFACE -DROCKSDB_LITE=1)
 
+  if(DEFINED PLATFORM_WINDOWS)
+    set(lib_name rocksdb.lib)
+    set(lib_target rocksdb_lite.lib)
+    set(configure_options
+      -DROCKSDB_INSTALL_ON_WINDOWS=ON
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=/MT\ /O2\ /Ob2\ /DNDEBUG
+    )
+  else()
+    set(lib_name librocksdb.a)
+    set(lib_target librocksdb_lite.a)
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://github.com/facebook/rocksdb/archive/v6.1.2.tar.gz
+    SHA256 df93f3b66caa1cbe1c2862c99c33e18a5c5b24a64fb51dfe8ef805e3c9fd1cad
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DROCKSDB_LITE=ON
+        -DWITH_GFLAGS=OFF
+        -DWITH_RUNTIME_DEBUG=OFF
+        -DWITH_TESTS=OFF
+        -DWITH_TOOLS=OFF
+        -DUSE_RTTI=OFF
+        -DPORTABLE=ON
+        -DFAIL_ON_WARNINGS=OFF
+        -DWITH_MD_LIBRARY=OFF
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install &&
+      mv <INSTALL_DIR>/lib/${lib_name} <INSTALL_DIR>/lib/${lib_target}
+  )
 endfunction()
 
 rocksdbMain()

--- a/third-party/rocksdb/librocksdb-5.7.2-1.patch
+++ b/third-party/rocksdb/librocksdb-5.7.2-1.patch
@@ -1,0 +1,23 @@
+diff --git a/build_tools/build_detect_platform b/build_tools/build_detect_platform
+index 440c6a5..1888eaa 100755
+--- a/build_tools/build_detect_platform
++++ b/build_tools/build_detect_platform
+@@ -216,7 +216,7 @@ EOF
+       #include <snappy.h>
+       int main() {}
+ EOF
+-    if [ "$?" = 0 ]; then
++    if [ 1 = 0 ]; then
+         COMMON_FLAGS="$COMMON_FLAGS -DSNAPPY"
+         PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lsnappy"
+         JAVA_LDFLAGS="$JAVA_LDFLAGS -lsnappy"
+@@ -274,7 +274,7 @@ EOF
+       #include <lz4hc.h>
+       int main() {}
+ EOF
+-    if [ "$?" = 0 ]; then
++    if [ 1 = 0 ]; then
+         COMMON_FLAGS="$COMMON_FLAGS -DLZ4"
+         PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -llz4"
+         JAVA_LDFLAGS="$JAVA_LDFLAGS -llz4"
+

--- a/third-party/sleuthkit/CMakeLists.txt
+++ b/third-party/sleuthkit/CMakeLists.txt
@@ -6,19 +6,31 @@
 
 function(sleuthkitMain)
   set(name "sleuthkit")
-  set(version "4.6.1")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "e9d63528b0b0e868453e1d9a26e29137b222e6b682e53415fccaa41783ea2e24")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "a841486e4972f262baf195d1e5ec91e9800d6f3934689407b270efc8ba465e51")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
   set(anchor_file "lib/libtsk.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://github.com/sleuthkit/sleuthkit/archive/sleuthkit-4.6.1.tar.gz
+    SHA256 bb2c936dbc88820fc4a875bc9b610f56c6a4a61b7bc8625f86be2549a948a7a9
+    CONFIGURE
+      ./bootstrap &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-java
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 sleuthkitMain()

--- a/third-party/smartmontools/CMakeLists.txt
+++ b/third-party/smartmontools/CMakeLists.txt
@@ -6,19 +6,31 @@
 
 function(smartmontoolsMain)
   set(name "smartmontools")
-  set(version "0.3.1")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "a63ecfbd80eb715c1278770c9be72d45578bd9650fc31196956d3a87dd3b2a66")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "2ad496686cef94cf46bbf040d6a1d9aa8e051d2281246bfc7517329fc4695e67")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
   set(anchor_file "lib/libsmartctl.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://github.com/allanliu/smartmontools/archive/v0.3.1.tar.gz
+    SHA256 a7bde3039f207a88bee72ae7c89bc4442dc65fbe76fc1a9974718d1a128a1c0b
+    CONFIGURE
+      ${REPLACE_CMD} "1.15 1.14" "1.16 1.15 1.14" "autogen.sh" &&
+      ./autogen.sh &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 smartmontoolsMain()

--- a/third-party/ssdeep-cpp/CMakeLists.txt
+++ b/third-party/ssdeep-cpp/CMakeLists.txt
@@ -6,20 +6,30 @@
 
 function(ssdeepCppMain)
   set(name "ssdeep-cpp")
-  set(version "2.14.1")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "d8248655050987524dc383d55d7b148803b18331cdbcb8bfd2a8198ca210298b")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "93f11f81eab1cc06bf11fd28bc42d7b9d02972e3705f864a9f8ef0f5ca90abcc")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     add_osquery_library(thirdparty_ssdeep-cpp INTERFACE)
     return()
   endif()
 
   set(anchor_file "lib/libfuzzy.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz
+    SHA256 ff2eabc78106f009b4fb2def2d76fb0ca9e12acf624cbbfad9b3eb390d931313
+    CONFIGURE
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 ssdeepCppMain()

--- a/third-party/thrift/CMakeLists.txt
+++ b/third-party/thrift/CMakeLists.txt
@@ -26,7 +26,7 @@ function(thrifMain)
 
   if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
     set(configure_options
-      -DCMAKE_CXX_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden $ENV{CXXFLAGS}"
+      -DCMAKE_CXX_FLAGS=-fvisibility=hidden\ -fvisibility-inlines-hidden\ $ENV{CXXFLAGS}
     )
   endif()
 

--- a/third-party/thrift/CMakeLists.txt
+++ b/third-party/thrift/CMakeLists.txt
@@ -6,34 +6,63 @@
 
 function(thrifMain)
   set(name "thrift")
-  set(version "0.11.0")
-
   set(anchor_file "lib/libthrift.a")
 
   set(additional_library
     "lib/libthriftz.a"
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "32d0a6c2220114272fe6819a30b5ddfe000d9bed03f0d1fc3b6b68d438b5cc1e")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "11a4f8565728e73a54808bf55517014cc69597ef965c3b2b7ebeb52f6dd43c26")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "8b115b46d7fbae38eafbd50c4fabca1dd7e14a86ad52bda601ec374b44dc5373")
-
-    set(anchor_file "lib/parse.lib")
+  if(DEFINED PLATFORM_WINDOWS)
+    set(anchor_file "lib/thriftzmt.lib")
 
     set(additional_libraries
-      lib/thriftzmt.lib
       lib/thriftmt.lib
     )
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_boost)
+
+  if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
+    set(configure_options
+      -DCMAKE_CXX_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden $ENV{CXXFLAGS}"
+    )
+  endif()
+
+  set(dependencies boost openssl)
+  definePrebuiltProject(${name}
+    URL https://github.com/apache/thrift/archive/0.11.0.tar.gz
+    SHA256 0e324569321a1b626381baabbb98000c8dd3a59697292dbcc71e67135af0fefd
+    PATCHES libthrift-0.11.0-1.patch
+    DEPENDS ${dependencies}
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DWITH_SHARED_LIB=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_C_GLIB=OFF
+        -DBUILD_JAVA=OFF
+        -DBUILD_PYTHON=OFF
+        -DBUILD_HASKELL=OFF
+        -DWITH_BOOST_STATIC=ON
+        -DWITH_STDTHREADS=OFF
+        -DWITH_BOOSTTHREADS=OFF
+        -DWITH_OPENSSL=ON
+        -DWITH_QT4=OFF
+        -DWITH_QT5=OFF
+        -DCMAKE_CXX_STANDARD=11
+        -DWITH_MT=ON
+        -DBOOST_ROOT=<INSTALL_DIR>
+        -DZLIB_ROOT=<INSTALL_DIR>
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 thrifMain()

--- a/third-party/thrift/libthrift-0.11.0-1.patch
+++ b/third-party/thrift/libthrift-0.11.0-1.patch
@@ -1,0 +1,37 @@
+diff --git a/lib/cpp/src/thrift/transport/TServerSocket.cpp b/lib/cpp/src/thrift/transport/TServerSocket.cpp
+index 87b6383..447c89d 100644
+--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
++++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
+@@ -584,6 +584,12 @@ shared_ptr<TTransport> TServerSocket::acceptImpl() {
+         // a certain number
+         continue;
+       }
++
++      // Special case because we expect setuid syscalls in other threads.
++      if (THRIFT_GET_SOCKET_ERROR == EINTR) {
++        continue;
++      }
++
+       int errno_copy = THRIFT_GET_SOCKET_ERROR;
+       GlobalOutput.perror("TServerSocket::acceptImpl() THRIFT_POLL() ", errno_copy);
+       throw TTransportException(TTransportException::UNKNOWN, "Unknown", errno_copy);
+diff --git a/configure.ac b/configure.ac
+index 6a7a1a5..8b4ddc2 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -307,12 +307,14 @@ AM_CONDITIONAL(WITH_TWISTED_TEST, [test "$have_trial" = "yes"])
+ # It's distro specific and far from ideal but needed to cross test py2-3 at once.
+ # TODO: find "python2" if it's 3.x
+ have_py3="no"
++if test "$with_py3" = "yes";  then
+ if python --version 2>&1 | grep -q "Python 2"; then
+   AC_PATH_PROGS([PYTHON3], [python3 python3.5 python35 python3.4 python34])
+   if test -n "$PYTHON3"; then
+     have_py3="yes"
+   fi
+ fi
++fi
+ AM_CONDITIONAL(WITH_PY3, [test "$have_py3" = "yes"])
+ 
+ AX_THRIFT_LIB(perl, [Perl], yes)
+

--- a/third-party/util-linux/CMakeLists.txt
+++ b/third-party/util-linux/CMakeLists.txt
@@ -10,18 +10,40 @@ function(utillinuxMain)
   endif()
 
   set(name "util-linux")
-  set(version "2.27.1")
-  set(hash "2c2e64f8364afeddc4804716ae835c674d48592c163e59903356de9c3b31da5d")
-  set(anchor_file "lib/libmount.a")
+  set(anchor_file "lib/libuuid.a")
 
   set(additional_libraries
     lib/libblkid.a
-    lib/libfdisk.a
-    lib/libsmartcols.a
-    lib/libuuid.a
   )
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}" ${additional_libraries})
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}" ${additional_libraries})
+
+  set(dependencies ncurses)
+  definePrebuiltProject(${name}
+    URL https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.xz
+    SHA256 0a818fcdede99aec43ffe6ca5b5388bff80d162f2f7bd4541dca94fecb87a290
+    DEPENDS ${dependencies}
+    CONFIGURE
+      export NCURSES_CFLAGS=-I${THIRD_PARTY_PREFIX}/include/ncurses &&
+      ./autogen.sh &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-all-programs
+        --disable-bash-completion
+        --without-ncurses
+        --enable-libuuid
+        --enable-libblkid
+        --disable-use-tty-group
+        --disable-kill
+        --disable-shared
+        --without-readline
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 utillinuxMain()

--- a/third-party/yara/CMakeLists.txt
+++ b/third-party/yara/CMakeLists.txt
@@ -5,22 +5,34 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(yaraMain)
-  set(name "yara")
-  set(version "3.7.1")
-
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "4706e8312c531c436b03be4ea429a94dbd06e2cd392764febc9e259777c8fc98")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "8cf4dfeb1e5f93fda206a200c1bce070c11bd486c1c335ede570980cdd196b0b")
-  else()
+  if(DEFINED PLATFORM_WINDOWS)
     return()
   endif()
 
+  set(name "yara")
   set(anchor_file "lib/libyara.a")
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
 
   target_link_libraries("thirdparty_${name}" INTERFACE thirdparty_openssl)
+
+  set(dependencies openssl)
+  definePrebuiltProject(${name}
+    URL https://github.com/VirusTotal/yara/archive/v3.7.1.tar.gz
+    SHA256 df077a29b0fffbf4e7c575f838a440f42d09b215fcb3971e6fb6360318a64892
+    DEPENDS ${dependencies}
+    CONFIGURE
+      ./bootstrap.sh &&
+      ./configure
+        --prefix=<INSTALL_DIR>
+        --disable-shared
+        --enable-static
+    BUILD
+      $(MAKE)
+    INSTALL
+      $(MAKE) install
+    BUILD_IN_SOURCE ON
+  )
 endfunction()
 
 yaraMain()

--- a/third-party/zlib/CMakeLists.txt
+++ b/third-party/zlib/CMakeLists.txt
@@ -6,22 +6,35 @@
 
 function(zlibMain)
   set(name "zlib")
-  set(version "1.2.11")
-
   set(anchor_file "lib/libz.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "c6dfd85ce6c440fbaead6d4a3246d7771ed2b9b9f9e8c43257f57e0881d390e9")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "7f9b44ca67eadb2c6dcf6b86688cb759b77b772858dae2a2380c032c7c1d9edd")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "1685157a99c419e5150cc5f44a61ad1a1f5ddf414bf1a451ed9b6c7faf26d4bc")
+  if(DEFINED PLATFORM_WINDOWS)
     set(anchor_file "lib/zlibstatic.lib")
-  else()
-    return()
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  if (DEFINED PLATFORM_WINDOWS)
+    set(configure_options
+      -DCMAKE_C_FLAGS_RELEASE:STRING=/MT\ /O2\ /Ob2\ /DNDEBUG
+    )
+  endif()
+
+  definePrebuiltProject(${name}
+    URL https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz
+    SHA256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+    DEPENDS ${dependencies}
+    CONFIGURE
+      cmake
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DBUILD_SHARED_LIBS=OFF
+        ${configure_options}
+        <SOURCE_DIR>
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 zlibMain()

--- a/third-party/zstd/CMakeLists.txt
+++ b/third-party/zstd/CMakeLists.txt
@@ -6,22 +6,30 @@
 
 function(zstdMain)
   set(name "zstd")
-  set(version "1.2.0")
-
   set(anchor_file "lib/libzstd.a")
 
-  if(DEFINED PLATFORM_LINUX)
-    set(hash "f9397aeea5816a7cabd0e7040be86e569d2ffd84832a2e3c4e4bda224d6e42a5")
-  elseif(DEFINED PLATFORM_MACOS)
-    set(hash "4cd66f8c05f735ccf6c1457116ddb4cb2b1b0260458bb3c1476475721c9d70d9")
-  elseif(DEFINED PLATFORM_WINDOWS)
-    set(hash "c214705dfd057b2e9b9e613c88131ccfde22c2f43787af37828ccf3f9bec918d")
-    set(anchor_file "lib/libzstd.lib")
-  else()
-    return()
+  if(DEFINED PLATFORM_WINDOWS)
+    set(anchor_file "lib/zstd_static.lib")
   endif()
 
-  importThirdPartyBinaryLibrary("${name}" "${version}" "${hash}" "${anchor_file}")
+  importThirdPartyBinaryLibrary("${name}" "${anchor_file}")
+
+  definePrebuiltProject(${name}
+    URL https://github.com/facebook/zstd/releases/download/v1.4.0/zstd-1.4.0.tar.gz
+    SHA256 7f323f0e0c18488748f3d9b2d4353f00e904ea2ccd0372ea04d7f77aa1156557
+    CONFIGURE
+      cmake
+        -DZSTD_USE_STATIC_RUNTIME=ON
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SHARED_LIBS=OFF
+        -DZSTD_BUILD_SHARED=OFF
+        <SOURCE_DIR>/build/cmake
+    BUILD
+      cmake --build . --config Release
+    INSTALL
+      cmake --build . --config Release --target install
+  )
 endfunction()
 
 zstdMain()

--- a/tools/build_prebuilt.sh
+++ b/tools/build_prebuilt.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+set -e
+
+# To setup in a CI or similar on Ubuntu 18.04/18.10
+# sudo apt-get install automake pkg-config libtool autopoint bison flex xsltproc texinfo
+# wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz
+# sudo tar xvf cmake-3.14.5-Linux-x86_64.tar.gz -C /usr/local --strip 1
+# wget https://github.com/theopolis/build-anywhere/releases/download/v5/x86_64-anywhere-linux-gnu-v5.tar.xz
+# tar xf x86_64-anywhere-linux-gnu-v5.tar.xz
+# source ./x86_64-anywhere-linux-gnu/scripts/anywhere-setup.sh
+
+# Configuration variables
+# Define the environent STATIC_ENFORCE
+STATIC_TOOLCHAIN=/home/vagrant #/usr/local/toolchain
+STATIC_CHECKOUT=/vagrant #/usr/local/osquery
+PREBUILT_FLAGS="-fPIC -DNDEBUG -march=x86-64 -Oz"
+DARWIN_BUILD=10.13
+
+# Relative paths
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOURCE_DIR="$( realpath "${SCRIPT_DIR}/.." )"
+THIRD_PARTY_BASE="${SOURCE_DIR}/third-party-prebuilt"
+
+if [ -n ${ENFORCE_STATIC} ]; then
+  if [ ! "${SOURCE_DIR}" = "${STATIC_CHECKOUT}" ]; then
+    echo "To build prebuilts reproducably you must checkout osquery to ${STATIC_CHECKOUT}"
+    false
+  fi
+fi
+
+function exists() {
+  TOOL=$1
+  if ! hash $TOOL 2>/dev/null; then
+    echo "Please install $TOOL"
+    false
+  fi
+}
+
+# Required tools
+exists automake
+exists pkg-config
+exists libtoolize
+exists autopoint
+exists autoreconf
+exists makeinfo # texinfo
+exists yacc # bison bison.yacc
+exists flex
+exists xsltproc
+exists cmake
+
+# Platform specific configuration
+if [ "$(uname)" == "Darwin" ]; then
+  PLATFORM=Darwin
+  PLATFORM_FLAGS="-mmacosx-version-min=${DARWIN_BUILD}"
+	PLATFORM_LDFLAGS="-mmacosx-version-min=${DARWIN_BUILD}"
+  PLATFORM_PATH="macos-x86_64"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  PLATFORM=Linux
+  PLATFORM_PATH="linux-x86_64"
+
+  # Enforce static location of toolchain and checkout
+  CC_PATH="$(which ${CC})"
+  if [ -n ${ENFORCE_STATIC} ]; then
+    if [ ! "${CC_PATH}" = "${STATIC_TOOLCHAIN}/x86_64-anywhere-linux-gnu/x86_64-anywhere-linux-gnu/sysroot/usr/bin/${CC}" ]; then
+      echo "To build prebuilts reproducably you must install an x86_64 toolchain to ${STATIC_TOOLCHAIN}"
+      false
+    fi
+  fi
+fi
+
+THIRD_PARTY_PREFIX="${THIRD_PARTY_BASE}/${PLATFORM_PATH}"
+
+# Environment control
+export CC=clang CXX=clang++
+export SOURCE_DATE_EPOCH="0"
+export ACLOCAL_PATH="${THIRD_PARTY_PREFIX}/share/aclocal:${ACLOCAL_PATH}"
+export PKG_CONFIG_PATH="${THIRD_PARTY_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export LDFLAGS="-L${THIRD_PARTY_PREFIX}/lib ${LDFLAGS} ${PLATFORM_LDFLAGS}"
+export CPATH="${THIRD_PARTY_PREFIX}/include:${CPATH}"
+export CFLAGS="-I${THIRD_PARTY_PREFIX}/include ${CFLAGS} ${PLATFORM_FLAGS} ${PREBUILT_FLAGS}"
+export CXXFLAGS="-I${THIRD_PARTY_PREFIX}/include ${CXXFLAGS} ${DISTRO_FLAGS} ${PREBUILT_FLAGS}"
+export PREFIX=${THIRD_PARTY_PREFIX}
+
+BUILD_DIR="${SOURCE_DIR}/build/deps" # prebuilt
+
+# If working in vagrant then the shared folder does not work
+if [ "${PLATFORM}" = "Linux" ]; then
+  FS_TYPE=$(stat --file-system --format=%T ${SOURCE_DIR} 2>&1)
+fi
+
+if [ "${FS_TYPE}" = "nfs" ]; then
+  mkdir -p ~/deps
+  ln -sf ~/deps "${SOURCE_DIR}/build"
+else
+  mkdir -p "${BUILD_DIR}"
+fi
+
+# CMake enforces these exist
+mkdir -p "${THIRD_PARTY_PREFIX}/include"
+mkdir -p "${THIRD_PARTY_PREFIX}/lib"
+
+if [ "${LEGACY_BUILD}" = "1" ]; then
+  make newdeps "${@}"
+else
+  ( cd "${BUILD_DIR}" && cmake "${SOURCE_DIR}" )
+  ( cd "${BUILD_DIR}" && make thirdparty_prebuilt "${@}" )
+fi
+
+# Create reproducible archives
+( cd "${THIRD_PARTY_PREFIX}/lib" && chmod -R +w * )
+for f in "${THIRD_PARTY_PREFIX}/lib/"*.a; do objcopy -D $f &>/dev/null; done
+for f in "${THIRD_PARTY_PREFIX}/lib/"*.a; do objcopy -D $f; done

--- a/tools/replace.py
+++ b/tools/replace.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+
+filename = sys.argv[3]
+findtext = sys.argv[1]
+replacetext = sys.argv[2]
+
+# Read in the file
+with open(filename, 'r') as file:
+  filedata = file.read()
+
+# Replace the target string
+filedata = filedata.replace(findtext, replacetext)
+
+# Write the file out again
+with open(filename, 'w') as file:
+  file.write(filedata)


### PR DESCRIPTION
This is the basic logic for using a submodule to hold prebuilt static libraries and headers.
- All static libraries and headers are held in a combined "prefix". This means all headers are available to all targets, this is not ideal, but in practice does not slow down the build.
- The hashes and versions are removed as the integrity of the prebuilds is based on the submodule. There is no versioning specific to each library but rather the submodule commit.

Known limitations
- macOS: Homebrew's binutils' `objcopy -D` makes archives deterministic but they cannot link
- windows: No known way to make static libraries deterministic
- Previous `autoconf` macros to remove `clock_gettime` are not included
- No check to see if new CPU extensions, such as AVX are used
- Linux and macOS rely on include directories set in `./tools/build_prebuilt.sh`