### PR TITLE
packaging: Fix up make_osx_package to work for version 4+

### DIFF
--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -8,34 +8,23 @@
 
 set -e
 
+# Defaults:
+#   Set OSQUERY_BUILD_VERSION or add -v VERSION
+#   Set BUILD_DIR or add -b DIR
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
-BUILD_DIR="$SOURCE_DIR/build/"
-if [[ ! -z "$DEBUG" ]]; then
-  BUILD_DIR="${BUILD_DIR}debug_"
-fi
-
-if [[ "$BUILD_VERSION" == "10.11" ]]; then
-  BUILD_DIR="${BUILD_DIR}darwin"
-else
-  BUILD_DIR="${BUILD_DIR}darwin$BUILD_VERSION"
-fi
-
-OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
+BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build"}
 
 source "$SOURCE_DIR/tools/lib.sh"
-distro "darwin" BUILD_VERSION
 
 # Binary identifiers
 VERSION=`(cd $SOURCE_DIR; git describe --tags HEAD) || echo 'unknown-version'`
 APP_VERSION=${OSQUERY_BUILD_VERSION:="$VERSION"}
+
 APP_IDENTIFIER="com.facebook.osquery"
-KERNEL_APP_IDENTIFIER="com.facebook.osquery.kernel"
 LD_IDENTIFIER="com.facebook.osqueryd"
 LD_INSTALL="/Library/LaunchDaemons/$LD_IDENTIFIER.plist"
-OUTPUT_PKG_PATH="$BUILD_DIR/osquery-$APP_VERSION.pkg"
-OUTPUT_DEBUG_PKG_PATH="$BUILD_DIR/osquery-debug-$APP_VERSION.pkg"
-KERNEL_OUTPUT_PKG_PATH="$BUILD_DIR/osquery-kernel-${APP_VERSION}.pkg"
 SIGNING_IDENTITY=""
 SIGNING_IDENTITY_COMMAND=""
 KEYCHAIN_IDENTITY=""
@@ -50,8 +39,8 @@ NEWSYSLOG_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.conf"
 NEWSYSLOG_DST="/private/var/osquery/$LD_IDENTIFIER.conf"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/private/var/osquery/packs/"
-LENSES_LICENSE="${OSQUERY_DEPS}/Cellar/augeas/*/COPYING"
-LENSES_SRC="${OSQUERY_DEPS}/share/augeas/lenses/dist"
+LENSES_LICENSE="libs/fb/augeas/augeas/1.9.0/COPYING"
+LENSES_SRC="libs/fb/augeas/augeas/1.9.0/share/augeas/lenses/dist"
 LENSES_DST="/private/var/osquery/lenses/"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/private/var/osquery/osquery.example.conf"
@@ -59,32 +48,12 @@ OSQUERY_CONFIG_SRC=""
 OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${OSQUERY_DEPS}/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${SCRIPT_DIR}/certs.pem"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/private/var/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
 OSQUERY_PKG_INCLUDE_DIRS=()
-
-WORKING_DIR=/tmp/osquery_packaging
-INSTALL_PREFIX="$WORKING_DIR/prefix"
-DEBUG_PREFIX="$WORKING_DIR/debug"
-SCRIPT_ROOT="$WORKING_DIR/scripts"
-PREINSTALL="$SCRIPT_ROOT/preinstall"
-POSTINSTALL="$SCRIPT_ROOT/postinstall"
 OSQUERYCTL_PATH="$SCRIPT_DIR/osqueryctl"
-
-# Kernel extension identifiers and config files
-KERNEL_INLINE=false
-KERNEL_UNLOAD_SCRIPT="$SOURCE_DIR/kernel/tools/unload_with_retry.sh"
-KERNEL_EXTENSION_IDENTIFIER="com.facebook.security.osquery"
-KERNEL_EXTENSION_SRC="$BUILD_DIR/kernel/osquery.kext"
-KERNEL_EXTENSION_DST="/Library/Extensions/osquery.kext"
-
-KERNEL_WORKING_DIR=/tmp/osquery_kernel_packaging
-KERNEL_INSTALL_PREFIX="$KERNEL_WORKING_DIR/prefix"
-KERNEL_SCRIPT_ROOT="$KERNEL_WORKING_DIR/scripts"
-KERNEL_PREINSTALL="$KERNEL_SCRIPT_ROOT/preinstall"
-KERNEL_POSTINSTALL="$KERNEL_SCRIPT_ROOT/postinstall"
 
 SCRIPT_PREFIX_TEXT="#!/usr/bin/env bash
 
