### PR TITLE
Enable Debug builds on the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,17 @@ jobs:
 
 # LINUX
 
-  - job: LinuxRelease
+  - job: LinuxBuild
+    displayName: Linux
+
+    strategy:
+      matrix:
+        Release:
+          BUILD_TYPE: Release
+          EXTRA_CMAKE_ARGS:
+        Debug:
+          BUILD_TYPE: Debug
+          EXTRA_CMAKE_ARGS: -DOSQUERY_NO_DEBUG_SYMBOLS=ON
 
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -23,10 +33,11 @@ jobs:
       inputs:
         workingDirectory: $(Build.BinariesDirectory)/build
         cmakeArgs:
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
           -DCMAKE_C_COMPILER=clang
           -DCMAKE_CXX_COMPILER=clang++
           -DBUILD_TESTING=ON
+          $(EXTRA_CMAKE_ARGS)
           $(Build.SourcesDirectory)
 
     - task: CMake@1
@@ -34,47 +45,6 @@ jobs:
       inputs:
         workingDirectory: $(Build.BinariesDirectory)/build
         cmakeArgs: --build . --target format_check
-
-    - task: CMake@1
-      displayName: "Build osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: --build . -j 3
-
-    - script: |
-        ctest --build-nocmake -V
-      displayName: "Run tests"
-      workingDirectory: $(Build.BinariesDirectory)/build
-
-    - script: |
-        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
-      name: JobResult
-
-
-  - job: LinuxDebug
-
-    pool:
-      vmImage: 'Ubuntu-16.04'
-
-    container:
-      image: trailofbits/osql-experimental:ubuntu-18.04
-      options: --privileged
-
-    steps:
-    - script: mkdir $(Build.BinariesDirectory)/build
-      displayName: "Create build folder"
-
-    - task: CMake@1
-      displayName: "Configure osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs:
-          -DCMAKE_BUILD_TYPE=Debug
-          -DCMAKE_C_COMPILER=clang
-          -DCMAKE_CXX_COMPILER=clang++
-          -DBUILD_TESTING=ON
-          -DOSQUERY_NO_DEBUG_SYMBOLS=ON
-          $(Build.SourcesDirectory)
 
     - task: CMake@1
       displayName: "Build osquery"
@@ -100,12 +70,11 @@ jobs:
     condition: succeededOrFailed()
 
     dependsOn:
-      - LinuxRelease
-      - LinuxDebug
+      - LinuxBuild
 
     variables:
-      LinuxReleaseStatus: $[ dependencies.LinuxRelease.outputs['JobResult.Status'] ]
-      LinuxDebugStatus: $[ dependencies.LinuxDebug.outputs['JobResult.Status'] ]
+      LinuxReleaseStatus: $[ dependencies.LinuxBuild.outputs['Release.JobResult.Status'] ]
+      LinuxDebugStatus: $[ dependencies.LinuxBuild.outputs['Debug.JobResult.Status'] ]
 
     steps:
     - checkout: none
@@ -120,7 +89,17 @@ jobs:
 
 # MACOS
 
-  - job: macOSRelease
+  - job: macOSBuild
+    displayName: macOS
+
+    strategy:
+      matrix:
+        Release:
+          BUILD_TYPE: Release
+          EXTRA_CMAKE_ARGS:
+        Debug:
+          BUILD_TYPE: Debug
+          EXTRA_CMAKE_ARGS: -DOSQUERY_NO_DEBUG_SYMBOLS=ON
 
     pool:
       vmImage: macos-10.14
@@ -139,44 +118,7 @@ jobs:
       displayName: "Configure osquery"
       inputs:
         workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON $(Build.SourcesDirectory)
-
-    - task: CMake@1
-      displayName: "Build osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: --build . -j 3
-
-    - script: |
-        ctest --build-nocmake -V
-      displayName: "Run tests"
-      workingDirectory: $(Build.BinariesDirectory)/build
-
-    - script: |
-        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
-      name: JobResult
-
-
-  - job: macOSDebug
-
-    pool:
-      vmImage: macos-10.14
-
-    steps:
-    - script: |
-        brew upgrade
-        brew install ccache
-      displayName: "Install Homebrew and prerequisites"
-      timeoutInMinutes: 20
-
-    - script: mkdir $(Build.BinariesDirectory)/build
-      displayName: "Create build folder"
-
-    - task: CMake@1
-      displayName: "Configure osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DOSQUERY_NO_DEBUG_SYMBOLS=ON $(Build.SourcesDirectory)
+        cmakeArgs: -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_TESTING=ON $(EXTRA_CMAKE_ARGS) $(Build.SourcesDirectory)
 
     - task: CMake@1
       displayName: "Build osquery"
@@ -202,12 +144,11 @@ jobs:
     condition: succeededOrFailed()
 
     dependsOn:
-      - macOSRelease
-      - macOSDebug
+      - macOSBuild
 
     variables:
-      macOSReleaseStatus: $[ dependencies.macOSRelease.outputs['JobResult.Status'] ]
-      macOSDebugStatus: $[ dependencies.macOSDebug.outputs['JobResult.Status'] ]
+      macOSReleaseStatus: $[ dependencies.macOSBuild.outputs['Release.JobResult.Status'] ]
+      macOSDebugStatus: $[ dependencies.macOSBuild.outputs['Debug.JobResult.Status'] ]
 
     steps:
     - checkout: none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,9 @@ jobs:
     pool:
       vmImage: 'Ubuntu-16.04'
 
-    container: trailofbits/osql-experimental:ubuntu-18.04
+    container:
+      image: trailofbits/osql-experimental:ubuntu-18.04
+      options: --privileged
 
     steps:
     - script: mkdir $(Build.BinariesDirectory)/build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
 
 # LINUX
 
