### PR TITLE
buck: fixing up buck config generation script for use on Windows

### DIFF
--- a/tools/generate_buck_config.ps1
+++ b/tools/generate_buck_config.ps1
@@ -64,7 +64,7 @@ param(
   [string] $SdkInstall = 'C:\tools\toolchains\vs2017_15.5\WindowsSdk\10.0.16299.91',
   [string] $SdkVersion = '10.0.16299.0',
   [string] $Python3Path = 'C:\Python36\python.exe',
-  [string] $BuckConfigRoot = (Join-Path $PSScriptRoot "..\..\buckconfigs")
+  [string] $BuckConfigRoot = (Join-Path $PSScriptRoot "buckconfigs")
 )
 
 function New-VsToolchainBuckConfig {
@@ -169,6 +169,8 @@ function New-VsToolchainBuckConfig {
       $regEntry = "HKCU:\Software\Python\PythonCore\$pyVer\InstallPath"
       $python3 = (Get-ItemProperty -Path $regEntry -Name 'ExecutablePath').ExecutablePath
     }
+  } else {
+    $python3 = $Python3Path
   }
   if (-not $python3 -or (-not (Test-Path $python3))) {
     Write-Host 'Failed to find python3, check install' -ForegroundColor Red
@@ -271,7 +273,11 @@ function New-VsToolchainBuckConfig {
   }
 
   # Only write out the file if all paths were able to be derived
-  $bcfg = Join-Path $BuckConfigRoot "windows-x86_64/toolchain/vs2017_15.5.bcfg"
+  $buck_root = Join-Path $BuckConfigRoot "windows-x86_64/toolchain"
+  if (-not (Test-Path $buck_root)) {
+    New-Item -ItemType Directory $buck_root
+  }
+  $bcfg = (Join-Path $buck_root "vs2017_15.5.bcfg")
   $outArgs = @{
     FilePath = $bcfg
     Encoding = "utf8"


### PR DESCRIPTION
## Summary:

The buck config generation script had a couple of small usage bugs.
This fixes it so it will properly generate a buck config on a new
Windows system

## Test Plan:
Start with no buck config on the system:
```
C:\Users\Nicholas\work\repos\osquery [win-buck-cfg-bug]> ls .\tools\buckconfigs\windows-x86_64\toolchain\vs2017_15.5.bcfg                                                    ls : Cannot find path 'C:\Users\Nicholas\work\repos\osquery\tools\buckconfigs\windows-x86_64\toolchain\vs2017_15.5.bcfg' because it does not exist.
At line:1 char:1
+ ls .\tools\buckconfigs\windows-x86_64\toolchain\vs2017_15.5.bcfg
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Nichol...s2017_15.5.bcfg:String) [Get-ChildItem], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand
```
Run the generation script using some blank defaults to force derivation of paths:
```
C:\Users\Nicholas\work\repos\osquery [win-buck-cfg-bug]> .\tools\generate_buck_config.ps1 -VsInstall '' -VcToolsVersion '' -SdkInstall '' -SdkVersion '' -Python3Path $(Get-Command python3).Source                                                                                                                                                       [+] Generating buck configs. . .
 => Checking Visual Studio install
 => Checking Win10 SDK install
 => Generating Buck Config for Win10 builds
Buck config written to C:\Users\Nicholas\work\repos\osquery\tools\buckconfigs\windows-x86_64\toolchain
```
And finally build osqueryd:
```
C:\Users\Nicholas\work\repos\osquery [win-buck-cfg-bug]> .\tools\generate_buck_config.ps1 -VsInstall '' -VcToolsVersion '' -SdkInstall '' -SdkVersion '' -Python3Path 'C:\Users\Nicholas\AppData\Local\Programs\Python\Python37\python.exe' -BuckConfigRoot .\tools\buckconfigs\                                                                                                                      [+] Generating buck configs. . .
 => Checking Visual Studio install
 => Checking Win10 SDK install
 => Generating Buck Config for Win10 builds
Buck config written to .\tools\buckconfigs\windows-x86_64\toolchain\vs2017_15.5.bcfg
C:\Users\Nicholas\work\repos\osquery [win-buck-cfg-bug]> buck clean; buck build @mode/windows-x86_64/release osquery:osqueryd                                                                      Not using buckd because watchman isn't installed.
Not using buckd because watchman isn't installed.
Parsing buck files: finished in 1.8 sec (100%)
Creating action graph: finished in 0.8 sec (100%)
Building... 2.7 sec (3%) 36/1155 jobs, 36 updated
 - //third-party/jinja2:jinja2_Jinja2-2.10-py2.py3-none-any.whl_file... 0.8 sec
 - //third-party/sqlite:archive#archive-download... 1.2 sec
 - //third-party/googletest:archive#archive-download... 1.1 sec
 - //specs:specs... 1.0 sec (running finalizing_build_rule[0.1 sec])

...
C:/Program Files (x86)/Windows Kits/10/Include/10.0.18362.0/um\winsock2.h(2219): note: see declaration of 'gethostbyname'
Info: Boost.Config is older than your compiler version - probably nothing bad will happen - but you may wish to look for an update Boost version.  Define BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE to suppress this message.
Parsing buck files: finished in 1.8 sec (100%)
Creating action graph: finished in 0.8 sec (100%)
Building: finished in 06:48.0 min (100%) 1155/1155 jobs, 1155 updated
  Total time: 06:50.7 min
```