### PR TITLE
Don't return nil rows for the programs table

### DIFF
--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -81,7 +81,9 @@ void keyEnumPrograms(const std::string& key,
         r["install_date"] = aKey.at("data");
       }
     }
-    results.push_back(r);
+    if (!r.empty()) {
+      results.push_back(r);
+    }
   }
 }
 


### PR DESCRIPTION
We see a lot of empty rows in the program table. Don't return an empty row.
