### PR TITLE
Make improvements to the build guide

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -1,16 +1,18 @@
 osquery supports many flavors of Linux, FreeBSD, macOS, and Windows.
 
-While osquery runs on a large number of operating systems, we only provide instructions for building on a select few.
+While osquery runs on a large number of operating systems, we only provide build instructions for a select few.
 
-The supported compilers are: clang/libc++ 6.0 on Linux, MSVC v141 on Windows, AppleClang from Xcode Command Line Tools 10.2.1.
+The supported compilers are: clang/libc++ 6.0 on Linux, MSVC v141 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
 
 # Building with CMake
 
-Git, CMake (>= 3.13.3), Python 2, and Python 3 are required to build. The rest of the dependencies are downloaded by CMake.
+Git, CMake (>= 3.14.4), Python 2, and Python 3 are required to build. The rest of the dependencies are downloaded by CMake.
 
 The default build type is `RelWithDebInfo` (optimizations active + debug symbols) and can be changed in the CMake configure phase by setting the `CMAKE_BUILD_TYPE` flag to `Release` or `Debug`.
 
-The build type is chosen when building on Windows, not during the configure phase, through the `--config` option.
+The build type is chosen when building on Windows, through the `--config` option, not during the configure phase.
+
+Note: the recommended system memory for building osquery is at least 8GB, or Clang may crash during the compilation of third-party dependencies.
 
 ## Linux
 
@@ -18,9 +20,9 @@ The root folder is assumed to be `/home/<user>`
 
 **Ubuntu 18.04**
 
-```
+```bash
 # Install the prerequisites
-sudo apt install git llvm clang libc++-dev libc++abi-dev liblzma-dev python python3
+sudo apt install git llvm clang libc++-dev libc++abi-dev liblzma-dev python python3 bison flex
 
 # Download and install a newer CMake
 wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz
@@ -36,7 +38,7 @@ cmake --build . -j10 # where 10 is the number of parallel build jobs
 
 **Ubuntu 18.10**
 
-```
+```bash
 # Install the prerequisites
 sudo apt install git llvm-6.0 clang-6.0 libc++-dev libc++abi-dev liblzma-dev python python3
 
@@ -54,13 +56,21 @@ cmake --build . -j10 # where 10 is the number of parallel build jobs
 
 ## macOS
 
