### PR TITLE
packaging: Fix up make_linux_package to work for version 4+

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -8,25 +8,37 @@
 
 set -e
 
+# Defaults:
+#   Set OSQUERY_BUILD_VERSION or add -v VERSION
+#   Set BUILD_DIR or add -b DIR
+#   Set FPM if installed outside of path
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
 BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build/linux"}
+FPM=${FPM:="fpm"}
+INSTALL_SOURCE=0
 
-OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
-
-export PATH="${OSQUERY_DEPS}/bin:$PATH"
 source "$SOURCE_DIR/tools/lib.sh"
 
+# Default version
 VERSION=`(cd $SOURCE_DIR; git describe --tags HEAD) || echo 'unknown-version'`
 PACKAGE_VERSION=${OSQUERY_BUILD_VERSION:="$VERSION"}
-PACKAGE_ARCH="x86_64"
-PACKAGE_TYPE=""
-PACKAGE_ITERATION=""
+
 DESCRIPTION="osquery is an operating system instrumentation toolchain."
 PACKAGE_NAME="osquery"
-if [[ $PACKAGE_VERSION == *"-"* ]]; then
-  DESCRIPTION="$DESCRIPTION (unstable/latest version)"
-fi
+PACKAGE_ARCH="x86_64"
+PACKAGE_VENDOR="osquery"
+PACKAGE_LICENSE="Apache 2.0 or GPL 2.0"
+
+PACKAGE_TYPE=""
+PACKAGE_ITERATION_DEFAULT="1.linux"
+PACKAGE_ITERATION_ARCH="1.arch"
+
+PACKAGE_DEB_DEPENDENCIES="libc6 (>=2.12), zlib1g"
+PACKAGE_RPM_DEPENDENCIES="glibc >= 2.12, zlib"
+PACKAGE_TGZ_DEPENDENCIES="zlib"
+PACKAGE_TAR_DEPENDENCIES="none"
 
 # Config files
 INITD_SRC="$SCRIPT_DIR/osqueryd.initd"
@@ -39,14 +51,14 @@ SYSTEMD_SYSCONFIG_DST_DEB="/etc/default/osqueryd"
 CTL_SRC="$SCRIPT_DIR/osqueryctl"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/usr/share/osquery/packs/"
-LENSES_LICENSE="${OSQUERY_DEPS}/Cellar/augeas/*/COPYING"
-LENSES_SRC="${OSQUERY_DEPS}/share/augeas/lenses/dist"
+LENSES_LICENSE="${SOURCE_DIR}/libraries/cmake/source/augeas/src/COPYING"
+LENSES_SRC="${SOURCE_DIR}/libraries/cmake/source/augeas/src/lenses"
 LENSES_DST="/usr/share/osquery/lenses/"
 OSQUERY_POSTINSTALL=${OSQUERY_POSTINSTALL:-"$SCRIPT_DIR/linux_postinstall.sh"}
 OSQUERY_PREUNINSTALL=${OSQUERY_PREUNINSTALL:-""}
 OSQUERY_CONFIG_SRC=${OSQUERY_CONFIG_SRC:-""}
 OSQUERY_TLS_CERT_CHAIN_SRC=${OSQUERY_TLS_CERT_CHAIN_SRC:-""}
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${OSQUERY_DEPS}/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${SCRIPT_DIR}/certs.pem"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"
@@ -54,22 +66,43 @@ OSQUERY_LOG_DIR="/var/log/osquery/"
 OSQUERY_VAR_DIR="/var/osquery"
 OSQUERY_ETC_DIR="/etc/osquery"
 
