### PR TITLE
Temporarily disable Buck tests on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,9 +100,11 @@ jobs:
       displayName: "Build osquery"
 
     - script: |
-        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-        buck test @mode/linux-x86_64/release osquery/... tests/... plugins/...
-      displayName: "Run tests"
+        # Buck compiles these tests in Debug mode, exhausting disk space.
+        # Until we find a solution, we'll disable the tests.
+        #export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        #buck test @mode/linux-x86_64/release osquery/... tests/... plugins/...
+      displayName: "Run tests (DISABLED)"
 
     - script: |
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"


### PR DESCRIPTION
Buck compiles tests in Debug mode even if supposedly told otherwise,
this exhausts disk space available on the CI and makes the step always fail.