### PR TITLE
crontab testcase fix

### DIFF
--- a/tests/integration/tables/crontab.cpp
+++ b/tests/integration/tables/crontab.cpp
@@ -50,7 +50,7 @@ TEST_F(Crontab, test_sanity) {
                             {"hour", CronValuesCheck(0, 23)},
                             {"day_of_month", CronValuesCheck(1, 31)},
                             {"month", CronValuesCheck(1, 31, month_list)},
-                            {"day_of_week", CronValuesCheck(0, 6, days_list)},
+                            {"day_of_week", CronValuesCheck(0, 7, days_list)},
                             {"command", NonEmptyString},
                             {"path", FileOnDisk}};
   validate_rows(data, row_map);

--- a/tests/integration/tables/crontab.cpp
+++ b/tests/integration/tables/crontab.cpp
@@ -38,14 +38,15 @@ TEST_F(Crontab, test_sanity) {
                                                 "dec"};
   std::unordered_set<std::string> days_list = {
       "mon", "tue", "wed", "thu", "fri", "sat", "sun"};
-  ValidatatioMap row_map = {{"event", SpecificValuesCheck{"",
-                                                          "@reboot",
-                                                          "@hourly",
-                                                          "@daily",
-                                                          "@weekly",
-                                                          "@monthly",
-                                                          "@annually",
-                                                          "@yearly"}},
+  ValidatatioMap row_map = {{"event",
+                             SpecificValuesCheck{"",
+                                                 "@reboot",
+                                                 "@hourly",
+                                                 "@daily",
+                                                 "@weekly",
+                                                 "@monthly",
+                                                 "@annually",
+                                                 "@yearly"}},
                             {"minute", CronValuesCheck(0, 59)},
                             {"hour", CronValuesCheck(0, 23)},
                             {"day_of_month", CronValuesCheck(1, 31)},


### PR DESCRIPTION
This test case failed for me. I believe range should be 0-7 not 0-6.

From man page of crontab
field allowed values
----- --------------
minute 0-59
hour 0-23
day of month 1-31
month 1-12 (or names, see below)
day of week 0-7 (0 or 7 is Sun, or use names)