### PR TITLE
Add platform_mask

### DIFF
--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -19,6 +19,7 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
+#include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/info/version.h>
 #include <osquery/utils/macros/macros.h>
 
@@ -215,6 +216,8 @@ QueryData genOsqueryInfo(QueryContext& context) {
   } else {
     r["watcher"] = "-1";
   }
+  r["platform_mask"] = INTEGER(static_cast<uint64_t>(kPlatformType));
+
 
   std::string uuid;
   r["uuid"] = (getHostUUID(uuid)) ? uuid : "";

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -218,7 +218,6 @@ QueryData genOsqueryInfo(QueryContext& context) {
   }
   r["platform_mask"] = INTEGER(static_cast<uint64_t>(kPlatformType));
 
-
   std::string uuid;
   r["uuid"] = (getHostUUID(uuid)) ? uuid : "";
 

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -20,6 +20,9 @@ namespace osquery {
  *
  * CMake, or the build tooling, will generate a OSQUERY_PLATFORM_MASK and pass
  * it to the library compile only.
+ *
+ * This information is exposed through the osquery_info table. Be cautious 
+ * changing values.
  */
 enum class PlatformType {
   TYPE_POSIX = 0x01,

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -21,7 +21,7 @@ namespace osquery {
  * CMake, or the build tooling, will generate a OSQUERY_PLATFORM_MASK and pass
  * it to the library compile only.
  *
- * This information is exposed through the osquery_info table. Be cautious 
+ * This information is exposed through the osquery_info table. Be cautious
  * changing values.
  */
 enum class PlatformType {

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -11,7 +11,7 @@ schema([
     Column("build_platform", TEXT, "osquery toolkit build platform"),
     Column("build_distro", TEXT, "osquery toolkit platform distribution name (os version)"),
     Column("start_time", INTEGER, "UNIX time in seconds when the process started"),
-    Column("watcher", INTEGER, "Process (or thread/handle) ID of optional watcher process")
+    Column("watcher", INTEGER, "Process (or thread/handle) ID of optional watcher process"),
     Column("platform_mask", INTEGER, "The osquery platform bitmask"),
 ])
 attributes(utility=True)

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -12,6 +12,7 @@ schema([
     Column("build_distro", TEXT, "osquery toolkit platform distribution name (os version)"),
     Column("start_time", INTEGER, "UNIX time in seconds when the process started"),
     Column("watcher", INTEGER, "Process (or thread/handle) ID of optional watcher process")
+    Column("platform_mask", INTEGER, "The osquery platform bitmask"),
 ])
 attributes(utility=True)
 implementation("osquery@genOsqueryInfo")


### PR DESCRIPTION
Right now, there is no way to tell what platform osquery is running on. We have `os_version.platform` and `os_version.platform_like`, but they are highly inconsistent, and require a lot of custom parsing to use. We should expose the underlying platform bitmask.

This adds the `platform_mask` to the `osquery_info` table.

This replaces https://github.com/osquery/osquery/pull/5488 Contrasting the approaches, I think the I like #5488 more. Exposing the booleans is a better API. This is useful, and better than status quo, but it means we're committing to not changing the bitmask fields