### PR TITLE
Upgrade Python tools to Python3 

### DIFF
--- a/libraries/cmake/facebook/modules/api.cmake
+++ b/libraries/cmake/facebook/modules/api.cmake
@@ -10,7 +10,7 @@ function(downloadRemoteFile identifier base_url file_name hash)
   set(destination "${CMAKE_CURRENT_BINARY_DIR}/${file_name}")
   set(url "${base_url}/${file_name}")
 
-  set(command_prefix "${EX_TOOL_PYTHON2_EXECUTABLE_PATH}")
+  set(command_prefix "${EX_TOOL_PYTHON3_EXECUTABLE_PATH}")
 
   add_custom_command(
     OUTPUT "${destination}"

--- a/mode/system.py
+++ b/mode/system.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import sys
@@ -98,14 +98,14 @@ def get_build_type(build_type):
     else:
         fail("Unsupported build type {}".format(build_type))
 
+class CustomArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        fail(message)
 
 if __name__ == "__main__":
 
-    class ThrowingArgumentParser(argparse.ArgumentParser):
-        def error(self, message):
-            fail(message)
 
-    parser = ThrowingArgumentParser(
+    parser = CustomArgumentParser(
         description="Automatically set the proper config files for buck. This is selected based on the platform"
     )
     parser.add_argument(

--- a/tools/analysis/fuzz.py
+++ b/tools/analysis/fuzz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
@@ -6,35 +6,26 @@
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import ast
 import os
 import random
 import subprocess
 import sys
+import argparse
 
-try:
-    import argparse
-except ImportError:
-    print("Cannot import argparse.")
-    exit(1)
+
 
 # Import the testing utils
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../tests/")
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../codegen/")
 
-import utils
 from gentable import \
-  table_name, schema, description, examples, attributes, implementation, \
-  extended_schema, fuzz_paths, \
-  WINDOWS, LINUX, POSIX, DARWIN, FREEBSD, \
-  Column, ForeignKey, table as TableState, TableState as _TableState, \
-  TEXT, DATE, DATETIME, INTEGER, BIGINT, UNSIGNED_BIGINT, DOUBLE, BLOB
-
+    table_name, schema, description, examples, attributes, implementation, \
+    extended_schema, fuzz_paths, \
+    WINDOWS, LINUX, POSIX, DARWIN, FREEBSD, \
+    Column, ForeignKey, table as TableState, TableState as _TableState, \
+    TEXT, DATE, DATETIME, INTEGER, BIGINT, UNSIGNED_BIGINT, DOUBLE, BLOB
+import utils
 
 def _fuzz_paths(shell, name, paths, query):
     cmd = [
@@ -48,7 +39,7 @@ def _fuzz_paths(shell, name, paths, query):
     cmd.append("--disable_extensions")
     cmd.append(query)
     if args.verbose:
-        print (" ".join(cmd))
+        print(" ".join(cmd))
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -58,9 +49,10 @@ def _fuzz_paths(shell, name, paths, query):
         print(stdout)
         print(stderr)
     if proc.returncode != 0:
-        print (" ".join(cmd))
+        print(" ".join(cmd))
         print(stderr)
     return proc.returncode
+
 
 def _fuzz_queries(shell, name, paths, examples=[]):
     print("Fuzzing file reads for: %s" % (name))
@@ -141,7 +133,7 @@ if __name__ == "__main__":
             if len(TableState.fuzz_paths) > 0:
                 # The table specification opted-into path-based fuzzing.
                 ret = _fuzz_queries(args.shell, TableState.table_name,
-                    TableState.fuzz_paths, TableState.examples)
+                                    TableState.fuzz_paths, TableState.examples)
                 if ret > 0:
                     exit_code = ret
                 if not args.c and ret != 0:

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import json
 import os
@@ -106,7 +101,7 @@ def check_leaks(shell, query, count=1, supp_file=None):
 
 def profile_leaks(shell, queries, count=1, rounds=1, supp_file=None):
     report = {}
-    for name, query in queries.iteritems():
+    for name, query in queries.items():
         print("Analyzing leaks in query: %s" % query)
         # Apply count (optionally run the query several times).
         summary = check_leaks(shell, query, count, supp_file)
@@ -144,14 +139,14 @@ def run_query(shell, query, timeout=0, count=1):
 
 def summary_line(name, result):
     if not args.n:
-        for key, v in result.iteritems():
+        for key, v in result.items():
             print("%s" % (
                 RANGES["colors"][v[0]]("%s:%s" % (
                     key[0].upper(), v[0]))),
                   end="")
         print(" ", end="")
     print("%s:" % name, end=" ")
-    for key, v in result.iteritems():
+    for key, v in result.items():
         print("%s: %s" % (key, v[1]), end=" ")
     print("")
 
@@ -165,7 +160,7 @@ def summary(results, display=False):
         return len(ranges)
 
     summary_results = {}
-    for name, result in results.iteritems():
+    for name, result in results.items():
         failed = "exit" in result and result["exit"] > 0
         summary_result = {}
         for key in RANGES:
@@ -186,7 +181,7 @@ def summary(results, display=False):
 
 def profile(shell, queries, timeout=0, count=1, rounds=1):
     report = {}
-    for name, query in queries.iteritems():
+    for name, query in queries.items():
         forced = True if name == "force" else False
         if not forced:
             print("Profiling query: %s" % query)
@@ -200,7 +195,7 @@ def profile(shell, queries, timeout=0, count=1, rounds=1):
             summary(
                 {"%s (%d/%d)" % (name, i + 1, rounds): result}, display=True)
             # Store each result round to return an average.
-            for k, v in result.iteritems():
+            for k, v in result.items():
                 results[k] = results.get(k, [])
                 results[k].append(v)
         average_results = {}

--- a/tools/analysis/stress.py
+++ b/tools/analysis/stress.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import sys
 import shutil
@@ -111,7 +106,7 @@ def stress(args):
     """Small utility to run unittests several times."""
     times = []
     test = args["run"] if args["run"] is not None else ["make", "test"]
-    for i in xrange(args["num"]):
+    for i in range(args["num"]):
         if args["audit"]:
             times.append(audit(args))
         else:

--- a/tools/analysis/system_stress.py
+++ b/tools/analysis/system_stress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
@@ -54,7 +54,7 @@ def init(e, po, n, j, l, count):
         return
 
     procs = []
-    for i in xrange(n):
+    for i in range(n):
         p = Process(target=init, args=(e, po, n, j + i + 1, l, count))
         p.start()
         procs.append(p)
@@ -86,7 +86,7 @@ def main(args):
 
     c = Value('i', 0)
     l = Lock()
-    for i in xrange(args.n):
+    for i in range(args.n):
         init(e, args.p, args.n, i, l, c)
     print("Executed %d (default shell) processes" % c.value)
     return 0

--- a/tools/cmake/downloader.py
+++ b/tools/cmake/downloader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-import urllib3
+from urllib.request import urlopen
 import hashlib
 
 def main(argc, argv):
@@ -14,9 +14,8 @@ def main(argc, argv):
   expected_hash = argv[3]
 
   try:
-    print("Downloading...")
-    http = urllib3.PoolManager()
-    response = http.request('GET', url)
+    print("Downloading...") 
+    response = urlopen(url)
 
     with open(destination_file, "wb") as f:
       f.write(response.data)

--- a/tools/cmake/downloader.py
+++ b/tools/cmake/downloader.py
@@ -18,7 +18,7 @@ def main(argc, argv):
     response = urlopen(url)
 
     with open(destination_file, "wb") as f:
-      f.write(response.data)
+      f.write(response.read())
 
   except Exception as e:
     print("Failed to retrieve the file from the given url")

--- a/tools/cmake/downloader.py
+++ b/tools/cmake/downloader.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
-import urllib2
+import urllib3
 import hashlib
 
 def main(argc, argv):
   if argc != 4:
-    print "Usage:\n\t%s https://url/to/file.txt /path/to/destination/file.txt <expected_sha256_hash>" % (argv[0])
+    print("Usage:\n\t{} https://url/to/file.txt /path/to/destination/file.txt <expected_sha256_hash>".format(argv[0]))
     return 1
 
   url = argv[1]
@@ -14,27 +14,29 @@ def main(argc, argv):
   expected_hash = argv[3]
 
   try:
-    print "Downloading..."
-    response = urllib2.urlopen(url)
+    print("Downloading...")
+    http = urllib3.PoolManager()
+    response = http.request('GET', url)
+
     with open(destination_file, "wb") as f:
-      f.write(response.read())
+      f.write(response.data)
 
   except Exception as e:
-    print "Failed to retrieve the file from the given url"
-    print str(e)
+    print("Failed to retrieve the file from the given url")
+    print(str(e))
     return 1
 
-  print "Verifying the file hash..."
+  print("Verifying the file hash...")
   file_hash = get_file_hash(destination_file)
   if file_hash == None:
-    print "Failed to compute the file hash"
+    print("Failed to compute the file hash")
     return 1
 
-  if file_hash <> expected_hash:
-    print "The downloaded file seems to be corrupted"
+  if file_hash != expected_hash:
+    print("The downloaded file seems to be corrupted")
     return 1
 
-  print "The file has been successfully downloaded!"
+  print("The file has been successfully downloaded!")
   return 0
 
 def get_file_hash(path):

--- a/tools/codegen/amalgamate.py
+++ b/tools/codegen/amalgamate.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import jinja2

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import ast
@@ -73,7 +68,7 @@ class Encoder(json.JSONEncoder):
     """
 
     def __init__(self, *args, **kwargs):
-        super(Encoder, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.kwargs = dict(kwargs)
         del self.kwargs['indent']
         self._replacement_map = {}
@@ -88,7 +83,7 @@ class Encoder(json.JSONEncoder):
 
     def encode(self, o):
         result = super(Encoder, self).encode(o)
-        for k, v in self._replacement_map.iteritems():
+        for k, v in self._replacement_map.items():
             result = result.replace('"@@%s@@"' % (k,), v)
         return result
 
@@ -145,7 +140,7 @@ def gen_diff(api_old_path, api_new_path):
     tables_removed = []
     columns_added = []
     columns_removed = []
-    for name, table in new_tables.iteritems():
+    for name, table in new_tables.items():
         if name not in old_tables:
             tables_added.append(name)
             continue
@@ -155,7 +150,7 @@ def gen_diff(api_old_path, api_new_path):
                 columns_added.append("%s:%s:%s:%s" % (category["name"],
                                                       table["name"], column["name"], column["type"]))
 
-    for name, table in old_tables.iteritems():
+    for name, table in old_tables.items():
         if name not in new_tables:
             tables_removed.append(name)
             continue
@@ -216,7 +211,7 @@ def gen_api(tables_path, profile={}):
                                                            blacklist=blacklist)
                 categories[platform]["tables"].append(table_spec)
     categories = [{"key": k, "name": v["name"], "tables": v["tables"]}
-                  for k, v in categories.iteritems()]
+                  for k, v in categories.items()]
     return categories
 
 

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import ast

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -398,7 +398,6 @@ def implementation(impl_string, generator=False):
     """
     define the path to the implementation file and the function which
     implements the virtual table. You should use the following format:
-
       # the path is "osquery/table/implementations/foo.cpp"
       # the function is "QueryData genFoo();"
       implementation("foo@genFoo")

--- a/tools/codegen/gentable/gentable.py
+++ b/tools/codegen/gentable/gentable.py
@@ -1,1 +1,0 @@
-/Users/adhaamehab/Documents/workspace/personal/osquery/tools/codegen/gentable.py

--- a/tools/codegen/gentable/gentable.py
+++ b/tools/codegen/gentable/gentable.py
@@ -1,0 +1,1 @@
+/Users/adhaamehab/Documents/workspace/personal/osquery/tools/codegen/gentable.py

--- a/tools/codegen/gentable/osquery/tools/tests/utils.py
+++ b/tools/codegen/gentable/osquery/tools/tests/utils.py
@@ -1,1 +1,0 @@
-/Users/adhaamehab/Documents/workspace/personal/osquery/tools/tests/utils.py

--- a/tools/codegen/gentable/osquery/tools/tests/utils.py
+++ b/tools/codegen/gentable/osquery/tools/tests/utils.py
@@ -1,0 +1,1 @@
+/Users/adhaamehab/Documents/workspace/personal/osquery/tools/tests/utils.py

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import argparse

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
@@ -16,11 +16,6 @@ Usage:
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import json
 import os

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
@@ -13,11 +13,6 @@ Usage:
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import io

--- a/tools/deployment/getfiles.py
+++ b/tools/deployment/getfiles.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import json
 import os

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/formatting/git-clang-format.py
+++ b/tools/formatting/git-clang-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #===- git-clang-format - ClangFormat Git Integration ---------*- python -*--===#
 #
@@ -348,7 +348,7 @@ def run_clang_format_and_save_to_tree(changed_lines, binary='clang-format',
 
     Returns the object ID (SHA-1) of the created tree."""
     def index_info_generator():
-        for filename, line_ranges in changed_lines.iteritems():
+        for filename, line_ranges in changed_lines.items():
             mode = oct(os.stat(filename).st_mode)
             blob_id = clang_format_to_blob(filename, line_ranges, binary=binary,
                                            style=style)

--- a/tools/formatting/git-clang-format.py
+++ b/tools/formatting/git-clang-format.py
@@ -124,7 +124,7 @@ def main():
     commit, files = interpret_args(opts.args, dash_dash, opts.commit)
 
     if len(files) > 0 and opts.exclude_folders:
-        print 'The --exclude-folders option cannot be used when specifying files to format'
+        print('The --exclude-folders option cannot be used when specifying files to format')
         return
 
     changed_lines = compute_diff_and_extract_lines(commit, files)

--- a/tools/formatting/git-clang-format.py
+++ b/tools/formatting/git-clang-format.py
@@ -9,7 +9,7 @@
 #
 #===------------------------------------------------------------------------===#
 
-r"""
+"""
 clang-format git integration
 ============================
 
@@ -123,7 +123,7 @@ def main():
 
     commit, files = interpret_args(opts.args, dash_dash, opts.commit)
 
-    if len(files) > 0 and opts.exclude_folders:
+    if files and opts.exclude_folders:
         print('The --exclude-folders option cannot be used when specifying files to format')
         return
 
@@ -133,21 +133,21 @@ def main():
 
     filter_by_extension(changed_lines, opts.extensions.lower().split(','))
 
-    if len(opts.exclude_folders) > 0:
+    if opts.exclude_folders:
         filter_by_path(changed_lines, opts.exclude_folders.split(','))
 
     if opts.verbose >= 1:
         ignored_files.difference_update(changed_lines)
         if ignored_files:
-            print 'Ignoring changes in the following files (wrong extension):'
+            print('Ignoring changes in the following files (wrong extension):')
             for filename in ignored_files:
-                print '   ', filename
+                print('   ', filename)
         if changed_lines:
-            print 'Running clang-format on the following files:'
+            print('Running clang-format on the following files:')
             for filename in changed_lines:
-                print '   ', filename
+                print('   ', filename)
     if not changed_lines:
-        print 'no modified files to format'
+        print('no modified files to format')
         return
     # The computed diff outputs absolute paths, so we must cd before accessing
     # those files.
@@ -157,20 +157,20 @@ def main():
                                                  binary=opts.binary,
                                                  style=opts.style)
     if opts.verbose >= 1:
-        print 'old tree:', old_tree
-        print 'new tree:', new_tree
+        print('old tree:', old_tree)
+        print('new tree:', new_tree)
     if old_tree == new_tree:
         if opts.verbose >= 0:
-            print 'clang-format did not modify any files'
+            print('clang-format did not modify any files')
     elif opts.diff:
         print_diff(old_tree, new_tree)
     else:
         changed_files = apply_changes(old_tree, new_tree, force=opts.force,
                                       patch_mode=opts.patch)
         if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
-            print 'changed files:'
+            print('changed files:')
             for filename in changed_files:
-                print '   ', filename
+                print('   ', filename)
 
 
 def load_git_config(non_string_options=None):

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import re

--- a/tools/hooks/pre-commit.py
+++ b/tools/hooks/pre-commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os

--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import shutil

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -1,16 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-# pyexpect.replwrap will not work with unicode_literals
-# from __future__ import unicode_literals
 
 import copy
 import getpass
@@ -147,13 +141,13 @@ class OsqueryWrapper(REPLWrapper):
             options[option] = args[option]
         options["database_path"] += str(random.randint(1000, 9999))
         command = command + " " + " ".join(
-            ["--%s=%s" % (k, v) for k, v in options.iteritems()])
+            ["--%s=%s" % (k, v) for k, v in options.items()])
         if os.name == "nt":
             proc = WinExpectSpawn(command, env=env)
         else:
             proc = pexpect.spawn(command, env=env)
 
-        super(OsqueryWrapper, self).__init__(
+        super().__init__(
             proc,
             self.PROMPT,
             None,

--- a/tools/tests/test_example_queries.py
+++ b/tools/tests/test_example_queries.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import json
 import os

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import glob
 import os

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import base64

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import signal

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -1,16 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-# pyexpect.replwrap will not work with unicode_literals
-# from __future__ import unicode_literals
 
 import os
 import random

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import os

--- a/tools/tests/test_windows_service.py
+++ b/tools/tests/test_windows_service.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import re
 import os

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import json
 import os
@@ -87,20 +82,20 @@ def queries_from_config(config_path):
         exit(1)
     queries = {}
     if "schedule" in config:
-        for name, details in config["schedule"].iteritems():
+        for name, details in config["schedule"].items()
             queries[name] = details["query"]
     if "packs" in config:
-        for keys,values in config["packs"].iteritems():
+        for keys,values in config["packs"].items()
             # Check if it is an internal pack definition
             if type(values) is dict:
-                for queryname, query in values["queries"].iteritems():
+                for queryname, query in values["queries"].items()
                     queries["pack_" + queryname] = query["query"]
             else:
                 with open(values) as fp:
                     packfile = fp.read()
                     packcontent = rmcomment.sub('', packfile)
                     packqueries = json.loads(packcontent)
-                    for queryname, query in packqueries["queries"].iteritems():
+                    for queryname, query in packqueries["queries"].items()
                         queries["pack_" + queryname] = query["query"]
 
     return queries

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -82,20 +82,20 @@ def queries_from_config(config_path):
         exit(1)
     queries = {}
     if "schedule" in config:
-        for name, details in config["schedule"].items()
+        for name, details in config["schedule"].items():
             queries[name] = details["query"]
     if "packs" in config:
-        for keys,values in config["packs"].items()
+        for keys,values in config["packs"].items():
             # Check if it is an internal pack definition
             if type(values) is dict:
-                for queryname, query in values["queries"].items()
+                for queryname, query in values["queries"].items():
                     queries["pack_" + queryname] = query["query"]
             else:
                 with open(values) as fp:
                     packfile = fp.read()
                     packcontent = rmcomment.sub('', packfile)
                     packqueries = json.loads(packcontent)
-                    for queryname, query in packqueries["queries"].items()
+                    for queryname, query in packqueries["queries"].items():
                         queries["pack_" + queryname] = query["query"]
 
     return queries

--- a/tools/tests/winexpect.py
+++ b/tools/tests/winexpect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
@@ -50,7 +50,7 @@ class REPLWrapper(object):
             self.child.proc.stdin.flush()
 
             # Wait for stderr/stdout to populate for at most timeout seconds
-            for i in xrange(self.timeout):
+            for i in range(self.timeout):
                 if not self.child.out_queue.empty():
                     break
                 time.sleep(1)


### PR DESCRIPTION
### A work in progress PR
This PR fixes #5762 

Note: Commits will be squashed after all the changes are done!
 
- [x] The Python shebang lines should be #!/usr/bin/env python3 unless the code is compatible with both Python 2.x and 3.x. If our script says it requires Python2 but the shebang line just says python, it will fail if the system resolves that to Python 3.
Python in the osquery build and test systems:

 - [x] osquery/tools/analysis/*
 - [x] osquery/tools/build_defs/oss/osquery/*
 - [x] osquery/tools/codegen/*
 - [x] osquery/tools/deployment/*
- [x] osquery/tools/get_platform.py
 - [x] osquery/tools/hooks/pre_commit.py
 - [x] osquery/tools/tests/*
 - [x] osquery/tools/cmake/downloader.py
 - [x] osquery/tools/formatting/*
