### PR TITLE
Fix for mount table interacting with direct autofs.

### DIFF
--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -25,9 +25,17 @@ QueryData genMounts(QueryContext& context) {
     return {};
   }
 
+  std::vector<std::string> mnt_type_blacklist = {
+    "autofs"
+  };
+
   struct mntent* ent = nullptr;
   while ((ent = getmntent(mounts))) {
     Row r;
+
+    if (std::find(mnt_type_blacklist.begin(), mnt_type_blacklist.end(), std::string(ent->mnt_type)) != mnt_type_blacklist.end()) {
+      continue;
+    }
 
     r["device"] = std::string(ent->mnt_fsname);
     r["device_alias"] = canonicalize_file_name(ent->mnt_fsname);

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -14,6 +14,8 @@
 #include <osquery/tables.h>
 #include <osquery/utils/system/filepath.h>
 
+const char * const kMntTypeBlacklist[] = {"autofs", NULL};
+
 namespace osquery {
 namespace tables {
 
@@ -25,17 +27,19 @@ QueryData genMounts(QueryContext& context) {
     return {};
   }
 
-  std::vector<std::string> mnt_type_blacklist = {
-    "autofs"
-  };
-
   struct mntent* ent = nullptr;
   while ((ent = getmntent(mounts))) {
     Row r;
 
-    if (std::find(mnt_type_blacklist.begin(), mnt_type_blacklist.end(), std::string(ent->mnt_type)) != mnt_type_blacklist.end()) {
-      continue;
+    int i=0;
+    while(kMntTypeBlacklist[i]){
+      if (!strcmp(kMntTypeBlacklist[i], ent->mnt_type))
+        break;
+      i++;
     }
+
+    if (kMntTypeBlacklist[i])
+      continue;
 
     r["device"] = std::string(ent->mnt_fsname);
     r["device_alias"] = canonicalize_file_name(ent->mnt_fsname);

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -14,7 +14,7 @@
 #include <osquery/tables.h>
 #include <osquery/utils/system/filepath.h>
 
-const char * const kMntTypeBlacklist[] = {"autofs", NULL};
+const char* const kMntTypeBlacklist[] = {"autofs", NULL};
 
 namespace osquery {
 namespace tables {
@@ -31,8 +31,8 @@ QueryData genMounts(QueryContext& context) {
   while ((ent = getmntent(mounts))) {
     Row r;
 
-    int i=0;
-    while(kMntTypeBlacklist[i]){
+    int i = 0;
+    while (kMntTypeBlacklist[i]) {
       if (!strcmp(kMntTypeBlacklist[i], ent->mnt_type))
         break;
       i++;


### PR DESCRIPTION
Hello osquery Devs!

**The issue:** 

Running statfs() on a /proc/mounts entry of type "autofs" will result in the mounting of that file system, changing the runtime state of the system.

**Why this is a problem:**

- The unintentional mounting of the file system changes the state of the machine, in violation of the first principle of contribution called out in the osquery/CONTRIBUTING.md guidelines: 
  - "_1. osquery doesn’t change the state of the system_"
- In an environment with a large number of autofs direct maps, the query "select * from mounts;" will take down the host in a "mount storm". In a large environment, the traffic generated from pushing this request across the environment will result in the mount storm taking out the filers as well. 

**What solution is proposed by this pull request:** 

This pull request implements a filesystem blacklist. If getmntent() returns a ent->mnt_type that is in the blacklist, the entry is skipped. The only fs type listed in the blacklist in this initial pull request is autofs. However, statfs()ing other types of filesystems may also cause problems so I wanted a data structure (std\:\:vector\<std\:\:string\>) that could be extended in the future.

**Where was this patch tested:**

x86_64 Ubuntu 16.04 (against 3.3.2) and x86_64 Ubuntu 18.04 (against master).

**Further information:**

Autofs has two types of maps, indirect and direct. Indirect maps are more common. An indirect mapping does not appear in /proc/mounts. Therefore the unpatched mounts.cpp code will never attempt to query an autofs indirect mapping. However, direct mappings do appear in /proc/mounts as type "autofs". After mounting a direct mapping this entry is replaced by one representing the now mounted filesystem, e.g. type "nfs". Calling statfs() on a direct mapping will result in the mounting. As such, statfs() on type autofs will never be beneficial and can be harmful. (This also brings up a possible reporting error race condition where after reporting on the autofs entry the unpatched mounts.cpp may also report again on the now mounted nfs/nfs4 entry.)

It is important to note that environments where this will be an issue are quite common in certain industries, such as EDA companies, animation companies, and any large super computing environments. In environments such as these it is not unusual to have more than 75k autofs entries, with roughly half being direct mappings, being consumed by more than 90k Linux hosts. Calling statfs() on each of these direct autofs mappings will kill the box. If this were pushed out to all 90k hosts, the resulting mount storm would also take out the filers and possibly intermediary networking appliances.

There are many other fs types where a statfs() may cause problems because it will alter the state of the system, cause broader system issues, or simply makes no sense in the context of the type of data statfs() collects. I have only observed the issue directly with autofs, so that's all this patch covers. I would suggest looking to existing tools for a guide on appropriate behavior in this space. The "update_db.sh" tool from the GNU findutils "locate" project calls out a reasonably good list of fs types that osquery may want to ignore. (At the least, it's a good list with which to start the discussion.)

From findutils-4.6.0/locate/updatedb.sh, line 258:
```
9P
NFS
afs
autofs
cifs
coda
devfs
devpts
ftpfs
iso9660
mfs
ncpfs
nfs
nfs4
proc
shfs
smbfs
sysfs
```

I would also point out that while I chose in my patch to skip the entry entirely, it is also reasonable to include the entry in the final listing, but skip the statfs(). 

Thank you for taking the time to consider this request.
