### PR TITLE
tests: Increase reliability of interfaces test

### DIFF
--- a/tests/integration/tables/interface_addresses.cpp
+++ b/tests/integration/tables/interface_addresses.cpp
@@ -29,7 +29,7 @@ TEST_F(InterfaceAddressesTest, test_sanity) {
   auto const row_map = ValidationMap{
       {"interface", NonEmptyString},
       {"address", verifyIpAddress},
-      {"mask", verifyIpAddress},
+      {"mask", verifyEmptyStringOrIpAddress},
       {"broadcast", verifyEmptyStringOrIpAddress},
       {"point_to_point", verifyEmptyStringOrIpAddress},
       {"type",


### PR DESCRIPTION
On macOS it is possible to have interfaces that have no netmask
set, for example:

| utun1 | 100.xx.xx.xx | | | 100.xx.xx.xx     | unknown |

This causes the interfaces test to fail. This change allows the
mask field to be blank and the test to pass on systems with this
type of interface configured.

The sockaddr for this interface has an ifa_netmask with sa_family
set to zero (AF_UNSPEC) which causes getnameinfo(3) to fail.
ifconfig does return a netmask for this interface but it's not
clear if the value is at all meaningful.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.
