### PR TITLE
Adding OSX Malware SearchAwesome to osx-attacks

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -602,6 +602,17 @@
       "version": "3.3.0",
       "description": "Finds processes that have active keyboard event taps, typically used by RATs and other malicious software for keylogging",
       "value": "Process with keyboard event taps"
+    },
+    "OSX_SearchAwesome": {
+      "query" : "SELECT * FROM file \
+         WHERE path = '/Applications/spi.app' OR \
+           path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR \
+           path = '/Users/%/Library/LaunchAgents/spid.plist' OR \
+           path = '/Users/%/Library/SPI';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",
+      "value": "Artifacts created by this malware"
     }
   }
 }


### PR DESCRIPTION
Continuing https://github.com/osquery/osquery/pull/5407...

## Overview

New OSX malware can be easily detected with osquery and it is consistent with other entries in the `osx-attacks` pack. More details can be found [here](https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/).

File artifacts are:
* `/Applications/spi.app`
* `~/Library/LaunchAgents/spid-uninstall.plist`
* `~/Library/LaunchAgents/spid.plist`
* `~/Library/SPI`
