### PR TITLE
deploy: updating osquery --install to wrap binary path and flagfile

### DIFF
--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -155,7 +155,8 @@ int startOsquery(int argc, char* argv[], std::function<void()> shutdown) {
 
   if (FLAGS_install) {
     auto binPath = fs::system_complete(fs::path(argv[0]));
-    if (installService(binPath.string())) {
+    // "Wrap" the binPath in the event it contains spaces
+    if (installService("\"" + binPath.string() + "\"")) {
       LOG(INFO) << "osqueryd service was installed successfully.";
       return 0;
     } else {


### PR DESCRIPTION
Build the binaries, run with `--install`, and verify that the paths are wrapped with quotes:

```
PS C:\Users\Nicholas\work\repos\osquery\build\windows10> .\osquery\Release\osqueryd.exe --install                                                        I0921 14:37:53.569830  7568 main.cpp:160] osqueryd service was installed successfully.
PS C:\Users\Nicholas\work\repos\osquery\build\windows10> sc.exe qc osqueryd                                                                              [SC] QueryServiceConfig SUCCESS

SERVICE_NAME: osqueryd
        TYPE               : 10  WIN32_OWN_PROCESS
        START_TYPE         : 2   AUTO_START
        ERROR_CONTROL      : 1   NORMAL
        BINARY_PATH_NAME   : "C:\Users\Nicholas\work\repos\osquery\build\windows10\osquery\Release\osqueryd.exe" --flagfile="\Program Files\osquery\osquery.flags"
        LOAD_ORDER_GROUP   :
        TAG                : 0
        DISPLAY_NAME       : osquery daemon service
        DEPENDENCIES       :
        SERVICE_START_NAME : LocalSystem
PS C:\Users\Nicholas\work\repos\osquery\build\windows10>
```
This addresses issue #5798 