### PR TITLE
wmi: adding utility function to convert datetime to FILETIME

### DIFF
--- a/osquery/events/windows/usn_journal_reader.cpp
+++ b/osquery/events/windows/usn_journal_reader.cpp
@@ -21,11 +21,11 @@
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 #include <osquery/utils/system/errno.h>
 
 #include "osquery/core/windows/wmi.h"
 #include "osquery/events/windows/usn_journal_reader.h"
-#include "osquery/filesystem/fileops.h"
 
 #ifndef FILE_ATTRIBUTE_RECALL_ON_OPEN
 #define FILE_ATTRIBUTE_RECALL_ON_OPEN 0x00040000

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -100,7 +100,9 @@ using PlatformHandle = int;
 using PlatformTimeType = struct timeval;
 #endif
 
-typedef struct { PlatformTimeType times[2]; } PlatformTime;
+typedef struct {
+  PlatformTimeType times[2];
+} PlatformTime;
 
 /// Constant for an invalid handle.
 const PlatformHandle kInvalidHandle = (PlatformHandle)-1;
@@ -142,11 +144,6 @@ std::string lastErrorMessage(unsigned long);
 enum SeekMode { PF_SEEK_BEGIN = 0, PF_SEEK_CURRENT, PF_SEEK_END };
 
 #ifdef WIN32
-/// Takes a Windows FILETIME object and returns seconds since epoch
-LONGLONG filetimeToUnixtime(const FILETIME& ft);
-
-LONGLONG longIntToUnixtime(LARGE_INTEGER& ft);
-
 std::string getFileAttribStr(unsigned long);
 
 Status platformStat(const boost::filesystem::path&, WINDOWS_STAT*);
@@ -437,4 +434,4 @@ Status platformLstat(const std::string& path, struct stat& d_stat);
  * @return osquery::Status
  */
 Status describeBSDFileFlags(std::string& output, std::uint32_t st_flags);
-}
+} // namespace osquery

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -589,7 +589,7 @@ std::string lsperms(int mode) {
 Status parseJSON(const fs::path& path, pt::ptree& tree) {
   try {
     pt::read_json(path.string(), tree);
-  } catch (const pt::json_parser::json_parser_error& e) {
+  } catch (const pt::json_parser::json_parser_error& /* e */) {
     return Status(1, "Could not parse JSON from file");
   }
   return Status::success();

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -11,6 +11,7 @@
 #include <osquery/process/process.h>
 #include <osquery/process/windows/process_ops.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
 #include <AclAPI.h>
 #include <LM.h>
@@ -1567,22 +1568,6 @@ Status socketExists(const fs::path& path, bool remove_socket) {
     }
   }
   return Status::success();
-}
-
-LONGLONG filetimeToUnixtime(const FILETIME& ft) {
-  LARGE_INTEGER date, adjust;
-  date.HighPart = ft.dwHighDateTime;
-  date.LowPart = ft.dwLowDateTime;
-  adjust.QuadPart = 11644473600000 * 10000;
-  date.QuadPart -= adjust.QuadPart;
-  return date.QuadPart / 10000000;
-}
-
-LONGLONG longIntToUnixtime(LARGE_INTEGER& ft) {
-  ULARGE_INTEGER ull;
-  ull.LowPart = ft.LowPart;
-  ull.HighPart = ft.HighPart;
-  return ull.QuadPart / 10000000ULL - 11644473600ULL;
 }
 
 std::string getFileAttribStr(unsigned long file_attributes) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -24,6 +24,7 @@
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
 #include <osquery/filesystem/fileops.h>
 #include <osquery/tables/system/windows/certificates.h>

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -25,7 +25,7 @@
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/core/windows/wmi.h>
 #include <osquery/utils/conversions/windows/strings.h>
