### PR TITLE
Enabled address and undefined sanitizer in DEBUG builds

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -240,6 +240,11 @@ function(generateGlobalSettingsTargets)
     target_link_options(cxx_settings INTERFACE
       -stdlib=libc++
     )
+    
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+      target_compile_options(cxx_settings INTERFACE -fsanitize=address,undefined)
+      target_link_options(cxx_settings INTERFACE -fsanitize=address,undefined)
+    endif()
 
     if(DEFINED PLATFORM_MACOS)
       target_compile_options(cxx_settings INTERFACE


### PR DESCRIPTION
This small PR will enable [address](https://clang.llvm.org/docs/AddressSanitizer.html) and [undefined](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) clang sanitizers for DEBUG builds in Linux and MacOS. This should help to catch subtle bugs, since runtime will exit/abort if when undefined behavior is used. 