### PR TITLE
libraries: Update RapidJSON to master 1a825d24

### DIFF
--- a/libraries/cmake/source/modules/Findrapidjson.cmake
+++ b/libraries/cmake/source/modules/Findrapidjson.cmake
@@ -12,6 +12,6 @@ importSourceSubmodule(
 
   NO_RECURSIVE
 
-  SHALLOW_SUBMODULES
+  SUBMODULES
     "src"
 )


### PR DESCRIPTION
With a small JSON input testcase, you can cause a wild read.

```json
0.0000074836628E-2147483636
```

```
./osquery/main/harnesses/osqueryfuzz-config /tmp/fuzz/clusterfuzz-testcase-minimized-osqueryfuzz-config-5751874325577728
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1020 15:48:17.027545  6973 database.cpp:77] Failed to activate database plugin "rocksdb": Cannot read RocksDB path: /var/osquery/osquery.db
INFO: Seed: 3643951471
INFO: Loaded 1 modules   (483657 inline 8-bit counters): 483657 [0x4953228, 0x49c9371), 
INFO: Loaded 1 PC tables (483657 PCs): 483657 [0x49c9378,0x512a808), 
./osquery/main/harnesses/osqueryfuzz-config: Running 1 inputs 1 time(s) each.
Running: /tmp/fuzz/clusterfuzz-testcase-minimized-osqueryfuzz-config-5751874325577728
AddressSanitizer:DEADLYSIGNAL
=================================================================
==6973==ERROR: AddressSanitizer: SEGV on unknown address 0x0001000c969f (pc 0x00000193c080 bp 0x7ffe59f70810 sp 0x7ffe59f707d0 T0)
==6973==The signal is caused by a READ memory access.
    #0 0x193c07f in rapidjson::internal::Pow10(int) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/internal/pow10.h:49:12
    #1 0x193c07f in rapidjson::internal::FastPath(double, int) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/internal/strtod.h:30
    #2 0x193b9f6 in rapidjson::internal::StrtodNormalPrecision(double, int) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/internal/strtod.h
    #3 0x193b194 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseNumber<4u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/reader.h:1364:24
    #4 0x1937829 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseValue<4u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/reader.h:1401:23
    #5 0x19357fd in rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::IterativeParsingState rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::Transit<4u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator> >(rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::IterativeParsingState, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::Token, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::IterativeParsingState, rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/reader.h:1792:13
    #6 0x19357fd in rapidjson::ParseResult rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::IterativeParse<4u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/reader.h:1832
    #7 0x1934fc7 in rapidjson::ParseResult rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::Parse<4u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/reader.h:487:20
    #8 0x1934fc7 in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::ParseStream<4u, rapidjson::UTF8<char>, rapidjson::GenericStringStream<rapidjson::UTF8<char> > >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/document.h:2159
    #9 0x1934d8b in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Parse<4u, rapidjson::UTF8<char> >(rapidjson::UTF8<char>::Ch const*) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/document.h:2224:16
    #10 0x3bb9f5b in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Parse<4u>(char const*) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/document.h:2233:16
    #11 0x3bb9f5b in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Parse(char const*) /home/teddy/git/osquery-prod/libraries/cmake/source/rapidjson/src/include/rapidjson/document.h:2240
    #12 0x3bb9f5b in osquery::JSON::fromString(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/teddy/git/osquery-prod/osquery/utils/json/json.cpp:290
    #13 0x152ce19 in osquery::Config::updateSource(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/teddy/git/osquery-prod/osquery/config/config.cpp:630:12
    #14 0x1529a51 in osquery::Config::update(std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > const&) /home/teddy/git/osquery-prod/osquery/config/config.cpp:767:19
    #15 0x18f36f9 in LLVMFuzzerTestOneInput /home/teddy/git/osquery-prod/osquery/main/harnesses/fuzz_config.cpp:34:26
    #16 0x13f11ea in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /opt/toolchain/llvm/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:533:15
    #17 0x13e4791 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /opt/toolchain/llvm/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:280:6
    #18 0x13e95fb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /opt/toolchain/llvm/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:709:9
    #19 0x14108a2 in main /opt/toolchain/llvm/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #20 0x7f3c083e2b96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310

````

I tried isolating some commits to RapidJSON and representing them as patches again v1.1.0 but this was not enough to fix the bug. I suggest we pin to a recent version of RapidJSON.