-#include <osquery/filesystem/fileops.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -15,10 +15,10 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include <osquery/filesystem/fileops.h>
 #include <osquery/process/windows/process_ops.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
 const std::map<int, std::string> kSessionStates = {
     {WTSActive, "active"},

--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -19,9 +19,8 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 #include <osquery/process/windows/process_ops.h>
-
-#include "osquery/filesystem/fileops.h"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -8,10 +8,10 @@
 
 #include <osquery/tables.h>
 
+#include <osquery/core/windows/wmi.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
-
-#include <osquery/core/windows/wmi.h>
+#include <osquery/utils/conversions/windows/strings.h>
 
 namespace osquery {
 namespace tables {
@@ -31,11 +31,15 @@ QueryData genOSVersion(QueryContext& context) {
     return {};
   }
 
-  wmiResults[0].GetString("InstallDate", r["install_date"]);
   std::string osName;
   wmiResults[0].GetString("Caption", osName);
   r["name"] = osName;
   r["codename"] = osName;
+
+  std::string cimInstallDate{""};
+  wmiResults[0].GetString("InstallDate", cimInstallDate);
+  r["install_date"] = BIGINT(cimDatetimeToUnixtime(cimInstallDate));
+
   wmiResults[0].GetString("Version", version_string);
   auto version = osquery::split(version_string, ".");
 

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -33,11 +33,11 @@
 #include <osquery/tables.h>
 
 #include <osquery/core/windows/wmi.h>
-#include <osquery/filesystem/fileops.h>
 #include <osquery/sql/dynamic_table_row.h>
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 #include <osquery/utils/scope_guard.h>
 
 namespace osquery {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -34,8 +34,8 @@
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
-#include <osquery/filesystem/fileops.h>
 #include <osquery/sql/sqlite_util.h>
 #include <osquery/tables/system/windows/registry.h>
 

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -20,8 +20,8 @@
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 
-#include <osquery/filesystem/fileops.h>
 #include <osquery/process/process.h>
 
 namespace osquery {

--- a/osquery/tables/system/windows/userassist.cpp
+++ b/osquery/tables/system/windows/userassist.cpp
@@ -7,13 +7,13 @@
  */
 
 #include <osquery/core.h>
-#include <osquery/filesystem/fileops.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/tables/system/windows/registry.h>
 #include <osquery/tables/system/windows/userassist.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
 #include <osquery/utils/system/time.h>
 #include <string>
 

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -13,8 +13,9 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
+#include <osquery/core/windows/wmi.h>
 #include <osquery/utils/conversions/tryto.h>
-#include "osquery/core/windows/wmi.h"
+#include <osquery/utils/conversions/windows/strings.h>
 
 namespace osquery {
 namespace tables {
@@ -33,7 +34,9 @@ QueryData genVideoInfo(QueryContext& context) {
     wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
     r["color_depth"] = INTEGER(bitsPerPixel);
     wmiResults[0].GetString("InstalledDisplayDrivers", r["driver"]);
-    wmiResults[0].GetString("DriverDate", r["driver_date"]);
+    std::string cimDriverDate{""};
+    wmiResults[0].GetString("DriverDate", cimDriverDate);
+    r["driver_date"] = BIGINT(cimDatetimeToUnixtime(cimDriverDate));
     wmiResults[0].GetString("DriverVersion", r["driver_version"]);
     wmiResults[0].GetString("AdapterCompatibility", r["manufacturer"]);
     wmiResults[0].GetString("VideoProcessor", r["model"]);

--- a/osquery/utils/conversions/CMakeLists.txt
+++ b/osquery/utils/conversions/CMakeLists.txt
@@ -32,6 +32,7 @@ function(generateOsqueryUtilsConversions)
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND source_files
       windows/strings.cpp
+      windows/windows_time.cpp
     )
   endif()
 
@@ -41,6 +42,8 @@ function(generateOsqueryUtilsConversions)
 
   target_link_libraries(osquery_utils_conversions PUBLIC
     osquery_cxx_settings
+    osquery_utils
+    osquery_utils_system_systemutils
     osquery_logger
     osquery_utils_conversions_to
     osquery_utils_expected
@@ -69,6 +72,7 @@ function(generateOsqueryUtilsConversions)
   elseif(DEFINED PLATFORM_WINDOWS)
     set(platform_public_header_files
       windows/strings.h
+      windows/windows_time.h
     )
   endif()
 
@@ -108,6 +112,7 @@ function(generateOsqueryUtilsConversionsConversionstestsTest)
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND source_files
       windows/tests/strings.cpp
+      windows/tests/windows_time.cpp
     )
   endif()
 

--- a/osquery/utils/conversions/windows/strings.h
+++ b/osquery/utils/conversions/windows/strings.h
@@ -37,6 +37,14 @@ std::string wstringToString(const std::wstring& src);
 std::string wstringToString(const wchar_t* src);
 
 /**
+ * @brief Windows helper function to convert a CIM Datetime to Unix timestamp
+ *
+ * @returns Given a CIM datetime generated from a WMI query, this helper
+ * function returns the equivalent Unix timestamp
+ */
+LONGLONG cimDatetimeToUnixtime(const std::string& src);
+
+/**
  * @brief Windows WMI Helper function to print the type associated with results
  *
  * @returns A string created from a BSTR

--- a/osquery/utils/conversions/windows/tests/strings.cpp
+++ b/osquery/utils/conversions/windows/tests/strings.cpp
@@ -14,13 +14,33 @@
 
 namespace osquery {
 
-class ConversionsTests : public testing::Test {};
+class ConversionsTests : public testing::Test {
+ public:
+  ConversionsTests() {}
+
+  void SetUp() {
+    auto ret = CoInitializeEx(0, COINIT_MULTITHREADED);
+    if (ret != S_OK) {
+      CoUninitialize();
+    }
+  }
+
+  void TearDown() {
+    CoUninitialize();
+  }
+};
 
 TEST_F(ConversionsTests, test_string_to_wstring) {
   std::string narrowString{"The quick brown fox jumps over the lazy dog"};
   auto wideString = stringToWstring(narrowString.c_str());
   std::wstring expected{L"The quick brown fox jumps over the lazy dog"};
   EXPECT_EQ(wideString, expected);
+}
+
+TEST_F(ConversionsTests, test_cim_datetime_to_unixtime) {
+  std::string cimDateTime{"20190724000000.000000-000"};
+  auto unixtime = cimDatetimeToUnixtime(cimDateTime);
+  EXPECT_EQ(unixtime, 1563926400);
 }
 
 TEST_F(ConversionsTests, test_wstring_to_string) {

--- a/osquery/utils/conversions/windows/tests/windows_time.cpp
+++ b/osquery/utils/conversions/windows/tests/windows_time.cpp
@@ -1,0 +1,43 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <osquery/utils/conversions/windows/windows_time.h>
+
+#include <time.h>
+#include <winbase.h>
+#include <winnt.h>
+
+namespace osquery {
+
+class ConversionsTests : public testing::Test {};
+
+TEST_F(ConversionsTests, test_filetime_to_unixtime) {
+  FILETIME ft;
+  time_t curr_time = 1593496251;
+  LONGLONG ll = Int32x32To64(curr_time, 10000000) + 116444736000000000;
+  ft.dwLowDateTime = static_cast<DWORD>(ll);
+  ft.dwHighDateTime = ll >> 32;
+
+  auto converted = filetimeToUnixtime(ft);
+  EXPECT_EQ(converted, curr_time);
+}
+
+TEST_F(ConversionsTests, test_long_int_to_unixtime) {
+  LARGE_INTEGER li;
+  li.HighPart = 30821541;
+  li.LowPart = 2060031803;
+
+  auto converted = longIntToUnixtime(li);
+  EXPECT_EQ(converted, 1593277666);
+}
+
+} // namespace osquery

--- a/osquery/utils/conversions/windows/windows_time.cpp
+++ b/osquery/utils/conversions/windows/windows_time.cpp
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/conversions/windows/windows_time.h>
+
+namespace osquery {
+
+LONGLONG filetimeToUnixtime(const FILETIME& ft) {
+  LARGE_INTEGER date, adjust;
+  date.HighPart = ft.dwHighDateTime;
+  date.LowPart = ft.dwLowDateTime;
+  adjust.QuadPart = 11644473600000 * 10000;
+  date.QuadPart -= adjust.QuadPart;
+  return date.QuadPart / 10000000;
+}
+
+LONGLONG longIntToUnixtime(LARGE_INTEGER& li) {
+  ULARGE_INTEGER ull;
+  ull.LowPart = li.LowPart;
+  ull.HighPart = li.HighPart;
+  return ull.QuadPart / 10000000ULL - 11644473600ULL;
+}
+
+} // namespace osquery

--- a/osquery/utils/conversions/windows/windows_time.h
+++ b/osquery/utils/conversions/windows/windows_time.h
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/utils/system/system.h>
+
+namespace osquery {
+
+/**
+ * @brief Windows helper function for converting FILETIME to Unix epoch
+ *
+ * @returns The unix epoch timestamp representation of the FILETIME
+ */
+LONGLONG filetimeToUnixtime(const FILETIME& ft);
+
+/**
+ * @brief Windows helper function for converting LARGE INTs to Unix epoch
+ *
+ * @returns The unix epoch timestamp representation of the LARGE int value
+ */
+LONGLONG longIntToUnixtime(LARGE_INTEGER& ft);
+
+} // namespace osquery

--- a/specs/os_version.table
+++ b/specs/os_version.table
@@ -13,7 +13,7 @@ schema([
     Column("arch", TEXT, "OS Architecture"),
 ])
 extended_schema(WINDOWS, [
-    Column("install_date", TEXT, "The install date of the OS."),
+    Column("install_date", BIGINT, "The install date of the OS."),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),

--- a/specs/windows/video_info.table
+++ b/specs/windows/video_info.table
@@ -3,7 +3,7 @@ description("Retrieve video card information of the machine.")
 schema([
     Column("color_depth", INTEGER, "The amount of bits per pixel to represent color."),
     Column("driver", TEXT, "The driver of the device."),
-    Column("driver_date", TEXT, "The date listed on the installed driver."),
+    Column("driver_date", BIGINT, "The date listed on the installed driver."),
     Column("driver_version", TEXT, "The version of the installed driver."),
     Column("manufacturer", TEXT, "The manufaturer of the gpu."),
     Column("model", TEXT, "The model of the gpu."),


### PR DESCRIPTION
Summary: 

See #5746 for more details. This PR adds a helper function to
convert datetime BSTRs passed back from WMI queries into FILETIME
structs, which we can convert using our existing utility into a Unix
Epoch time.

Test Plan:
Sample queries against `video_info`:
```
osquery> select driver_date from video_info;
+-------------+
| driver_date |
+-------------+
| 1563926400  |
+-------------+
```
Checking that time:
```
In [2]: datetime.datetime.fromtimestamp(1563926400  )
Out[2]: datetime.datetime(2019, 7, 23, 17, 0)
```
And `os_version`:
```
osquery> select install_date from os_version;
+--------------+
| install_date |
+--------------+
| 1558581844   |
+--------------+
```
And that time in a datetime:
```
In [3]: datetime.datetime.fromtimestamp(1558581844)
Out[3]: datetime.datetime(2019, 5, 22, 20, 24, 4)
```
Both look pretty accurate.