-WORKING_DIR=/tmp/osquery_packaging
-INSTALL_PREFIX=$WORKING_DIR/prefix
-DEBUG_PREFIX=$WORKING_DIR/debug
-
 function usage() {
-  fatal "Usage: $0 -t deb|rpm -i REVISION -d DEPENDENCY_LIST
+  fatal "Usage: $0 -t deb|rpm|pacman|tar
+    [-b|--build] /path/to/build/dir
+    [-d|--dependencies] DEPENDENCY_LIST string
+    [-i|--iteration] REVISION
     [-u|--preuninst] /path/to/pre-uninstall
     [-p|--postinst] /path/to/post-install
     [-c|--config] /path/to/embedded.config
+    [-v|--version] OSQUERY_BUILD_VERSION override
+
   This will generate an Linux package with:
-  (1) An example config /usr/share/osquery/osquery.example.conf
-  (2) An init.d script /etc/init.d/osqueryd
-  (3) A systemd service file /usr/lib/systemd/system/osqueryd.service and
-      a sysconfig file /etc/{default|sysconfig}/osqueryd as appropriate
-  (4) A default TLS certificate bundle (provided by cURL)
-  (5) The osquery toolset /usr/bin/osquery*"
+    (1) An example config /usr/share/osquery/osquery.example.conf
+    (2) An init.d script /etc/init.d/osqueryd
+    (3) A systemd service file /usr/lib/systemd/system/osqueryd.service and
+        a sysconfig file /etc/{default|sysconfig}/osqueryd as appropriate
+    (4) A default TLS certificate bundle (provided by cURL)
+    (5) The osquery toolset /usr/bin/osquery*"
+}
+
+function check_parsed_args() {
+  if [[ -z $PACKAGE_TYPE ]]; then
+    usage
+  fi
+
+  if [[ ! -d $BUILD_DIR ]]; then
+    log "Cannot find build dir [-b|--build]: $BUILD_DIR"
+    usage
+  fi
+
+  if [ ! -z "$OSQUERY_CONFIG_SRC" ] && [ ! -f "$OSQUERY_CONFIG_SRC" ]; then
+    log "$OSQUERY_CONFIG_SRC is not a file."
+    usage
+  fi
+
+  if ! command -v $FPM > /dev/null; then
+    fatal "Cannot find fpm script (is fpm installed?)"
+  fi
 }
 
 function parse_args() {
@@ -93,16 +126,44 @@ function parse_args() {
       -c | --config )         shift
                               OSQUERY_CONFIG_SRC=$1
                               ;;
+      -b | --build )          shift
+                              BUILD_DIR=$1
+                              ;;
+      -v | --version )        shift
+                              PACKAGE_VERSION=$1
+                              ;;
+      -s | --source )         INSTALL_SOURCE=1
+                              ;;
       -h | --help )           usage
                               ;;
     esac
     shift
   done
-}
 
-function check_parsed_args() {
-  if [[ $PACKAGE_TYPE = "" ]] || [[ $PACKAGE_ITERATION = "" ]]; then
-    usage
+  check_parsed_args
+
+  if [[ -z $PACKAGE_ITERATION ]]; then
+    if [[ $PACKAGE_TYPE == "pacman" ]]; then
+      PACKAGE_ITERATION=$PACKAGE_ITERATION_ARCH
+    else
+      PACKAGE_ITERATION=$PACKAGE_ITERATION_DEFAULT
+    fi
+  fi
+
+  if [[ -z $PACKAGE_DEPENDENCIES ]]; then
+    if [[ $PACKAGE_TYPE == "deb" ]]; then
+      PACKAGE_DEPENDENCIES=$PACKAGE_DEB_DEPENDENCIES
+    elif [[ $PACKAGE_TYPE == "rpm" ]]; then
+      PACKAGE_DEPENDENCIES=$PACKAGE_RPM_DEPENDENCIES
+    elif [[ $PACKAGE_TYPE == "pacman" ]]; then
+      PACKAGE_DEPENDENCIES=$PACKAGE_TGZ_DEPENDENCIES
+    else
+      PACKAGE_DEPENDENCIES=$PACKAGE_TAR_DEPENDENCIES
+    fi
+  fi
+
+  if [[ $PACKAGE_VERSION == *"-"* ]]; then
+    DESCRIPTION="$DESCRIPTION (unstable/latest version)"
   fi
 }
 