@@ -103,41 +72,58 @@ touch $FLAGFILE_DST
 launchctl load $LD_INSTALL
 "
 
-KERNEL_POSTINSTALL_UNLOAD_TEXT="
-./unload_with_retry.sh
-"
-
-KERNEL_POSTINSTALL_AUTOSTART_TEXT="
-kextload $KERNEL_EXTENSION_DST
-"
-
 POSTINSTALL_CLEAN_TEXT="
 rm -rf $OSQUERY_DB_LOCATION
 "
 
 function usage() {
-  fatal "Usage: $0 [-c path/to/your/osquery.conf] [-l path/to/osqueryd.plist]
-    -c PATH embed an osqueryd config.
-    -l PATH override the default launchd plist.
-    -t PATH to embed a certificate chain file for TLS server validation
-    -o PATH override the output path.
-    -a start the daemon when the package is installed
-    -x force the daemon to start fresh, removing any results previously stored in the database
-  This will generate an OSX package with:
-  (1) An example config /var/osquery/osquery.example.config
-  (2) An optional config /var/osquery/osquery.config if [-c] is used
-  (3) A LaunchDaemon plist /var/osquery/com.facebook.osqueryd.plist
-  (4) A default TLS certificate bundle (provided by cURL)
-  (5) The osquery toolset /usr/local/bin/osquery*
+  fatal "Usage: $0
+    [-b|--build] /path/to/build/dir
+    [-c|--config] PATH embed an osqueryd config.
+    [-l|--launchd] PATH override the default launchd plist.
+    [-t|--cert-chain] PATH to embed a certificate chain file for TLS server validation
+    [-o|--output] PATH override the output path.
+    [-a|--autostart] start the daemon when the package is installed
+    [-x|--clean] force the daemon to start fresh, removing any results previously stored in the database
+
+  This will generate an macOS package with:
+    (1) An example config /var/osquery/osquery.example.config
+    (2) An optional config /var/osquery/osquery.config if [-c] is used
+    (3) A LaunchDaemon plist /var/osquery/com.facebook.osqueryd.plist
+    (4) A default TLS certificate bundle (provided by cURL)
+    (5) The osquery toolset /usr/local/bin/osquery*
 
   To enable osqueryd to run at boot using Launchd, pass the -a flag.
   If the LaunchDaemon was previously installed a newer version of this package
   will reload (unload/load) the daemon."
 }
 
+function check_parsed_args() {
+  if [[ ! -d $BUILD_DIR ]]; then
+    fatal "Cannot find build dir [-b|--builddir]: $BUILD_DIR"
+  fi
+
+  if [[ ! -z $OSQUERY_CONFIG_SRC ]]; then
+    log "using $OSQUERY_CONFIG_SRC as the config source"
+  fi
+
+  log "using $LAUNCHD_SRC as the launchd source"
+
+  if [[ ! -z "$OSQUERY_CONFIG_SRC" ]] && [[ ! -f $OSQUERY_CONFIG_SRC ]]; then
+    log "The config [-c] $OSQUERY_CONFIG_SRC is not a file"
+    usage
+  fi
+}
+
 function parse_args() {
   while [ "$1" != "" ]; do
     case $1 in
+      -b | --build )          shift
+                              BUILD_DIR=$1
+                              ;;
+      -v | --version )        shift
+                              APP_VERSION=$1
+                              ;;
       -c | --config )         shift
                               OSQUERY_CONFIG_SRC=$1
                               ;;
@@ -171,41 +157,38 @@ function parse_args() {
     esac
     shift
   done
-}
 
