### PR TITLE
windows/certificates: Fix bug in environment variable expansion

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -557,6 +557,11 @@ void findUserPersonalCertsOnDisk(const std::string& username,
 
   std::string homeDir;
   auto homeDirUnexpanded = getUserHomeDir(sid);
+  if (homeDirUnexpanded.empty()) {
+    VLOG(1) << "Could not find home dir for account " << username;
+    return;
+  }
+
   // System accounts have environment variables in their paths
   auto ret = expandEnvironmentVariables(homeDirUnexpanded, homeDir);
   if (!ret.ok() || homeDir.empty()) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -530,9 +530,9 @@ void addCertRow(PCCERT_CONTEXT certContext,
   results.push_back(r);
 }
 
-Status expandEnvironmentVariablesImpl(const std::string& src,
-                                      std::string& dest) {
-  auto srcW = stringToWstring(src).c_str();
+Status expandEnvironmentVariables(const std::string& src, std::string& dest) {
+  auto srcWstring = stringToWstring(src);
+  auto srcW = srcWstring.c_str();
   auto expandedSize = ExpandEnvironmentStringsW(srcW, nullptr, 0);
   if (expandedSize == 0) {
     return Status::failure("Unable to get expanded size");
@@ -548,19 +548,6 @@ Status expandEnvironmentVariablesImpl(const std::string& src,
 
   dest = wstringToString(buf.data());
   return Status::success();
-}
-
-Status expandEnvironmentVariables(const std::string& src, std::string& dest) {
-  const int MAX_RETRY = 100;
-  int i = 0;
-  Status ret{};
-
-  do {
-    ret = expandEnvironmentVariablesImpl(src, dest);
-    i++;
-  } while (!ret.ok() && i < MAX_RETRY);
-
-  return ret;
 }
 
 void findUserPersonalCertsOnDisk(const std::string& username,

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -530,7 +530,8 @@ void addCertRow(PCCERT_CONTEXT certContext,
   results.push_back(r);
 }
 
-Status expandEnvironmentVariablesImpl(const std::string& src, std::string& dest) {
+Status expandEnvironmentVariablesImpl(const std::string& src,
+                                      std::string& dest) {
   auto srcW = stringToWstring(src).c_str();
   auto expandedSize = ExpandEnvironmentStringsW(srcW, nullptr, 0);
   if (expandedSize == 0) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -530,7 +530,7 @@ void addCertRow(PCCERT_CONTEXT certContext,
   results.push_back(r);
 }
 
-Status expandEnvironmentVariables(const std::string& src, std::string& dest) {
+Status expandEnvironmentVariablesImpl(const std::string& src, std::string& dest) {
   auto srcW = stringToWstring(src).c_str();
   auto expandedSize = ExpandEnvironmentStringsW(srcW, nullptr, 0);
   if (expandedSize == 0) {
@@ -541,10 +541,25 @@ Status expandEnvironmentVariables(const std::string& src, std::string& dest) {
   auto ret = ExpandEnvironmentStringsW(srcW, buf.data(), expandedSize);
   if (ret == 0) {
     return Status::failure("Environment variable expansion failed");
+  } else if (ret != expandedSize) {
+    return Status::failure("Partial data written");
   }
 
   dest = wstringToString(buf.data());
   return Status::success();
+}
+
+Status expandEnvironmentVariables(const std::string& src, std::string& dest) {
+  const int MAX_RETRY = 100;
+  int i = 0;
+  Status ret{};
+
+  do {
+    ret = expandEnvironmentVariablesImpl(src, dest);
+    i++;
+  } while (!ret.ok() && i < MAX_RETRY);
+
+  return ret;
 }
 
 void findUserPersonalCertsOnDisk(const std::string& username,


### PR DESCRIPTION
This is a followup to #5640. This should be the last one :)

This fixes a bug in environment variable expansion that occurs when paths to Personal certificate directories are constructed for system accounts.