@@ -122,7 +183,10 @@ function get_pkg_suffix() {
 
 function main() {
   parse_args $@
-  check_parsed_args
+
+  WORKING_DIR=$BUILD_DIR/_packaging
+  INSTALL_PREFIX=$WORKING_DIR/prefix
+  DEBUG_PREFIX=$WORKING_DIR/debug
 
   platform OS
   distro $OS DISTRO
@@ -133,7 +197,7 @@ function main() {
   rm -f $OUTPUT_PKG_PATH
   mkdir -p $INSTALL_PREFIX
 
-  log "copying osquery binaries"
+  log "copying osquery binaries to $INSTALL_PREFIX"
   BINARY_INSTALL_DIR="$INSTALL_PREFIX/usr/bin/"
   mkdir -p $BINARY_INSTALL_DIR
   cp "$BUILD_DIR/osquery/osqueryd" $BINARY_INSTALL_DIR
@@ -142,7 +206,7 @@ function main() {
   cp "$CTL_SRC" $BINARY_INSTALL_DIR
 
   # Create the prefix log dir and copy source configs
-  log "copying osquery configurations"
+  log "copying osquery configurations to $INSTALL_PREFIX"
   mkdir -p $INSTALL_PREFIX/$OSQUERY_VAR_DIR
   mkdir -p $INSTALL_PREFIX/$OSQUERY_LOG_DIR
   mkdir -p $INSTALL_PREFIX/$OSQUERY_ETC_DIR
@@ -154,18 +218,18 @@ function main() {
   cp $LENSES_LICENSE $INSTALL_PREFIX/$LENSES_DST
   cp $LENSES_SRC/*.aug $INSTALL_PREFIX/$LENSES_DST
 
-  if [[ $OSQUERY_CONFIG_SRC != "" ]] && [[ -f $OSQUERY_CONFIG_SRC ]]; then
-    log "config setup"
+  if [[ ! -z $OSQUERY_CONFIG_SRC ]] && [[ -f $OSQUERY_CONFIG_SRC ]]; then
+    log "copying optional config into $INSTALL_PREFIX$OSQUERY_ETC_DIR"
     cp $OSQUERY_CONFIG_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/osquery.conf
   fi
 
-  if [[ $OSQUERY_TLS_CERT_CHAIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_SRC ]]; then
-    log "custom tls server certs file setup"
+  if [[ ! -z $OSQUERY_TLS_CERT_CHAIN_SRC ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_SRC ]]; then
+    log "copying optional tls server certs file into $INSTALL_PREFIX$OSQUERY_ETC_DIR"
     cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/tls-server-certs.pem
   fi
 
-  if [[ $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC ]]; then
-    log "built-in tls server certs file setup"
+  if [[ ! -z $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC ]]; then
+    log "copying built-in tls server certs file into $INSTALL_PREFIX$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST"
     mkdir -p `dirname $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST`
     cp $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST
   fi
@@ -175,7 +239,7 @@ function main() {
     SYSTEMD_SYSCONFIG_DST=$SYSTEMD_SYSCONFIG_DST_DEB
   fi
 
-  log "copying osquery init scripts"
+  log "copying osquery init scripts into $INSTALL_PREFIX"
   mkdir -p `dirname $INSTALL_PREFIX$INITD_DST`
   mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SERVICE_DST`
   mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST`
@@ -199,16 +263,13 @@ function main() {
     PACKAGE_DEPENDENCIES="$PACKAGE_DEPENDENCIES -d \"$element\""
   done
 
-  # Let callers provide their own fpm if desired
-  FPM=${FPM:="fpm"}
-
   POSTINST_CMD=""
-  if [[ $OSQUERY_POSTINSTALL != "" ]] && [[ -f $OSQUERY_POSTINSTALL ]]; then
+  if [[ ! -z $OSQUERY_POSTINSTALL ]] && [[ -f $OSQUERY_POSTINSTALL ]]; then
     POSTINST_CMD="--after-install $OSQUERY_POSTINSTALL"
   fi
 
   PREUNINST_CMD=""
-  if [[ $OSQUERY_PREUNINSTALL != "" ]] && [[ -f $OSQUERY_PREUNINSTALL ]]; then
+  if [[ ! -z $OSQUERY_PREUNINSTALL ]] && [[ -f $OSQUERY_PREUNINSTALL ]]; then
     PREUNINST_CMD="--before-remove $OSQUERY_PREUNINSTALL"
   fi
 
@@ -217,8 +278,8 @@ function main() {
 
   EPILOG="--url https://osquery.io \
     -m osquery@osquery.io          \
-    --vendor Facebook              \
-    --license BSD                  \
+    --vendor \"$PACKAGE_VENDOR\"       \
+    --license \"$PACKAGE_LICENSE\" \
     --description \"$DESCRIPTION\""
 
   CMD="$FPM -s dir -t $PACKAGE_TYPE \
@@ -271,14 +332,16 @@ function main() {
     ln -s osqueryd "$BINARY_DEBUG_DIR/osqueryi.debug"
 
     # Finally install the source.
-    SOURCE_DEBUG_DIR=$DEBUG_PREFIX/usr/src/debug/osquery-$PACKAGE_VERSION
-    BUILD_DIR=`readlink --canonicalize "$BUILD_DIR"`
-    SOURCE_DIR=`readlink --canonicalize "$SOURCE_DIR"`
-    for file in `"$SCRIPT_DIR/getfiles.py" --build "$BUILD_DIR/" --base "$SOURCE_DIR/"`
-    do
-      mkdir -p `dirname "$SOURCE_DEBUG_DIR/$file"`
-      cp "$file" "$SOURCE_DEBUG_DIR/$file"
-    done
+    if [[ $INSTALL_SOURCE == "1" ]]; then
+      SOURCE_DEBUG_DIR=$DEBUG_PREFIX/usr/src/debug/osquery-$PACKAGE_VERSION
+      BUILD_DIR=`readlink --canonicalize "$BUILD_DIR"`
+      SOURCE_DIR=`readlink --canonicalize "$SOURCE_DIR"`
+      for file in `"$SCRIPT_DIR/getfiles.py" --build "$BUILD_DIR/" --base "$SOURCE_DIR/"`
+      do
+        mkdir -p `dirname "$SOURCE_DEBUG_DIR/$file"`
+        cp "$file" "$SOURCE_DEBUG_DIR/$file"
+      done
+    fi
   fi
 
   PACKAGE_DEBUG_DEPENDENCIES=`echo "$PACKAGE_DEBUG_DEPENDENCIES"|tr '-' '_'`


### PR DESCRIPTION
Example test plan:
```
» ./tools/deployment/make_linux_package.sh -b ./build -t rpm                                        
[+] copying osquery binaries to ./build/_packaging/prefix
[+] copying osquery configurations to ./build/_packaging/prefix
[+] copying built-in tls server certs file into ./build/_packaging/prefix/usr/share/osquery/certs/certs.pem
[+] copying osquery init scripts into ./build/_packaging/prefix
[+] creating rpm package
Created package {:path=>"/home/teddy/git/osquery-prod/build/osquery-4.0.2_7_gfadcfbca-1.linux.x86_64.rpm"}
[+] package created at /home/teddy/git/osquery-prod/build/osquery-4.0.2_7_gfadcfbca-1.linux.x86_64.rpm
Created package {:path=>"/home/teddy/git/osquery-prod/build/osquery-debuginfo-4.0.2_7_gfadcfbca-1.linux.x86_64.rpm"}
[+] debug created at /home/teddy/git/osquery-prod/build/osquery-debuginfo-4.0.2_7_gfadcfbca-1.linux.x86_64.rpm

» ./tools/deployment/make_linux_package.sh -h               
[!] Usage: ./tools/deployment/make_linux_package.sh -t deb|rpm|pacman|tar
    [-b|--builddir] /path/to/build/dir
    [-d|--dependencies] DEPENDENCY_LIST string
    [-i|--iteration] REVISION
    [-u|--preuninst] /path/to/pre-uninstall
    [-p|--postinst] /path/to/post-install
    [-c|--config] /path/to/embedded.config
    [-v|--version] OSQUERY_BUILD_VERSION override

  This will generate an Linux package with:
    (1) An example config /usr/share/osquery/osquery.example.conf
    (2) An init.d script /etc/init.d/osqueryd
    (3) A systemd service file /usr/lib/systemd/system/osqueryd.service and
        a sysconfig file /etc/{default|sysconfig}/osqueryd as appropriate
    (4) A default TLS certificate bundle (provided by cURL)
    (5) The osquery toolset /usr/bin/osquery*
```