### PR TITLE
Restore extension SDK support to osquery 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ cscope.out
 
 # Ignored components
 /external/*
+!/external/cmake/cmakelibs.cmake
 !/external/CMakeLists.txt
 
 # Buck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ function(main)
   add_subdirectory("plugins")
   add_subdirectory("tools")
   add_subdirectory("specs")
+  add_subdirectory("external")
   add_subdirectory("tests")
 
   identifyPackagingSystem()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+# - osquery external project builds
+# Symlink directories for extensions or modules here.
+# If a directory includes: "extension_NAME" it is built as an extension.
+# If a directory includes: "module_NAME" it is built as a module.
+
+add_custom_target(externals)
+
+include(cmake/cmakelibs.cmake)
+
+set(EXTERNALS_DIR "${CMAKE_SOURCE_DIR}/external")
+
+add_library(external_options INTERFACE)
+target_compile_options(external_options INTERFACE -DOSQUERY_EXTERNAL)
+
+function(subdirlist output path)
+  file(GLOB children RELATIVE ${path} "${path}/*")
+  set(DIRS "")
+  foreach(child ${children})
+    get_filename_component(full_child "${path}/${child}" REALPATH)
+    if(IS_DIRECTORY "${full_child}")
+      list(APPEND DIRS "${path}/${child}")
+    elseif(NOT "${child}" STREQUAL "CMakeLists.txt")
+      message(WARNING "External project: ${full_child} must be a directory")
+    endif()
+  endforeach()
+  set(${output} ${DIRS} PARENT_SCOPE)
+endfunction()
+
+function(externalsMain)
+  # Discover the implementation for extensions or modules in external directory
+  subdirlist(EXTERNAL_PROJECTS ${EXTERNALS_DIR})
+
+  # Each project may:
+  #   1. Be named "external_PROJECT_NAME", all .cpp, .c, .mm files will be compiled.
+  #   2. Be named "module_PROJECT_NAME", the same applies.
+  #   3. Contain a "CMakeLists.txt", the project will be added to CMake's evaluation.
+  foreach(external_project ${EXTERNAL_PROJECTS})
+    get_filename_component(PROJECT_NAME "${external_project}" NAME)
+    # check for the cmake having utilities functions
+    if(${PROJECT_NAME} MATCHES "cmake")
+      continue()
+    endif()
+    if(EXISTS "${external_project}/CMakeLists.txt")
+      add_subdirectory("${external_project}")
+    else()
+      file(GLOB_RECURSE PROJECT_FILES "${external_project}/*")
+      set(PROJECT_SOURCES "")
+      foreach(source ${PROJECT_FILES})
+        if(${source} MATCHES "^.*(cpp|c|mm)$")
+          list(APPEND PROJECT_SOURCES ${source})
+        endif()
+      endforeach()
+      if("${PROJECT_NAME}" MATCHES "(^extension_.*)")
+        addOsqueryExtension(external_${PROJECT_NAME} ${PROJECT_SOURCES})
+        add_dependencies(externals external_${PROJECT_NAME})
+      elseif("${PROJECT_NAME}" MATCHES "(^module_.*)")
+        addOsqueryModule(external_${PROJECT_NAME} ${PROJECT_SOURCES})
+        add_dependencies(externals external_${PROJECT_NAME})
+      else()
+        message(WARNING "External project: ${external_project} is incorrectly named")
+      endif()
+    endif()
+  endforeach()
+endfunction()
+
+externalsMain()

--- a/external/cmake/cmakelibs.cmake
+++ b/external/cmake/cmakelibs.cmake
@@ -1,0 +1,173 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+# This function takes the global properties saved by addOsqueryExtensionEx and 
+# generates a single extension executable containing all the user code
+function(generateOsqueryExtensionGroup)
+  get_property(extension_source_files GLOBAL PROPERTY OSQUERY_EXTENSION_GROUP_SOURCES)
+  if("${extension_source_files}" STREQUAL "")
+    return()
+  endif()
+
+  if(DEFINED ENV{OSQUERY_EXTENSION_GROUP_NAME} OR ENV{OSQUERY_EXTENSION_GROUP_VERSION})
+    message(WARNING "ENV {OSQUERY_EXTENSION_GROUP_NAME/VERSION} has been deprecated. Please set cache variable!")
+  endif()
+
+  set(OSQUERY_EXTENSION_GROUP_NAME "osquery_extension_group" CACHE STRING "Overrides osquery extension group name")
+
+  set(OSQUERY_EXTENSION_GROUP_VERSION "1.0" CACHE STRING "Overrides osquery extension group version")
+  
+  # Build the include list; this contains the files required to declare
+  # the classes used in the REGISTER_EXTERNAL directives
+  # Note: The variables in uppercase are used by the template
+  get_property(main_include_list GLOBAL PROPERTY OSQUERY_EXTENSION_GROUP_MAIN_INCLUDES)
+  foreach(include_file ${main_include_list})
+    set(OSQUERY_EXTENSION_GROUP_INCLUDES "${OSQUERY_EXTENSION_GROUP_INCLUDES}\n#include <${include_file}>")
+  endforeach()
+
+  # We need to generate the main.cpp file, containing all the required REGISTER_EXTERNAL directives
+  get_property(OSQUERY_EXTENSION_GROUP_INITIALIZERS GLOBAL PROPERTY OSQUERY_EXTENSION_GROUP_INITIALIZERS)
+  configure_file(
+    "${CMAKE_SOURCE_DIR}/tools/codegen/templates/osquery_extension_group_main.cpp.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/osquery_extension_group_main.cpp"
+  )
+
+  # Extensions can no longer control which compilation flags to use here (as they are shared) so
+  # we are going to enforce sane defaults
+  if(DEFINED PLATFORM_POSIX)
+    set(extension_cxx_flags -DBOOST_ASIO_DISABLE_STD_STRING_VIEW)
+  else()
+    set(extension_cxx_flags /W4)
+  endif()
+
+  # Generate the extension target
+  add_executable("${OSQUERY_EXTENSION_GROUP_NAME}"
+    "${CMAKE_CURRENT_BINARY_DIR}/osquery_extension_group_main.cpp"
+    ${extension_source_files}
+  )
+
+  set_property(TARGET "${OSQUERY_EXTENSION_GROUP_NAME}" PROPERTY INCLUDE_DIRECTORIES "")
+  target_compile_options("${OSQUERY_EXTENSION_GROUP_NAME}" PRIVATE ${extension_cxx_flags})
+
+  target_link_libraries("${OSQUERY_EXTENSION_GROUP_NAME}" PUBLIC
+    osquery_sdk_pluginsdk
+    osquery_extensions_implthrift
+    thirdparty_boost
+    osquery_cxx_settings
+    external_options
+  )
+  
+  if(DEFINED PLATFORM_LINUX)
+    target_link_libraries("${OSQUERY_EXTENSION_GROUP_NAME}" PUBLIC
+      thirdparty_libiptc
+    )
+  endif()
+
+  set_target_properties("${OSQUERY_EXTENSION_GROUP_NAME}" PROPERTIES
+    OUTPUT_NAME "${OSQUERY_EXTENSION_GROUP_NAME}.ext"
+  )
+
+  get_property(include_folder_list GLOBAL PROPERTY OSQUERY_EXTENSION_GROUP_INCLUDE_FOLDERS)
+  if(NOT "${include_folder_list}" STREQUAL "")
+    target_include_directories("${OSQUERY_EXTENSION_GROUP_NAME}" PRIVATE ${include_folder_list})
+  endif()
+
+  # Apply the user (extension) settings
+  get_property(library_list GLOBAL PROPERTY OSQUERY_EXTENSION_GROUP_LIBRARIES)
+  if(NOT "${library_list}" STREQUAL "")
+    target_link_libraries("${OSQUERY_EXTENSION_GROUP_NAME}" PUBLIC ${library_list})
+  endif()
+endfunction()
+
+function(addOsqueryExtensionEx class_name extension_type extension_name ${ARGN})
+  # Make sure the extension type is valid
+  if(NOT "${extension_type}" STREQUAL "config" AND NOT "${extension_type}" STREQUAL "table")
+    message(FATAL_ERROR "Invalid extension type specified")
+  endif()
+
+  # Update the initializer list; this will be added to the main.cpp file of the extension group
+  set_property(GLOBAL APPEND_STRING PROPERTY
+    OSQUERY_EXTENSION_GROUP_INITIALIZERS
+    "REGISTER_EXTERNAL(${class_name}, \"${extension_type}\", \"${extension_name}\");\n"
+  )
+
+  # Loop through each argument
+  foreach(argument ${ARGN})
+    if("${argument}" STREQUAL "SOURCES" OR "${argument}" STREQUAL "LIBRARIES" OR
+      "${argument}" STREQUAL "INCLUDEDIRS" OR "${argument}" STREQUAL "MAININCLUDES")
+      set(current_scope "${argument}")
+      continue()
+    endif()
+
+    if("${current_scope}" STREQUAL "SOURCES")
+      if(NOT IS_ABSOLUTE "${argument}")
+        set(argument "${CMAKE_CURRENT_SOURCE_DIR}/${argument}")
+      endif()
+      list(APPEND source_file_list "${argument}")
+
+    elseif("${current_scope}" STREQUAL "INCLUDEDIRS")
+      if(NOT IS_ABSOLUTE "${argument}")
+        set(argument "${CMAKE_CURRENT_SOURCE_DIR}/${argument}")
+      endif()
+      list(APPEND include_folder_list "${argument}")
+
+    elseif("${current_scope}" STREQUAL "LIBRARIES")
+      list(APPEND library_list "${argument}")
+
+    elseif("${current_scope}" STREQUAL "MAININCLUDES")
+      list(APPEND main_include_list "${argument}")
+    else()
+      message(FATAL_ERROR "Invalid scope")
+    endif()
+  endforeach()
+
+  # Validate the arguments
+  if("${source_file_list}" STREQUAL "")
+    message(FATAL_ERROR "Source files are missing")
+  endif()
+
+  if("${main_include_list}" STREQUAL "")
+    message(FATAL_ERROR "The main include list is missing")
+  endif()
+
+  # Update the global properties
+  set_property(GLOBAL APPEND PROPERTY OSQUERY_EXTENSION_GROUP_SOURCES
+    ${source_file_list}
+  )
+
+  set_property(GLOBAL APPEND PROPERTY OSQUERY_EXTENSION_GROUP_MAIN_INCLUDES
+    ${main_include_list}
+  )
+
+  if(NOT "${library_list}" STREQUAL "")
+    set_property(GLOBAL APPEND PROPERTY OSQUERY_EXTENSION_GROUP_LIBRARIES
+      ${library_list}
+    )
+  endif()
+
+  if(NOT "${include_folder_list}" STREQUAL "")
+    set_property(GLOBAL APPEND PROPERTY OSQUERY_EXTENSION_GROUP_INCLUDE_FOLDERS
+      ${include_folder_list}
+    )
+  endif()
+endfunction()
+
+function(add_osquery_extension_ex class_name extension_type extension_name ${ARGN})
+  message(WARNING "add_osquery_extension_ex has been deprecated. Please use addOsqueryExtensionEx!")
+  addOsqueryExtensionEx(${class_name} ${extension_type} ${extension_name} ${ARGN})
+endfunction()
+
+function(addOsqueryExtension TARGET)
+  add_executable(${TARGET} ${ARGN})
+  set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME "${TARGET}.ext")
+  target_compile_options(${TARGET} PRIVATE -DOSQUERY_EXTERNAL)
+endfunction()
+
+function(addOsqueryModule TARGET)
+  add_library(${TARGET} STATIC ${ARGN})
+  set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET})
+  target_compile_options(${TARGET} PRIVATE -DOSQUERY_EXTERNAL)
+endfunction()

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -41,6 +41,10 @@ function(boostMain)
     thirdparty_boost_uuid
     thirdparty_boost_beast
     thirdparty_boost_xpressive
+    thirdparty_boost_process
+    thirdparty_boost_iostreams
+    thirdparty_boost_winapi
+    thirdparty_boost_circularbuffer
   )
 
   find_package(icu REQUIRED)
@@ -243,6 +247,10 @@ function(importBoostInterfaceLibraries)
     "lexical_cast:range,numeric_conversion,integer,array,container,math"
     "system:config"
     "tuple:config"
+    "process:config"
+    "circular_buffer:config"
+    "winapi:config"
+    "iostreams:config"
   )
 
   add_library(thirdparty_boost_config INTERFACE)

--- a/libraries/cmake/source/modules/Findboost.cmake
+++ b/libraries/cmake/source/modules/Findboost.cmake
@@ -83,4 +83,8 @@ importSourceSubmodule(
     "src/libs/serialization"
     "src/libs/random"
     "src/libs/config"
+    "src/libs/process"
+    "src/libs/circular_buffer"
+    "src/libs/winapi"
+    "src/libs/iostreams"
 )

--- a/tools/codegen/templates/osquery_extension_group_main.cpp.in
+++ b/tools/codegen/templates/osquery_extension_group_main.cpp.in
@@ -6,7 +6,7 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <osquery/sdk.h>
+#include <osquery/sdk/sdk.h>
 #include <osquery/system.h>
 
 using namespace osquery;


### PR DESCRIPTION
Restore the extension SDK support which was lost during refactoring. The changes include the CMake library functions and external directory for the extension source code.  

It also updates the library descriptor list for the boost. The changes follow the external extensions build process as documented.
https://osquery.readthedocs.io/en/stable/development/osquery-sdk/
