### PR TITLE
CMake: Improve submodule patching system

### DIFF
--- a/libraries/cmake/source/googletest/CMakeLists.txt
+++ b/libraries/cmake/source/googletest/CMakeLists.txt
@@ -27,7 +27,7 @@ function(googleTestMain)
     set("${option_name}" true CACHE BOOL "" FORCE)
   endforeach()
 
-  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set(library_root "${OSQUERY_googletest_ROOT_DIR}")
   add_subdirectory("${library_root}" "${CMAKE_CURRENT_BINARY_DIR}/submodule" EXCLUDE_FROM_ALL)
 
   set(target_list

--- a/libraries/cmake/source/libudev/CMakeLists.txt
+++ b/libraries/cmake/source/libudev/CMakeLists.txt
@@ -7,7 +7,7 @@
 # http://pkgs.fedoraproject.org/repo/pkgs/udev/udev-173.tar.bz2/91a88a359b60bbd074b024883cc0dbde/udev-173.tar.bz2
 
 function(libudevMain)
-  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set(library_root "${OSQUERY_libudev_ROOT_DIR}")
 
   add_library(thirdparty_libudev
     "${library_root}/libudev/libudev-device-private.c"

--- a/libraries/cmake/source/modules/Findgoogletest.cmake
+++ b/libraries/cmake/source/modules/Findgoogletest.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )

--- a/libraries/cmake/source/modules/Findlibudev.cmake
+++ b/libraries/cmake/source/modules/Findlibudev.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )

--- a/libraries/cmake/source/modules/Findthrift.cmake
+++ b/libraries/cmake/source/modules/Findthrift.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )

--- a/libraries/cmake/source/modules/Findutil-linux.cmake
+++ b/libraries/cmake/source/modules/Findutil-linux.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )

--- a/libraries/cmake/source/modules/utils.cmake
+++ b/libraries/cmake/source/modules/utils.cmake
@@ -78,9 +78,10 @@ function(patchSubmoduleSourceCode patches_dir source_dir apply_to_dir)
   endif()
 
 
-  # We patch in source before moving because git apply won't apply the patch if the directory
-  # is in it's the correct one, but it's inside a repository and it's not the root of that.
-  # This happens when the build folder is inside the source folder.
+  # We patch the submodule before moving it to the binary folder
+  # because if git apply working directory is inside a repository or submodule
+  # and it's not its root directory, patching will fail silently.
+  # This can happen for instance when the build directory is inside the source directory.
   foreach(patch ${submodule_patches})
     execute_process(
       COMMAND "${GIT_EXECUTABLE}" apply "${patch}"

--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -4,8 +4,8 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 
-function(thrifMain)
-  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/cpp")
+function(thriftMain)
+  set(library_root "${OSQUERY_thrift_ROOT_DIR}/lib/cpp")
 
   add_library(thirdparty_thrift
     # libthrift
@@ -111,4 +111,4 @@ function(thrifMain)
   )
 endfunction()
 
-thrifMain()
+thriftMain()

--- a/libraries/cmake/source/util-linux/CMakeLists.txt
+++ b/libraries/cmake/source/util-linux/CMakeLists.txt
@@ -9,7 +9,7 @@ function(utillinuxMain)
     return()
   endif()
 
-  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set(library_root "${OSQUERY_util-linux_ROOT_DIR}")
 
   add_library(thirdparty_util-linux
     "${library_root}/libblkid/src/getsize.c"


### PR DESCRIPTION
Keep patched source in the build directory instead of the source.

A new variable with the format OSQUERY_<submodule name>_ROOT_DIR
is set to the directory of where the submodule is, in case it's patched.

A new option PATCH has been added to importSourceModule
to let the patching system know that the submodule has to be patched
and which is the main submodule folder.
