### PR TITLE
windows/certificates: Fix enumeration bugs, add columns

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -151,6 +151,8 @@ std::string getFileAttribStr(unsigned long);
 
 Status platformStat(const boost::filesystem::path&, WINDOWS_STAT*);
 
+Status getCurrentUserInfo(PTOKEN_USER& info);
+
 /**
  * @brief Stores information about the last Windows async request
  *

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -151,7 +151,7 @@ std::string getFileAttribStr(unsigned long);
 
 Status platformStat(const boost::filesystem::path&, WINDOWS_STAT*);
 
-Status getCurrentUserInfo(PTOKEN_USER& info);
+std::unique_ptr<BYTE[]> getCurrentUserInfo();
 
 /**
  * @brief Stores information about the last Windows async request

--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -64,6 +64,7 @@ osquery_cxx_library(
             WINDOWS,
             [
                 "windows/registry.h",
+                "windows/certificates.h",
             ],
         ),
     ],

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -293,6 +293,7 @@ function(generateOsqueryTablesSystemSystemtable)
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND platform_public_header_files
       windows/registry.h
+      windows/certificates.h
     )
   endif()
 

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -332,6 +332,8 @@ function(generateOsqueryTablesSystemSystemtable)
       osquery_tables_system_tests_startupitemstests-test
       PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
     )
+  elseif(DEFINED PLATFORM_WINDOWS)
+    add_test(NAME osquery_tables_system_tests_certificatestests-test COMMAND osquery_tables_system_tests_certificatestests-test)
   endif()
 
   add_test(NAME osquery_tables_system_tests_systemtablestests-test COMMAND osquery_tables_system_tests_systemtablestests-test)

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -258,7 +258,7 @@ osquery_cxx_test(
 )
 
 osquery_cxx_test(
-    name = "macos_certificates_tests",
+    name = "certificates_tests",
     env = {
         "TEST_CONF_FILES_DIR": "$(location {})".format(
             osquery_target("tools/tests:test_files"),
@@ -271,26 +271,6 @@ osquery_cxx_test(
                 "darwin/certificates_tests.cpp",
             ],
         ),
-    ],
-    visibility = ["PUBLIC"],
-    deps = [
-        osquery_target("osquery/config/tests:test_utils"),
-        osquery_target("osquery/core:core"),
-        osquery_target("osquery/core/sql:core_sql"),
-        osquery_target("osquery/database:database"),
-        osquery_target("osquery/filesystem:osquery_filesystem"),
-        osquery_target("osquery/filesystem:osquery_filesystem"),
-        osquery_target("osquery/remote/tests:remote_test_utils"),
-        osquery_target("osquery/tables/system:system_table"),
-        osquery_target("osquery/utils:utils"),
-        osquery_target("osquery/utils/conversions:conversions"),
-        osquery_target("plugins/database:ephemeral"),
-    ],
-)
-
-osquery_cxx_test(
-    name = "windows_certificates_tests",
-    platform_srcs = [
         (
             WINDOWS,
             [

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -6,7 +6,7 @@
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
-load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX", "MACOSX", "POSIX")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX", "MACOSX", "POSIX", "WINDOWS")
 
 osquery_cxx_test(
     name = "md_tables_tests",
@@ -258,7 +258,7 @@ osquery_cxx_test(
 )
 
 osquery_cxx_test(
-    name = "certificates_tests",
+    name = "macos_certificates_tests",
     env = {
         "TEST_CONF_FILES_DIR": "$(location {})".format(
             osquery_target("tools/tests:test_files"),
@@ -269,6 +269,32 @@ osquery_cxx_test(
             MACOSX,
             [
                 "darwin/certificates_tests.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/config/tests:test_utils"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/core/sql:core_sql"),
+        osquery_target("osquery/database:database"),
+        osquery_target("osquery/filesystem:osquery_filesystem"),
+        osquery_target("osquery/filesystem:osquery_filesystem"),
+        osquery_target("osquery/remote/tests:remote_test_utils"),
+        osquery_target("osquery/tables/system:system_table"),
+        osquery_target("osquery/utils:utils"),
+        osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("plugins/database:ephemeral"),
+    ],
+)
+
+osquery_cxx_test(
+    name = "windows_certificates_tests",
+    platform_srcs = [
+        (
+            WINDOWS,
+            [
+                "windows/certificates_tests.cpp",
             ],
         ),
     ],

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -34,6 +34,10 @@ function(osqueryTablesSystemTestsMain)
     generateOsqueryTablesSystemTestsStartupitemstestsTest()
     generateOsqueryTablesSystemTestsSignaturetestsTest()
   endif()
+
+  if(DEFINED PLATFORM_WINDOWS)
+    generateOsqueryTablesSystemTestsCertificatestestsTest()
+  endif()
 endfunction()
 
 function(generateOsqueryTablesSystemTestsMdtablestestsTest)
@@ -388,6 +392,25 @@ function(generateOsqueryTablesSystemTestsSignaturetestsTest)
   add_osquery_executable(osquery_tables_system_tests_signaturetests-test darwin/signature_tests.mm)
 
   target_link_libraries(osquery_tables_system_tests_signaturetests-test PRIVATE
+    global_cxx_settings
+    osquery_config_tests_testutils
+    osquery_core
+    osquery_core_sql
+    osquery_database
+    osquery_filesystem
+    osquery_remote_tests_remotetestutils
+    osquery_tables_system_systemtable
+    osquery_utils
+    osquery_utils_conversions
+    plugins_database_ephemeral
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsqueryTablesSystemTestsCertificatestestsTest)
+  add_osquery_executable(osquery_tables_system_tests_certificatestests-test windows/certificates_tests.cpp)
+
+  target_link_libraries(osquery_tables_system_tests_certificatestests-test PRIVATE
     global_cxx_settings
     osquery_config_tests_testutils
     osquery_core

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ function(osqueryTablesSystemTestsMain)
   if(DEFINED PLATFORM_MACOS)
     generateOsqueryTablesSystemTestsAppstestsTest()
     generateOsqueryTablesSystemTestsAsltestsTest()
-    generateOsqueryTablesSystemTestsCertificatestestsTest()
+    generateOsqueryTablesSystemTestsMacOsCertificatestestsTest()
     generateOsqueryTablesSystemTestsExtendedattributestestsTest()
     generateOsqueryTablesSystemTestsFirewalltestsTest()
     generateOsqueryTablesSystemTestsLaunchdtestsTest()
@@ -36,7 +36,7 @@ function(osqueryTablesSystemTestsMain)
   endif()
 
   if(DEFINED PLATFORM_WINDOWS)
-    generateOsqueryTablesSystemTestsCertificatestestsTest()
+    generateOsqueryTablesSystemTestsWindowsCertificatestestsTest()
   endif()
 endfunction()
 
@@ -231,7 +231,7 @@ function(generateOsqueryTablesSystemTestsAsltestsTest)
   )
 endfunction()
 
-function(generateOsqueryTablesSystemTestsCertificatestestsTest)
+function(generateOsqueryTablesSystemTestsMacOsCertificatestestsTest)
   add_osquery_executable(osquery_tables_system_tests_certificatestests-test darwin/certificates_tests.cpp)
 
   target_link_libraries(osquery_tables_system_tests_certificatestests-test PRIVATE
@@ -407,7 +407,7 @@ function(generateOsqueryTablesSystemTestsSignaturetestsTest)
   )
 endfunction()
 
-function(generateOsqueryTablesSystemTestsCertificatestestsTest)
+function(generateOsqueryTablesSystemTestsWindowsCertificatestestsTest)
   add_osquery_executable(osquery_tables_system_tests_certificatestests-test windows/certificates_tests.cpp)
 
   target_link_libraries(osquery_tables_system_tests_certificatestests-test PRIVATE

--- a/osquery/tables/system/tests/windows/certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/certificates_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/windows/certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/certificates_tests.cpp
@@ -1,0 +1,107 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/database.h>
+#include <osquery/flags.h>
+#include <osquery/registry.h>
+#include <osquery/system.h>
+#include <osquery/tables.h>
+
+#include <osquery/tables/system/windows/certificates.h>
+
+namespace osquery {
+
+DECLARE_bool(disable_database);
+
+namespace tables {
+
+class CertificatesTablesTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    Initializer::platformSetup();
+    registryAndPluginInit();
+
+    FLAGS_disable_database = true;
+    DatabasePlugin::setAllowOpen(true);
+    DatabasePlugin::initPlugin();
+  }
+};
+
+TEST_F(CertificatesTablesTest, test_only_store_non_special_case) {
+  LPCWSTR input = L"My";
+  std::string storeLocation = "CurrentService";
+  std::string serviceNameOrUserId, sid, storeName;
+
+  parseSystemStoreString(
+      input, storeLocation, serviceNameOrUserId, sid, storeName);
+
+  EXPECT_EQ(serviceNameOrUserId, "");
+  EXPECT_EQ(sid, "");
+  EXPECT_EQ(storeName, "Personal");
+}
+
+TEST_F(CertificatesTablesTest, test_service) {
+  LPCWSTR input = L"RpcSs\\My"; // This service should always exist
+  std::string storeLocation = "Services";
+  std::string serviceNameOrUserId, sid, storeName;
+
+  parseSystemStoreString(
+      input, storeLocation, serviceNameOrUserId, sid, storeName);
+
+  EXPECT_EQ(serviceNameOrUserId, "RpcSs");
+  EXPECT_EQ(sid, kNetworkService);
+  EXPECT_EQ(storeName, "Personal");
+}
+
+TEST_F(CertificatesTablesTest, test_user_default) {
+  LPCWSTR input = L".DEFAULT\\My";
+  std::string storeLocation = "Users";
+  std::string serviceNameOrUserId, sid, storeName;
+
+  parseSystemStoreString(
+      input, storeLocation, serviceNameOrUserId, sid, storeName);
+
+  EXPECT_EQ(serviceNameOrUserId, ".DEFAULT");
+  EXPECT_EQ(sid, kLocalSystem);
+  EXPECT_EQ(storeName, "Personal");
+}
+
+TEST_F(CertificatesTablesTest, test_user_sid) {
+  LPCWSTR input = L"S-1-5-18\\Root";
+  std::string storeLocation = "Users";
+  std::string serviceNameOrUserId, sid, storeName;
+
+  parseSystemStoreString(
+      input, storeLocation, serviceNameOrUserId, sid, storeName);
+
+  EXPECT_EQ(serviceNameOrUserId, "S-1-5-18");
+  EXPECT_EQ(sid, kLocalSystem);
+  EXPECT_EQ(storeName, "Trusted Root Certification Authorities");
+}
+
+TEST_F(CertificatesTablesTest, test_user_classes) {
+  LPCWSTR input =
+      L"S-1-5-21-2821152761-3909955410-1545212275-1001_Classes\\Root";
+  std::string storeLocation = "Users";
+  std::string serviceNameOrUserId, sid, storeName;
+
+  parseSystemStoreString(
+      input, storeLocation, serviceNameOrUserId, sid, storeName);
+
+  EXPECT_EQ(serviceNameOrUserId,
+            "S-1-5-21-2821152761-3909955410-1545212275-1001_Classes");
+  EXPECT_EQ(sid, "S-1-5-21-2821152761-3909955410-1545212275-1001");
+  EXPECT_EQ(storeName, "Trusted Root Certification Authorities");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/windows/certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/certificates_tests.cpp
@@ -38,9 +38,10 @@ TEST_F(CertificatesTablesTest, test_only_store_non_special_case) {
   LPCWSTR input = L"My";
   std::string storeLocation = "CurrentService";
   std::string serviceNameOrUserId, sid, storeName;
+  ServiceNameMap cache;
 
   parseSystemStoreString(
-      input, storeLocation, serviceNameOrUserId, sid, storeName);
+      input, storeLocation, cache, serviceNameOrUserId, sid, storeName);
 
   EXPECT_EQ(serviceNameOrUserId, "");
   EXPECT_EQ(sid, "");
@@ -51,9 +52,10 @@ TEST_F(CertificatesTablesTest, test_service) {
   LPCWSTR input = L"RpcSs\\My"; // This service should always exist
   std::string storeLocation = "Services";
   std::string serviceNameOrUserId, sid, storeName;
+  ServiceNameMap cache;
 
   parseSystemStoreString(
-      input, storeLocation, serviceNameOrUserId, sid, storeName);
+      input, storeLocation, cache, serviceNameOrUserId, sid, storeName);
 
   EXPECT_EQ(serviceNameOrUserId, "RpcSs");
   EXPECT_EQ(sid, kNetworkService);
@@ -64,9 +66,10 @@ TEST_F(CertificatesTablesTest, test_user_default) {
   LPCWSTR input = L".DEFAULT\\My";
   std::string storeLocation = "Users";
   std::string serviceNameOrUserId, sid, storeName;
+  ServiceNameMap cache;
 
   parseSystemStoreString(
-      input, storeLocation, serviceNameOrUserId, sid, storeName);
+      input, storeLocation, cache, serviceNameOrUserId, sid, storeName);
 
   EXPECT_EQ(serviceNameOrUserId, ".DEFAULT");
   EXPECT_EQ(sid, kLocalSystem);
@@ -77,9 +80,10 @@ TEST_F(CertificatesTablesTest, test_user_sid) {
   LPCWSTR input = L"S-1-5-18\\Root";
   std::string storeLocation = "Users";
   std::string serviceNameOrUserId, sid, storeName;
+  ServiceNameMap cache;
 
   parseSystemStoreString(
-      input, storeLocation, serviceNameOrUserId, sid, storeName);
+      input, storeLocation, cache, serviceNameOrUserId, sid, storeName);
 
   EXPECT_EQ(serviceNameOrUserId, "S-1-5-18");
   EXPECT_EQ(sid, kLocalSystem);
@@ -91,9 +95,10 @@ TEST_F(CertificatesTablesTest, test_user_classes) {
       L"S-1-5-21-2821152761-3909955410-1545212275-1001_Classes\\Root";
   std::string storeLocation = "Users";
   std::string serviceNameOrUserId, sid, storeName;
+  ServiceNameMap cache;
 
   parseSystemStoreString(
-      input, storeLocation, serviceNameOrUserId, sid, storeName);
+      input, storeLocation, cache, serviceNameOrUserId, sid, storeName);
 
   EXPECT_EQ(serviceNameOrUserId,
             "S-1-5-21-2821152761-3909955410-1545212275-1001_Classes");

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -243,9 +243,9 @@ std::string getServiceSid(const std::string& serviceNameOrSid) {
 
 /// Parse the given system store string whose structure is:
 /// `(<prefix>\)?<unlocalized system store name>`
-/// (e.g. "Third-Party Root Certification Authorities")
-/// (e.g. "S-1-5-18\Trusted Root Certification Authorities")
-/// (e.g. "SshdBroker\Third-Party Root Certification Authorities")
+/// (e.g. "My")
+/// (e.g. "S-1-5-18\My")
+/// (e.g. "SshdBroker\My")
 ///
 /// <prefix> can be a SID, service name (`SshdBroker`) (for service stores), or
 /// SID with `_Classes` appended (for user accounts). If it exists, it is

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -149,13 +149,13 @@ std::string getLocalizedStoreName(LPCWSTR storeNameW) {
 /// Expects @name to be the `lpServiceStartName` from
 /// `QueryServiceConfig`
 std::string getSidFromAccountName(const std::string& name) {
+  // `lpServiceStartName` has been observed to contain both uppercase
+  // and lowercase versions of these values
   if (boost::iequals(name, "LocalSystem")) {
-    // `lpServiceStartName` has been observed to contain both uppercase
-    // and lowercase versions of "LocalSystem"
     return kLocalSystem;
-  } else if (name == "NT Authority\\LocalService") {
+  } else if (boost::iequals(name, "NT Authority\\LocalService")) {
     return kLocalService;
-  } else if (name == "NT Authority\\NetworkService") {
+  } else if (boost::iequals(name, "NT Authority\\NetworkService")) {
     return kNetworkService;
   }
   return "";

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -203,7 +203,7 @@ std::string getUsernameFromSid(const std::string& sidString) {
 }
 
 bool isValidSid(const std::string& maybeSid) {
-  return getUsernameFromSid(maybeSid).length();
+  return getUsernameFromSid(maybeSid).length() != 0;
 }
 
 /// Given a string that can contain either a service name or SID: if it is

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -24,6 +24,7 @@
 #include <osquery/utils/conversions/windows/strings.h>
 
 #include <osquery/filesystem/fileops.h>
+#include <osquery/tables/system/windows/certificates.h>
 
 namespace osquery {
 namespace tables {
@@ -46,10 +47,6 @@ typedef struct _ENUM_ARG {
   QueryData* results;
   std::string storeLocation;
 } ENUM_ARG, *PENUM_ARG;
-
-const static std::string kLocalSystem = "S-1-5-18";
-const static std::string kLocalService = "S-1-5-19";
-const static std::string kNetworkService = "S-1-5-20";
 
 std::string cryptOIDToString(const char* objId) {
   if (objId == nullptr) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -296,13 +296,13 @@ void parseSystemStoreString(LPCWSTR sysStoreW,
           0, serviceNameOrUserId.length() - suffix.length());
     }
   } else if (storeLocation == "CurrentUser") {
-    PTOKEN_USER currentUserInfo;
-    auto ret = getCurrentUserInfo(currentUserInfo);
-    if (!ret.ok()) {
+    auto currentUserInfoSmartPtr = getCurrentUserInfo();
+    if (currentUserInfoSmartPtr == nullptr) {
       VLOG(1) << "Accessing current user info failed (" << GetLastError()
               << ")";
     } else {
-      sid = psidToString(currentUserInfo->User.Sid);
+      auto ptu = reinterpret_cast<PTOKEN_USER>(currentUserInfoSmartPtr.get());
+      sid = psidToString(ptu->User.Sid);
     }
   }
 }

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -207,8 +207,8 @@ bool isValidSid(const std::string& maybeSid) {
 /// a service name, return the SID corresponding to the service account.
 /// Otherwise simply return the input string.
 std::string getServiceSid(const std::string& serviceNameOrSid) {
-  // This cache assumes a service will not stop, then restart under a different
-  // account while osquery is running.
+  // FIXME: This cache assumes a service will not stop, then restart under a
+  // different account while osquery is running.
   static std::unordered_map<std::string, std::string> service2accountCache;
 
   if (isValidSid(serviceNameOrSid)) {

--- a/osquery/tables/system/windows/certificates.h
+++ b/osquery/tables/system/windows/certificates.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/windows/certificates.h
+++ b/osquery/tables/system/windows/certificates.h
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+const static std::string kLocalSystem = "S-1-5-18";
+const static std::string kLocalService = "S-1-5-19";
+const static std::string kNetworkService = "S-1-5-20";
+
+void parseSystemStoreString(LPCWSTR sysStoreW,
+                            const std::string& storeLocation,
+                            std::string& serviceNameOrUserId,
+                            std::string& sid,
+                            std::string& storeName);
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/certificates.h
+++ b/osquery/tables/system/windows/certificates.h
@@ -14,12 +14,15 @@
 namespace osquery {
 namespace tables {
 
+using ServiceNameMap = std::unordered_map<std::string, std::string>;
+
 const static std::string kLocalSystem = "S-1-5-18";
 const static std::string kLocalService = "S-1-5-19";
 const static std::string kNetworkService = "S-1-5-20";
 
 void parseSystemStoreString(LPCWSTR sysStoreW,
                             const std::string& storeLocation,
+                            ServiceNameMap& service2sidCache,
                             std::string& serviceNameOrUserId,
                             std::string& sid,
                             std::string& storeName);

--- a/specs/macwin/certificates.table
+++ b/specs/macwin/certificates.table
@@ -19,5 +19,14 @@ schema([
     Column("serial", TEXT, "Certificate serial number"),
 
 ])
+
+extended_schema(WINDOWS, [
+    Column("sid", TEXT, "SID"),
+    Column("store_location", TEXT, "Certificate system store location"),
+    Column("store", TEXT, "Certificate system store"),
+    Column("username", TEXT, "Username"),
+    Column("store_id", TEXT, "Exists for service/user stores. Contains raw store id provided by WinAPI."),
+])
+
 attributes(cacheable=True)
 implementation("certificates@genCerts")


### PR DESCRIPTION
This PR addresses a few bugs in the certificates table on Windows (which was somewhat broken), and also implements some additional functionality (new columns). This is the first of two PRs, the second of which improves the table's completeness with respect to the `Personal` certificate store.

Bugs Fixed
1. The store enumeration API (certEnumSystemStoreCallback) returned False during error handling, but this prematurely ends the enumeration of cert store locations and cert stores. The callback has been adjusted to always return true, which ensures complete enumeration. (https://docs.microsoft.com/en-us/windows/desktop/api/wincrypt/nc-wincrypt-pfn_cert_enum_system_store#return-value)
2. The CertOpenSystemStore API (https://docs.microsoft.com/en-us/windows/desktop/api/wincrypt/nf-wincrypt-certopensystemstorea) was used for opening system stores, however this is not the correct API, since it only opens stores in the `Current User` store location. The `CertOpenStore` API is now used, which is the correct functionality for opening arbitrary stores in arbitrary locations.
3. The table previously included deduplication functionality which actually resulted in certificates being hidden. If a certificate was found in multiple users' stores, it would only appear as one entry due to this deduplication. Deduplication has been removed.

Improvements Made
- Fixing bug 1. reveals bugs in the handling of the `const void* systemStore` parameter that `certEnumSystemStoreCallback` receives. Specifically, that `systemStore` parameter could also contain information about the service or user store location that the store was in (previously, the code expected something like `My`, and now that parameter could contain something like `S-1-5-18\My`). Handling this required adding more parsing logic (`parseSystemStoreString`) and refactoring to use the additional provided information.
- Various new columns have been added to the table to make using it more ergonomic for Windows. Previously, a variety of data was concatenated and put in the `path` column. That functionality has been preserved, but that information (username, SID, store location, store) has been broken out into individual columns so it can be queried for.


Testing Notes
- Verbose debug logging has been added to show the certificate store enumeration process
- `select common_name, path, sid, username, store_location from certificates;` is a good starting query
- Unit tests have been added for one small string parsing routine, however, much of the table is untested. I took a look at restructuring the code to create a layer between the table and the system APIs and it was very difficult due to the way the system APIs use (nested) callback functions extensively.

Questions
- The table currently does an internal SQL query to map a service's name to its SID. It caches these lookups, however the cache assumes that services will not restart under a different user while osquery is running. Is this too dangerous of an assumption?
- Some files contain comments at the top with a Facebook copyright notice, since they were copied from other files. Should that be removed, and what should go in place of them, if anything?
