### PR TITLE
Specify PATH when calling format_check if using the custom toolchain

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -235,15 +235,21 @@ function(generateSpecialTargets)
     "libraries/cmake/source"
   )
 
+  set(command_prefix)
+  if(OSQUERY_TOOLCHAIN_SYSROOT)
+    set(command_prefix "${CMAKE_COMMAND}" -E env "PATH=${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin:$ENV{PATH}")
+  endif()
+
   add_custom_target(format_check
-    COMMAND ${EX_TOOL_PYTHON2_EXECUTABLE_PATH} ${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py --exclude-folders ${excluded_folders} origin/master
+    COMMAND ${command_prefix} ${EX_TOOL_PYTHON2_EXECUTABLE_PATH} ${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py --exclude-folders ${excluded_folders} origin/master
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     VERBATIM
   )
   add_custom_target(format
-    COMMAND ${EX_TOOL_PYTHON2_EXECUTABLE_PATH} ${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py --exclude-folders ${excluded_folders} -f --style=file
+    COMMAND ${command_prefix} ${EX_TOOL_PYTHON2_EXECUTABLE_PATH} ${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py --exclude-folders ${excluded_folders} -f --style=file
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    VERBATIM)
+    VERBATIM
+  )
 endfunction()
 
 function(collectInterfaceOptionsFromTarget)


### PR DESCRIPTION
The script would not find clang-format or it would use the system one,
which it shouldn't.