### PR TITLE
Fix prepare_for_ide target on macOS and Windows

### DIFF
--- a/third-party/libudev/CMakeLists.txt
+++ b/third-party/libudev/CMakeLists.txt
@@ -5,6 +5,12 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(libudevMain)
+
+  if (DEFINED PLATFORM_WINDOWS OR DEFINED PLATFORM_MACOS)
+    add_osquery_library(thirdparty_libudev INTERFACE)
+    return()
+  endif()
+
   set(name "libudev")
   set(version "173")
   set(hash "fc1483fa27cb92876661e453bceef0c5752e4dbe83074a1653928ce44078aa34")


### PR DESCRIPTION
This is a hotfix to let the prepare_for_ide target work on Windows and
macOS, avoiding to download libudev that it's not needed and
doesn't exist for those platforms.

In theory for all the third-party libraries that do not exist for a
platform we should have an INTERFACE library as a substitute,
instead of avoiding to define any target.
We wait to do this change, because we are going to refactor how
dependencies are downloaded and imported.