### PR TITLE
Restoring CLI_FLAG semantic

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -64,7 +64,7 @@ CREATE_REGISTRY(ConfigPlugin, "config");
 CREATE_LAZY_REGISTRY(ConfigParserPlugin, "config_parser");
 
 /// The config plugin must be known before reading options.
-CLI_FLAG(string, config_plugin, "filesystem", "Config plugin name");
+FLAG(string, config_plugin, "filesystem", "Config plugin name");
 
 CLI_FLAG(bool,
          config_check,
@@ -73,7 +73,7 @@ CLI_FLAG(bool,
 
 CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration");
 
-CLI_FLAG(uint64,
+FLAG(uint64,
          config_refresh,
          0,
          "Optional interval in seconds to re-read configuration");

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -115,7 +115,11 @@ std::string Flag::getDescription(const std::string& name) {
 }
 
 Status Flag::updateValue(const std::string& name, const std::string& value) {
-  if (instance().flags_.count(name) > 0) {
+  auto it = instance().flags_.find(name);
+  if (it != instance().flags_.end()) {
+    if (it->second.cli) {
+      return Status(1, "Can not override cli flag --" + name);
+    }
     flags::SetCommandLineOption(name.c_str(), value.c_str());
     return Status::success();
   } else if (instance().aliases_.count(name) > 0) {

--- a/osquery/core/tests/flags_tests.cpp
+++ b/osquery/core/tests/flags_tests.cpp
@@ -38,18 +38,26 @@ class FlagsTests : public testing::Test {
 };
 
 FLAG(string, test_string_flag, "TEST STRING", "TEST DESCRIPTION");
+CLI_FLAG(string, test_string_cli_flag, "CLI_FLAG_STRING", "Non-mutalbe CLI_FLAG test");
 
 TEST_F(FlagsTests, test_set_get) {
   // Test the core gflags functionality.
   EXPECT_EQ(FLAGS_test_string_flag, "TEST STRING");
+  EXPECT_EQ(FLAGS_test_string_cli_flag, "CLI_FLAG_STRING");
 
   // Check that the gflags flag name was recorded in the osquery flag tracker.
   auto all_flags = Flag::flags();
   EXPECT_EQ(all_flags.count("test_string_flag"), 1U);
+  EXPECT_EQ(all_flags.count("test_string_cli_flag"), 1U);
 
   // Update the value of the flag, and access through the osquery wrapper.
   FLAGS_test_string_flag = "NEW TEST STRING";
   EXPECT_EQ(Flag::getValue("test_string_flag"), "NEW TEST STRING");
+
+  // Update and access value of the flag through the osquery wrapper.
+  Flag::updateValue("test_string_cli_flag", "CLI_FLAG_STRING2");
+  // Check if value is immutable.
+  EXPECT_EQ(Flag::getValue("test_string_cli_flag"), "CLI_FLAG_STRING");
 }
 
 TEST_F(FlagsTests, test_defaults) {

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -33,7 +33,7 @@ CLI_FLAG(bool,
          "Disable enrollment functions on related config/logger plugins");
 
 /// Path to optional enrollment secret data, sent with enrollment requests.
-CLI_FLAG(string,
+FLAG(string,
          enroll_secret_path,
          "",
          "Path to an optional client enrollment-auth secret");

--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -38,7 +38,7 @@ CLI_FLAG(uint64,
          "same as [config_tls_max_attempts]");
 
 /// Enrollment TLS endpoint (path) using TLS hostname.
-CLI_FLAG(string,
+FLAG(string,
          enroll_tls_endpoint,
          "",
          "TLS/HTTPS endpoint for client enrollment");

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -24,7 +24,7 @@ namespace osquery {
 const std::string kTLSUserAgentBase = "osquery/";
 
 /// TLS server hostname.
-CLI_FLAG(string,
+FLAG(string,
          tls_hostname,
          "",
          "TLS/HTTPS hostname for Config, Logger, and Enroll plugins");
@@ -33,7 +33,7 @@ CLI_FLAG(string,
 CLI_FLAG(string, proxy_hostname, "", "Optional HTTP proxy hostname");
 
 /// Path to optional TLS server/CA certificate(s), used for pinning.
-CLI_FLAG(string,
+FLAG(string,
          tls_server_certs,
          OSQUERY_CERTS_HOME "certs.pem",
          "Optional path to a TLS server PEM certificate(s) bundle");

--- a/plugins/config/tls_config.cpp
+++ b/plugins/config/tls_config.cpp
@@ -34,7 +34,7 @@ CLI_FLAG(uint64,
          "Number of attempts to retry a TLS config request");
 
 /// Config retrieval TLS endpoint (path) using TLS hostname.
-CLI_FLAG(string,
+FLAG(string,
          config_tls_endpoint,
          "",
          "TLS/HTTPS endpoint for config retrieval");

--- a/tests/integration/tables/etc_protocols.cpp
+++ b/tests/integration/tables/etc_protocols.cpp
@@ -26,7 +26,7 @@ TEST_F(EtcProtocolsTest, test_sanity) {
   auto const row_map = ValidationMap{
       {"name", NonEmptyString},
       {"number", NonNegativeInt},
-      {"alias", NonEmptyString},
+      {"alias", NormalType},
       {"comment", NormalType},
   };
   validate_rows(rows, row_map);

--- a/tests/integration/tables/etc_protocols.cpp
+++ b/tests/integration/tables/etc_protocols.cpp
@@ -26,7 +26,7 @@ TEST_F(EtcProtocolsTest, test_sanity) {
   auto const row_map = ValidationMap{
       {"name", NonEmptyString},
       {"number", NonNegativeInt},
-      {"alias", NormalType},
+      {"alias", NonEmptyString},
       {"comment", NormalType},
   };
   validate_rows(rows, row_map);


### PR DESCRIPTION
According to functionality -
FLAG - can be set within a flagfile, as a command line switch, or via a configuration's "options" key
CLI_FLAG - can be set within a flagfile, as a command line switch, but cannot be set within configuration "options" key

But this is not the case CLI_FLAG behaved like FLAG,

Fix in this PR contains -
1. Restoring CLI_FLAG semantic
2. Some of the CLI_FLAG type flags changed to type FLAGS since before this fix both type of flags were same and changing type of those flags were required. 
3. Fix for the failed test EtcProtocolsTest.test_sanity -

91: [----------] 1 test from EtcProtocolsTest
91: [ RUN      ] EtcProtocolsTest.test_sanity
91: /home/np/programs/osquery/tests/integration/tables/helper.cpp:160: Failure
91: Value of: validate_value_using_flags(value, flags)
91:   Actual: false
91: Expected: true
91: Standard validator of the column "alias" with value "" failed
91: [  FAILED  ] EtcProtocolsTest.test_sanity (1 ms)

