### PR TITLE
Fix detection of some headers on some IDEs

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -15,6 +15,8 @@ endif()
 # This may be useful to speed up development builds
 option(BUILD_SHARED_LIBS "Whether to build shared libraries (like *.dll or *.so) or static ones (like *.a)" ${BUILD_SHARED_LIBS_DEFAULT_VALUE})
 
+option(ADD_HEADERS_AS_SOURCES "Whether to add headers as sources of a target or not. This is needed for some IDEs which wouldn't detect headers properly otherwise")
+
 # This is the default S3 storage used by Facebook to store 3rd party dependencies; it
 # is provided here as a configuration option
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -36,6 +36,13 @@ function(generateIncludeNamespace target_name namespace_path mode)
 
   add_dependencies("${target_name}" "${root_target_name}")
 
+  get_target_property(target_type "${target_name}" TYPE)
+  if("${target_type}" STREQUAL "INTERFACE_LIBRARY")
+    set(target_mode "INTERFACE")
+  else()
+    set(target_mode "PUBLIC")
+  endif()
+
   foreach(relative_source_file_path ${ARGN})
     get_filename_component(source_name "${relative_source_file_path}" NAME)
 
@@ -61,19 +68,16 @@ function(generateIncludeNamespace target_name namespace_path mode)
     string(REPLACE "/" "_" file_generator_name "${target_name}_ns_${relative_source_file_path}")
     add_custom_target("${file_generator_name}" DEPENDS "${output_source_file_path}")
     add_dependencies("${root_target_name}" "${file_generator_name}")
-  endforeach()
 
-  get_target_property(target_type "${target_name}" TYPE)
-  if("${target_type}" STREQUAL "INTERFACE_LIBRARY")
-    set(mode "INTERFACE")
-  else()
-    set(mode "PUBLIC")
-  endif()
+    if(ADD_HEADERS_AS_SOURCES)
+      target_sources("${target_name}" ${target_mode} "${absolute_source_file_path}")
+    endif()
+  endforeach()
 
   # So that the IDE finds all the necessary headers
   add_dependencies("prepare_for_ide" "${root_target_name}")
 
-  target_include_directories("${target_name}" ${mode} "${target_namespace_root_directory}")
+  target_include_directories("${target_name}" ${target_mode} "${target_namespace_root_directory}")
 endfunction()
 
 # Generates the global_c_settings, global_cxx_settings targets and the respective thirdparty variant


### PR DESCRIPTION
Some IDE require that the headers are assigned to a target, so they know
which TU uses them and also that they are part of the project.
The option ADD_HEADERS_AS_SOURCES has been added, if it's ON,
we assign those headers as INTERFACE sources of the target that publish
them.
