### PR TITLE
[shell] support previously supported on|off toggle for osqueryi shell functions

### DIFF
--- a/osquery/utils/conversions/tryto.cpp
+++ b/osquery/utils/conversions/tryto.cpp
@@ -17,38 +17,38 @@ namespace osquery {
 namespace impl {
 
 Expected<bool, ConversionError> stringToBool(std::string from) {
- static const auto table = std::unordered_map<std::string, bool>{
-     {"1", true},
-     {"0", false},
-     {"y", true},
-     {"yes", true},
-     {"n", false},
-     {"no", false},
-     {"t", true},
-     {"true", true},
-     {"f", false},
-     {"false", false},
-     {"ok", true},
-     {"disable", false},
-     {"enable", true},
-     {"on", true},
-     {"off", false},
- };
- using CharType = std::string::value_type;
- // Classic locale could be used here because all available string
- // representations of boolean have ascii encoding. It must be a bit faster.
- static const auto& ctype =
-     std::use_facet<std::ctype<CharType>>(std::locale::classic());
- for (auto& ch : from) {
-   ch = ctype.tolower(ch);
- }
- const auto it = table.find(from);
- if (it == table.end()) {
-   return createError(ConversionError::InvalidArgument)
-          << "Wrong string representation of boolean "
-          << boost::io::quoted(from);
- }
- return it->second;
+  static const auto table = std::unordered_map<std::string, bool>{
+      {"1", true},
+      {"0", false},
+      {"y", true},
+      {"yes", true},
+      {"n", false},
+      {"no", false},
+      {"t", true},
+      {"true", true},
+      {"f", false},
+      {"false", false},
+      {"ok", true},
+      {"disable", false},
+      {"enable", true},
+      {"on", true},
+      {"off", false},
+  };
+  using CharType = std::string::value_type;
+  // Classic locale could be used here because all available string
+  // representations of boolean have ascii encoding. It must be a bit faster.
+  static const auto& ctype =
+      std::use_facet<std::ctype<CharType>>(std::locale::classic());
+  for (auto& ch : from) {
+    ch = ctype.tolower(ch);
+  }
+  const auto it = table.find(from);
+  if (it == table.end()) {
+    return createError(ConversionError::InvalidArgument)
+           << "Wrong string representation of boolean "
+           << boost::io::quoted(from);
+  }
+  return it->second;
 }
 
 } // namespace impl

--- a/osquery/utils/conversions/tryto.cpp
+++ b/osquery/utils/conversions/tryto.cpp
@@ -31,6 +31,8 @@ Expected<bool, ConversionError> stringToBool(std::string from) {
      {"ok", true},
      {"disable", false},
      {"enable", true},
+     {"on", true},
+     {"off", false},
  };
  using CharType = std::string::value_type;
  // Classic locale could be used here because all available string


### PR DESCRIPTION
Previously the `osqueryi` shell supported `ON` or `OFF` as valid boolean toggles for various shell functions like `timer` or `echo`.

Currently trying to use these functions causes an error, even though the help message indicates that it is supported.

```
➜ ./osqueryd -S
Using a virtual database. Need help, type '.help'
osquery> .echo on
ERROR: Not a boolean value: "on". Assuming "no".
osquery> .timer on
ERROR: Not a boolean value: "on". Assuming "no".
osquery> .help
Welcome to the osquery shell. Please explore your OS!
You are connected to a transient 'in-memory' virtual database.


.bail ON|OFF     Stop after hitting an error
.echo ON|OFF     Turn command echo on or off
.timer ON|OFF    Turn the CPU timer measurement on or off
```

This small PR restores the original functionality.