### PR TITLE
Fix bugs and update pathname variables in MSI package build script

### DIFF
--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -42,7 +42,7 @@ Get-Help .\tools\deployment\make_windows_package.ps1 -detailed
 
 .NOTES
 If you don't specify a parameter by default it will build a chocolatey install package
-Last Updated: 02/08/18
+Last Updated: 08/30/19
 
 .LINK
 https://osquery.io
@@ -74,7 +74,7 @@ $osqRoot = "$PSScriptRoot\..\..\"
 function New-MsiPackage() {
   param(
     [string] $configPath = '',
-    [string] $packsPath = $(Join-Path $(Get-Location) 'packs'),
+    [string] $packsPath = $(Join-Path $osqRoot 'packs'),
     [string] $certsPath = '',
     [string] $flagsPath = '',
     [string] $shell = '',
@@ -83,7 +83,7 @@ function New-MsiPackage() {
     [array] $Extras = @()
   )
 
-  $workingDir = Get-Location
+  $workingDir = $PSScriptRoot
   $scriptPath = $workingDir
   if ((-not (Get-Command 'candle.exe')) -or
       (-not (Get-Command 'light.exe'))) {
@@ -92,14 +92,11 @@ function New-MsiPackage() {
     exit 1
   }
 
-  if ($PSVersionTable.PSVersion.Major -lt 5) {
-    Write-Host '[-] Powershell 5.0 or great is required for this script.' `
-      -ForegroundColor Red
-    exit 1
-  }
-
-  if (-not (Test-Path (Join-Path (Get-location).Path 'tools\osquery.ico'))) {
-    Write-Host '[-] This script must be run from the osquery repo root.' `
+  # use the existence of the icon file as a check that the script appears
+  # to be invoked from the right location
+  $iconPath = Join-Path $PSScriptRoot '..\osquery.ico'
+  if (-not (Test-Path $iconPath)) {
+    Write-Host '[-] This script must be run from the osquery root source directory.' `
       -ForegroundColor Red
     exit 1
   }
@@ -123,23 +120,27 @@ function New-MsiPackage() {
   }
 
   # Working directory and output of files will be in `build/msi`
-  $buildPath = Join-Path $BuildPath 'msi'
-  if (-not (Test-Path $buildPath)) {
-    New-Item -Force -ItemType Directory -Path $buildPath
+  $outputPath = Join-Path $BuildPath 'msi'
+  if (-not (Test-Path $outputPath)) {
+    New-Item -Force -ItemType Directory -Path $outputPath
   }
-  Set-Location $buildPath
+  Set-Location $outputPath
 
   # if no flags file specified, create a stub to run the service
   if ($flagsPath -eq '') {
-    $flagspath = Join-Path $buildPath 'osquery.flags'
+    $flagspath = Join-Path $outputPath 'osquery.flags'
     New-Item -Force -ItemType file $flagspath
+  }
+  if (-not (Test-Path $flagsPath)) {
+    Write-Host '[-] This script requires an osquery.flags, not found.' `
+      -ForegroundColor Red
+    exit 1
   }
 
   # We take advantage of a trick with WiX to copy folders
   Copy-Item -Recurse -Force $certsPath $(Join-Path $(Get-Location) 'certs')
   Copy-Item -Recurse -Force $packsPath $(Join-Path $(Get-Location) 'packs')
-  $iconPath = Join-Path $scriptPath 'tools\osquery.ico'
-  Copy-Item -Force $iconPath $buildPath
+  Copy-Item -Force $iconPath $outputPath
 
   $wix =
   @'
@@ -323,23 +324,23 @@ $wix += @'
   $wix = $wix -Replace 'OSQUERY_DAEMON_PATH', "$daemon"
   $wix = $wix -Replace 'OSQUERY_UTILS_PATH', "$utils"
   $wix = $wix -Replace 'OSQUERY_CERTS_PATH', "certs"
-  $wix = $wix -Replace 'OSQUERY_IMAGE_PATH', "$buildPath\osquery.ico"
+  $wix = $wix -Replace 'OSQUERY_IMAGE_PATH', "$outputPath\osquery.ico"
   $wix = $wix -Replace 'OSQUERY_MGMT_PATH', "$scriptPath\tools\manage-osqueryd.ps1"
   $wix = $wix -Replace 'OSQUERY_MAN_PATH', "$scriptPath\tools\wel\osquery.man"
 
-  $wix | Out-File -Encoding 'UTF8' "$buildPath\osquery.wxs"
+  $wix | Out-File -Encoding 'UTF8' "$outputPath\osquery.wxs"
 
   $candle = (Get-Command 'candle').Source
   $candleArgs = @(
-    "$buildPath\osquery.wxs"
+    "$outputPath\osquery.wxs"
   )
   Start-OsqueryProcess $candle $candleArgs
 
-  $msi = Join-Path $buildPath "osquery.$version.msi"
+  $msi = Join-Path $outputPath "osquery.$version.msi"
   $light = (Get-Command 'light').Source
   $lightArgs = @(
     '-ext WiXUtilExtension',
-    "$buildPath\osquery.wixobj",
+    "$outputPath\osquery.wixobj",
     "-o $msi"
   )
   Start-OsqueryProcess $light $lightArgs
@@ -363,22 +364,15 @@ function New-ChocolateyPackage() {
     [string] $latest = '0.0.0'
   )
 
-
   $working_dir = Get-Location
   if (-not (Get-Command '7z.exe')) {
-    $msg = '[-] 7z note found, run .\tools\make-win64-dev-env.bat.'
-    Write-Host $msg -ForegroundColor Red
-    exit 1
-  }
-
-  if ($PSVersionTable.PSVersion.Major -lt 5) {
-    $msg = '[-] Powershell 5.0 or great is required for this script.'
+    $msg = '[-] 7z not found, please install and ensure that 7z.exe is in the system path.'
     Write-Host $msg -ForegroundColor Red
     exit 1
   }
 
   # Listing of artifacts bundled with osquery
-  $scriptPath = Get-Location
+  $scriptPath = $osqRoot
   $chocoPath = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'Machine')
   $certs = Join-Path "$chocoPath" 'lib\openssl\local\certs'
   if (-not (Test-Path $certs)) {
@@ -386,27 +380,24 @@ function New-ChocolateyPackage() {
     Write-Host $msg -ForegroundColor Yellow
   }
 
-  $conf = Join-Path $scriptPath 'tools\deployment\osquery.example.conf'
+  $conf = Join-Path $osqRoot 'tools\deployment\osquery.example.conf'
   if (-not (Test-Path $conf)) {
     $msg = '[*] Did not find example configuration'
     Write-Host $msg -ForegroundColor Yellow
   }
 
-  $packs = Join-Path $scriptPath 'packs'
+  $packs = Join-Path $osqRoot 'packs'
   if (-not (Test-Path $packs)) {
     Write-Host "[*] Did not find example packs" -ForegroundColor Yellow
   }
 
-  $lic = Join-Path $scriptPath 'LICENSE'
+  $lic = Join-Path $osqRoot 'LICENSE'
   if (-not (Test-Path $lic)) {
     $msg = '[*] Did not find LICENSE file, package will fail ' +
            'chocolatey validation'
     Write-Host $msg -ForegroundColor Yellow
   }
 
-  $buildDir = "$scriptPath\build\windows10\osquery\Release\"
-  $clientPath = Join-Path $buildDir 'osqueryi.exe'
-  $daemonPath = Join-Path $buildDir 'osqueryd.exe'
   $windowsEventLogManifestPath = Join-Path (Get-location).Path "tools\wel\osquery.man"
   $mgmtScript = "$scriptPath\tools\manage-osqueryd.ps1"
 
@@ -477,9 +468,9 @@ function New-ChocolateyPackage() {
   @'
 To verify the osquery binaries are valid and not corrupted, one can run one of the following:
 
-C:\Users\> Get-FileHash -Algorithm SHA256 .\build\windows10\osquery\Release\osqueryd.exe
-C:\Users\> Get-FileHash -Algorithm SHA1 .\build\windows10\osquery\Release\osqueryd.exe
-C:\Users\> Get-FileHash -Algorithm MD5 .\build\windows10\osquery\Release\osqueryd.exe
+C:\Users\> Get-FileHash -Algorithm SHA256 C:\Program Files\osquery\osqueryd\osqueryd.exe
+C:\Users\> Get-FileHash -Algorithm SHA1 C:\Program Files\osquery\osqueryd\osqueryd.exe
+C:\Users\> Get-FileHash -Algorithm MD5 C:\Program Files\osquery\osqueryd\osqueryd.exe
 
 And verify that the digests match one of the below values:
 
@@ -512,7 +503,7 @@ And verify that the digests match one of the below values:
   )
   Start-OsqueryProcess $7z $7zArgs
   Set-Location "$osqueryChocoPath"
-  choco pack
+  Start-OsqueryProcess choco pack
 
   $packagePath = Join-Path $osqueryChocoPath "osquery.$version.nupkg"
   Write-Host "[+] Chocolatey Package written to $packagePath" `
@@ -605,21 +596,22 @@ function Main() {
     Get-Help
   }
 
+  # If the BuildPath wasn't specified, check the default locations
   if ($BuildPath -eq '') {
-    # Check the default Buck build locations
-    $BuildPath = Join-Path $osqRoot 'build\windows10\osquery\Release'
+    # Check the default CMake build location
+    $BuildPath = Join-Path "$PSScriptRoot\..\..\..\" 'build\osquery\RelWithDebInfo'
 
+    # If that path doesn't exist, check the default Buck build location
     if (-not (Test-Path $BuildPath)) {
-      # Check the default CMake build locations
       $BuildPath = Join-Path $osqRoot 'buck-out\release\gen\osquery'
     }
   }
 
-  # Make sure our BuildPath exists either specified or defined
+  # Whether specified by the user or not, check that the BuildPath exists
   if (-not (Test-Path $BuildPath)) {
     $msg = "[-] Did not find build directory at $BuildPath. Check build script output."
-    Write-Host ($msg) -ForegroundColor Red
-    exit
+    Write-Host $msg -ForegroundColor Red
+    exit 1
   }
 
   $daemon = Join-Path $BuildPath 'osqueryd.exe'
@@ -629,8 +621,7 @@ function Main() {
     exit 1
   }
   
-  $scriptPath = Get-Location
-  $utils = Join-Path $scriptPath 'tools\provision\chocolatey\osquery_utils.ps1'
+  $utils = Join-Path $osqRoot 'tools\provision\chocolatey\osquery_utils.ps1'
   if (-not (Test-Path $utils)) {
     $msg = '[-] Did not find osquery utils script, check build script output.'
     Write-Host $msg -ForegroundColor Red
@@ -665,7 +656,7 @@ function Main() {
     $chocoPath = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'Machine')
     $certs = $(Join-Path $chocoPath 'lib\openssl\local\certs')
     if ($ConfigFilePath -eq '') {
-      $ConfigFilePath = $(Join-Path (Get-Location) 'tools\deployment\osquery.example.conf')
+      $ConfigFilePath = $(Join-Path $osqRoot 'tools\deployment\osquery.example.conf')
     }
     New-MsiPackage -shell $shell `
                    -daemon $daemon `

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -366,7 +366,7 @@ function New-ChocolateyPackage() {
 
   $working_dir = Get-Location
   if (-not (Get-Command '7z.exe')) {
-    $msg = '[-] 7z not found, please install and ensure that 7z.exe is in the system path.'
+    $msg = '[-] 7z not found, please install and ensure that 7z.exe is in the system PATH.'
     Write-Host $msg -ForegroundColor Red
     exit 1
   }


### PR DESCRIPTION
Related to https://github.com/osquery/osquery/issues/5586 but I would appreciate @muffins review on my proposed fix. It builds the working MSI package for me now when run from the source directory and pointed at the build directory (CMake).