### PR TITLE
Remove cloud tables from windows

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -36,11 +36,6 @@ function(generateOsqueryTablesTableimplementations)
       osquery_tables_cloud
       osquery_tables_smart
     )
-
-  elseif(DEFINED PLATFORM_WINDOWS)
-    target_link_libraries(osquery_tables_tableimplementations INTERFACE
-      osquery_tables_cloud
-    )
   endif()
 
   target_link_libraries(osquery_tables_tableimplementations INTERFACE

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -16,7 +16,7 @@ function(osqueryTablesMain)
   add_subdirectory("system")
   add_subdirectory("utility")
   add_subdirectory("yara")
-  
+
   generateOsqueryTablesTableimplementations()
 endfunction()
 
@@ -33,8 +33,13 @@ function(generateOsqueryTablesTableimplementations)
 
   if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
     target_link_libraries(osquery_tables_tableimplementations INTERFACE
-      osquery_tables_cloud
       osquery_tables_smart
+    )
+  endif()
+
+  if(DEFINED PLATFORM_LINUX)
+    target_link_libraries(osquery_tables_tableimplementations INTERFACE
+      osquery_tables_cloud
     )
   endif()
 

--- a/osquery/tables/cloud/CMakeLists.txt
+++ b/osquery/tables/cloud/CMakeLists.txt
@@ -5,7 +5,9 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(osqueryTablesCloudMain)
-  generateOsqueryTablesCloud()
+  if(NOT DEFINED PLATFORM_WINDOWS)
+    generateOsqueryTablesCloud()
+  endif()
 endfunction()
 
 function(generateOsqueryTablesCloud)

--- a/osquery/tables/cloud/CMakeLists.txt
+++ b/osquery/tables/cloud/CMakeLists.txt
@@ -5,7 +5,7 @@
 # the LICENSE file found in the root directory of this source tree.
 
 function(osqueryTablesCloudMain)
-  if(NOT DEFINED PLATFORM_WINDOWS)
+  if(DEFINED PLATFORM_LINUX)
     generateOsqueryTablesCloud()
   endif()
 endfunction()


### PR DESCRIPTION
It does not look like the EC2 tables are available on Windows
(due to spec-file configuration).

Please see https://osquery.io/schema/3.3.2#ec2_instance_tags

This removes the EC2 library linking requirement until we revisit this
feature.