### PR TITLE
Derive version from git

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -50,41 +50,6 @@ endif()
 
 set(TEST_CONFIGS_DIR "${CMAKE_BINARY_DIR}/test_configs")
 
-# osquery versions.
-#
-# 1. $OSQUERY_VERSION is set, use that.
-# 2. Else derive from git
-# 3. If set, append $OSQUERY_VERSION_SUFFIX
-
-if(NOT DEFINED ENV{OSQUERY_VERSION})
-  set(OSQUERY_VERSION 0.0.0)
-  find_package(Git REQUIRED)
-
-  if(GIT_FOUND)
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty
-      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-      OUTPUT_VARIABLE branch_version
-      RESULT_VARIABLE exit_code
-    )
-
-    if(NOT ${exit_code} EQUAL 0)
-      message(WARNING "Failed to detect osquery version, it will be left to 0.0.0")
-    else()
-      string(REGEX REPLACE "\n$" "" branch_version "${branch_version}")
-      set(OSQUERY_VERSION ${branch_version})
-    endif()
-  endif()
-else()
-  set(OSQUERY_VERSION "$ENV{OSQUERY_VERSION}")
-endif()
-
-if(DEFINED ENV{OSQUERY_VERSION_SUFFIX})
-  string(APPEND OSQUERY_VERSION "-$ENV{OSQUERY_VERSION_SUFFIX}")
-endif()
-
-message(STATUS "osquery version: ${OSQUERY_VERSION}")
-
 # Cache variables
 set(PACKAGING_SYSTEM "" CACHE STRING "Packaging system to generate when building packages")
 if(DEFINED PLATFORM_WINDOWS)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -26,3 +26,54 @@ option(BUILD_TESTING "Whether to enable and build tests or not")
 if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")
   set(THIRD_PARTY_REPOSITORY_URL "https://s3.amazonaws.com/osquery-packages")
 endif()
+
+# osquery versions.
+#
+# 1. $OSQUERY_VERSION is set, use that.
+# 2. Else derive from git
+# 3. If set, append $OSQUERY_VERSION_SUFFIX
+#
+# Note that the build won't like it if the version isn't a semvar.
+
+option(OSQUERY_VERSION "Manually set the osquery version")
+option(OSQUERY_VERSION_SUFFIX "String to append to the version")
+
+if(NOT OSQUERY_VERSION OR OSQUERY_VERSION STREQUAL "git")
+  message(STATUS "Detecting version from git")
+
+  set(OSQUERY_VERSION 0.0.0)
+  find_package(Git REQUIRED)
+
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      OUTPUT_VARIABLE branch_version
+      RESULT_VARIABLE exit_code
+    )
+
+    if(NOT ${exit_code} EQUAL 0)
+      message(WARNING "Failed to detect osquery version, it will be left to 0.0.0")
+    else()
+      string(REGEX REPLACE "\n$" "" branch_version "${branch_version}")
+      set(OSQUERY_VERSION ${branch_version})
+    endif()
+  endif()
+endif()
+
+if(OSQUERY_VERSION_SUFFIX)
+  string(APPEND OSQUERY_VERSION "${OSQUERY_VERSION_SUFFIX}")
+endif()
+
+string(REPLACE "." ";" osquery_version_components "${OSQUERY_VERSION}")
+
+list(LENGTH osquery_version_components osquery_version_components_len)
+if(NOT osquery_version_components_len GREATER_EQUAL 3)
+  message(FATAL_ERROR "Version should have at least 3 components (semvar).")
+endif()
+
+list(GET osquery_version_components 0 CPACK_PACKAGE_VERSION_MAJOR)
+list(GET osquery_version_components 1 CPACK_PACKAGE_VERSION_MINOR)
+list(GET osquery_version_components 2 CPACK_PACKAGE_VERSION_PATCH)
+
+message(STATUS "osquery version: ${OSQUERY_VERSION}")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -234,12 +234,6 @@ endfunction()
 
 function(generatePackageTarget)
 
-string(REPLACE "." ";" osquery_version_components "${OSQUERY_VERSION}")
-
-list(GET osquery_version_components 0 CPACK_PACKAGE_VERSION_MAJOR)
-list(GET osquery_version_components 1 CPACK_PACKAGE_VERSION_MINOR)
-list(GET osquery_version_components 2 CPACK_PACKAGE_VERSION_PATCH)
-
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "osquery is an operating system instrumentation toolchain.")
 set(CPACK_PACKAGE_VENDOR "osquery")
 set(CPACK_PACKAGE_CONTACT "osquery@osquery.io")


### PR DESCRIPTION
This derives the version from git. It is based on @Smjert's work in https://github.com/osquery/osquery/pull/5630 and adds some additional option handling.

1. If OSQUERY_VERSION use that directly.
2. Else, let take the version from the git tags. Note that if we're not on a tag, you will get a much longer version.
3. When OSQUERY_VERSION_SUFFIX is set, append it.

I have not removed OSQUERY_BUILD_VERSION from the source code, but perhaps we should