### PR TITLE
RegistryInterface: add locks to more methods

### DIFF
--- a/osquery/include/osquery/registry_interface.h
+++ b/osquery/include/osquery/registry_interface.h
@@ -233,6 +233,9 @@ class RegistryInterface : private boost::noncopyable {
   mutable Mutex mutex_;
 
  private:
+  void removeUnsafe(const std::string& item_name);
+
+ private:
   friend class RegistryFactory;
 
   bool isInternal_(const std::string& item_name) const;

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -270,15 +270,13 @@ Status RegistryInterface::addExternal(const RouteUUID& uuid,
 
 /// Remove all the routes for a given uuid.
 void RegistryInterface::removeExternal(const RouteUUID& uuid) {
+  WriteLock lock(mutex_);
   std::vector<std::string> removed_items;
 
-  {
-    ReadLock rlock(mutex_);
-    // Create list of items to remove by filtering uuid
-    for (const auto& item : external_) {
-      if (item.second == uuid) {
-        removed_items.push_back(item.first);
-      }
+  // Create list of items to remove by filtering uuid
+  for (const auto& item : external_) {
+    if (item.second == uuid) {
+      removed_items.push_back(item.first);
     }
   }
 
@@ -286,13 +284,10 @@ void RegistryInterface::removeExternal(const RouteUUID& uuid) {
     removeExternalPlugin(item);
   }
 
-  {
-    WriteLock wlock(mutex_);
-    // Remove items belonging to the external uuid.
-    for (const auto& item : removed_items) {
-      external_.erase(item);
-      routes_.erase(item);
-    }
+  // Remove items belonging to the external uuid.
+  for (const auto& item : removed_items) {
+    external_.erase(item);
+    routes_.erase(item);
   }
 }
 

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -13,6 +13,8 @@
 
 namespace osquery {
 void RegistryInterface::remove(const std::string& item_name) {
+  WriteLock lock(mutex_);
+
   if (items_.count(item_name) > 0) {
     items_[item_name]->tearDown();
     items_.erase(item_name);
@@ -330,6 +332,8 @@ void RegistryInterface::setname(const std::string& name) {
 }
 
 bool RegistryInterface::isInternal_(const std::string& item_name) const {
+  ReadLock lock(mutex_);
+
   if (std::find(internal_.begin(), internal_.end(), item_name) ==
       internal_.end()) {
     return false;
@@ -339,6 +343,8 @@ bool RegistryInterface::isInternal_(const std::string& item_name) const {
 
 bool RegistryInterface::exists_(const std::string& item_name,
                                 bool local) const {
+  ReadLock lock(mutex_);
+
   bool has_local = (items_.count(item_name) > 0);
   bool has_external = (external_.count(item_name) > 0);
   bool has_route = (routes_.count(item_name) > 0);


### PR DESCRIPTION
Several methods in the `RegistryInterface` class are reading and/or modifying member variables without locks. I've seen the `osqueryd --S` process terminate abnormally from this, and after debugging, the `RegistryInterface::remove` method was the culprit (more precisely `items_.erase(item_name)`).

This PR adds locks to the remaining methods in the class that read and/or modify member variables.
