### PR TITLE
Fix regression in calling core only plugins from extensions

### DIFF
--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -126,9 +126,6 @@ RegistryRoutes RegistryInterface::getRoutes() const {
 Status RegistryInterface::call(const std::string& item_name,
                                const PluginRequest& request,
                                PluginResponse& response) {
-  if (item_name.empty()) {
-    return Status::failure("No registry item name specified");
-  }
   PluginRef plugin;
   {
     ReadLock lock(mutex_);


### PR DESCRIPTION
PR osquery/osquery#5464 makes it impossible to call plugins
which are only registered in the core, as its happening with osquery/osquery#5839.

What happens when this is working is that the filesystem plugin is not present
in the extension registry, so when Registry::call tries to search for a plugin
that provides the "config" feature, it won't find one and the resulting plugin name,
and later item_name, will be empty.
This results in the RegistryInterface::call reroute the call to the core,
through Thrift, which will end up in the plugin correctly answering.

It's not clear though what issue exactly PR osquery/osquery#5464 was trying to solve (do we have any way to know more about it?).
At the same time it's indeed not clear why an empty item_name is accepted and why the extension registry could not contain the plugins provided by the core, plus the information that those are in the core.