### PR TITLE
Fix OpenSSL build when no system ar is installed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       vmImage: 'Ubuntu-16.04'
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain
+      image: trailofbits/osquery:ubuntu-18.04-toolchain-v2
       options: --privileged
 
     timeoutInMinutes: 120

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -26,7 +26,7 @@ function(opensslMain)
     URL "https://www.openssl.org/source/openssl-1.0.2o.tar.gz"
 
     CONFIGURE_COMMAND
-      "${CMAKE_COMMAND}" -E env CC="${CMAKE_C_COMPILER}"
+      "${CMAKE_COMMAND}" -E env CC="${CMAKE_C_COMPILER}" AR="${CMAKE_AR}"
       perl ./Configure "--prefix=${CMAKE_INSTALL_PREFIX}" "--openssldir=${CMAKE_INSTALL_PREFIX}/etc/openssl"
         no-ssl2
         no-ssl3


### PR DESCRIPTION
OpenSSL should use the ar binary provided by the custom toolchain.
Also updated the docker image to avoid installing binutils
and hiding the issue.