### PR TITLE
Explicitly add BUILD_TESTING CMake option

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -19,6 +19,8 @@ option(ADD_HEADERS_AS_SOURCES "Whether to add headers as sources of a target or 
 
 option(OSQUERY_NO_DEBUG_SYMBOLS "Whether to build without debug symbols or not, even if a build type that normally have them has been selected")
 
+option(BUILD_TESTING "Whether to enable and build tests or not")
+
 # This is the default S3 storage used by Facebook to store 3rd party dependencies; it
 # is provided here as a configuration option
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")


### PR DESCRIPTION
This way is visible as a variable in the cache that can be set.
