### PR TITLE
Light refactor on users & groups

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -113,8 +113,8 @@ QueryData genGroups(QueryContext& context) {
         if (grp != nullptr) {
           genGroupRow(r, grp);
         } else {
-	  r["groupname"] = TEXT(groupname.first);
-	}
+          r["groupname"] = TEXT(groupname.first);
+        }
 
         results.push_back(r);
       }
@@ -181,8 +181,8 @@ QueryData genUsers(QueryContext& context) {
         if (pwd != nullptr) {
           genUserRow(r, pwd);
         } else {
-	  r["username"] = TEXT(username.first.c_str());
-	}
+          r["username"] = TEXT(username.first.c_str());
+        }
 
         results.push_back(r);
       }

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -71,6 +71,12 @@ void genODEntries(ODRecordType record_type,
   }
 }
 
+void genGroupRow(Row& r, group* grp) {
+  r["groupname"] = grp->gr_name;
+  r["gid"] = BIGINT(grp->gr_gid);
+  r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
+}
+
 QueryData genGroups(QueryContext& context) {
   QueryData results;
   @autoreleasepool {
@@ -87,26 +93,28 @@ QueryData genGroups(QueryContext& context) {
         genODEntries(kODRecordTypeGroups, groupname, groupnames);
 
         Row r;
-        r["groupname"] = grp->gr_name;
+        genGroupRow(r, grp);
         r["is_hidden"] = INTEGER(groupnames[r["groupname"]]);
-        r["gid"] = BIGINT(grp->gr_gid);
-        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
         results.push_back(r);
       }
     } else {
       std::map<std::string, bool> groupnames;
       genODEntries(kODRecordTypeGroups, nil, groupnames);
       for (const auto& groupname : groupnames) {
+        // opendirectory and getgrnam are documented as having
+        // different code paths. Thus we may see cases where
+        // genODEntries produces responses that are not in
+        // getgrnam. So with a surfeit of caution we populate some of
+        // the row here
+        Row r;
+        r["groupname"] = TEXT(groupname.first);
+        r["is_hidden"] = INTEGER(groupname.second);
+
         struct group* grp = getgrnam(groupname.first.c_str());
-        if (grp == nullptr) {
-          continue;
+        if (grp != nullptr) {
+          genGroupRow(r, grp);
         }
 
-        Row r;
-        r["groupname"] = groupname.first;
-        r["is_hidden"] = INTEGER(groupname.second);
-        r["gid"] = BIGINT(grp->gr_gid);
-        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
         results.push_back(r);
       }
     }
@@ -115,6 +123,7 @@ QueryData genGroups(QueryContext& context) {
 }
 
 void genUserRow(Row& r, const passwd* pwd) {
+  r["username"] = TEXT(pwd->pw_name);
   r["uid"] = BIGINT(pwd->pw_uid);
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
@@ -151,24 +160,28 @@ QueryData genUsers(QueryContext& context) {
         genODEntries(kODRecordTypeUsers, username, usernames);
 
         Row r;
-        r["username"] = pwd->pw_name;
-        r["is_hidden"] = INTEGER(usernames[r["username"]]);
         genUserRow(r, pwd);
+        r["is_hidden"] = INTEGER(usernames[r["username"]]);
         results.push_back(r);
       }
     } else {
       std::map<std::string, bool> usernames;
       genODEntries(kODRecordTypeUsers, nil, usernames);
       for (const auto& username : usernames) {
+        // opendirectory and getpwnam are documented as having
+        // different code paths. Thus we may see cases where
+        // genODEntries produces responses that are not in
+        // getpwnam. So with a surfeit of caution we populate some of
+        // the row here
+        Row r;
+        r["username"] = TEXT(username.first.c_str());
+        r["is_hidden"] = INTEGER(username.second);
+
         struct passwd* pwd = getpwnam(username.first.c_str());
-        if (pwd == nullptr) {
-          continue;
+        if (pwd != nullptr) {
+          genUserRow(r, pwd);
         }
 
-        Row r;
-        r["username"] = pwd->pw_name;
-        r["is_hidden"] = INTEGER(usernames[r["username"]]);
-        genUserRow(r, pwd);
         results.push_back(r);
       }
     }

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -107,13 +107,14 @@ QueryData genGroups(QueryContext& context) {
         // getgrnam. So with a surfeit of caution we populate some of
         // the row here
         Row r;
-        r["groupname"] = TEXT(groupname.first);
         r["is_hidden"] = INTEGER(groupname.second);
 
         struct group* grp = getgrnam(groupname.first.c_str());
         if (grp != nullptr) {
           genGroupRow(r, grp);
-        }
+        } else {
+	  r["groupname"] = TEXT(groupname.first);
+	}
 
         results.push_back(r);
       }
@@ -174,13 +175,14 @@ QueryData genUsers(QueryContext& context) {
         // getpwnam. So with a surfeit of caution we populate some of
         // the row here
         Row r;
-        r["username"] = TEXT(username.first.c_str());
         r["is_hidden"] = INTEGER(username.second);
 
         struct passwd* pwd = getpwnam(username.first.c_str());
         if (pwd != nullptr) {
           genUserRow(r, pwd);
-        }
+        } else {
+	  r["username"] = TEXT(username.first.c_str());
+	}
 
         results.push_back(r);
       }

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -49,7 +49,7 @@ TEST_F(groups, test_sanity) {
   validate_rows(rows, row_map);
 
   // select with a specific gid
-  auto test_gid = rows.front().at("gid").c_str();
+  auto test_gid = rows.front().at("gid");
   auto const rows_one =
       execute_query(std::string("select * from groups where gid=") + test_gid);
   ASSERT_GE(rows_one.size(), 1ul);

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -28,7 +28,7 @@ TEST_F(groups, test_sanity) {
   // Build validation map
   // See helper.h for avaialbe flags
   // Or use custom DataCheck object
-  ValidatatioMap row_map = {
+  ValidationMap row_map = {
       {"gid", IntType},
       {"gid_signed", IntType},
       {"groupname", NormalType},

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -50,9 +50,7 @@ TEST_F(groups, test_sanity) {
 
   // select with a specific gid
   auto test_gid = rows.front().at("gid").c_str();
-  char query_string[50];
-  sprintf(query_string, "select * from groups where gid=%s", test_gid);
-  auto const rows_one = execute_query(query_string);
+  auto const rows_one = execute_query(std::string("select * from groups where gid=") + test_gid);
   ASSERT_GE(rows_one.size(), 1ul);
   validate_rows(rows_one, row_map);
 }

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -50,7 +50,8 @@ TEST_F(groups, test_sanity) {
 
   // select with a specific gid
   auto test_gid = rows.front().at("gid").c_str();
-  auto const rows_one = execute_query(std::string("select * from groups where gid=") + test_gid);
+  auto const rows_one =
+      execute_query(std::string("select * from groups where gid=") + test_gid);
   ASSERT_GE(rows_one.size(), 1ul);
   validate_rows(rows_one, row_map);
 }

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -38,6 +38,11 @@ TEST_F(groups, test_sanity) {
     row_map.emplace("is_hidden", IntType);
   }
 
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    row_map.emplace("comment", NormalType);
+    row_map.emplace("group_sid", NormalType);
+  }
+
   // select * case
   auto const rows = execute_query("select * from groups");
   ASSERT_GE(rows.size(), 1ul);

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -11,36 +11,47 @@
 
 #include <osquery/tests/integration/tables/helper.h>
 
+#include <osquery/utils/info/platform_type.h>
+
 namespace osquery {
 namespace table_tests {
+namespace {
 
 class groups : public testing::Test {
-  protected:
-    void SetUp() override {
-      setUpEnvironment();
-    }
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
 };
 
 TEST_F(groups, test_sanity) {
-  // 1. Query data
-  auto const data = execute_query("select * from groups");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
+  // Build validation map
   // See helper.h for avaialbe flags
   // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"gid", IntType}
-  //      {"gid_signed", IntType}
-  //      {"groupname", NormalType}
-  //      {"group_sid", NormalType}
-  //      {"comment", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+  ValidatatioMap row_map = {
+      {"gid", IntType},
+      {"gid_signed", IntType},
+      {"groupname", NormalType},
+  };
+
+  if (isPlatform(PlatformType::TYPE_OSX)) {
+    row_map.emplace("is_hidden", IntType);
+  }
+
+  // select * case
+  auto const rows = execute_query("select * from groups");
+  ASSERT_GE(rows.size(), 1ul);
+  validate_rows(rows, row_map);
+
+  // select with a specific gid
+  auto test_gid = rows.front().at("gid").c_str();
+  char query_string[50];
+  sprintf(query_string, "select * from groups where gid=%s", test_gid);
+  auto const rows_one = execute_query(query_string);
+  ASSERT_GE(rows_one.size(), 1ul);
+  validate_rows(rows_one, row_map);
 }
 
+} // namespace
 } // namespace table_tests
 } // namespace osquery

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -63,9 +63,7 @@ TEST_F(UsersTest, test_sanity) {
 
   // select with a specified uid
   auto test_uid = rows.front().at("uid").c_str();
-  char query_string[50];
-  sprintf(query_string, "select * from users where uid=%s", test_uid);
-  auto const rows_one = execute_query(query_string);
+  auto const rows_one = execute_query(std::string("select * from users where uid=") + test_uid);
   ASSERT_GE(rows_one.size(), 1ul);
   validate_rows(rows_one, row_map);
 }

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -62,8 +62,6 @@ TEST_F(UsersTest, test_sanity) {
   validate_rows(rows, row_map);
 
   // select with a specified uid
-  //auto test_uid = rows.front().find("uid").c_str();
-  //auto test_uid = 1; // FIXME: Use something more clever, as above
   auto test_uid = rows.front().at("uid").c_str();
   char query_string[50];
   sprintf(query_string, "select * from users where uid=%s", test_uid);

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -9,6 +9,8 @@
 // Sanity check integration test for users
 // Spec file: specs/users.table
 
+#include <string.h>
+
 #include <osquery/tests/integration/tables/helper.h>
 
 #include <osquery/utils/info/platform_type.h>
@@ -25,9 +27,7 @@ class UsersTest : public testing::Test {
 };
 
 TEST_F(UsersTest, test_sanity) {
-  auto const rows = execute_query("select * from users");
-  ASSERT_GE(rows.size(), 1ul); // There must be at least one user
-  auto row_map = ValidationMap{
+  auto row_map = ValidatatioMap{
       {"uid", NonNegativeInt},
       {"uid_signed", IntType},
       {"gid_signed", IntType},
@@ -55,7 +55,21 @@ TEST_F(UsersTest, test_sanity) {
   } else {
     row_map.emplace("uuid", NormalType);
   }
+
+  // select * case
+  auto const rows = execute_query("select * from users");
+  ASSERT_GE(rows.size(), 1ul);
   validate_rows(rows, row_map);
+
+  // select with a specified uid
+  //auto test_uid = rows.front().find("uid").c_str();
+  //auto test_uid = 1; // FIXME: Use something more clever, as above
+  auto test_uid = rows.front().at("uid").c_str();
+  char query_string[50];
+  sprintf(query_string, "select * from users where uid=%s", test_uid);
+  auto const rows_one = execute_query(query_string);
+  ASSERT_GE(rows_one.size(), 1ul);
+  validate_rows(rows_one, row_map);
 }
 
 } // namespace

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -27,7 +27,7 @@ class UsersTest : public testing::Test {
 };
 
 TEST_F(UsersTest, test_sanity) {
-  auto row_map = ValidatatioMap{
+  auto row_map = ValidationMap{
       {"uid", NonNegativeInt},
       {"uid_signed", IntType},
       {"gid_signed", IntType},

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -63,7 +63,8 @@ TEST_F(UsersTest, test_sanity) {
 
   // select with a specified uid
   auto test_uid = rows.front().at("uid").c_str();
-  auto const rows_one = execute_query(std::string("select * from users where uid=") + test_uid);
+  auto const rows_one =
+      execute_query(std::string("select * from users where uid=") + test_uid);
   ASSERT_GE(rows_one.size(), 1ul);
   validate_rows(rows_one, row_map);
 }

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -9,7 +9,7 @@
 // Sanity check integration test for users
 // Spec file: specs/users.table
 
-#include <string.h>
+#include <string>
 
 #include <osquery/tests/integration/tables/helper.h>
 
@@ -62,7 +62,7 @@ TEST_F(UsersTest, test_sanity) {
   validate_rows(rows, row_map);
 
   // select with a specified uid
-  auto test_uid = rows.front().at("uid").c_str();
+  auto test_uid = rows.front().at("uid");
   auto const rows_one =
       execute_query(std::string("select * from users where uid=") + test_uid);
   ASSERT_GE(rows_one.size(), 1ul);


### PR DESCRIPTION
This does a little refactoring on the users and groups tables. It pulls update from https://github.com/osquery/osquery/pull/5669 into the fixes on the users table

* Create a `genGroupRow` to normalize the path with and without constraints.
* Start populating results from open directory, and then fill in with getpwnam.
* Add integrations tests to check that is_hidden is populated for with and without constraints
