### PR TITLE
Fix #5737: Add FileVersionRaw column to file table for windows

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -91,6 +91,7 @@ typedef struct win_stat {
   std::string attributes;
   std::string volume_serial;
   std::string product_version;
+  std::string file_version;
 
 } WINDOWS_STAT;
 
@@ -188,14 +189,17 @@ Status windowsShortPathToLongPath(const std::string& shortPath,
                                   std::string& rLongPath);
 
 /*
- * @brief Get the product version associated with a file
+ * @brief Get the product and file version associated with a file
  *
  * @param path: Full path to the file
- * @param rVersion: String representing the product version, e.g. "16.0.8201.0"
- *
+ * @param product_version: String representing the product version, e.g.
+ * "16.0.8201.0"
+ * @param file_version: String representing the file version
  * @return Success if the version could be retrieved, otherwise failure
  */
-Status windowsGetFileVersion(const std::string& path, std::string& rVersion);
+Status windowsGetVersionInfo(const std::string& path,
+                             std::string& product_version,
+                             std::string& file_version);
 #endif
 
 /**

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1836,7 +1836,7 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
   (!ret) ? wfile_stat->ctime = -1
          : wfile_stat->ctime = longIntToUnixtime(basic_info.ChangeTime);
 
-  windowsGetFileVersion(wstringToString(path.wstring()),
+  windowsGetVersionInfo(wstringToString(path.wstring()),
                         wfile_stat->product_version,
                         wfile_stat->file_version);
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -118,7 +118,9 @@ Status windowsShortPathToLongPath(const std::string& shortPath,
   return Status::success();
 }
 
-Status windowsGetFileVersion(const std::string& path, std::string& rVersion) {
+Status windowsGetVersionInfo(const std::string& path,
+                             std::string& product_version,
+                             std::string& file_version) {
   DWORD handle = 0;
   std::wstring wpath = stringToWstring(path).c_str();
   auto verSize = GetFileVersionInfoSizeW(wpath.c_str(), &handle);
@@ -138,11 +140,16 @@ Status windowsGetFileVersion(const std::string& path, std::string& rVersion) {
   if (err == 0) {
     return Status(GetLastError(), "Failed to query version value");
   }
-  rVersion =
+  product_version =
       std::to_string((pFileInfo->dwProductVersionMS >> 16 & 0xffff)) + "." +
       std::to_string((pFileInfo->dwProductVersionMS >> 0 & 0xffff)) + "." +
       std::to_string((pFileInfo->dwProductVersionLS >> 16 & 0xffff)) + "." +
       std::to_string((pFileInfo->dwProductVersionLS >> 0 & 0xffff));
+  file_version =
+      std::to_string((pFileInfo->dwFileVersionMS >> 16 & 0xffff)) + "." +
+      std::to_string((pFileInfo->dwFileVersionMS >> 0 & 0xffff)) + "." +
+      std::to_string((pFileInfo->dwFileVersionLS >> 16 & 0xffff)) + "." +
+      std::to_string((pFileInfo->dwFileVersionLS >> 0 & 0xffff));
   return Status::success();
 }
 
@@ -1830,7 +1837,8 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
          : wfile_stat->ctime = longIntToUnixtime(basic_info.ChangeTime);
 
   windowsGetFileVersion(wstringToString(path.wstring()),
-                        wfile_stat->product_version);
+                        wfile_stat->product_version,
+                        wfile_stat->file_version);
 
   CloseHandle(file_handle);
 

--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -76,10 +76,10 @@ static inline Status getBHOs(QueryData& results) {
         r["path"] = std::move(fullPath);
       }
 
-      std::string version;
-      ret = windowsGetFileVersion(exec, version);
+      std::string productVersion, fileVersion;
+      ret = windowsGetVersionInfo(exec, productVersion, fileVersion);
       if (ret.ok()) {
-        r["version"] = std::move(version);
+        r["version"] = std::move(productVersion);
       }
 
       r["registry_path"] = res.at("path");

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -140,6 +140,7 @@ void genFileInfo(const fs::path& path,
   r["file_id"] = SQL_TEXT(file_stat.file_id);
   r["volume_serial"] = SQL_TEXT(file_stat.volume_serial);
   r["product_version"] = SQL_TEXT(file_stat.product_version);
+  r["file_version"] = SQL_TEXT(file_stat.file_version);
 
 #endif
 

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -23,6 +23,7 @@ extended_schema(WINDOWS, [
     Column("attributes", TEXT, "File attrib string. See: https://ss64.com/nt/attrib.html"),
     Column("volume_serial", TEXT, "Volume serial number"),
     Column("file_id", TEXT, "file ID"),
+    Column("file_version", TEXT, "File version"),
     Column("product_version", TEXT, "File product version"),
 ])
 extended_schema(DARWIN, [

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -71,6 +71,7 @@ TEST_F(FileTests, test_sanity) {
   row_map["volume_serial"] = NormalType;
   row_map["file_id"] = NormalType;
   row_map["product_version"] = NormalType;
+  row_map["file_version"] = NormalType;
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
I have added the file_version column to the file table for windows. I have used the approach of adding a new parameter to the windowsGetFileVersion(). I have refactored the name of the method as well as the parameters. Here is a blueprint of the same:

/*
 * @brief Get the product and file version associated with a file
 *
 * @param path: Full path to the file
 * @param product_version: String representing the product version, e.g. "16.0.8201.0"
 * @param file_version: String representing the file version
 * @return Success if the version could be retrieved, otherwise failure
 */
Status windowsGetVersionInfo(const std::string& path, std::string& product_version, std::string& file_version);

I have added the additional field for the fileVersion in the row structure as well as have placed a validation test in the file table.

Tackling issue: https://github.com/osquery/osquery/issues/5737