-  - job: Linux
+  - job: LinuxRelease
 
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -22,7 +22,12 @@ jobs:
       displayName: "Configure osquery"
       inputs:
         workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_TESTING=ON $(Build.SourcesDirectory)
+        cmakeArgs:
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DBUILD_TESTING=ON
+          $(Build.SourcesDirectory)
 
     - task: CMake@1
       displayName: "Check code formatting"
@@ -41,11 +46,79 @@ jobs:
       displayName: "Run tests"
       workingDirectory: $(Build.BinariesDirectory)/build
 
+    - script: |
+        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
+      name: JobResult
+
+
+  - job: LinuxDebug
+
+    pool:
+      vmImage: 'Ubuntu-16.04'
+
+    container: trailofbits/osql-experimental:ubuntu-18.04
+
+    steps:
+    - script: mkdir $(Build.BinariesDirectory)/build
+      displayName: "Create build folder"
+
+    - task: CMake@1
+      displayName: "Configure osquery"
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)/build
+        cmakeArgs:
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DBUILD_TESTING=ON
+          -DOSQUERY_NO_DEBUG_SYMBOLS=ON
+          $(Build.SourcesDirectory)
+
+    - task: CMake@1
+      displayName: "Build osquery"
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)/build
+        cmakeArgs: --build . -j 3
+
+    - script: |
+        ctest --build-nocmake -V
+      displayName: "Run tests"
+      workingDirectory: $(Build.BinariesDirectory)/build
+
+    - script: |
+        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
+      name: JobResult
+
+
+  - job: Linux
+
+    pool:
+      vmImage: 'Ubuntu-16.04'
+
+    condition: succeededOrFailed()
+
+    dependsOn:
+      - LinuxRelease
+      - LinuxDebug
+
+    variables:
+      LinuxReleaseStatus: $[ dependencies.LinuxRelease.outputs['JobResult.Status'] ]
+      LinuxDebugStatus: $[ dependencies.LinuxDebug.outputs['JobResult.Status'] ]
+
+    steps:
+    - checkout: none
+
+    - script: |
+        if [ -z "$(LinuxReleaseStatus)" ] || [ -z "$(LinuxDebugStatus)" ]; then
+          exit 1
+        fi
+      displayName: "Detect Linux Release and Debug build status"
+
 # LINUX
 
 # MACOS
 
-  - job: macOS
+  - job: macOSRelease
 
     pool:
       vmImage: macos-10.14
@@ -76,6 +149,72 @@ jobs:
         ctest --build-nocmake -V
       displayName: "Run tests"
       workingDirectory: $(Build.BinariesDirectory)/build
+
+    - script: |
+        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
+      name: JobResult
+
+
+  - job: macOSDebug
+
+    pool:
+      vmImage: macos-10.14
+
+    steps:
+    - script: |
+        brew upgrade
+        brew install ccache
+      displayName: "Install Homebrew and prerequisites"
+      timeoutInMinutes: 20
+
+    - script: mkdir $(Build.BinariesDirectory)/build
+      displayName: "Create build folder"
+
+    - task: CMake@1
+      displayName: "Configure osquery"
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)/build
+        cmakeArgs: -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DOSQUERY_NO_DEBUG_SYMBOLS=ON $(Build.SourcesDirectory)
+
+    - task: CMake@1
+      displayName: "Build osquery"
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)/build
+        cmakeArgs: --build . -j 3
+
+    - script: |
+        ctest --build-nocmake -V
+      displayName: "Run tests"
+      workingDirectory: $(Build.BinariesDirectory)/build
+
+    - script: |
+        echo "##vso[task.setvariable variable=Status;isOutput=true]1"
+      name: JobResult
+
+
+  - job: macOS
+
+    pool:
+      vmImage: 'Ubuntu-16.04'
+
+    condition: succeededOrFailed()
+
+    dependsOn:
+      - macOSRelease
+      - macOSDebug
+
+    variables:
+      macOSReleaseStatus: $[ dependencies.macOSRelease.outputs['JobResult.Status'] ]
+      macOSDebugStatus: $[ dependencies.macOSDebug.outputs['JobResult.Status'] ]
+
+    steps:
+    - checkout: none
+
+    - script: |
+        if [ -z "$(macOSReleaseStatus)" ] || [ -z "$(macOSDebugStatus)" ]; then
+          exit 1
+        fi
+      displayName: "Detect macOS Release and Debug build status"
 
 # MACOS
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -17,6 +17,8 @@ option(BUILD_SHARED_LIBS "Whether to build shared libraries (like *.dll or *.so)
 
 option(ADD_HEADERS_AS_SOURCES "Whether to add headers as sources of a target or not. This is needed for some IDEs which wouldn't detect headers properly otherwise")
 
+option(OSQUERY_NO_DEBUG_SYMBOLS "Whether to build without debug symbols or not, even if a build type that normally have them has been selected")
+
 # This is the default S3 storage used by Facebook to store 3rd party dependencies; it
 # is provided here as a configuration option
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -132,8 +132,14 @@ function(generateGlobalSettingsTargets)
       gdi32.lib
     )
   else()
+    if(OSQUERY_NO_DEBUG_SYMBOLS)
+      set(debug_level -g0)
+    else()
+      set(debug_level -g)
+    endif()
+
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-      target_compile_options(global_settings INTERFACE -gdwarf-2 -g3)
+      target_compile_options(global_settings INTERFACE ${debug_level})
     endif()
 
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")


### PR DESCRIPTION
Debug builds have been enabled on the CI, for macOS and Linux only, since Windows cannot build in Debug for now.

A new option has also been added to avoid generating debug symbols which are not useful on the CI and occupy too much disk space.