### PR TITLE
Don't return a battery row, if there are no results

### DIFF
--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -189,14 +189,14 @@ BOOL genAdvancedBatteryInfo(Row& r) {
 }
 
 QueryData genBatteryInfo(QueryContext& context) {
+  QueryData results;
   Row row;
   @autoreleasepool {
     if (genIopmBatteryInfo(row)){
       genAdvancedBatteryInfo(row);
+      results.push_back(row);
     }
   }
-  QueryData results;
-  results.push_back(row);
   return results;
 }
 


### PR DESCRIPTION
If there are no battery results, don't return a nil row. Return an empty set.

Fixes: https://github.com/osquery/osquery/issues/5649