### PR TITLE
Linux custom toolchain integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ cmake_minimum_required(VERSION 3.14.6)
 
 cmake_policy(SET CMP0083 NEW)
 
+# toolchain.cmake needs to be included before project() because the former sets the compiler path for the custom toolchain,
+# if the user specify it and the latter does compiler detection.
+# utilities.cmake is a dependency of toolchain.cmake.
+include(cmake/utilities.cmake)
+include(cmake/toolchain.cmake)
+
 project(osquery)
 
 if(OSQUERY_BUILD_TESTS)
@@ -15,10 +21,13 @@ if(OSQUERY_BUILD_TESTS)
 endif()
 
 include(cmake/globals.cmake)
-include(cmake/utilities.cmake)
 include(cmake/options.cmake)
 include(cmake/flags.cmake)
 include(cmake/packaging.cmake)
+
+if (OSQUERY_TOOLCHAIN_SYSROOT AND NOT DEFINED PLATFORM_LINUX)
+  message(FATAL_ERROR "The custom toolchain can only be used with Linux, undefine OSQUERY_TOOLCHAIN_SYSROOT and specify a compiler to use")
+endif()
 
 function(main)
   message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       vmImage: 'Ubuntu-16.04'
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04
+      image: trailofbits/osquery:ubuntu-18.04-toolchain
       options: --privileged
 
     timeoutInMinutes: 120
@@ -38,8 +38,7 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)/build
         cmakeArgs:
           -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
-          -DCMAKE_C_COMPILER=clang
-          -DCMAKE_CXX_COMPILER=clang++
+          -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain
           -DOSQUERY_BUILD_TESTS=ON
           $(EXTRA_CMAKE_ARGS)
           $(Build.SourcesDirectory)

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -2,6 +2,9 @@ include(CheckPIESupported)
 check_pie_supported()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+set(CMAKE_LINK_SEARCH_START_STATIC ON)
+set(CMAKE_LINK_SEARCH_END_STATIC ON)
+
 function(setupBuildFlags)
   add_library(cxx_settings INTERFACE)
   add_library(c_settings INTERFACE)
@@ -55,16 +58,9 @@ function(setupBuildFlags)
       -Woverloaded-virtual
       -Wnon-virtual-dtor
       -Weffc++
-      -stdlib=libc++
     )
 
     set(posix_cxx_link_options
-      -stdlib=libc++
-    )
-
-    set(posix_cxx_libraries
-      c++
-      c++abi
     )
 
     set(posix_c_compile_options
@@ -107,19 +103,31 @@ function(setupBuildFlags)
         --no-undefined
       )
 
+      set(linux_cxx_link_libraries
+        libc++abi.a
+        rt
+        dl
+      )
+
       list(APPEND osquery_defines ${osquery_linux_common_defines})
       target_link_options(cxx_settings INTERFACE
         ${osquery_linux_common_link_options}
         ${linux_cxx_link_options}
       )
