### PR TITLE
cpack: Add TGZ optional generator for Linux

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -7,6 +7,7 @@
 set(linux_supported_packaging_systems
   DEB
   RPM
+  TGZ
 )
 
 set(windows_supported_packaging_system


### PR DESCRIPTION
We used to provide basic tarballs for Linux flavors that do not support DEB or RPMs.