-function check_parsed_args() {
-  if [[ $OSQUERY_CONFIG_SRC = "" ]]; then
-    log "notice: no config source specified"
-  else
-    log "using $OSQUERY_CONFIG_SRC as the config source"
-  fi
-
-  log "using $LAUNCHD_SRC as the launchd source"
-
-  if [ "$OSQUERY_CONFIG_SRC" != "" ] && [ ! -f $OSQUERY_CONFIG_SRC ]; then
-    log "$OSQUERY_CONFIG_SRC is not a file."
-    usage
-  fi
+  check_parsed_args
 }
 
 function main() {
   parse_args $@
-  check_parsed_args
+
+  WORKING_DIR=$BUILD_DIR/_packaging
+  INSTALL_PREFIX="$WORKING_DIR/prefix"
+  DEBUG_PREFIX="$WORKING_DIR/debug"
+  SCRIPT_ROOT="$WORKING_DIR/scripts"
+  PREINSTALL="$SCRIPT_ROOT/preinstall"
+  POSTINSTALL="$SCRIPT_ROOT/postinstall"
 
   platform OS
   if [[ ! "$OS" = "darwin" ]]; then
     fatal "This script must be run on macOS"
   fi
 
+  OUTPUT_PKG_PATH="$BUILD_DIR/osquery-$APP_VERSION.pkg"
+  OUTPUT_DEBUG_PKG_PATH="$BUILD_DIR/osquery-debug-$APP_VERSION.pkg"
+
   rm -rf $WORKING_DIR
   rm -f $OUTPUT_PKG_PATH
   mkdir -p $INSTALL_PREFIX
   mkdir -p $SCRIPT_ROOT
-  # we don't need the preinstall for anything so let's skip it until we do
+
+  # We don't need the preinstall for anything so let's skip it until we do
   # echo "$SCRIPT_PREFIX_TEXT" > $PREINSTALL
   # chmod +x $PREINSTALL
 
-  log "copying osquery binaries"
+  log "copying osquery binaries into $INSTALL_PREFIX"
   BINARY_INSTALL_DIR="$INSTALL_PREFIX/usr/local/bin/"
   mkdir -p $BINARY_INSTALL_DIR
   cp "$BUILD_DIR/osquery/osqueryd" $BINARY_INSTALL_DIR
@@ -239,8 +222,8 @@ function main() {
   cp $NEWSYSLOG_SRC $INSTALL_PREFIX$NEWSYSLOG_DST
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
   cp $PACKS_SRC/* $INSTALL_PREFIX$PACKS_DST
-  cp $LENSES_LICENSE $INSTALL_PREFIX/$LENSES_DST
-  cp $LENSES_SRC/*.aug $INSTALL_PREFIX$LENSES_DST
+  cp $BUILD_DIR/$LENSES_LICENSE $INSTALL_PREFIX/$LENSES_DST
+  cp $BUILD_DIR/$LENSES_SRC/*.aug $INSTALL_PREFIX$LENSES_DST
   if [[ "$TLS_CERT_CHAIN_SRC" != "" && -f "$TLS_CERT_CHAIN_SRC" ]]; then
     cp $TLS_CERT_CHAIN_SRC $INSTALL_PREFIX$TLS_CERT_CHAIN_DST
   fi
@@ -290,84 +273,6 @@ function main() {
            --version $APP_VERSION             \
            $OUTPUT_DEBUG_PKG_PATH 2>&1  1>/dev/null
   log "package created at $OUTPUT_DEBUG_PKG_PATH"
-
-
-  # We optionally create an RPM equivalent.
-  FPM=$(which fpm || true)
-  RPMBUILD=$(which rpmbuild || true)
-  if [[ ! "$FPM" = "" && ! "$RPMBUILD" = "" ]]; then
-    rm -f "$OUTPUT_RPM_PATH"
-    log "creating RPM equivalent"
-
-    # Yes, RPMs on OS X like i386 as the arch.
-    PACKAGE_ARCH=i386
-    PACKAGE_ITERATION="1.darwin"
-    RPM_APP_VERSION=$(echo ${APP_VERSION}|tr '-' '_')
-    OUTPUT_RPM_PATH="$BUILD_DIR/osquery-$RPM_APP_VERSION-$PACKAGE_ITERATION.$PACKAGE_ARCH.rpm"
-    rm -f $OUTPUT_RPM_PATH
-    CMD="$FPM -s dir -t rpm \
-      -n osquery \
-      -v $RPM_APP_VERSION \
-      --iteration $PACKAGE_ITERATION -a $PACKAGE_ARCH \
-      -p $OUTPUT_RPM_PATH \
-      --url https://osquery.io -m osquery@osquery.io \
-      --vendor Facebook --license BSD \
-      \"$INSTALL_PREFIX/=/\""
-    eval "$CMD"
-    log "RPM package (also) created at $OUTPUT_RPM_PATH"
-
-    OUTPUT_DEBUG_RPM_PATH="$BUILD_DIR/osquery-debug-$RPM_APP_VERSION-$PACKAGE_ITERATION.$PACKAGE_ARCH.rpm"
-    rm -f $OUTPUT_DEBUG_RPM_PATH
-    CMD="$FPM -s dir -t rpm \
-      -n osquery-debug \
-      -v $RPM_APP_VERSION \
-      --iteration $PACKAGE_ITERATION -a $PACKAGE_ARCH \
-      -p $OUTPUT_DEBUG_RPM_PATH \
-      --url https://osquery.io -m osquery@osquery.io \
-      --vendor Facebook --license BSD \
-      \"$DEBUG_PREFIX/=/\""
-    eval "$CMD"
-    log "RPM package (also) created at $OUTPUT_DEBUG_RPM_PATH"
-  else
-    log "Skipping OS X RPM package build: Cannot find fpm and rpmbuild"
-  fi
-
-  # Check if a kernel extension should be built alongside.
-  if [[ -d "$KERNEL_EXTENSION_SRC" ]]; then
-    rm -rf $KERNEL_WORKING_DIR
-    rm -f $KERNEL_OUTPUT_PKG_PATH
-    mkdir -p $KERNEL_INSTALL_PREFIX
-    mkdir -p $KERNEL_SCRIPT_ROOT
-
-    log "copying osquery kernel bundles"
-    mkdir -p $KERNEL_INSTALL_PREFIX$KERNEL_EXTENSION_DST
-    cp -R $KERNEL_EXTENSION_SRC/ $KERNEL_INSTALL_PREFIX$KERNEL_EXTENSION_DST
-
-    log "finalizing kernel preinstall and postinstall scripts"
-    if [ $AUTOSTART == true ]; then
-      echo "$SCRIPT_PREFIX_TEXT" > $KERNEL_POSTINSTALL
-      chmod +x $KERNEL_POSTINSTALL
-      # Install the normal post install unload to unload the daemons.
-      echo "$POSTINSTALL_UNLOAD_TEXT" >> $KERNEL_POSTINSTALL
-      # Handler kernel extension unloading/reloading.
-      cp $KERNEL_UNLOAD_SCRIPT $KERNEL_SCRIPT_ROOT
-      echo "$KERNEL_POSTINSTALL_UNLOAD_TEXT" >> $KERNEL_POSTINSTALL
-      echo "$KERNEL_POSTINSTALL_AUTOSTART_TEXT" >> $KERNEL_POSTINSTALL
-      # Install the normal post install reload to reload daemons.
-      echo "$POSTINSTALL_AUTOSTART_TEXT" >> $KERNEL_POSTINSTALL
-    fi
-
-    log "creating kernel package"
-    pkgbuild --root $KERNEL_INSTALL_PREFIX             \
-             --scripts $KERNEL_SCRIPT_ROOT             \
-             --identifier $KERNEL_APP_IDENTIFIER       \
-             --version ${APP_VERSION}                  \
-             $KERNEL_OUTPUT_PKG_PATH 2>&1  1>/dev/null
-    log "kernel package created at $KERNEL_OUTPUT_PKG_PATH"
-  else
-    log "skipping kernel package, no kext found"
-  fi
-
 }
 
 main $@


### PR DESCRIPTION
Example test plan:
```
$ ./tools/deployment/make_osx_package1.sh 
[+] using /vagrant/tools/deployment/com.facebook.osqueryd.plist as the launchd source
[+] copying osquery binaries into /vagrant/tools/deployment/../../build/_packaging/prefix
[+] copying osquery configurations
[+] finalizing preinstall and postinstall scripts
[+] creating package
[+] package created at /vagrant/tools/deployment/../../build/osquery-4.0.2-7-g33f7c6fc.pkg
[+] creating debug package
[+] package created at /vagrant/tools/deployment/../../build/osquery-debug-4.0.2-7-g33f7c6fc.pkg
```