-Please ensure [homebrew](https://brew.sh/) has been installed. The root folder is assumed to be `/Users/<user>`
+The root folder is assumed to be `/Users/<user>`
 
-```
+**Step 1: Install the prerequisites**
+
+Please ensure [Homebrew](https://brew.sh/) has been installed, first. Then do the following.
+
+```bash
 # Install prerequisites
 xcode-select --install
 brew install git cmake python@2 python
+```
 
+**Step 2: Download and build**
+
+```bash
 # Download and build
 git clone https://github.com/osquery/osquery
 
@@ -78,15 +88,15 @@ The root folder is assumed to be `C:\Users\<user>`
 
 **Step 1: Install the prerequisites**
 
-- [CMake](https://cmake.org/) (>= 3.14.4): be sure to put it into the `PATH`
-- [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16): from the installer choose the C++ build tools workload, then on the right, under Installation details, also check MSVC v141
+- [CMake](https://cmake.org/) (>= 3.14.4): the MSI installer is recommended. During installation, select the option to add it to the system `PATH` for all users. If there is any older version of CMake installed (e.g., using Chocolatey), uninstall that version first!
+- [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16): from the installer choose the C++ build tools workload, then on the right, under "C++ build tools",  "Optional", select "MSVC v141 - VS 2017 C++". Do not install CMake using the Visual Studio Installer, because it will be an older version than needed.
 - [Git for Windows](https://github.com/git-for-windows/git/releases/latest) (or equivalent)
-- [Python 2](https://www.python.org/downloads/windows/)
-- [Python 3](https://www.python.org/downloads/windows/)
+- [Python 2](https://www.python.org/downloads/windows/), specifically the 64-bit version.
+- [Python 3](https://www.python.org/downloads/windows/), specifically the 64-bit version.
 
 **Step 2: Download and build**
 
-```
+```PowerShell
 # Download using a PowerShell console
 git clone https://github.com/osquery/osquery
 
@@ -106,20 +116,20 @@ To build with tests active, add `-DOSQUERY_BUILD_TESTS=ON` to the osquery config
 
 To run the tests and get just a summary report:
 
-```
+```PowerShell
 cmake --build . --config <RelWithDebInfo|Release|Debug> --target run_tests
 ```
 
-To get more information when a test fails using powershell:
+To get more information when a test fails using PowerShell:
 
-```
+```PowerShell
 $Env:CTEST_OUTPUT_ON_FAILURE=1
 cmake --build . --config <RelWithDebInfo|Release|Debug> --target run_tests
 ```
 
 To run a single test, in verbose mode:
 
-```
+```PowerShell
 ctest -R <test name> -C <RelWithDebInfo|Release|Debug> -V
 ```
 
@@ -127,18 +137,19 @@ ctest -R <test name> -C <RelWithDebInfo|Release|Debug> -V
 
 To run the tests and get just a summary report:
 
-```
+```bash
 cmake --build . --target test
 ```
 
 To get more information when a test fails:
-```
+
+```bash
 CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test
 ```
 
 To run a single test, in verbose mode:
 
-```
+```bash
 ctest -R <test name> -V
 ```
 
@@ -146,32 +157,32 @@ ctest -R <test name> -V
 
 Building and testing is the same on all platforms. Each platform section below describes how to install the required tools and dependencies.
 
-## Linux
+## Linux (Buck)
 
 Install required tools on Ubuntu 18.04 or Ubuntu 18.10
 
-```
+```bash
 sudo apt install openjdk-8-jre clang libc++1 libc++-dev libc++abi1 libc++abi-dev python python3 python3-distutils
 ```
 
 Install library dependencies
 
-```
+```bash
 sudo apt install liblzma-dev
 ```
 
 Install `buck`
 
-```
+```bash
 wget 'https://github.com/facebook/buck/releases/download/v2018.10.29.01/buck.2018.10.29.01_all.deb'
 sudo apt install ./buck.2018.10.29.01_all.deb
 ```
 
-## macOS
+## macOS (Buck)
 
-Install required tools using Homebrew
+Install required tools using Homebrew:
 
-```
+```bash
 xcode-select --install
 
 brew tap caskroom/cask
@@ -179,35 +190,35 @@ brew tap caskroom/versions
 brew cask install java8
 ```
 
-Install `buck` and `watchman`. Watchman isn't mandatory but will make builds faster.
+Install `buck` and `watchman`. Watchman isn't mandatory, but will make builds faster.
 
-```
+```bash
 brew tap facebook/fb
 brew install buck watchman
 ```
 
-## FreeBSD
+## FreeBSD (Buck)
 
-Install required tools on FreeBSD 11.2
+Install required tools on FreeBSD 11.2.
 
-```
+```bash
 sudo pkg install openjdk8 python3 python2 clang35
 ```
 
-Install `buck`
+Install `buck`.
 
-```
+```bash
 sudo curl --output /usr/local/bin/buck 'https://jitpack.io/com/github/facebook/buck/v2018.10.29.01/buck-v2018.10.29.01.pex'
 sudo chmod +x /usr/local/bin/buck
 ```
 
-Install library dependencies
+Install library dependencies.
 
-```
+```bash
 sudo pkg install glog thrift thrift-cpp boost-libs magic rocksdb-lite rapidjson zstd linenoise-ng augeas ssdeep sleuthkit yara aws-sdk-cpp lldpd libxml++-2 smartmontools lldpd
 ```
 
-## Windows 10
+## Windows 10 (Buck)
 
 You'll need to have the following software installed before you can build osquery on Windows:
 
@@ -223,7 +234,7 @@ Once you've installed the above requirements, run `.\tools\generate_buck_config.
 To build simply run the following command replacing `<platform>` and `<mode>`
 appropriately:
 
-```
+```bash
 buck build @mode/<platform>/<mode> //osquery:osqueryd
 ```
 
@@ -231,7 +242,7 @@ When buck finishes find the binary at `buck-out/<mode>/gen/osquery/osqueryd`.
 
 Similarly to run tests just run:
 
-```
+```bash
 buck test @mode/<platform>/<mode> //...
 ```
 
@@ -239,36 +250,36 @@ This will run all tests, you can replace `//...` with a specific target to run s
 
 Supported platforms:
 
-* `linux-x86_64`
-* `macos-x86_64`
-* `windows-x86_64`
-* `freebsd-x86_64`
+- `linux-x86_64`
+- `macos-x86_64`
+- `windows-x86_64`
+- `freebsd-x86_64`
 
 Supported modes:
 
-* `release`
-* `debug`
+- `release`
+- `debug`
 
 # Using Vagrant
 
-If you are familiar with Vagrant there is a helpful configuration in the root directory for testing osquery.
+If you are familiar with Vagrant, there is a helpful configuration in the root directory for testing osquery.
 
-## AWS EC2 Backed Vagrant Targets
+## AWS-EC2-Backed Vagrant Targets
 
 The osquery vagrant infrastructure supports leveraging AWS EC2 to run virtual machines.
 This capability is provided by the [vagrant-aws](https://github.com/mitchellh/vagrant-aws) plugin, which is installed as follows:
 
 ```sh
-$ vagrant plugin install vagrant-aws
+vagrant plugin install vagrant-aws
 ```
 
 Next, add a vagrant dummy box for AWS:
 
 ```sh
-$ vagrant box add andytson/aws-dummy
+vagrant box add andytson/aws-dummy
 ```
 
-Before launching an AWS-backed virtual machine, a few environment variables must be set:
+Before launching an AWS-backed virtual machine, set a few environment variables:
 
 ```sh
 # Required. Credentials for AWS API. vagrant-aws will error if these are unset.
@@ -292,8 +303,8 @@ export AWS_SUBNET_ID=...
 Spin up a VM in EC2 and SSH in (remember to suspect/destroy when finished):
 
 ```sh
-$ vagrant up aws-amazon2015.03 --provider=aws
-$ vagrant ssh aws-amazon2015.03
+vagrant up aws-amazon2015.03 --provider=aws
+vagrant ssh aws-amazon2015.03
 ```
 
 # Custom Packages
@@ -302,11 +313,11 @@ Package creation is facilitated by CPack.
 
 # Build Performance
 
-Generating a virtual table should NOT impact system performance. This is easier said than done as some tables may _seem_ inherently latent such as `SELECT * from suid_bin;` if your expectation is a complete filesystem traversal looking for binaries with suid permissions. Please read the osquery features and guide on [performance safety](../deployment/performance-safety.md).
+Generating a virtual table should *not* impact system performance. This is easier said than done, as some tables may _seem_ inherently latent (if you expect to run queries like `SELECT * from suid_bin;` which performs a complete filesystem traversal looking for binaries with suid permissions). Please read the osquery features and guide on [performance safety](../deployment/performance-safety.md).
 
 Some quick features include:
 
-* Performance regression and leak detection CI guards.
-* Blacklisting performance-impacting virtual tables.
-* Scheduled query optimization and profiling.
-* Query implementation isolation options.
+- Performance regression and leak detection CI guards.
+- Blacklisting performance-impacting virtual tables.
+- Scheduled query optimization and profiling.
+- Query implementation isolation options.


### PR DESCRIPTION
In response to @theopolis's invitation to contribute edits to the ReadTheDocs documentation, I've tested the build steps in the build guide by running CMake builds on macOS 10.14, Windows 10, and Ubuntu Linux 18.04. Then I made some minor improvements to the build instructions based on this. They are accurate to the `thirdparty-submodules` development branch, as well.

This is related to issue #5688.