### PR TITLE
Fix optional AWS table compilation on Windows

### DIFF
--- a/osquery/tables/cloud/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/ec2_instance_tags.cpp
@@ -15,7 +15,6 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/aws/aws_util.h>
-//Make windows happy https://github.com/aws/aws-sdk-cpp/issues/402
 #ifdef WIN32
 #undef GetMessage
 #endif

--- a/osquery/tables/cloud/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/ec2_instance_tags.cpp
@@ -15,9 +15,6 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/aws/aws_util.h>
-#ifdef WIN32
-#undef GetMessage
-#endif
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/cloud/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/ec2_instance_tags.cpp
@@ -15,6 +15,10 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/aws/aws_util.h>
+//Make windows happy https://github.com/aws/aws-sdk-cpp/issues/402
+#ifdef WIN32
+#undef GetMessage
+#endif
 
 namespace osquery {
 namespace tables {

--- a/osquery/utils/aws/aws_util.h
+++ b/osquery/utils/aws/aws_util.h
@@ -25,6 +25,14 @@
 
 #include <osquery/utils/status/status.h>
 
+// This macro from the Windows headers is used to map the GetMessage
+// name to either GetMessageW or GetMessageA depending on the UNICODE
+// define. We have to undefine this because it causes a method in the
+// AWS sdk to be renamed, causing a compilation error.
+#ifdef WIN32 && defined(GetMessage)
+#undef GetMessage
+#endif
+
 namespace osquery {
 
 using RegionName = const char* const;

--- a/plugins/logger/aws_log_forwarder.h
+++ b/plugins/logger/aws_log_forwarder.h
@@ -21,14 +21,6 @@
 
 #include <osquery/utils/aws/aws_util.h>
 
-// This macro from the Windows headers is used to map the GetMessage
-// name to either GetMessageW or GetMessageA depending on the UNICODE
-// define. We have to undefine this because it causes a method in the
-// AWS sdk to be renamed, causing a compilation error.
-#if defined(WINDOWS) && defined(GetMessage)
-#undef GetMessage
-#endif
-
 namespace osquery {
 template <typename RecordType,
           typename ClientType,


### PR DESCRIPTION
Attempting to include the ec2-instance-tags on windows will error out, apparently, this is due to a known issue https://github.com/aws/aws-sdk-cpp/issues/402 with the C++ AWS SDK, fix successfully compiles.