### PR TITLE
json: Configure rapidjson to use iterative parsing

### DIFF
--- a/osquery/utils/json/json.h
+++ b/osquery/utils/json/json.h
@@ -19,6 +19,14 @@
 #pragma warning(disable : 4715)
 #endif
 
+/**
+ * This protects parsing from overflowing the stack.
+ * See http://rapidjson.org/md_doc_features.html for more details.
+ *
+ * This must be defined before including RapidJSON headers.
+ */
+#define RAPIDJSON_PARSE_DEFAULT_FLAGS (kParseIterativeFlag)
+
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/stringbuffer.h>

--- a/osquery/utils/json/tests/json.cpp
+++ b/osquery/utils/json/tests/json.cpp
@@ -228,4 +228,17 @@ TEST_F(ConversionsTests, test_json_bool_like) {
   EXPECT_FALSE(JSON::valueToBool(doc.doc()["false6"]));
 }
 
+/*
+ * By default, rapidjson will use recursive parsing without stack guards,
+ * which would result in a segfault for this test. To guard against
+ * malicious json, we should be configured to use iterative mode.
+ * https://github.com/Tencent/rapidjson/issues/632
+ */
+TEST_F(ConversionsTests, test_iterativeparsing) {
+  std::string json(543210, '[');
+  auto doc = JSON::newObject();
+
+  EXPECT_FALSE(doc.fromString(json).ok());
+}
+
 } // namespace osquery


### PR DESCRIPTION
If osquery reads a user-controlled JSON it has the potential of overflowing the stack, exhausting stack memory due to recursing and allocating too many frames.