### PR TITLE
macOS keychain sanity test

### DIFF
--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -55,8 +55,16 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
   // Any tag that does not exist for the item will prevent the entire result.
   for (const auto& attr_tag : kKeychainItemAttrs) {
     tags[0] = attr_tag.first;
-    SecKeychainItemCopyAttributesAndData(
+    auto status = SecKeychainItemCopyAttributesAndData(
         item, &info, &item_class, &attr_list, 0, nullptr);
+
+    if (status == errSecNoSuchAttr) {
+      // This attr does not exist, skip it.
+      continue;
+    } else if (status != errSecSuccess) {
+      // If this keychain item is not valid then don't add it to results.
+      return;
+    }
 
     if (attr_list != nullptr) {
       // Expect each specific tag to return string data.

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -55,13 +55,13 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
   // Any tag that does not exist for the item will prevent the entire result.
   for (const auto& attr_tag : kKeychainItemAttrs) {
     tags[0] = attr_tag.first;
-    auto status = SecKeychainItemCopyAttributesAndData(
+    auto os_status = SecKeychainItemCopyAttributesAndData(
         item, &info, &item_class, &attr_list, 0, nullptr);
 
-    if (status == errSecNoSuchAttr) {
+    if (os_status == errSecNoSuchAttr) {
       // This attr does not exist, skip it.
       continue;
-    } else if (status != errSecSuccess) {
+    } else if (os_status != errSecSuccess) {
       // If this keychain item is not valid then don't add it to results.
       return;
     }

--- a/tests/integration/tables/keychain_items.cpp
+++ b/tests/integration/tables/keychain_items.cpp
@@ -14,34 +14,31 @@
 namespace osquery {
 namespace table_tests {
 
-class keychainItems : public testing::Test {
+class KeychainItemsTest : public testing::Test {
  protected:
   void SetUp() override {
     setUpEnvironment();
   }
 };
 
-TEST_F(keychainItems, test_sanity) {
-  // 1. Query data
+TEST_F(KeychainItemsTest, test_sanity) {
   auto const data = execute_query("select * from keychain_items");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"label", NormalType}
-  //      {"description", NormalType}
-  //      {"comment", NormalType}
-  //      {"created", NormalType}
-  //      {"modified", NormalType}
-  //      {"type", NormalType}
-  //      {"path", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+
+  ValidationMap row_map = {
+      {"label", NormalType},
+      {"description", NormalType},
+      {"comment", NormalType},
+      {"created", NormalType},
+      {"modified", NormalType},
+      {"type",
+       SpecificValuesCheck{"password",
+                           "certificate",
+                           "symmetric key",
+                           "public key",
+                           "private key"}},
+      {"path", NonEmptyString},
+  };
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/keychain_items.cpp
+++ b/tests/integration/tables/keychain_items.cpp
@@ -23,7 +23,7 @@ class KeychainItemsTest : public testing::Test {
 
 TEST_F(KeychainItemsTest, test_sanity) {
   auto const data = execute_query("select * from keychain_items");
-
+  ASSERT_GE(data.size(), 0ul);
   ValidationMap row_map = {
       {"label", NormalType},
       {"description", NormalType},

--- a/tests/integration/tables/keychain_items.cpp
+++ b/tests/integration/tables/keychain_items.cpp
@@ -23,7 +23,7 @@ class KeychainItemsTest : public testing::Test {
 
 TEST_F(KeychainItemsTest, test_sanity) {
   auto const data = execute_query("select * from keychain_items");
-  ASSERT_GE(data.size(), 0ul);
+  ASSERT_GT(data.size(), 0ul);
   ValidationMap row_map = {
       {"label", NormalType},
       {"description", NormalType},


### PR DESCRIPTION

This adds a sanity test for the macOS keychain table. Running this test exposed an issue which was causing a number of blank rows to be returned at the end of the table. An additional patch avoids this issue by adding some more error checking to the keychain APIs used and allows the test to pass.

This PR is intended to close issue #5021 