### PR TITLE
docs: Update README to correct email and build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ src="https://github.com/facebook/osquery/raw/master/docs/img/logo-2x-dark.png" /
 <p align="center">
 osquery is a SQL powered operating system instrumentation, monitoring, and analytics framework.
 <br>
-Available for Linux, macOS, Windows and FreeBSD.
+Available for Linux, macOS, Windows, and FreeBSD.
 </p>
 
 | Platform | Build status  | | | |
@@ -88,7 +88,7 @@ visit [https://osquery.io/downloads](https://osquery.io/downloads/).
 
 ## Build from source
 
-Building osquery from source is encouraged! Check out our [build guide](BUILD.md).
+Building osquery from source is encouraged! Check out our [build guide](https://osquery.readthedocs.io/en/latest/development/building/).
 
 Also check out our [contributing guide](CONTRIBUTING.md) and join the community on [Slack](https://slack.osquery.io).
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -32,8 +32,6 @@ Additionally, osquery's codebase is made up of high-performance, modular compone
 
 If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/facebook/osquery/issues). Keep in touch with osquery developers and users in our Slack [https://osquery-slack.herokuapp.com/](https://osquery-slack.herokuapp.com/).
 
-If you have long-form questions, please email [osquery@fb.com](mailto:osquery@fb.com).
-
 ## Documentation
 
 This wiki, hosted on ReadTheDocs.org, is written in Markdown and kept within the osquery Github repository in the [docs/wiki](https://github.com/facebook/osquery/tree/master/docs/wiki) directory. Please submit changes using Github pull requests. The wiki is built automatically with every commit and available as "[latest](http://osquery.readthedocs.io/en/latest/)". A "stable" release is built alongside osquery versions using Github's tagged-releases.


### PR DESCRIPTION
The email in the wiki is no longer relevant. It does not make sense to have an email for a "more help" method either. Folks should be directed to Slack.

The build guide on the README is a broken link that should point to ReadTheDocs.