### PR TITLE
rpm: Check for glibc version and librpm secure_getenv

### DIFF
--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -22,6 +22,14 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
+// librpm may be configured and compiled with glibc < 2.17.
+#if defined(__GLIBC__) && __GLIBC_MINOR__ > 17
+extern "C" char* __secure_getenv(const char* _s) __attribute__((weak));
+extern "C" char* __secure_getenv(const char* _s) {
+  return secure_getenv(_s);
+}
+#endif
+
 namespace osquery {
 namespace tables {
 


### PR DESCRIPTION
The librpm dependency may be configured with a glibc version < 2.17. If
so then it will expect `__secure_getenv` to be available.
