### PR TITLE
format: Fix auto-formatting and format checking

### DIFF
--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -14,24 +14,19 @@ import sys
 
 def check(base_commit, exclude_folders):
     try:
+        cmd = [
+          "python",
+          os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-clang-format.py"),
+          "--style=file",
+          "--diff",
+          "--commit",
+          base_commit,
+        ]
 
-        exclude_folders_option=""
         if exclude_folders:
-            exclude_folders_option = "--exclude_folders " + exclude_folders
+            cmd += ["--exclude-folders", exclude_folders]
 
-        p = subprocess.Popen(
-                [
-                    "python",
-                    os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-clang-format.py"),
-                    "--style=file",
-                    "--diff",
-                    "--commit",
-                    base_commit,
-                    "-v",
-                    exclude_folders_option,
-                    ],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-                )
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
     except OSError as e:
         print("{}\n\n{!r}".format("Failed to call git-clang-format.py", e))


### PR DESCRIPTION
I was curious why recent diffs were not causing a CI build failure when the code was not formatted. 