### PR TITLE
Support source and build directory to be on different filesystems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ function(importLibraries)
       endif()
 
     else()
-      message(FATAL_ERROR "The '${library}' was found but it couldn't be imported correctly")
+      message(FATAL_ERROR "The '${library}' library was found but it couldn't be imported correctly")
     endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
Instead of moving a patched submodule from source to build directory,
we copy it and then hard reset the submodule to its original HEAD.

Minor message change when a library fails to be imported.