### PR TITLE
Fix ATC mounting of SQLite DBs using WAL journaling

### DIFF
--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -463,4 +463,13 @@ Status genTableRowsForSqliteTable(const boost::filesystem::path& sqlite_db,
                                   const std::string& sqlite_query,
                                   TableRows& results,
                                   bool respect_locking = true);
+
+/**
+ * @brief Detect journal_mode of d SQLite database file
+ *
+ * Returns a Status, if successful contains the journal mode as message
+ *
+ * @param sqlite_db Path to the sqlite_db
+ */
+Status getSqliteJournalMode(const boost::filesystem::path& sqlite_db);
 } // namespace osquery

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -30,7 +30,16 @@ TableRows ATCPlugin::generate(QueryContext& context) {
     LOG(WARNING) << "Could not glob: " << path_;
   }
   for (const auto& path : paths) {
-    s = genTableRowsForSqliteTable(path, sqlite_query_, result, false);
+    s = getSqliteJournalMode(path);
+    bool preserve_locking = false;
+    if (!s.ok()) {
+      VLOG(1)
+          << "Unable to detect journal mode, applying default locking policy";
+    } else {
+      preserve_locking = s.getMessage() == "wal";
+    }
+    s = genTableRowsForSqliteTable(
+        path, sqlite_query_, result, preserve_locking);
     if (!s.ok()) {
       LOG(WARNING) << "Error Code: " << s.getCode()
                    << " Could not generate data: " << s.getMessage();


### PR DESCRIPTION
This fix addresses issue https://github.com/osquery/osquery/issues/5225.
This idea came from reading the [SQLite WAL documentation](https://www.sqlite.org/wal.html) where it states:

> WAL normally requires that the VFS support shared-memory primitives...

It didn't clearly state that "shared-memory" requires the locking primitives to be enabled, but that's what I inferred since you usually don't want concurrent things to freely mess around with memory.
So I tried to load a WAL DB as ATC flipping the `respect_locking` parameter and it ended up working properly (hurray).
I'm sure the original reason why it was chosen to use the `*-none` (no-op locking primitives) VFSes by default is to avoid getting rejections from locked databases, but that's not the case with WAL since (again from the SQLite docs):

> WAL provides more concurrency as readers do not block writers and a writer does not block readers. Reading and writing can proceed concurrently.

That said, the logic of this fix is to simply test the journal mode with a PRAGMA statement before loading the table. The possible outcomes are:
- the DB uses WAL -> PRAGMA statement returns "wal" and the table is loaded with default VFS (locking enabled);
- the DB uses _something else_ and it's not locked -> PRAGMA statement returns _"something else"_ and the table is loaded with a `*-none` VFS (as it happened before);
- the DB uses _something else_ and it's locked -> PRAGMA statement fails and the table is loaded with a `*-none` VFS (as it happened before);

I tried to add the code in a place which looked more or less appropriate and to use the routines that I found to be available at a quick glance through the codebase. If there is a better way to write this, please point it out to me and I'll try address such suggestions.

Tested on MacOS 10.14.5 against Mozilla Firefox (WAL) and Google Chrome (non WAL) history databases.