### PR TITLE
Replace java8 with adoptopenjdk8 as the brew package name

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -144,7 +144,7 @@ xcode-select --install
 
 brew tap caskroom/cask
 brew tap caskroom/versions
-brew cask install java8
+brew cask install adoptopenjdk8
 ```
 
 *Install Buck and Watchman*


### PR DESCRIPTION
java8 brew cask is deprecated due to a license change, adoptopenjdk8 is the recommended replacement.

