### PR TITLE
Fix shallow clone support for libraries in recent git versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,9 +187,6 @@ jobs:
     - script: |
         brew upgrade
         brew install ccache flex bison
-        brew unlink git
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/1024ec738fe0972e467859ce55687e9e0131f83a/Formula/git.rb
-        brew switch git 2.21.0
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20
 

--- a/libraries/cmake/source/modules/Findlibcryptsetup.cmake
+++ b/libraries/cmake/source/modules/Findlibcryptsetup.cmake
@@ -10,6 +10,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 importSourceSubmodule(
   NAME "libcryptsetup"
 
-  SHALLOW_SUBMODULES
+  # This git repo is hosted on gitlab, which doesn't properly support
+  # making a shallow clone.
+  SUBMODULES
     "src"
 )

--- a/libraries/cmake/source/modules/Findlibgcrypt.cmake
+++ b/libraries/cmake/source/modules/Findlibgcrypt.cmake
@@ -10,6 +10,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 importSourceSubmodule(
   NAME "libgcrypt"
 
-  SHALLOW_SUBMODULES
+  # Hosting for this repo does not support shallow clones in newer
+  # versions of git.
+  SUBMODULES
     "src"
 )

--- a/libraries/cmake/source/modules/Findlibgpg-error.cmake
+++ b/libraries/cmake/source/modules/Findlibgpg-error.cmake
@@ -10,6 +10,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 importSourceSubmodule(
   NAME "libgpg-error"
 
-  SHALLOW_SUBMODULES
+  # Hosting for this repo does not support shallow clones in newer
+  # versions of git.
+  SUBMODULES
     "src"
 )

--- a/libraries/cmake/source/modules/utils.cmake
+++ b/libraries/cmake/source/modules/utils.cmake
@@ -31,10 +31,19 @@ function(initializeGitSubmodule submodule_path no_recursive shallow)
     set(optional_depth_arg "")
   endif()
 
+  # In git versions >= 2.18.0 we need to explicitly set the protocol
+  # in order to do a shallow clone without error.
+  if(GIT_VERSION_STRING VERSION_EQUAL "2.18.0" OR GIT_VERSION_STRING VERSION_GREATER "2.18.0")
+    set(optional_protocol_arg -c protocol.version=2)
+  else()
+    set(optional_protocol_arg "")
+  endif()
+
+
   get_filename_component(working_directory "${submodule_path}" DIRECTORY)
 
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" submodule update --init ${optional_recursive_arg} ${optional_depth_arg} "${submodule_path}"
+    COMMAND "${GIT_EXECUTABLE}" ${optional_protocol_arg} submodule update --init ${optional_recursive_arg} ${optional_depth_arg} "${submodule_path}"
     RESULT_VARIABLE process_exit_code
     WORKING_DIRECTORY "${working_directory}"
   )


### PR DESCRIPTION
Enables the v2 protocol which allows the repositories to be shallow
cloned without error.