### PR TITLE
tables: implement ibridge table to report on T1/T2 chip for mac notebooks

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -189,6 +189,7 @@ osquery_cxx_library(
                 "darwin/firewall.cpp",
                 "darwin/gatekeeper.cpp",
                 "darwin/homebrew_packages.cpp",
+                "darwin/ibridge.cpp",
                 "darwin/iokit_registry.cpp",
                 "darwin/kernel_extensions.cpp",
                 "darwin/kernel_info.cpp",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -102,6 +102,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/firewall.cpp
       darwin/gatekeeper.cpp
       darwin/homebrew_packages.cpp
+      darwin/ibridge.cpp
       darwin/iokit_registry.cpp
       darwin/kernel_extensions.cpp
       darwin/kernel_info.cpp

--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -1,0 +1,119 @@
+/**
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/utils/conversions/darwin/iokit.h>
+
+namespace osquery {
+namespace tables {
+
+#define kIODeviceEfiPath_ ":/efi/platform"
+#define kIODeviceChosenPath_ ":/chosen"
+#define kEmbeddedOSClass_ "AppleEmbeddedOSSupportHost"
+#define kAppleCoprocessorVersionKey_ "apple-coprocessor-version"
+
+/// as defined in
+/// /System/Library/Frameworks/Kernel.framework/Headers/IOKit/IOPlatformExpert.h
+static const std::unordered_map<uint32_t, std::string> kCoprocessorVersions = {
+    {0x00000000, ""},
+    {0x00010000, "Apple T1 Chip"},
+    {0x00020000, "Apple T2 Chip"},
+};
+
+static inline void genBootUuid(Row& r) {
+  auto chosen = IORegistryEntryFromPath(
+      kIOMasterPortDefault, kIODeviceTreePlane kIODeviceChosenPath_);
+  if (chosen == MACH_PORT_NULL) {
+    return;
+  }
+
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      chosen, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(chosen);
+
+  if (kr != KERN_SUCCESS) {
+    LOG(WARNING) << "Cannot get EFI properties";
+    return;
+  }
+
+  r["boot_uuid"] = getIOKitProperty(properties, "boot-uuid");
+  CFRelease(properties);
+}
+
+static inline void genAppleCoprocessorVersion(Row& r) {
+  auto asoc = IORegistryEntryFromPath(kIOMasterPortDefault,
+                                      kIODeviceTreePlane kIODeviceEfiPath_);
+  if (asoc == MACH_PORT_NULL) {
+    LOG(WARNING) << "Cannot open EFI Device Tree";
+    return;
+  }
+
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      asoc, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(asoc);
+
+  if (kr != KERN_SUCCESS) {
+    LOG(WARNING) << "Cannot get EFI properties";
+    return;
+  }
+
+  if (CFDictionaryContainsKey(properties,
+                              CFSTR(kAppleCoprocessorVersionKey_))) {
+    auto version_data = (CFDataRef)CFDictionaryGetValue(
+        properties, CFSTR(kAppleCoprocessorVersionKey_));
+    auto range = CFRangeMake(0, CFDataGetLength(version_data));
+
+    auto buffer = std::vector<unsigned char>(range.length + 1, 0);
+    CFDataGetBytes(version_data, range, &buffer[0]);
+
+    uint32_t version = 0;
+    memcpy(&version, buffer.data(), 4);
+    r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
+                                   ? kCoprocessorVersions.at(version)
+                                   : "unknown";
+  }
+  CFRelease(properties);
+}
+
+QueryData genIBridgeInfo(QueryContext& context) {
+  QueryData results;
+  Row r;
+
+  genAppleCoprocessorVersion(r);
+  genBootUuid(r);
+
+  auto eos = IOServiceNameMatching(kEmbeddedOSClass_);
+  if (eos == nullptr) {
+    LOG(WARNING)
+        << "EmbeddedOS class not found. Perhaps this mac doesn't have T* chip";
+    return results;
+  }
+
+  auto service = IOServiceGetMatchingService(kIOMasterPortDefault, eos);
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      service, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(service);
+
+  if (kr != KERN_SUCCESS) {
+    LOG(WARNING) << "Cannot get EmbeddedOS properties";
+    IOObjectRelease(service);
+    return results;
+  }
+
+  r["unique_chip_id"] = getIOKitProperty(properties, "DeviceUniqueChipID");
+  r["firmware_version"] = getIOKitProperty(properties, "DeviceBuildVersion");
+
+  CFRelease(properties);
+  IOObjectRelease(service);
+
+  results.push_back(std::move(r));
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -37,6 +37,9 @@ static inline void genBootUuid(Row& r) {
 
   if (kr != KERN_SUCCESS) {
     LOG(WARNING) << "Cannot get EFI properties";
+    if (properties != nullptr) {
+      CFRelease(properties);
+    }
     return;
   }
 
@@ -59,6 +62,9 @@ static inline void genAppleCoprocessorVersion(Row& r) {
 
   if (kr != KERN_SUCCESS) {
     LOG(WARNING) << "Cannot get EFI properties";
+    if (properties != nullptr) {
+      CFRelease(properties);
+    }
     return;
   }
 
@@ -72,7 +78,7 @@ static inline void genAppleCoprocessorVersion(Row& r) {
     CFDataGetBytes(version_data, range, &buffer[0]);
 
     uint32_t version = 0;
-    memcpy(&version, buffer.data(), 4);
+    memcpy(&version, buffer.data(), sizeof(uint32_t));
     r["coprocessor_version"] = (kCoprocessorVersions.count(version) > 0)
                                    ? kCoprocessorVersions.at(version)
                                    : "unknown";
@@ -102,7 +108,9 @@ QueryData genIBridgeInfo(QueryContext& context) {
 
   if (kr != KERN_SUCCESS) {
     LOG(WARNING) << "Cannot get EmbeddedOS properties";
-    IOObjectRelease(service);
+    if (properties != nullptr) {
+      CFRelease(properties);
+    }
     return results;
   }
 
@@ -110,7 +118,6 @@ QueryData genIBridgeInfo(QueryContext& context) {
   r["firmware_version"] = getIOKitProperty(properties, "DeviceBuildVersion");
 
   CFRelease(properties);
-  IOObjectRelease(service);
 
   results.push_back(std::move(r));
   return results;

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -125,7 +125,7 @@ osquery_gentable_cxx_library(
             "macos",
         ),
         (
-            "darwin/ibridge.table",
+            "darwin/ibridge_info.table",
             "macos",
         ),
         (

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -125,6 +125,10 @@ osquery_gentable_cxx_library(
             "macos",
         ),
         (
+            "darwin/ibridge.table",
+            "macos",
+        ),
+        (
             "darwin/iokit_devicetree.table",
             "macos",
         ),

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -91,7 +91,7 @@ function(generateNativeTables)
     "darwin/gatekeeper.table:macos"
     "darwin/gatekeeper_approved_apps.table:macos"
     "darwin/homebrew_packages.table:macos"
-    "darwin/ibridge.table:macos"
+    "darwin/ibridge_info.table:macos"
     "darwin/iokit_devicetree.table:macos"
     "darwin/iokit_registry.table:macos"
     "darwin/kernel_extensions.table:macos"

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -91,6 +91,7 @@ function(generateNativeTables)
     "darwin/gatekeeper.table:macos"
     "darwin/gatekeeper_approved_apps.table:macos"
     "darwin/homebrew_packages.table:macos"
+    "darwin/ibridge.table:macos"
     "darwin/iokit_devicetree.table:macos"
     "darwin/iokit_registry.table:macos"
     "darwin/kernel_extensions.table:macos"

--- a/specs/darwin/ibridge.table
+++ b/specs/darwin/ibridge.table
@@ -1,0 +1,10 @@
+table_name("ibridge")
+description("Information about the Apple iBridge hardware controller.")
+schema([
+    Column("boot_uuid", TEXT, "Boot UUID of the iBridge controller"),
+    Column("coprocessor_version", TEXT, "The manufacturer and chip version"),
+    Column("firmware_version", TEXT, "The build version of the firmware"),
+    Column("unique_chip_id", TEXT, "unique id"),
+])
+attributes(cacheable=True)
+implementation("system/ibridge@genIBridgeInfo")

--- a/specs/darwin/ibridge_info.table
+++ b/specs/darwin/ibridge_info.table
@@ -1,10 +1,10 @@
-table_name("ibridge")
+table_name("ibridge_info")
 description("Information about the Apple iBridge hardware controller.")
 schema([
     Column("boot_uuid", TEXT, "Boot UUID of the iBridge controller"),
     Column("coprocessor_version", TEXT, "The manufacturer and chip version"),
     Column("firmware_version", TEXT, "The build version of the firmware"),
-    Column("unique_chip_id", TEXT, "unique id"),
+    Column("unique_chip_id", TEXT, "Unique id of the iBridge controller"),
 ])
 attributes(cacheable=True)
 implementation("system/ibridge@genIBridgeInfo")

--- a/tests/integration/tables/BUCK
+++ b/tests/integration/tables/BUCK
@@ -204,6 +204,7 @@ osquery_cxx_test(
                 "gatekeeper.cpp",
                 "gatekeeper_approved_apps.cpp",
                 "homebrew_packages.cpp",
+                "ibridge.cpp",
                 "iokit_devicetree.cpp",
                 "iokit_registry.cpp",
                 "kernel_extensions.cpp",

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -206,6 +206,7 @@ function(generateTestsIntegrationTablesTestsTest)
       gatekeeper.cpp
       gatekeeper_approved_apps.cpp
       homebrew_packages.cpp
+      ibridge.cpp
       iokit_devicetree.cpp
       iokit_registry.cpp
       kernel_extensions.cpp

--- a/tests/integration/tables/ibridge.cpp
+++ b/tests/integration/tables/ibridge.cpp
@@ -20,7 +20,7 @@ class IBridgeTest : public testing::Test {
 };
 
 TEST_F(IBridgeTest, test_sanity) {
-  auto rows = execute_query("select * from ibridge");
+  auto rows = execute_query("select * from ibridge_info");
   if (rows.empty()) {
     VLOG(1) << "Empty result for table: ibridge, skipping test";
   } else {

--- a/tests/integration/tables/ibridge.cpp
+++ b/tests/integration/tables/ibridge.cpp
@@ -4,7 +4,7 @@
  */
 
 // Sanity check integration test for ibridge
-// Spec file: specs/darwin/ibridge.table
+// Spec file: specs/darwin/ibridge_info.table
 
 #include <osquery/logger.h>
 #include <osquery/tests/integration/tables/helper.h>

--- a/tests/integration/tables/ibridge.cpp
+++ b/tests/integration/tables/ibridge.cpp
@@ -1,0 +1,39 @@
+/**
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+// Sanity check integration test for ibridge
+// Spec file: specs/darwin/ibridge.table
+
+#include <osquery/logger.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class IBridgeTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(IBridgeTest, test_sanity) {
+  auto rows = execute_query("select * from ibridge");
+  if (rows.empty()) {
+    VLOG(1) << "Empty result for table: ibridge, skipping test";
+  } else {
+    ASSERT_EQ(rows.size(), 1ul);
+    ValidatatioMap validation_map = {
+        {"boot_uuid", NormalType},
+        {"coprocessor_version", NonEmptyString},
+        {"firmware_version", NonEmptyString},
+        {"unique_chip_id", NonEmptyString},
+    };
+    validate_rows(rows, validation_map);
+  }
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
Previous discussion in #5203 and #5166 

This add `ibridge` table in macOS to report on T1/T2 SOC (currently notebooks only).

Here is the output:
```
osquery> .all ibridge;
          boot_uuid = B8EC353D-74E5-3437-B580-531F5D952DF3
coprocessor_version = Apple T1 Chip
   firmware_version = 14Y904
     unique_chip_id = 854183246450470
```

Tests pass:

```

90: [----------] 1 test from IBridgeTest
90: [ RUN      ] IBridgeTest.test_sanity
90: [       OK ] IBridgeTest.test_sanity (1 ms)
90: [----------] 1 test from IBridgeTest (1 ms total)

```

Tested with both CMake and Buck on macOS 10.13 and 10.14

Ideally we would want to report everything reported by `/usr/libexec/remotectl dumpstate`, but because of private APIs/frameworks and entitlements that is not going be possible/easy now.