### PR TITLE
Fix runningApps.test_sanity

### DIFF
--- a/tests/integration/tables/running_apps.cpp
+++ b/tests/integration/tables/running_apps.cpp
@@ -15,7 +15,12 @@
 namespace osquery {
 namespace table_tests {
 
-class runningApps : public testing::Test {};
+class runningApps : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
 
 TEST_F(runningApps, test_sanity) {
   // 1. Query data
@@ -23,10 +28,9 @@ TEST_F(runningApps, test_sanity) {
   QueryData specific_query_data =
       execute_query("select * from running_apps where is_active = 1");
   // 2. Check size before validation
-  ASSERT_GE(general_query_data.size(), 0ul);
+  ASSERT_GT(general_query_data.size(), 0ul);
   ASSERT_EQ(general_query_data[0].size(), 3ul);
 
-  ASSERT_GE(specific_query_data.size(), 0ul);
   ASSERT_EQ(specific_query_data.size(), 1ul);
   ASSERT_EQ(specific_query_data[0].size(), 3ul);
   // 3. Build validation map


### PR DESCRIPTION
When run alone, using --gtest_filter to select the specific test,
it throws an exception because the tables are not registered.
    
It also wrongly checks for the query rows number to be >= 0 and then
proceeds to access the first one.

