### PR TITLE
Suppress Boost warnings about newer compiler

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -230,6 +230,7 @@ function(setupBuildFlags)
       OSQUERY_WINDOWS=1
       OSQUERY_BUILD_PLATFORM=windows
       OSQUERY_BUILD_DISTRO=10
+      BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE=1
     )
 
     set(windows_common_defines


### PR DESCRIPTION
These warnings consumed a significant amount of the compilation output and did not serve a useful purpose.