### PR TITLE
tables: Add optimization back to macOS users and groups

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -14,24 +14,35 @@
 namespace osquery {
 namespace tables {
 
-void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
-  ODSession* s = [ODSession defaultSession];
+/**
+ * @brief Lookup usernames/groupnames or a single name's hidden value.
+ *
+ * @param record_type Either usernames or groupnames.
+ * @param record Look for a specific record by name or nil for all.
+ * @param [out] names A list of discovered names and hidden status.
+ */
+void genODEntries(ODRecordType record_type,
+                  NSString* record,
+                  std::map<std::string, bool>& names) {
+  ODSession* session = [ODSession defaultSession];
   NSError* err = nullptr;
-  ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+  ODNode* root = [ODNode nodeWithSession:session
+                                    name:@"/Local/Default"
+                                   error:&err];
   if (err != nullptr) {
     TLOG << "Error with OpenDirectory node: "
          << std::string([[err localizedDescription] UTF8String]);
     return;
   }
 
-  ODQuery* q = [ODQuery queryWithNode:root
-                       forRecordTypes:type
-                            attribute:kODAttributeTypeUniqueID
-                            matchType:kODMatchEqualTo
-                          queryValues:nil
-                     returnAttributes:kODAttributeTypeAllTypes
-                       maximumResults:0
-                                error:&err];
+  ODQuery* query = [ODQuery queryWithNode:root
+                           forRecordTypes:record_type
+                                attribute:kODAttributeTypeUniqueID
+                                matchType:kODMatchEqualTo
+                              queryValues:record
+                         returnAttributes:kODAttributeTypeAllTypes
+                           maximumResults:0
+                                    error:&err];
   if (err != nullptr) {
     TLOG << "Error with OpenDirectory query: "
          << std::string([[err localizedDescription] UTF8String]);
@@ -39,24 +50,18 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
   }
 
   // Obtain the results synchronously, not good for very large sets.
-  NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
+  NSArray* od_results = [query resultsAllowingPartial:NO error:&err];
   if (err != nullptr) {
     TLOG << "Error with OpenDirectory results: "
          << std::string([[err localizedDescription] UTF8String]);
     return;
   }
 
-  NSError* attrErr = nullptr;
-  // if IsHidden does not exist or has an invalid value it's equivalent
-  // to IsHidden: 0
-  bool isHidden;
-
+  // Missing or invalid IsHidden is equivalent to IsHidden: 0.
   for (ODRecord* re in od_results) {
+    bool isHidden = false;
     auto isHiddenValue = [re valuesForAttribute:@"dsAttrTypeNative:IsHidden"
-                                          error:&attrErr];
-
-    // set isHidden back to 0 before processing atrribute
-    isHidden = false;
+                                          error:&err];
     if (isHiddenValue.count >= 1) {
       isHidden =
           tryTo<bool>(std::string([isHiddenValue[0] UTF8String])).takeOr(false);
@@ -67,23 +72,49 @@ void genODEntries(ODRecordType type, std::map<std::string, bool>& names) {
 
 QueryData genGroups(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> groupnames;
-  genODEntries(kODRecordTypeGroups, groupnames);
-  for (const auto& groupname : groupnames) {
-    Row r;
-    struct group* grp = getgrnam(groupname.first.c_str());
-    r["groupname"] = groupname.first;
-    if (grp != nullptr) {
-      r["is_hidden"] = INTEGER(groupname.second);
-      r["gid"] = BIGINT(grp->gr_gid);
-      r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+  @autoreleasepool {
+    if (context.constraints["gid"].exists(EQUALS)) {
+      auto gids = context.constraints["gid"].getAll<long long>(EQUALS);
+      for (const auto& gid : gids) {
+        struct group* grp = getgrgid(gid);
+        if (grp == nullptr) {
+          continue;
+        }
+
+        std::map<std::string, bool> groupnames;
+        id groupname = [NSString stringWithUTF8String:grp->gr_name];
+        genODEntries(kODRecordTypeGroups, groupname, groupnames);
+
+        Row r;
+        r["groupname"] = grp->gr_name;
+        r["is_hidden"] = INTEGER(groupnames[r["groupname"]]);
+        r["gid"] = BIGINT(grp->gr_gid);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+        results.push_back(r);
+      }
+    } else {
+      std::map<std::string, bool> groupnames;
+      genODEntries(kODRecordTypeGroups, nil, groupnames);
+      for (const auto& groupname : groupnames) {
+        struct group* grp = getgrnam(groupname.first.c_str());
+        if (grp == nullptr) {
+          continue;
+        }
+
+        Row r;
+        r["groupname"] = groupname.first;
+        r["is_hidden"] = INTEGER(groupname.second);
+        r["gid"] = BIGINT(grp->gr_gid);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+        results.push_back(r);
+      }
     }
-    results.push_back(std::move(r));
   }
   return results;
 }
 
-void setRow(Row& r, passwd* pwd) {
+void genUserRow(Row& r, passwd* pwd) {
+  r["uid"] = BIGINT(pwd->pw_uid);
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
   r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
@@ -105,22 +136,41 @@ void setRow(Row& r, passwd* pwd) {
 
 QueryData genUsers(QueryContext& context) {
   QueryData results;
-  std::map<std::string, bool> usernames;
   @autoreleasepool {
-    genODEntries(kODRecordTypeUsers, usernames);
-  }
-  for (const auto& username : usernames) {
-    struct passwd* pwd = getpwnam(username.first.c_str());
-    if (pwd == nullptr) {
-      continue;
-    }
+    if (context.constraints["uid"].exists(EQUALS)) {
+      auto uids = context.constraints["uid"].getAll<long long>(EQUALS);
+      for (const auto& uid : uids) {
+        struct passwd* pwd = getpwuid(uid);
+        if (pwd == nullptr) {
+          continue;
+        }
 
-    Row r;
-    r["is_hidden"] = INTEGER(username.second);
-    r["uid"] = BIGINT(pwd->pw_uid);
-    r["username"] = username.first;
-    setRow(r, pwd);
-    results.push_back(std::move(r));
+        std::map<std::string, bool> usernames;
+        id username = [NSString stringWithUTF8String:pwd->pw_name];
+        genODEntries(kODRecordTypeUsers, username, usernames);
+
+        Row r;
+        r["username"] = pwd->pw_name;
+        r["is_hidden"] = INTEGER(usernames[r["username"]]);
+        genUserRow(r, pwd);
+        results.push_back(r);
+      }
+    } else {
+      std::map<std::string, bool> usernames;
+      genODEntries(kODRecordTypeUsers, nil, usernames);
+      for (const auto& username : usernames) {
+        struct passwd* pwd = getpwnam(username.first.c_str());
+        if (pwd == nullptr) {
+          continue;
+        }
+
+        Row r;
+        r["username"] = pwd->pw_name;
+        r["is_hidden"] = INTEGER(usernames[r["username"]]);
+        genUserRow(r, pwd);
+        results.push_back(r);
+      }
+    }
   }
   return results;
 }
@@ -143,7 +193,7 @@ QueryData genUserGroups(QueryContext& context) {
       }
     } else {
       std::map<std::string, bool> usernames;
-      genODEntries(kODRecordTypeUsers, usernames);
+      genODEntries(kODRecordTypeUsers, nil, usernames);
       for (const auto& username : usernames) {
         struct passwd* pwd = getpwnam(username.first.c_str());
         if (pwd != nullptr) {
@@ -158,5 +208,5 @@ QueryData genUserGroups(QueryContext& context) {
   }
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -8,6 +8,7 @@
 
 #import <OpenDirectory/OpenDirectory.h>
 #include <membership.h>
+
 #include <osquery/tables/system/user_groups.h>
 #include <osquery/utils/conversions/tryto.h>
 
@@ -113,7 +114,7 @@ QueryData genGroups(QueryContext& context) {
   return results;
 }
 
-void genUserRow(Row& r, passwd* pwd) {
+void genUserRow(Row& r, const passwd* pwd) {
   r["uid"] = BIGINT(pwd->pw_uid);
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -88,25 +88,52 @@ TEST_F(SystemsTablesTests, test_processes) {
 
 TEST_F(SystemsTablesTests, test_users) {
   {
-    SQL results("select uid, uuid, username from users limit 1");
+    SQL results("select * from users limit 1");
     ASSERT_EQ(results.rows().size(), 1U);
 
     EXPECT_FALSE(results.rows()[0].at("uid").empty());
+    EXPECT_FALSE(results.rows()[0].at("username").empty());
     if (!isPlatform(PlatformType::TYPE_LINUX)) {
       EXPECT_FALSE(results.rows()[0].at("uuid").empty());
     }
-    EXPECT_FALSE(results.rows()[0].at("username").empty());
   }
 
   {
     // Make sure that we can query all users without crash or hang: Issue #3079
-    SQL results("select uid, uuid, username from users");
+    SQL results("select * from users");
     EXPECT_GT(results.rows().size(), 1U);
   }
 
   {
     // Make sure an invalid pid within the query constraint returns no rows.
     SQL results("select uuid, username from users where uuid = -1");
+    EXPECT_EQ(results.rows().size(), 0U);
+  }
+
+  {
+    // Make sure an invalid pid within the query constraint returns no rows.
+    SQL results("select * from users where uid = -1");
+    EXPECT_EQ(results.rows().size(), 0U);
+  }
+}
+
+TEST_F(SystemsTablesTests, test_groups) {
+  {
+    SQL results("select * from groups limit 1");
+    ASSERT_EQ(results.rows().size(), 1U);
+
+    EXPECT_FALSE(results.rows()[0].at("gid").empty());
+  }
+
+  {
+    // Make sure that we can query all users without crash or hang
+    SQL results("select * from groups");
+    EXPECT_GT(results.rows().size(), 1U);
+  }
+
+  {
+    // Make sure an invalid pid within the query constraint returns no rows.
+    SQL results("select * from groups where gid = -1");
     EXPECT_EQ(results.rows().size(), 0U);
   }
 }

--- a/osquery/tables/system/user_groups.h
+++ b/osquery/tables/system/user_groups.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <grp.h>
 #include <pwd.h>
@@ -23,16 +23,16 @@
 
 #ifdef __APPLE__
 // This symbol is exported from libSystem.B and has been since 10.6.
-extern "C" int getgroupcount(const char *name, gid_t basegid);
+extern "C" int getgroupcount(const char* name, gid_t basegid);
 #endif
 
 namespace osquery {
 namespace tables {
 
 template <typename T>
-static inline void addGroupsToResults(QueryData &results,
+static inline void addGroupsToResults(QueryData& results,
                                       int uid,
-                                      const T *groups,
+                                      const T* groups,
                                       int ngroups) {
   for (int i = 0; i < ngroups; i++) {
     Row r;
@@ -46,17 +46,17 @@ static inline void addGroupsToResults(QueryData &results,
 
 template <typename uid_type, typename gid_type>
 struct user_t {
-  const char *name;
+  const char* name;
   uid_type uid;
   gid_type gid;
 };
 
 template <typename uid_type, typename gid_type>
-static void getGroupsForUser(QueryData &results,
-                             const user_t<uid_type, gid_type> &user) {
+static void getGroupsForUser(QueryData& results,
+                             const user_t<uid_type, gid_type>& user) {
 #ifdef __APPLE__
   int ngroups = getgroupcount(user.name, user.gid);
-  gid_type *groups = new gid_type[ngroups];
+  gid_type* groups = new gid_type[ngroups];
   if (getgrouplist(user.name, user.gid, groups, &ngroups) < 0) {
     TLOG << "Could not get users group list";
   } else {
@@ -65,7 +65,7 @@ static void getGroupsForUser(QueryData &results,
   delete[] groups;
 #else
   gid_type groups_buf[EXPECTED_GROUPS_MAX];
-  gid_type *groups = groups_buf;
+  gid_type* groups = groups_buf;
   int ngroups = EXPECTED_GROUPS_MAX;
 
   // GLIBC version before 2.3.3 may have a buffer overrun:
@@ -93,5 +93,5 @@ static void getGroupsForUser(QueryData &results,
 
   return;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
This PR supersedes #5669 with an alternate approach of moving forward
without a revert of #5368.

This includes a `cherry-pick`ed version of the code cleanup within #5669, thus needing a merge-with-rebase. 

- Lightly update the logic, to make the code paths similar between
  no-constraint, and specified uid cases.
- Add tests to the group table.

@directionless I am interested if this PR's approach will cause missing data due to your code-comments here: https://github.com/osquery/osquery/pull/5669/commits/bb1e9b57af9cfd2b0ab28919ef81ccc01b0a7f40#r310408443