### PR TITLE
Improve error reporting from extension manager

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -651,13 +651,15 @@ void Initializer::start() const {
   // internal 'shutdown' method.
   auto s = osquery::startExtensionManager();
   if (!s.ok()) {
-    auto severity = (Watcher::get().hasManagedExtensions()) ? google::GLOG_ERROR
-                                                            : google::GLOG_INFO;
+    auto error_message =
+        "An error occured during extension manager startup: " + s.getMessage();
+    auto severity =
+        (FLAGS_disable_extensions) ? google::GLOG_INFO : google::GLOG_ERROR;
     if (severity == google::GLOG_INFO) {
-      VLOG(1) << "Cannot start extension manager: " + s.getMessage();
+      VLOG(1) << error_message;
     } else {
       google::LogMessage(__FILE__, __LINE__, severity).stream()
-          << "Cannot start extension manager: " + s.getMessage();
+          << error_message;
     }
   }
 


### PR DESCRIPTION
Change the message that is logged when a required extension is not
loaded or found from "Extension not autoloaded: <extension id>" to
"Required extension not found or not loaded: <extension id>".

Change the message that is logged when the extension manager have an
error happening during startup from "Cannot start extension manager:
<error>" to "An error occured during extension manager startup: <error>"

Add the possibility of startExtensionManager returning with an error
if the Dispatcher failed to properly add the ExtensionManagerWatcher
or ExtensionManagerRunner.

Fallback to logging the startExtensionManager error message with a
serverity of INFO only if extensions are required to be disabled.

Add tests for starting the extension manager with a nonexistent
socket path and a nonexistent required extension.

Issue osquery/osquery#5679

Reasoning:
For the two error messages, they were not actually referring to the part that was failing, so I've corrected it.
Specifically for the startExtensionManager returning an error, the reasoning is that the extension manager in some cases actually runs fine, it's the additional request to be sure that some extensions are loaded that fails, but this doesn't stop extensions or the extension manager to work.
Moreover the cases where the extension manager would actually not be working weren't tracked.

For the severity change, I'm not 100% sure what was the intention previously, but I feel like that any error returning from startExtensionManager has to be treated as an error, because even when mistyping a required extension id, the program wasn't able to do what the user requested.
It makes sense to log to INFO if the extensions are disabled, and so the user is not interested in failures from its framework.
