### PR TITLE
Fix for #5315. Ensure view recreated on startup.

### DIFF
--- a/plugins/config/parsers/views.cpp
+++ b/plugins/config/parsers/views.cpp
@@ -77,9 +77,7 @@ Status ViewsConfigParserPlugin::update(const std::string& source,
       // created and we don't need to create it. Except, at startup,
       // the view always needs to be created.
       if (!first_time_ && old_query == query) {
-        if (old_query == query) {
-          continue;
-        }
+        continue;
       }
 
       // View has been updated

--- a/plugins/config/parsers/views.cpp
+++ b/plugins/config/parsers/views.cpp
@@ -102,7 +102,7 @@ Status ViewsConfigParserPlugin::update(const std::string& source,
 
   first_time_ = false;
   return Status(0, "OK");
-  }
+}
 
 REGISTER_INTERNAL(ViewsConfigParserPlugin, "config_parser", "views");
 }


### PR DESCRIPTION
Added flag to check if the views config is updated the first time, and if query already exists in the local db store, then all we need to do is create the view.
I don't understand why the views are stored in the local db, but have left those as is, and remedied only the issue.

Issue: https://github.com/osquery/osquery/issues/5315

Previous pull request for same change, which was discarded - https://github.com/osquery/osquery/pull/5317
