### PR TITLE
Fix MSI Service Error handling

### DIFF
--- a/cmake/wix_patches/osquery_wix_patch.xml
+++ b/cmake/wix_patches/osquery_wix_patch.xml
@@ -15,7 +15,7 @@
             Start='auto'
             Type='ownProcess'
             Vital='yes'
-            ErrorControl='critical'/>
+            ErrorControl='normal'/>
         <ServiceControl Id='osqueryd'
             Name='osqueryd'
             Stop='both'


### PR DESCRIPTION
When ErrorControl is set to `critical`, a failure to start osquery results in a system reboot. Instead, this should be set to `normal` where it is logged and the startup proceeds.

Upstream docs are Docs are http://wixtoolset.org/documentation/manual/v3/xsd/wix/serviceinstall.html

This was fixed in https://github.com/osquery/osquery/pull/5467 and seems to have gotten lost.