### PR TITLE
tests: Enable RocksDB plugin tests

### DIFF
--- a/plugins/database/CMakeLists.txt
+++ b/plugins/database/CMakeLists.txt
@@ -61,10 +61,6 @@ function(generatePluginsDatabaseRocksdbplugin)
   generateIncludeNamespace(plugins_database_rocksdbplugin "plugins/database" "FILE_ONLY" ${public_header_files})
 
   add_test(NAME plugins_database_tests_rocksdbtests-test COMMAND plugins_database_tests_rocksdbtests-test)
-
-  set_tests_properties(plugins_database_tests_rocksdbtests-test PROPERTIES
-    DISABLED True
-  )
 endfunction()
 
 function(generatePluginsDatabaseSqliteplugin)

--- a/plugins/database/tests/BUCK
+++ b/plugins/database/tests/BUCK
@@ -35,7 +35,7 @@ osquery_cxx_test(
 osquery_cxx_test(
     name = "rocksdb_tests",
     srcs = [
-        # "rocksdb.cpp", # TODO: it is failing :(
+        "rocksdb.cpp",
     ],
     visibility = ["PUBLIC"],
     deps = [

--- a/plugins/database/tests/rocksdb.cpp
+++ b/plugins/database/tests/rocksdb.cpp
@@ -39,9 +39,7 @@ TEST_F(RocksDBDatabasePluginTests, test_corruption) {
 
   // Mark the database as corrupted
   RocksDBDatabasePlugin::setCorrupted();
-  printf("set corrupt\n");
   resetDatabase();
-  printf("did reset\n");
 
   EXPECT_TRUE(pathExists(path_ + ".backup"));
 

--- a/plugins/database/tests/utils.cpp
+++ b/plugins/database/tests/utils.cpp
@@ -47,11 +47,12 @@ void DatabasePluginTests::SetUp() {
   rf.plugin("database", existing_plugin_)->tearDown();
 
   setName(name());
-  path_ = FLAGS_database_path;
+  previous_path_ = FLAGS_database_path;
   FLAGS_database_path = (
       fs::temp_directory_path() /
       fs::unique_path("osquery.database_plugin_tests.%%%%.%%%%.%%%%.%%%%.db")
   ).string();
+  path_ = FLAGS_database_path;
   // removePath(path_);
 
   auto plugin = rf.plugin("database", getName());
@@ -65,8 +66,8 @@ void DatabasePluginTests::TearDown() {
   auto& rf = RegistryFactory::get();
   rf.plugin("database", name_)->tearDown();
   rf.setActive("database", existing_plugin_);
-  fs::remove_all(fs::path(FLAGS_database_path));
-  FLAGS_database_path = path_;
+  fs::remove_all(fs::path(path_));
+  FLAGS_database_path = previous_path_;
 }
 
 void DatabasePluginTests::testPluginCheck() {

--- a/plugins/database/tests/utils.h
+++ b/plugins/database/tests/utils.h
@@ -54,6 +54,9 @@ class DatabasePluginTests : public testing::Test {
   /// Path to testing database.
   std::string path_;
 
+  /// Previous (before SetUp) database path.
+  std::string previous_path_;
+
  protected:
   /// Require each plugin tester to implement a set name.
   virtual std::string name() = 0;


### PR DESCRIPTION
Not sure why this was disabled. If it was enabled we would have had less breakage in 4.0.1.