### PR TITLE
Light refactor and fixes for the users and groups table

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -8,13 +8,13 @@
 
 #import <OpenDirectory/OpenDirectory.h>
 #include <membership.h>
+
 #include <osquery/tables/system/user_groups.h>
-#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
 
-void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
+void genODEntries(ODRecordType type, std::set<std::string>& names) {
   ODSession* s = [ODSession defaultSession];
   NSError* err = nullptr;
   ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
@@ -29,7 +29,7 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
                             attribute:kODAttributeTypeUniqueID
                             matchType:kODMatchEqualTo
                           queryValues:nil
-                     returnAttributes:kODAttributeTypeAllTypes
+                     returnAttributes:kODAttributeTypeStandardOnly
                        maximumResults:0
                                 error:&err];
   if (err != nullptr) {
@@ -46,39 +46,38 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
     return;
   }
 
-  NSError* attrErr = nullptr;
-  // if IsHidden does not exist or has an invalid value it's equivalent
-  // to IsHidden: 0
-  bool isHidden;
-
   for (ODRecord* re in od_results) {
-    auto isHiddenValue = [re valuesForAttribute:@"dsAttrTypeNative:IsHidden"
-                                          error:&attrErr];
-
-    // set isHidden back to 0 before processing atrribute
-    isHidden = false;
-    if (isHiddenValue.count >= 1) {
-      isHidden =
-          tryTo<bool>(std::string([isHiddenValue[0] UTF8String])).takeOr(false);
-    }
-    names[[[re recordName] UTF8String]] = isHidden;
+    names.insert([[re recordName] UTF8String]);
   }
 }
 
 QueryData genGroups(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> groupnames;
-  genODEntries(kODRecordTypeGroups, groupnames);
-  for (const auto& groupname : groupnames) {
-    Row r;
-    struct group* grp = getgrnam(groupname.first.c_str());
-    r["groupname"] = groupname.first;
-    if (grp != nullptr) {
-      r["is_hidden"] = INTEGER(groupname.second);
-      r["gid"] = BIGINT(grp->gr_gid);
-      r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+  if (context.constraints["gid"].exists(EQUALS)) {
+    auto gids = context.constraints["gid"].getAll<long long>(EQUALS);
+    for (const auto& gid : gids) {
+      Row r;
+      struct group* grp = getgrgid(gid);
+      r["gid"] = BIGINT(gid);
+      if (grp != nullptr) {
+        r["groupname"] = std::string(grp->gr_name);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+      }
+      results.push_back(r);
     }
-    results.push_back(std::move(r));
+  } else {
+    std::set<std::string> groupnames;
+    genODEntries(kODRecordTypeGroups, groupnames);
+    for (const auto& groupname : groupnames) {
+      Row r;
+      struct group* grp = getgrnam(groupname.c_str());
+      r["groupname"] = groupname;
+      if (grp != nullptr) {
+        r["gid"] = BIGINT(grp->gr_gid);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+      }
+      results.push_back(r);
+    }
   }
   return results;
 }
@@ -105,22 +104,37 @@ void setRow(Row& r, passwd* pwd) {
 
 QueryData genUsers(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> usernames;
-  @autoreleasepool {
-    genODEntries(kODRecordTypeUsers, usernames);
-  }
-  for (const auto& username : usernames) {
-    struct passwd* pwd = getpwnam(username.first.c_str());
-    if (pwd == nullptr) {
-      continue;
-    }
+  if (context.constraints["uid"].exists(EQUALS)) {
+    auto uids = context.constraints["uid"].getAll<long long>(EQUALS);
+    for (const auto& uid : uids) {
+      struct passwd* pwd = getpwuid(uid);
+      if (pwd == nullptr) {
+        continue;
+      }
 
-    Row r;
-    r["is_hidden"] = INTEGER(username.second);
-    r["uid"] = BIGINT(pwd->pw_uid);
-    r["username"] = username.first;
-    setRow(r, pwd);
-    results.push_back(std::move(r));
+      Row r;
+      r["uid"] = BIGINT(uid);
+      r["username"] = std::string(pwd->pw_name);
+      setRow(r, pwd);
+      results.push_back(r);
+    }
+  } else {
+    std::set<std::string> usernames;
+    @autoreleasepool {
+      genODEntries(kODRecordTypeUsers, usernames);
+    }
+    for (const auto& username : usernames) {
+      struct passwd* pwd = getpwnam(username.c_str());
+      if (pwd == nullptr) {
+        continue;
+      }
+
+      Row r;
+      r["uid"] = BIGINT(pwd->pw_uid);
+      r["username"] = username;
+      setRow(r, pwd);
+      results.push_back(r);
+    }
   }
   return results;
 }
@@ -142,10 +156,10 @@ QueryData genUserGroups(QueryContext& context) {
         }
       }
     } else {
-      std::map<std::string, bool> usernames;
+      std::set<std::string> usernames;
       genODEntries(kODRecordTypeUsers, usernames);
       for (const auto& username : usernames) {
-        struct passwd* pwd = getpwnam(username.first.c_str());
+        struct passwd* pwd = getpwnam(username.c_str());
         if (pwd != nullptr) {
           user_t<int, int> user;
           user.name = pwd->pw_name;

--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -19,6 +19,12 @@ namespace tables {
 
 Mutex grpEnumerationMutex;
 
+void setGroupRow(Row& r, group* grp) {
+  r["groupname"] = TEXT(grp->gr_name);
+  r["gid"] = INTEGER(grp->gr_gid);
+  r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
+}
+
 QueryData genGroups(QueryContext& context) {
   QueryData results;
   struct group* grp = nullptr;
@@ -26,13 +32,13 @@ QueryData genGroups(QueryContext& context) {
   if (context.constraints["gid"].exists(EQUALS)) {
     auto gids = context.constraints["gid"].getAll<long long>(EQUALS);
     for (const auto& gid : gids) {
-      Row r;
       grp = getgrgid(gid);
-      r["gid"] = BIGINT(gid);
-      if (grp != nullptr) {
-        r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
-        r["groupname"] = TEXT(grp->gr_name);
+      if (grp == nullptr) {
+        continue;
       }
+
+      Row r;
+      setGroupRow(r, grp);
       results.push_back(r);
     }
   } else {
@@ -43,9 +49,7 @@ QueryData genGroups(QueryContext& context) {
       if (std::find(groups_in.begin(), groups_in.end(), grp->gr_gid) ==
           groups_in.end()) {
         Row r;
-        r["gid"] = INTEGER(grp->gr_gid);
-        r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
-        r["groupname"] = TEXT(grp->gr_name);
+        setGroupRow(r, grp);
         results.push_back(r);
         groups_in.insert(grp->gr_gid);
       }
@@ -56,5 +60,5 @@ QueryData genGroups(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -88,25 +88,52 @@ TEST_F(SystemsTablesTests, test_processes) {
 
 TEST_F(SystemsTablesTests, test_users) {
   {
-    SQL results("select uid, uuid, username from users limit 1");
+    SQL results("select * from users limit 1");
     ASSERT_EQ(results.rows().size(), 1U);
 
     EXPECT_FALSE(results.rows()[0].at("uid").empty());
+    EXPECT_FALSE(results.rows()[0].at("username").empty());
     if (!isPlatform(PlatformType::TYPE_LINUX)) {
       EXPECT_FALSE(results.rows()[0].at("uuid").empty());
     }
-    EXPECT_FALSE(results.rows()[0].at("username").empty());
   }
 
   {
     // Make sure that we can query all users without crash or hang: Issue #3079
-    SQL results("select uid, uuid, username from users");
+    SQL results("select * from users");
     EXPECT_GT(results.rows().size(), 1U);
   }
 
   {
     // Make sure an invalid pid within the query constraint returns no rows.
     SQL results("select uuid, username from users where uuid = -1");
+    EXPECT_EQ(results.rows().size(), 0U);
+  }
+
+  {
+    // Make sure an invalid pid within the query constraint returns no rows.
+    SQL results("select * from users where uid = -1");
+    EXPECT_EQ(results.rows().size(), 0U);
+  }
+}
+
+TEST_F(SystemsTablesTests, test_groups) {
+  {
+    SQL results("select * from groups limit 1");
+    ASSERT_EQ(results.rows().size(), 1U);
+
+    EXPECT_FALSE(results.rows()[0].at("gid").empty());
+  }
+
+  {
+    // Make sure that we can query all users without crash or hang
+    SQL results("select * from groups");
+    EXPECT_GT(results.rows().size(), 1U);
+  }
+
+  {
+    // Make sure an invalid pid within the query constraint returns no rows.
+    SQL results("select * from groups where gid = -1");
     EXPECT_EQ(results.rows().size(), 0U);
   }
 }

--- a/osquery/tables/system/user_groups.h
+++ b/osquery/tables/system/user_groups.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <grp.h>
 #include <pwd.h>
@@ -23,16 +23,16 @@
 
 #ifdef __APPLE__
 // This symbol is exported from libSystem.B and has been since 10.6.
-extern "C" int getgroupcount(const char *name, gid_t basegid);
+extern "C" int getgroupcount(const char* name, gid_t basegid);
 #endif
 
 namespace osquery {
 namespace tables {
 
 template <typename T>
-static inline void addGroupsToResults(QueryData &results,
+static inline void addGroupsToResults(QueryData& results,
                                       int uid,
-                                      const T *groups,
+                                      const T* groups,
                                       int ngroups) {
   for (int i = 0; i < ngroups; i++) {
     Row r;
@@ -46,17 +46,17 @@ static inline void addGroupsToResults(QueryData &results,
 
 template <typename uid_type, typename gid_type>
 struct user_t {
-  const char *name;
+  const char* name;
   uid_type uid;
   gid_type gid;
 };
 
 template <typename uid_type, typename gid_type>
-static void getGroupsForUser(QueryData &results,
-                             const user_t<uid_type, gid_type> &user) {
+static void getGroupsForUser(QueryData& results,
+                             const user_t<uid_type, gid_type>& user) {
 #ifdef __APPLE__
   int ngroups = getgroupcount(user.name, user.gid);
-  gid_type *groups = new gid_type[ngroups];
+  gid_type* groups = new gid_type[ngroups];
   if (getgrouplist(user.name, user.gid, groups, &ngroups) < 0) {
     TLOG << "Could not get users group list";
   } else {
@@ -65,7 +65,7 @@ static void getGroupsForUser(QueryData &results,
   delete[] groups;
 #else
   gid_type groups_buf[EXPECTED_GROUPS_MAX];
-  gid_type *groups = groups_buf;
+  gid_type* groups = groups_buf;
   int ngroups = EXPECTED_GROUPS_MAX;
 
   // GLIBC version before 2.3.3 may have a buffer overrun:
@@ -93,5 +93,5 @@ static void getGroupsForUser(QueryData &results,
 
   return;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/specs/groups.table
+++ b/specs/groups.table
@@ -9,10 +9,6 @@ extended_schema(WINDOWS, [
     Column("group_sid", TEXT, "Unique group ID", index=True),
     Column("comment", TEXT, "Remarks or comments associated with the group"),
 ])
-
-extended_schema(DARWIN, [
-    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory"),
-])
 implementation("groups@genGroups")
 examples([
   "select * from groups where gid = 0",

--- a/specs/users.table
+++ b/specs/users.table
@@ -14,10 +14,6 @@ schema([
 extended_schema(WINDOWS, [
     Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),
 ])
-
-extended_schema(DARWIN, [
-    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory")
-])
 implementation("users@genUsers")
 examples([
   "select * from users where uid = 1000",

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -51,7 +51,6 @@ TEST_F(UsersTest, test_sanity) {
   }
   if (isPlatform(PlatformType::TYPE_OSX)) {
     row_map.emplace("uuid", ValidUUID);
-    row_map.emplace("is_hidden", IntType);
   } else {
     row_map.emplace("uuid", NormalType);
   }


### PR DESCRIPTION
- Lightly update the logic, to make the code paths similar between no-constraint, and specified uid cases.
- Add tests to the group table.
- Discover, and repair, bug where groups with a bad uid would return data.

This is a followup to https://github.com/osquery/osquery/pull/5667