### PR TITLE
Migrate glog and gflags to source build on macOS and Windows

### DIFF
--- a/libraries/cmake/source_migration/modules/Findgflags.cmake
+++ b/libraries/cmake/source_migration/modules/Findgflags.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+include("${CMAKE_SOURCE_DIR}/libraries/cmake/source/modules/Findgflags.cmake")

--- a/libraries/cmake/source_migration/modules/Findglog.cmake
+++ b/libraries/cmake/source_migration/modules/Findglog.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+include("${CMAKE_SOURCE_DIR}/libraries/cmake/source/modules/Findglog.cmake")

--- a/osquery/logger/logger.h
+++ b/osquery/logger/logger.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #ifdef WIN32
+#ifndef GLOG_NO_ABBREVIATED_SEVERITIES
 #define GLOG_NO_ABBREVIATED_SEVERITIES
+#endif
 #define GOOGLE_GLOG_DLL_DECL
 #endif
 


### PR DESCRIPTION
Note that glog and gflags must be migrated at the same time, otherwise
linker errors are generated on macOS.