### PR TITLE
Update WTSFreeMemoryEx to WTSFreeMemory

### DIFF
--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -122,7 +122,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
         getSidFromUsername(stringToWstring(wtsSession->UserName));
 
     if (sessionInfo != nullptr) {
-      WTSFreeMemory(clientInfo);
+      WTSFreeMemory(sessionInfo);
       sessionInfo = nullptr;
     }
 
@@ -142,7 +142,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
   }
 
   if (pSessionInfo != nullptr) {
-    WTSFreeMemory(clientInfo);
+    WTSFreeMemory(pSessionInfo);
     pSessionInfo = nullptr;
   }
 

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -94,6 +94,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
       VLOG(1) << "Error querying WTS session information (" << GetLastError()
               << ")";
       results.push_back(r);
+      WTSFreeMemory(sessionInfo);
       continue;
     }
 
@@ -112,7 +113,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
     r["pid"] = INTEGER(-1);
 
     if (clientInfo != nullptr) {
-      WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, clientInfo, count);
+      WTSFreeMemory(clientInfo);
       clientInfo = nullptr;
       wtsClient = nullptr;
     }
@@ -121,7 +122,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
         getSidFromUsername(stringToWstring(wtsSession->UserName));
 
     if (sessionInfo != nullptr) {
-      WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, sessionInfo, count);
+      WTSFreeMemory(clientInfo);
       sessionInfo = nullptr;
     }
 
@@ -141,7 +142,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
   }
 
   if (pSessionInfo != nullptr) {
-    WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, pSessionInfo, count);
+    WTSFreeMemory(clientInfo);
     pSessionInfo = nullptr;
   }
 


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/4655

I don't have much context here, other than the listed bug report. An internet search finds a slightly more in depth blog article http://redplait.blogspot.com/2018/06/interesting-case-of-memory-leak.html

As mentioned, the docs do reference using `WTSFreeMemory` to free.

Thanks for the bug report [redplait](https://github.com/redplait)