### PR TITLE
Fix users table performance -- Revert PR5368

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -8,13 +8,13 @@
 
 #import <OpenDirectory/OpenDirectory.h>
 #include <membership.h>
+
 #include <osquery/tables/system/user_groups.h>
-#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
 
-void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
+void genODEntries(ODRecordType type, std::set<std::string>& names) {
   ODSession* s = [ODSession defaultSession];
   NSError* err = nullptr;
   ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
@@ -29,7 +29,7 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
                             attribute:kODAttributeTypeUniqueID
                             matchType:kODMatchEqualTo
                           queryValues:nil
-                     returnAttributes:kODAttributeTypeAllTypes
+                     returnAttributes:kODAttributeTypeStandardOnly
                        maximumResults:0
                                 error:&err];
   if (err != nullptr) {
@@ -46,39 +46,38 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
     return;
   }
 
-  NSError* attrErr = nullptr;
-  // if IsHidden does not exist or has an invalid value it's equivalent
-  // to IsHidden: 0
-  bool isHidden;
-
   for (ODRecord* re in od_results) {
-    auto isHiddenValue = [re valuesForAttribute:@"dsAttrTypeNative:IsHidden"
-                                          error:&attrErr];
-
-    // set isHidden back to 0 before processing atrribute
-    isHidden = false;
-    if (isHiddenValue.count >= 1) {
-      isHidden =
-          tryTo<bool>(std::string([isHiddenValue[0] UTF8String])).takeOr(false);
-    }
-    names[[[re recordName] UTF8String]] = isHidden;
+    names.insert([[re recordName] UTF8String]);
   }
 }
 
 QueryData genGroups(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> groupnames;
-  genODEntries(kODRecordTypeGroups, groupnames);
-  for (const auto& groupname : groupnames) {
-    Row r;
-    struct group* grp = getgrnam(groupname.first.c_str());
-    r["groupname"] = groupname.first;
-    if (grp != nullptr) {
-      r["is_hidden"] = INTEGER(groupname.second);
-      r["gid"] = BIGINT(grp->gr_gid);
-      r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+  if (context.constraints["gid"].exists(EQUALS)) {
+    auto gids = context.constraints["gid"].getAll<long long>(EQUALS);
+    for (const auto& gid : gids) {
+      Row r;
+      struct group* grp = getgrgid(gid);
+      r["gid"] = BIGINT(gid);
+      if (grp != nullptr) {
+        r["groupname"] = std::string(grp->gr_name);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+      }
+      results.push_back(r);
     }
-    results.push_back(std::move(r));
+  } else {
+    std::set<std::string> groupnames;
+    genODEntries(kODRecordTypeGroups, groupnames);
+    for (const auto& groupname : groupnames) {
+      Row r;
+      struct group* grp = getgrnam(groupname.c_str());
+      r["groupname"] = groupname;
+      if (grp != nullptr) {
+        r["gid"] = BIGINT(grp->gr_gid);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+      }
+      results.push_back(r);
+    }
   }
   return results;
 }
@@ -105,22 +104,37 @@ void setRow(Row& r, passwd* pwd) {
 
 QueryData genUsers(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> usernames;
-  @autoreleasepool {
-    genODEntries(kODRecordTypeUsers, usernames);
-  }
-  for (const auto& username : usernames) {
-    struct passwd* pwd = getpwnam(username.first.c_str());
-    if (pwd == nullptr) {
-      continue;
-    }
+  if (context.constraints["uid"].exists(EQUALS)) {
+    auto uids = context.constraints["uid"].getAll<long long>(EQUALS);
+    for (const auto& uid : uids) {
+      struct passwd* pwd = getpwuid(uid);
+      if (pwd == nullptr) {
+        continue;
+      }
 
-    Row r;
-    r["is_hidden"] = INTEGER(username.second);
-    r["uid"] = BIGINT(pwd->pw_uid);
-    r["username"] = username.first;
-    setRow(r, pwd);
-    results.push_back(std::move(r));
+      Row r;
+      r["uid"] = BIGINT(uid);
+      r["username"] = std::string(pwd->pw_name);
+      setRow(r, pwd);
+      results.push_back(r);
+    }
+  } else {
+    std::set<std::string> usernames;
+    @autoreleasepool {
+      genODEntries(kODRecordTypeUsers, usernames);
+    }
+    for (const auto& username : usernames) {
+      struct passwd* pwd = getpwnam(username.c_str());
+      if (pwd == nullptr) {
+        continue;
+      }
+
+      Row r;
+      r["uid"] = BIGINT(pwd->pw_uid);
+      r["username"] = username;
+      setRow(r, pwd);
+      results.push_back(r);
+    }
   }
   return results;
 }
@@ -142,10 +156,10 @@ QueryData genUserGroups(QueryContext& context) {
         }
       }
     } else {
-      std::map<std::string, bool> usernames;
+      std::set<std::string> usernames;
       genODEntries(kODRecordTypeUsers, usernames);
       for (const auto& username : usernames) {
-        struct passwd* pwd = getpwnam(username.first.c_str());
+        struct passwd* pwd = getpwnam(username.c_str());
         if (pwd != nullptr) {
           user_t<int, int> user;
           user.name = pwd->pw_name;

--- a/specs/groups.table
+++ b/specs/groups.table
@@ -9,10 +9,6 @@ extended_schema(WINDOWS, [
     Column("group_sid", TEXT, "Unique group ID", index=True),
     Column("comment", TEXT, "Remarks or comments associated with the group"),
 ])
-
-extended_schema(DARWIN, [
-    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory"),
-])
 implementation("groups@genGroups")
 examples([
   "select * from groups where gid = 0",

--- a/specs/users.table
+++ b/specs/users.table
@@ -14,10 +14,6 @@ schema([
 extended_schema(WINDOWS, [
     Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),
 ])
-
-extended_schema(DARWIN, [
-    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory")
-])
 implementation("users@genUsers")
 examples([
   "select * from users where uid = 1000",

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -51,7 +51,6 @@ TEST_F(UsersTest, test_sanity) {
   }
   if (isPlatform(PlatformType::TYPE_OSX)) {
     row_map.emplace("uuid", ValidUUID);
-    row_map.emplace("is_hidden", IntType);
   } else {
     row_map.emplace("uuid", NormalType);
   }


### PR DESCRIPTION
This reverts https://github.com/osquery/osquery/pull/5368 and removes the `is_hidden` column from users and groups.

This is being done, because the new version is non-performant, and these tables are frequently joined against.

Folks involved in the original PR: @drakearonhalt @akindyakov @fmanco if y'all want this data, let's find another way to get it.