### PR TITLE
Resolve compilation error of implicitly-deleted default constructor o…

### DIFF
--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -292,7 +292,7 @@ std::vector<std::string> platformGlob(const std::string& find_path) {
   auto data = (glob_t*)alloca(sizeof(glob_t));
   ::glob(
       find_path.c_str(), GLOB_TILDE | GLOB_MARK | GLOB_BRACE, nullptr, data);
-  size_t count = data -> gl_pathc;
+  size_t count = data->gl_pathc;
 
   for (size_t index = 0; index < count; index++) {
     results.push_back(data->gl_pathv[index]);

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -289,16 +289,17 @@ bool platformChmod(const std::string& path, mode_t perms) {
 std::vector<std::string> platformGlob(const std::string& find_path) {
   std::vector<std::string> results;
 
-  glob_t data;
+  glob_t * data;
+  data = (glob_t *)alloca(sizeof(glob_t));
   ::glob(
-      find_path.c_str(), GLOB_TILDE | GLOB_MARK | GLOB_BRACE, nullptr, &data);
-  size_t count = data.gl_pathc;
+      find_path.c_str(), GLOB_TILDE | GLOB_MARK | GLOB_BRACE, nullptr, data);
+  size_t count = data -> gl_pathc;
 
   for (size_t index = 0; index < count; index++) {
-    results.push_back(data.gl_pathv[index]);
+    results.push_back(data -> gl_pathv[index]);
   }
 
-  ::globfree(&data);
+  ::globfree(data);
   return results;
 }
 

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -289,14 +289,13 @@ bool platformChmod(const std::string& path, mode_t perms) {
 std::vector<std::string> platformGlob(const std::string& find_path) {
   std::vector<std::string> results;
 
-  glob_t * data;
-  data = (glob_t *)alloca(sizeof(glob_t));
+  auto data = (glob_t*)alloca(sizeof(glob_t));
   ::glob(
       find_path.c_str(), GLOB_TILDE | GLOB_MARK | GLOB_BRACE, nullptr, data);
   size_t count = data -> gl_pathc;
 
   for (size_t index = 0; index < count; index++) {
-    results.push_back(data -> gl_pathv[index]);
+    results.push_back(data->gl_pathv[index]);
   }
 
   ::globfree(data);


### PR DESCRIPTION
Fix to resolve next.
https://github.com/osquery/osquery/issues/5826

Touched the code of `platformGlob(const std::string& find_path)` function to resolve the compilation error of  *implicitly-deleted default constructor*.

Now memory for data of glob_t is prepared by `alloca` instead of local variable of structure.
