### PR TITLE
azure/macos: Fix for brew/ant install failing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,6 +207,8 @@ jobs:
         brew tap facebook/fb
         brew upgrade
         brew cask install adoptopenjdk8
+        # See https://github.com/Homebrew/homebrew-core/pull/44581 where a longer-term fix is being discussed.
+        sed -i.bak 's/www.apache.org\/dyn\/closer.cgi?path=/archive.apache.org\/dist\//' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/ant.rb
         brew install buck watchman
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,11 +204,10 @@ jobs:
 
     steps:
     - script: |
+        brew update
         brew tap facebook/fb
         brew upgrade
-        brew cask install adoptopenjdk8
-        # See https://github.com/Homebrew/homebrew-core/pull/44581 where a longer-term fix is being discussed.
-        sed -i.bak 's/www.apache.org\/dyn\/closer.cgi?path=/archive.apache.org\/dist\//' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/ant.rb
+        brew cask install adoptopenjdk
         brew install buck watchman
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20


### PR DESCRIPTION
~~We'll want to revisit this in the near future, but for now the CI is broken due to `ant` and `bcel` being removed from Apache's mirrors.~~

Edit: This adds a `brew update` to the macOS Buck job.