+
       target_link_options(c_settings INTERFACE
         ${osquery_linux_common_link_options}
+      )
+
+      target_link_libraries(cxx_settings INTERFACE
+        ${linux_cxx_link_libraries}
       )
     elseif(DEFINED PLATFORM_MACOS)
       set(macos_cxx_compile_options
         -x objective-c++
         -fobjc-arc
         -Wabi-tag
+        -stdlib=libc++
       )
 
       set(macos_cxx_link_options
@@ -135,6 +143,7 @@ function(setupBuildFlags)
         "SHELL:-framework Security"
         "SHELL:-framework ServiceManagement"
         "SHELL:-framework SystemConfiguration"
+        -stdlib=libc++
       )
 
       set(macos_cxx_link_libraries
@@ -142,6 +151,7 @@ function(setupBuildFlags)
         cups
         bsm
         xar
+        c++abi
       )
 
       set(osquery_macos_common_defines

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,7 @@
+set(OSQUERY_TOOLCHAIN_SYSROOT "" CACHE PATH "Path to the sysroot that contains the custom toolchain to use to compile osquery. Linux only.")
+
+if(OSQUERY_TOOLCHAIN_SYSROOT)
+  overwrite_cache_variable("CMAKE_C_COMPILER" "STRING" "${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin/clang")
+  overwrite_cache_variable("CMAKE_CXX_COMPILER" "STRING" "${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin/clang++")
+  overwrite_cache_variable("CMAKE_SYSROOT" "PATH" "${OSQUERY_TOOLCHAIN_SYSROOT}")
+endif()

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -2,7 +2,7 @@ osquery supports many flavors of Linux, FreeBSD, macOS, and Windows.
 
 While osquery runs on a large number of operating systems, we only provide build instructions for a select few.
 
-The supported compilers are: clang/libc++ 6.0 on Linux, MSVC v141 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
+The supported compilers are: the osquery toolchain (LLVM/Clang 8.0.1) on Linux, MSVC v141 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
 
 # Building with CMake
 
@@ -18,11 +18,15 @@ Note: the recommended system memory for building osquery is at least 8GB, or Cla
 
 The root folder is assumed to be `/home/<user>`
 
-**Ubuntu 18.04**
+**Ubuntu 18.04/18.10**
 
 ```bash
 # Install the prerequisites
-sudo apt install git llvm clang libc++-dev libc++abi-dev liblzma-dev python python3 bison flex
+sudo apt install git python python3 bison flex
+
+# Download and install the osquery toolchain
+wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz
+sudo tar xvf osquery-toolchain-1.0.0.tar.xz -C /usr/local
 
 # Download and install a newer CMake
 wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
@@ -34,27 +38,7 @@ git clone https://github.com/osquery/osquery
 
 # Build osquery
 mkdir build; cd build
-cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
-cmake --build . -j10 # where 10 is the number of parallel build jobs
-```
-
-**Ubuntu 18.10**
-
-```bash
-# Install the prerequisites
-sudo apt install git llvm-6.0 clang-6.0 libc++-dev libc++abi-dev liblzma-dev python python3 bison flex
-
-# Download and install a newer CMake
-wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
-sudo tar xvf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1
-# Verify that `/usr/local/bin` is in the `PATH` and comes before `/usr/bin`
-
-# Download source
-git clone https://github.com/osquery/osquery
-
-# Build osquery
-mkdir build; cd build
-cmake -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 ..
+cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..
 cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 

--- a/libraries/cmake/formula/modules/utils.cmake
+++ b/libraries/cmake/formula/modules/utils.cmake
@@ -51,7 +51,15 @@ function(importFormula library_name)
     endif()
 
     execute_process(
-      COMMAND "${CMAKE_COMMAND}" -G ${generator_option} ${toolset_option} "-DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}" "-DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}" "-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}" "-DCMAKE_INSTALL_PREFIX:STRING=${install_prefix}" "${project_directory_path}"
+      COMMAND "${CMAKE_COMMAND}"
+      -G ${generator_option}
+      ${toolset_option}
+      "-DCMAKE_SYSROOT:PATH=${CMAKE_SYSROOT}"
+      "-DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}"
+      "-DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}"
+      "-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}"
+      "-DCMAKE_INSTALL_PREFIX:STRING=${install_prefix}"
+      "${project_directory_path}"
       WORKING_DIRECTORY "${build_directory_path}"
       RESULT_VARIABLE error
       OUTPUT_VARIABLE std_output

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -12,7 +12,12 @@ function(opensslMain)
     return()
   endif()
 
-  set(openssl_c_flags -fPIC)
+  set(openssl_c_flags
+    -fPIC
+    --sysroot=${CMAKE_SYSROOT}
+    -l:libunwind.a
+    -lpthread
+  )
   list(APPEND openssl_c_flags ${C_FLAGS})
   string(REPLACE ";" " " openssl_c_flags "${openssl_c_flags}")
 

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -176,6 +176,11 @@ function(importBoostInterfaceLibrary folder_name)
     "${library_root}/include"
   )
 
+  if("${folder_name}" STREQUAL "uuid")
+    target_compile_definitions(${target_name} INTERFACE
+      BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX)
+  endif()
+
   foreach(additional_dependency ${ARGN})
     string(REPLACE "_" "" additional_dependency "${additional_dependency}")
 

--- a/libraries/cmake/source/librpm/config/config.h
+++ b/libraries/cmake/source/librpm/config/config.h
@@ -91,9 +91,6 @@
 /* Define to 1 if you have the <gelf.h> header file. */
 /* #undef HAVE_GELF_H */
 
-/* Define to 1 if you have the `getauxval' function. */
-#define HAVE_GETAUXVAL 1
-
 /* Define to 1 if you have the `getcwd' function. */
 #define HAVE_GETCWD 1
 
@@ -209,7 +206,7 @@
 /* #undef HAVE_SECHASH_H */
 
 /* Define to 1 if you have the `secure_getenv' function. */
-#define HAVE_SECURE_GETENV 1
+#define HAVE_SECURE_GETENV 0
 
 /* Define to 1 if you have the `setenv' function. */
 #define HAVE_SETENV 1


### PR DESCRIPTION
- Always link to libc++abi.a, dl and rt

- Add OSQUERY_TOOLCHAIN_SYSROOT option which should contain
  the path to the sysroot where the portable compiler and its libraries are in.

- Fix OpenSSL build with custom toolchain

- Always include the custom toolchain cmake.
  Unfortunately system name detection is done when project() is called
  which is also when compiler detection is done, and we need the compiler
  to be set before that, so we always include the cmake file.

- Do not use getrandom syscall in Boost, for glibc < 2.25 support.

- Remove usage of secure_getenv and getauxval in librpm.

- Update CI to use the toolchain.

- Reflect changes in the docs.