### PR TITLE
windows/certificates: Improve table completeness for Personal certificates for system accounts

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -718,9 +718,7 @@ BOOL WINAPI certEnumSystemStoreLocationsCallback(LPCWSTR storeLocation,
  * users' registry hives are currently mounted.
  */
 void genPersonalCertsFromDisk(QueryData& results) {
-  SQL sql(
-      "SELECT uuid, username FROM users WHERE username NOT IN ('SYSTEM', "
-      "'LOCAL SERVICE', 'NETWORK SERVICE')");
+  SQL sql("SELECT uuid, username FROM users");
   if (!sql.ok()) {
     VLOG(1) << sql.getStatus().getMessage();
     return;


### PR DESCRIPTION
Small follow up to #5640. 

When proactively searching disk for personal certificates, there is no
need to filter system accounts (SYSTEM, Local Service, etc) anymore
because `findUserPersonalCertsOnDisk` is now capable of handling those
accounts by dynamically finding a user's home dir (rather than by
constructing a hard coded path).

This now makes the table even more complete; any certificates found in
the system accounts directories will always be found. Previously they
could be found but only if there was a store location other than the
`Users` store location that had a system store string that looked like
`S-1-5-18\My` or `.DEFAULT\My`.

This is what it looked like previously. This is on a system where there are no store locations other than Users that have a system store string like the above two. However, there is a certificate installed into the Local System certificate directory.
![image](https://user-images.githubusercontent.com/2467355/62658394-adfe2f80-b936-11e9-9a98-06dd4703dfbe.png)

This is with the PR.
![image](https://user-images.githubusercontent.com/2467355/62659089-6f697480-b938-11e9-820e-10ff8cf0b918.png)

