### PR TITLE
windows/certificates: Improve table's coverage of Personal certificates

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -65,6 +65,7 @@ osquery_cxx_library(
             [
                 "windows/registry.h",
                 "windows/certificates.h",
+                "windows/users.h",
             ],
         ),
     ],

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -294,6 +294,7 @@ function(generateOsqueryTablesSystemSystemtable)
     list(APPEND platform_public_header_files
       windows/registry.h
       windows/certificates.h
+      windows/users.h
     )
   endif()
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -691,8 +691,15 @@ BOOL WINAPI certEnumSystemStoreLocationsCallback(LPCWSTR storeLocation,
  * users' registry hives are currently mounted.
  */
 void genPersonalCertsFromDisk(QueryData& results) {
-  auto users = SQL::selectAllFrom("users");
-  for (const auto& row : users) {
+  SQL sql(
+      "SELECT uuid, username FROM users WHERE username NOT IN ('SYSTEM', "
+      "'LOCAL SERVICE', 'NETWORK SERVICE')");
+  if (!sql.ok()) {
+    VLOG(1) << sql.getStatus().getMessage();
+    return;
+  }
+
+  for (const auto& row : sql.rows()) {
     auto sid = row.at("uuid");
     auto username = row.at("username");
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -334,9 +334,9 @@ void parseSystemStoreString(LPCWSTR sysStoreW,
 
 #pragma pack(push, 1)
 struct Header {
-  DWORD propid;
-  DWORD unknown;
-  DWORD size;
+  unsigned long propid;
+  unsigned long unknown;
+  unsigned long size;
 };
 #pragma pack(pop)
 
@@ -353,7 +353,7 @@ struct Header {
  */
 Status getEncodedCert(std::basic_istream<BYTE>& blob,
                       std::vector<BYTE>& encodedCert) {
-  static const DWORD CERT_CERT_PROP_ID = 0x20;
+  static const unsigned long CERT_CERT_PROP_ID = 0x20;
 
   Header hdr;
 
@@ -553,7 +553,7 @@ void findUserPersonalCertsOnDisk(const std::string& username,
       auto ctx =
           CertCreateCertificateContext(X509_ASN_ENCODING,
                                        encodedCert.data(),
-                                       static_cast<DWORD>(encodedCert.size()));
+                                       static_cast<unsigned long>(encodedCert.size()));
 
       addCertRow(
           ctx, results, storeId, sid, storeName, username, storeLocation);
@@ -717,7 +717,7 @@ void genNonPersonalCerts(QueryData& results) {
   ENUM_ARG enumArg;
 
   unsigned long flags = 0;
-  DWORD locationId = CERT_SYSTEM_STORE_CURRENT_USER_ID;
+  unsigned long locationId = CERT_SYSTEM_STORE_CURRENT_USER_ID;
 
   enumArg.dwFlags = flags;
   enumArg.pvStoreLocationPara = nullptr;

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -363,11 +363,11 @@ Status getEncodedCert(std::basic_istream<BYTE>& blob,
 
 void addCertRow(PCCERT_CONTEXT certContext,
                 QueryData& results,
-                std::string storeId,
-                std::string sid,
-                std::string storeName,
-                std::string username,
-                std::string storeLocation) {
+                const std::string& storeId,
+                const std::string& sid,
+                const std::string& storeName,
+                const std::string& username,
+                const std::string& storeLocation) {
   std::vector<char> certBuff;
   getCertCtxProp(certContext, CERT_HASH_PROP_ID, certBuff);
   std::string fingerprint;
@@ -509,10 +509,10 @@ void addCertRow(PCCERT_CONTEXT certContext,
 }
 
 void findUserPersonalCertsOnDisk(const std::string& username,
-                                 const std::string storeId,
-                                 const std::string sid,
-                                 const std::string storeName,
-                                 const std::string storeLocation,
+                                 const std::string& storeId,
+                                 const std::string& sid,
+                                 const std::string& storeName,
+                                 const std::string& storeLocation,
                                  QueryData& results) {
   std::stringstream certsPath;
   certsPath

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -418,7 +418,7 @@ void addCertRow(PCCERT_CONTEXT certContext,
                              issuerSize);
   r["issuer"] = issuerSize == 0 ? "" : certBuff.data();
 
-  // TODO: Find the right API calls to get whether a cert is for a CA
+  // TODO(#5654) 1: Find the right API calls to get whether a cert is for a CA
   r["ca"] = INTEGER(-1);
 
   r["self_signed"] =
@@ -567,16 +567,7 @@ void enumerateCertStore(const HCERTSTORE& certStore,
       if (storeLocation != "Users" || boost::ends_with(storeId, "_Classes")) {
         TLOG << "    Trying harder to get Personal store.";
 
-        // TODO: This can technically be optimized. In certain cases, we will
-        // end up retrieving Personal certificates from disk that have already
-        // been fetched for a user/SID. For example, the Services store
-        // location has stores like
-        // S-1-5-21-2821152761-3909955410-1545212275-1001\My. That user's
-        // Personal certs will have already been fetched up front and in this
-        // specific case, we will refetch from disk. We could conceivably save
-        // those results, and reuse them here. Only thing is we'd need to update
-        // the storeId and storeLocation fields to match where we currently are
-        // in the enumeration process.
+        // TODO(#5654) 2: Potential future optimization
         findUserPersonalCertsOnDisk(
             username, storeId, sid, storeName, storeLocation, results);
       }

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -553,7 +553,7 @@ void enumerateCertStore(const HCERTSTORE& certStore,
     TLOG << "    Store was empty.";
 
     // Personal stores for other users come back as empty, even if they are not.
-    if (storeName == "Personal") {
+    if (storeName == "Personal" && !username.empty()) {
       // Avoid duplicate rows for personal certs we've already inserted up
       // front.
       if (storeLocation != "Users" || boost::ends_with(storeId, "_Classes")) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -520,8 +520,7 @@ void findUserPersonalCertsOnDisk(const std::string& username,
       << "\\AppData\\Roaming\\Microsoft\\SystemCertificates\\My\\Certificates";
 
   try {
-    for (fs::directory_entry& x :
-         fs::directory_iterator(fs::path(certsPath.str()))) {
+    for (auto& x : fs::directory_iterator(fs::path(certsPath.str()))) {
       std::basic_ifstream<BYTE> inp(x.path().string(), std::ios::binary);
 
       std::vector<BYTE> encodedCert;

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -319,11 +319,19 @@ struct Header {
 };
 #pragma pack(pop)
 
+/**
+ * This function extracts an encoded certificate from a proprietary Windows
+ * file format, which is described in the links below. Briefly, the file is
+ * an array of elements where each element contains a header followed by a
+ * variable length data buffer. The encoded certificate is stored in the data
+ * buffer of one of these elements whose header has a specific `propid` field.
+ *
+ * Links:
+ * https://itsme.home.xs4all.nl/projects/xda/smartphone-certificates.html
+ * https://github.com/wine-mirror/wine/blob/f9301c2b66450a1cdd986e9052fcaa76535ba8b7/dlls/crypt32/crypt32_private.h#L146
+ */
 Status getEncodedCert(std::basic_istream<BYTE>& blob,
                       std::vector<BYTE>& encodedCert) {
-  // See these links for details on this magic number:
-  // https://itsme.home.xs4all.nl/projects/xda/smartphone-certificates.html
-  // https://github.com/wine-mirror/wine/blob/f9301c2b66450a1cdd986e9052fcaa76535ba8b7/dlls/crypt32/crypt32_private.h#L146
   static const DWORD CERT_CERT_PROP_ID = 0x20;
 
   Header hdr;

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -388,7 +388,7 @@ void addCertRow(PCCERT_CONTEXT certContext,
                     certBuff.data(),
                     static_cast<unsigned long>(certBuff.size()));
   r["common_name"] = certBuff.data();
-  TLOG << "    cert name: " << certBuff.data();
+  VLOG(1) << "cert name: " << certBuff.data();
 
   auto subjSize = CertNameToStr(certContext->dwCertEncodingType,
                                 &(certContext->pCertInfo->Subject),
@@ -558,14 +558,14 @@ void enumerateCertStore(const HCERTSTORE& certStore,
   auto certContext = CertEnumCertificatesInStore(certStore, nullptr);
 
   if (certContext == nullptr && GetLastError() == CRYPT_E_NOT_FOUND) {
-    TLOG << "    Store was empty.";
+    VLOG(1) << "Store was empty.";
 
     // Personal stores for other users come back as empty, even if they are not.
     if (storeName == "Personal" && !username.empty()) {
       // Avoid duplicate rows for personal certs we've already inserted up
       // front.
       if (storeLocation != "Users" || boost::ends_with(storeId, "_Classes")) {
-        TLOG << "    Trying harder to get Personal store.";
+        VLOG(1) << "Trying harder to get Personal store.";
 
         // TODO(#5654) 2: Potential future optimization
         findUserPersonalCertsOnDisk(
@@ -605,7 +605,7 @@ BOOL WINAPI certEnumSystemStoreCallback(const void* systemStore,
   auto* storeArg = static_cast<ENUM_ARG*>(arg);
   auto* sysStoreW = static_cast<LPCWSTR>(systemStore);
 
-  VLOG(1) << "  Enumerating cert store: " << wstringToString(sysStoreW);
+  VLOG(1) << "Enumerating cert store: " << wstringToString(sysStoreW);
 
   auto systemStoreLocation = flags & CERT_SYSTEM_STORE_LOCATION_MASK;
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -502,11 +502,11 @@ void addCertRow(PCCERT_CONTEXT certContext,
 }
 
 void findUserPersonalCertsOnDisk(const std::string& username,
-                                 QueryData& results,
-                                 std::string storeId,
-                                 std::string sid,
-                                 std::string storeName,
-                                 std::string storeLocation) {
+                                 const std::string storeId,
+                                 const std::string sid,
+                                 const std::string storeName,
+                                 const std::string storeLocation,
+                                 QueryData& results) {
   std::stringstream certsPath;
   certsPath
       << "C:\\Users\\" << username
@@ -570,8 +570,8 @@ void enumerateCertStore(const HCERTSTORE& certStore,
         // those results, and reuse them here. Only thing is we'd need to update
         // the storeId and storeLocation fields to match where we currently are
         // in the enumeration process.
-        findPersonalCertsOnDisk(
-            username, results, storeId, sid, storeName, storeLocation);
+        findUserPersonalCertsOnDisk(
+            username, storeId, sid, storeName, storeLocation, results);
       }
     }
     return;
@@ -673,12 +673,11 @@ void genPersonalCertsFromDisk(QueryData& results) {
     auto username = row.at("username");
 
     findUserPersonalCertsOnDisk(username,
-                                results,
                                 sid,
                                 sid,
                                 "Personal", // storeName
-                                "Users" // storeLocation
-    );
+                                "Users", // storeLocation
+                                results);
   }
 }
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -413,7 +413,6 @@ void addCertRow(PCCERT_CONTEXT certContext,
                     certBuff.data(),
                     static_cast<unsigned long>(certBuff.size()));
   r["common_name"] = certBuff.data();
-  VLOG(1) << "cert name: " << certBuff.data();
 
   auto subjSize = CertNameToStr(certContext->dwCertEncodingType,
                                 &(certContext->pCertInfo->Subject),
@@ -581,8 +580,6 @@ void enumerateCertStore(const HCERTSTORE& certStore,
   auto certContext = CertEnumCertificatesInStore(certStore, nullptr);
 
   if (certContext == nullptr && GetLastError() == CRYPT_E_NOT_FOUND) {
-    VLOG(1) << "Store was empty.";
-
     // Personal stores for other users come back as empty, even if they are not.
     auto is_personal_store = storeName == "Personal" && !username.empty();
     // Avoid duplicate rows for personal certs we've already inserted up
@@ -633,8 +630,6 @@ BOOL WINAPI certEnumSystemStoreCallback(const void* systemStore,
                                         void* arg) {
   auto* storeArg = static_cast<ENUM_ARG*>(arg);
   auto* sysStoreW = static_cast<LPCWSTR>(systemStore);
-
-  VLOG(1) << "Enumerating cert store: " << wstringToString(sysStoreW);
 
   auto systemStoreLocation = flags & CERT_SYSTEM_STORE_LOCATION_MASK;
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -526,7 +526,7 @@ void findUserPersonalCertsOnDisk(const std::string& username,
       std::vector<BYTE> encodedCert;
       auto ret = getEncodedCert(inp, encodedCert);
       if (!ret.ok()) {
-        return;
+        continue;
       }
 
       auto ctx =

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -55,6 +55,11 @@ typedef struct _ENUM_ARG {
   ServiceNameMap service2sidCache;
 } ENUM_ARG, *PENUM_ARG;
 
+template <typename Iterator>
+inline void toHexStr(Iterator begin, Iterator end, std::string& output) {
+  boost::algorithm::hex(std::string(begin, end), back_inserter(output));
+}
+
 std::string cryptOIDToString(const char* objId) {
   if (objId == nullptr) {
     return "";
@@ -392,8 +397,7 @@ void addCertRow(PCCERT_CONTEXT certContext,
   std::vector<char> certBuff;
   getCertCtxProp(certContext, CERT_HASH_PROP_ID, certBuff);
   std::string fingerprint;
-  boost::algorithm::hex(std::string(certBuff.begin(), certBuff.end()),
-                        back_inserter(fingerprint));
+  toHexStr(certBuff.begin(), certBuff.end(), fingerprint);
 
   Row r;
   r["sid"] = sid;
@@ -467,8 +471,7 @@ void addCertRow(PCCERT_CONTEXT certContext,
   certBuff.clear();
   getCertCtxProp(certContext, CERT_KEY_IDENTIFIER_PROP_ID, certBuff);
   std::string subjectKeyId;
-  boost::algorithm::hex(std::string(certBuff.begin(), certBuff.end()),
-                        back_inserter(subjectKeyId));
+  toHexStr(certBuff.begin(), certBuff.end(), subjectKeyId);
   r["subject_key_id"] = subjectKeyId;
 
   r["path"] =
@@ -477,11 +480,10 @@ void addCertRow(PCCERT_CONTEXT certContext,
   r["store"] = storeName;
 
   std::string serial;
-  boost::algorithm::hex(
-      std::string(certContext->pCertInfo->SerialNumber.pbData,
-                  certContext->pCertInfo->SerialNumber.pbData +
-                      certContext->pCertInfo->SerialNumber.cbData),
-      back_inserter(serial));
+  toHexStr(certContext->pCertInfo->SerialNumber.pbData,
+           certContext->pCertInfo->SerialNumber.pbData +
+               certContext->pCertInfo->SerialNumber.cbData,
+           serial);
   r["serial"] = serial;
 
   std::string authKeyId;
@@ -514,10 +516,9 @@ void addCertRow(PCCERT_CONTEXT certContext,
         auto authKeyIdBlob =
             reinterpret_cast<CERT_AUTHORITY_KEY_ID2_INFO*>(certBuff.data());
 
-        boost::algorithm::hex(std::string(authKeyIdBlob->KeyId.pbData,
-                                          authKeyIdBlob->KeyId.pbData +
-                                              authKeyIdBlob->KeyId.cbData),
-                              back_inserter(authKeyId));
+        toHexStr(authKeyIdBlob->KeyId.pbData,
+                 authKeyIdBlob->KeyId.pbData + authKeyIdBlob->KeyId.cbData,
+                 authKeyId);
       } else {
         VLOG(1) << "Failed to decode authority_key_id with (" << GetLastError()
                 << ")";

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -27,6 +27,7 @@
 
 #include <osquery/filesystem/fileops.h>
 #include <osquery/tables/system/windows/certificates.h>
+#include <osquery/tables/system/windows/users.h>
 
 namespace fs = boost::filesystem;
 
@@ -537,9 +538,15 @@ void findUserPersonalCertsOnDisk(const std::string& username,
                                  QueryData& results) {
   VLOG(1) << "Checking disk for Personal certificates for user: " << username;
 
+  auto homeDir = getUserHomeDir(sid);
+  if (homeDir.empty()) {
+    VLOG(1) << "User " << username << " had no home directory.";
+    return;
+  }
+
   std::stringstream certsPath;
   certsPath
-      << getSystemRoot().root_name().string() << "\\Users\\" << username
+      << homeDir
       << "\\AppData\\Roaming\\Microsoft\\SystemCertificates\\My\\Certificates";
 
   try {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -311,12 +311,13 @@ void parseSystemStoreString(LPCWSTR sysStoreW,
   }
 }
 
-#pragma pack(1)
+#pragma pack(push, 1)
 struct Header {
   DWORD propid;
   DWORD unknown;
   DWORD size;
 };
+#pragma pack(pop)
 
 Status getEncodedCert(std::basic_istream<BYTE>& blob,
                       std::vector<BYTE>& encodedCert) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -360,7 +360,6 @@ void addCertRow(PCCERT_CONTEXT certContext,
                 std::string storeName,
                 std::string username,
                 std::string storeLocation) {
-  // Get the cert fingerprint and ensure we haven't already processed it
   std::vector<char> certBuff;
   getCertCtxProp(certContext, CERT_HASH_PROP_ID, certBuff);
   std::string fingerprint;

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -516,7 +516,7 @@ void findUserPersonalCertsOnDisk(const std::string& username,
                                  QueryData& results) {
   std::stringstream certsPath;
   certsPath
-      << "C:\\Users\\" << username
+      << getSystemRoot().root_name().string() << "\\Users\\" << username
       << "\\AppData\\Roaming\\Microsoft\\SystemCertificates\\My\\Certificates";
 
   try {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -560,17 +560,20 @@ void enumerateCertStore(const HCERTSTORE& certStore,
     VLOG(1) << "Store was empty.";
 
     // Personal stores for other users come back as empty, even if they are not.
-    if (storeName == "Personal" && !username.empty()) {
-      // Avoid duplicate rows for personal certs we've already inserted up
-      // front.
-      if (storeLocation != "Users" || boost::ends_with(storeId, "_Classes")) {
-        VLOG(1) << "Trying harder to get Personal store.";
+    auto is_personal_store = storeName == "Personal" && !username.empty();
+    // Avoid duplicate rows for personal certs we've already inserted up
+    // front.
+    auto not_already_added =
+        storeLocation != "Users" || boost::ends_with(storeId, "_Classes");
 
-        // TODO(#5654) 2: Potential future optimization
-        findUserPersonalCertsOnDisk(
-            username, storeId, sid, storeName, storeLocation, results);
-      }
+    if (is_personal_store && not_already_added) {
+      VLOG(1) << "Trying harder to get Personal store.";
+
+      // TODO(#5654) 2: Potential future optimization
+      findUserPersonalCertsOnDisk(
+          username, storeId, sid, storeName, storeLocation, results);
     }
+
     return;
   }
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -551,10 +551,10 @@ void findUserPersonalCertsOnDisk(const std::string& username,
         continue;
       }
 
-      auto ctx =
-          CertCreateCertificateContext(X509_ASN_ENCODING,
-                                       encodedCert.data(),
-                                       static_cast<unsigned long>(encodedCert.size()));
+      auto ctx = CertCreateCertificateContext(
+          X509_ASN_ENCODING,
+          encodedCert.data(),
+          static_cast<unsigned long>(encodedCert.size()));
 
       addCertRow(
           ctx, results, storeId, sid, storeName, username, storeLocation);

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -542,8 +542,8 @@ void findUserPersonalCertsOnDisk(const std::string& username,
       << "\\AppData\\Roaming\\Microsoft\\SystemCertificates\\My\\Certificates";
 
   try {
-    for (auto& x : fs::directory_iterator(fs::path(certsPath.str()))) {
-      std::basic_ifstream<BYTE> inp(x.path().string(), std::ios::binary);
+    for (auto& file : fs::directory_iterator(fs::path(certsPath.str()))) {
+      std::basic_ifstream<BYTE> inp(file.path().string(), std::ios::binary);
 
       std::vector<BYTE> encodedCert;
       auto ret = getEncodedCert(inp, encodedCert);

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -559,12 +559,16 @@ void enumerateCertStore(const HCERTSTORE& certStore,
       if (storeLocation != "Users" || boost::ends_with(storeId, "_Classes")) {
         TLOG << "    Trying harder to get Personal store.";
 
-        // TODO: This can be optimized, we shouldn't need to call
-        // findPersonalCertsOnDisk twice. We can cache the initial data fetch,
-        // and then use that here. Just need to make sure the rows from the
-        // intial fetch have the columns patched to present where we are
-        // currently in the enumeration. Just the storeId and storeLocation
-        // fields.
+        // TODO: This can technically be optimized. In certain cases, we will
+        // end up retrieving Personal certificates from disk that have already
+        // been fetched for a user/SID. For example, the Services store
+        // location has stores like
+        // S-1-5-21-2821152761-3909955410-1545212275-1001\My. That user's
+        // Personal certs will have already been fetched up front and in this
+        // specific case, we will refetch from disk. We could conceivably save
+        // those results, and reuse them here. Only thing is we'd need to update
+        // the storeId and storeLocation fields to match where we currently are
+        // in the enumeration process.
         findPersonalCertsOnDisk(
             username, results, storeId, sid, storeName, storeLocation);
       }

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -535,6 +535,8 @@ void findUserPersonalCertsOnDisk(const std::string& username,
                                  const std::string& storeName,
                                  const std::string& storeLocation,
                                  QueryData& results) {
+  VLOG(1) << "Checking disk for Personal certificates for user: " << username;
+
   std::stringstream certsPath;
   certsPath
       << getSystemRoot().root_name().string() << "\\Users\\" << username
@@ -588,9 +590,6 @@ void enumerateCertStore(const HCERTSTORE& certStore,
         storeLocation != "Users" || boost::ends_with(storeId, "_Classes");
 
     if (is_personal_store && not_already_added) {
-      VLOG(1) << "Checking disk for Personal certificates for user: "
-              << username;
-
       // TODO(#5654) 2: Potential future optimization
       findUserPersonalCertsOnDisk(
           username, storeId, sid, storeName, storeLocation, results);

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -584,8 +584,7 @@ void enumerateCertStore(const HCERTSTORE& certStore,
   if (certContext == nullptr && GetLastError() == CRYPT_E_NOT_FOUND) {
     // Personal stores for other users come back as empty, even if they are not.
     auto is_personal_store = storeName == "Personal" && !username.empty();
-    // Avoid duplicate rows for personal certs we've already inserted up
-    // front.
+    // Avoid duplicate rows for personal certs we've already inserted up front
     auto not_already_added =
         storeLocation != "Users" || boost::ends_with(storeId, "_Classes");
 

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -16,6 +16,7 @@
 #include <osquery/logger.h>
 
 #include "osquery/tables/system/windows/registry.h"
+#include "osquery/tables/system/windows/users.h"
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/process/process.h>

--- a/osquery/tables/system/windows/users.h
+++ b/osquery/tables/system/windows/users.h
@@ -1,0 +1,20 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+std::string getUserHomeDir(const std::string& sid);
+
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
This is a follow up PR to #5631.

The winapis for certificate store enumeration generally do not show any certificates for other users' Personal stores, even when there are certificates there. Furthermore, whether the table shows information about other users' stores depends on whether the user has a registry hive mounted, which can be affected by events e.g. whether the user has logged in since boot. Personal certificates are actually stored on disk, rather than in the registry, which makes it possible to reliably read them (from an Admin process), regardless of whether they belong to a different user, and regardless of the state of the system's login history. This PR takes advantage of this to make the certificates table more complete wrt Personal certificates; Personal certificates are now guaranteed to show for all users, regardless of login history.

--------

Testing:

I measured performance of the table with the `findUserPersonalCertsOnDisk` function enabled and disabled (return immediately). Ran `Measure-Command { .\osqueryd.exe -S "select * from certificates;" }` 20 times. My system has 3 local users with 1 Personal cert each.

Disabled (average, ms): 1582
Enabled (average, ms): 1594

It really depends on the number of local users on the system, and the number of personal certs on disk each of them have, but I believe those should typically both be fairly low, so I don't think this PR should affect performance dramatically.

Here's an example screenshot of it running:

![image](https://user-images.githubusercontent.com/2467355/62331015-84ea2480-b488-11e9-91f4-25749f6a953c.png)

Here's 1 full line of output when run in json mode (happens to have been run on a different machine):

```
{
  "authority_key_id": "",
  "ca": "-1",
  "common_name": "mark personal",
  "issuer": "mark personal",
  "key_algorithm": "RSA",
  "key_strength": "2160",
  "key_usage": "",
  "not_valid_after": "1586623066",
  "not_valid_before": "1555087066",
  "path": "Users\\S-1-5-21-1619915134-2097428126-357372618-1001\\Personal",
  "self_signed": "1",
  "serial": "E08887AB0F182CE800",
  "sha1": "3CB80D8A584A7246897900D1355464B8BEC54189",
  "sid": "S-1-5-21-1619915134-2097428126-357372618-1001",
  "signing_algorithm": "sha256RSA",
  "store": "Personal",
  "store_id": "S-1-5-21-1619915134-2097428126-357372618-1001",
  "store_location": "Users",
  "subject": "mark personal",
  "subject_key_id": "83754CEB635DF2190DF1EE9E7EAE4CFBE1BBD68A",
  "username": "mark"
}
```



Here's a gist of full output after a fresh boot where only `mark` has logged in. Notice how `user` and `tmp` only have entries in the `Users` store location for the `Personal` store (because they are proactively searched for). No entries for other stores.
https://gist.github.com/mossberg/31df3182aa719673a5eb3ba56d8a61ce

Here's full output after `user` and `tmp` have logged in; there are entries in the `Users` store location  for other stores because their hives have been loaded, so the winapis find them. https://gist.github.com/mossberg/048d4fb04c75bdd9f1d66c27e549ded7

For additional testing, I added a certificate into the Local System account's directory for Personal certificates. This exists inside `C:\Windows\system32\config\systemprofile`. I then verified that the table will find certificates within this directory for the Local System account. (To install a certificate there, I actually installed it to a local account, and then manually copied the blob file from the local user's certificate directory to Local System's).

![image](https://user-images.githubusercontent.com/2467355/62504998-dd8f2980-b7c8-11e9-8ef3-c78c27792b92.png)
![image](https://user-images.githubusercontent.com/2467355/62505009-e67ffb00-b7c8-11e9-8804-fa52fd9369fa.png)



This code is hard to unit test because the testing system needs to have certificates and user accounts set up in a certain way. Writing a mock layer is also difficult due to the nature of the system APIs and the way they use (nested) callbacks. In general, for testing I placed a number of certificates explicitly in the Personal stores of several users on the system and ensured the queries could always find at least all Personal certificates I had installed, regardless of the user login history.
