### PR TITLE
Prune Vagrant boxes and fix AWS support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,7 @@
+# We provide this Vagrantfile as a convenience. It is not officially
+# supported.  If adding boxes, please limit sources to well-known
+# organizations, not individual authors.
+
 targets = {
   "debian7" => {
     "box" => "bento/debian-7"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,4 @@
 targets = {
-  "win10" => {
-    "box" => "inclusivedesign/windows10-eval"
-  },
-  "macos10.12" => {
-    "box" => "jhcook/macos-sierra"
-  },
-  "macos10.13" => {
-    "box" => "monsenso/macos-10.13"
-  },
   "debian7" => {
     "box" => "bento/debian-7"
   },
@@ -66,7 +57,7 @@ targets = {
     "box" => "elastic/sles-12-x86_64"
   },
   "aws-amazon2015.03" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-1ecae776",
       "us-west-1" => "ami-d114f295",
@@ -75,7 +66,7 @@ targets = {
     "username" => "ec2-user"
   },
   "aws-rhel7.1" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-12663b7a",
       "us-west-1" => "ami-a540a5e1",
@@ -84,7 +75,7 @@ targets = {
     "username" => "ec2-user"
   },
   "aws-rhel6.5" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-1643ff7e",
       "us-west-1" => "ami-2b171d6e",
@@ -93,7 +84,7 @@ targets = {
     "username" => "ec2-user"
   },
   "aws-ubuntu10" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-1e6f6176",
       "us-west-1" => "ami-250fe361",
@@ -102,7 +93,7 @@ targets = {
     "username" => "ubuntu"
   },
   "aws-oracle6.6" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-20e4b748",
       "us-west-1" => "ami-f3d83db7",
@@ -111,7 +102,7 @@ targets = {
     "username" => "ec2-user"
   },
   "aws-oracle5.11" => {
-    "box" => "andytson/aws-dummy",
+    "box" => "osquery/aws-dummy",
     "regions" => {
       "us-east-1" => "ami-0ecd7766",
       "us-west-1" => "ami-4b00150e",
@@ -184,7 +175,7 @@ Vagrant.configure("2") do |config|
       build.vm.box = box
       if name.start_with?('aws-')
         build.vm.provider :aws do |aws, override|
-          if aws.subnet_id != nil
+          if aws.subnet_id != Vagrant::Plugin::V2::Config::UNSET_VALUE
             aws.associate_public_ip = true
           end
           aws.ami = target['regions'][targets["active_region"]]

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -273,12 +273,6 @@ This capability is provided by the [vagrant-aws](https://github.com/mitchellh/va
 vagrant plugin install vagrant-aws
 ```
 
-Next, add a vagrant dummy box for AWS:
-
-```sh
-vagrant box add andytson/aws-dummy
-```
-
 Before launching an AWS-backed virtual machine, set a few environment variables:
 
 ```sh
@@ -287,20 +281,22 @@ export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 # Name of AWS keypair for launching and accessing the EC2 instance.
 export AWS_KEYPAIR_NAME=my-osquery-vagrant-security-group
+# Path to local private key for SSH authentication
 export AWS_SSH_PRIVATE_KEY_PATH=/path/to/keypair.pem
 # Name of AWS security group that allows TCP/22 from vagrant host.
+# Leaving this unset may work in some AWS/EC2 configurations.
 # If using a non-default VPC use the security group ID instead.
 export AWS_SECURITY_GROUP=my-osquery-vagrant-security-group
 # Set this to the AWS region, "us-east-1" (default) or "us-west-1".
 export AWS_DEFAULT_REGION=...
-# Set this to the AWS instance type. If unset, m3.medium is used.
-export AWS_INSTANCE_TYPE=m3.large
+# Set this to the AWS instance type. If unset, m3.large is used.
+export AWS_INSTANCE_TYPE=m3.medium
 # (Optional) Set this to the VPC subnet ID.
 # (Optional) Make sure your subnet assigns public IPs and there is a route.
 export AWS_SUBNET_ID=...
 ```
 
-Spin up a VM in EC2 and SSH in (remember to suspect/destroy when finished):
+Spin up a VM in EC2 and SSH in (remember to suspend/destroy when finished):
 
 ```sh
 vagrant up aws-amazon2015.03 --provider=aws


### PR DESCRIPTION
- Remove Vagrant boxes provided by individual users and not well-known organizations.
- Use osquery/aws-dummy box for AWS support.
- Fix AWS startup when used without VPC and subnet.
