### PR TITLE
linux: Add --build-id linker option

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -97,6 +97,7 @@ function(setupBuildFlags)
 
       set(osquery_linux_common_link_options
         -Wl,-z,relro,-z,now
+        -Wl,--build-id
       )
 
       set(linux_cxx_link_options


### PR DESCRIPTION
This is a nice-to-have and helps with building debug packages.
