### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,9 @@
 # precedence.
 
 # General write access
-* @osquery/osquery-committers, @osquery/facebook-osquery-write
+* @osquery/osquery-committers, @osquery/facebook-osquery-write, @osquery/foundation-committers
 
 # As CODEOWNERS is last match oriented, we restrict slightly more
 # sensitive files here.
 CODEOWNERS		@osquery/foundation-committers
-azure-pipelines.yml	@osquery/foundation-committers
+azure-pipelines.yml	@osquery/foundation-committers, @osquery/osquery-build-wardens, @osquery/osquery-test-wardens


### PR DESCRIPTION
Until osquery-committers is better populated, grant foundation-committers broad commit access via CODEOWNERS. (I think this is in keeping with the original intent)

Flag the build/test wardens on the pipeline configs
