### PR TITLE
tests: enabling certificates table sanity checks

### DIFF
--- a/tests/integration/tables/certificates.cpp
+++ b/tests/integration/tables/certificates.cpp
@@ -11,6 +11,8 @@
 
 #include <osquery/tests/integration/tables/helper.h>
 
+#include <osquery/utils/info/platform_type.h>
+
 namespace osquery {
 namespace table_tests {
 
@@ -22,35 +24,38 @@ class certificates : public testing::Test {
 };
 
 TEST_F(certificates, test_sanity) {
-  // 1. Query data
   auto const data = execute_query("select * from certificates");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"common_name", NormalType}
-  //      {"subject", NormalType}
-  //      {"issuer", NormalType}
-  //      {"ca", IntType}
-  //      {"self_signed", IntType}
-  //      {"not_valid_before", NormalType}
-  //      {"not_valid_after", NormalType}
-  //      {"signing_algorithm", NormalType}
-  //      {"key_algorithm", NormalType}
-  //      {"key_strength", NormalType}
-  //      {"key_usage", NormalType}
-  //      {"subject_key_id", NormalType}
-  //      {"authority_key_id", NormalType}
-  //      {"sha1", NormalType}
-  //      {"path", NormalType}
-  //      {"serial", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"common_name", NormalType},
+      {"subject", NormalType},
+      {"issuer", NormalType},
+      {"ca", IntType},
+      {"self_signed", IntType},
+      {"not_valid_before", NormalType},
+      {"not_valid_after", NormalType},
+      {"signing_algorithm", NormalType},
+      {"key_algorithm", NormalType},
+      {"key_strength", NormalType},
+      {"key_usage", NormalType},
+      {"subject_key_id", NormalType},
+      {"authority_key_id", NormalType},
+      {"sha1", NormalType},
+      {"path", NormalType},
+      {"serial", NormalType},
+  };
+
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    row_map["sid"] = NormalType;
+    row_map["store_location"] = NormalType;
+    row_map["store"] = NormalType;
+    row_map["username"] = NormalType;
+    row_map["store_id"] = NormalType;
+  }
+
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
Summary:

We already have some tests for the `certificates` table on Windows, but this ungates the sanity tests for macos and Windows to ensure schema validation for this table.

Test Plan: run the tests:
```
PS C:\Users\Nicholas\work\repos\osquery\build\windows10> cmake --build . --config RelWithDebInfo -j10 --target run_tests         Microsoft (R) Build Engine version 16.3.1+1def00d3d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Test project C:/Users/Nicholas/work/repos/osquery/build/windows10
        Start  1: osquery_dispatcher_tests-test
   1/69 Test  #1: osquery_dispatcher_tests-test .................................   Passed    0.03 sec
        Start  2: osquery_dispatcher_tests_scheduler-test
   2/69 Test  #2: osquery_dispatcher_tests_scheduler-test .......................   Passed    4.43 sec
        Start  3: osquery_sql_tests-test
   3/69 Test  #3: osquery_sql_tests-test ........................................   Passed    0.05 sec
        Start  4: osquery_sql_tests_virtualtabletests-test
   4/69 Test  #4: osquery_sql_tests_virtualtabletests-test ......................   Passed    0.27 sec
        Start  5: osquery_sql_tests_sqliteutilstests-test
   5/69 Test  #5: osquery_sql_tests_sqliteutilstests-test .......................   Passed    0.31 sec
        Start  6: osquery_sdk_tests_pluginsdktests-test
   6/69 Test  #6: osquery_sdk_tests_pluginsdktests-test .........................   Passed    0.02 sec
        Start  7: osquery_numericmonitoring_tests-test
   7/69 Test  #7: osquery_numericmonitoring_tests-test ..........................   Passed    0.03 sec
        Start  8: osquery_numericmonitoring_tests_preaggregationcache-test
   8/69 Test  #8: osquery_numericmonitoring_tests_preaggregationcache-test ......   Passed    0.03 sec
        Start  9: osquery_killswitch_tests-test
   9/69 Test  #9: osquery_killswitch_tests-test .................................   Passed    0.03 sec
        Start 10: osquery_registry_tests-test
  10/69 Test #10: osquery_registry_tests-test ...................................   Passed    0.03 sec
        Start 11: osquery_logger_tests-test
  11/69 Test #11: osquery_logger_tests-test .....................................   Passed    0.04 sec
        Start 12: osquery_distributed_tests-test
  12/69 Test #12: osquery_distributed_tests-test ................................   Passed    0.02 sec
        Start 13: osquery_carver_tests-test
  13/69 Test #13: osquery_carver_tests-test .....................................   Passed    0.08 sec
        Start 14: osquery_tables_events_tests_fileeventstests-test
  14/69 Test #14: osquery_tables_events_tests_fileeventstests-test ..............   Passed    0.03 sec
        Start 15: osquery_tables_networking_tests_networkingtablestests-test
  15/69 Test #15: osquery_tables_networking_tests_networkingtablestests-test ....   Passed    2.40 sec
        Start 16: osquery_tables_system_tests_certificatestests-test
  16/69 Test #16: osquery_tables_system_tests_certificatestests-test ............   Passed    0.25 sec
        Start 17: osquery_tables_system_tests_registrytests-test
  17/69 Test #17: osquery_tables_system_tests_registrytests-test ................   Passed    1.10 sec
        Start 18: osquery_tables_system_tests_systemtablestests-test
  18/69 Test #18: osquery_tables_system_tests_systemtablestests-test ............   Passed    5.34 sec
        Start 19: osquery_remote_tests_requeststests-test
  19/69 Test #19: osquery_remote_tests_requeststests-test .......................   Passed    0.03 sec
        Start 20: osquery_remote_serializers_remotejsonserializerstests-test
  20/69 Test #20: osquery_remote_serializers_remotejsonserializerstests-test ....   Passed    0.01 sec
        Start 21: osquery_remote_enroll_remoteenrolltests-test
  21/69 Test #21: osquery_remote_enroll_remoteenrolltests-test ..................   Passed    0.04 sec
        Start 22: osquery_core_tests_flagstests-test
  22/69 Test #22: osquery_core_tests_flagstests-test ............................   Passed    0.03 sec
        Start 23: osquery_core_tests_systemtests-test
  23/69 Test #23: osquery_core_tests_systemtests-test ...........................   Passed    0.03 sec
        Start 24: osquery_core_tests_tablestests-test
  24/69 Test #24: osquery_core_tests_tablestests-test ...........................   Passed    0.03 sec
        Start 25: osquery_core_tests_watcherpermissionstests-test
  25/69 Test #25: osquery_core_tests_watcherpermissionstests-test ...............   Passed    0.03 sec
        Start 26: osquery_core_tests_querytests-test
  26/69 Test #26: osquery_core_tests_querytests-test ............................   Passed    0.03 sec
        Start 27: osquery_core_tests_processtests-test
  27/69 Test #27: osquery_core_tests_processtests-test ..........................   Passed    0.10 sec
        Start 28: osquery_config_tests-test
  28/69 Test #28: osquery_config_tests-test .....................................***Failed   11.63 sec
        Start 29: osquery_config_tests_packs-test
  29/69 Test #29: osquery_config_tests_packs-test ...............................   Passed    0.10 sec
        Start 30: osquery_utils_utilstests-test
  30/69 Test #30: osquery_utils_utilstests-test .................................   Passed    0.03 sec
        Start 31: osquery_utils_aws_tests-test
  31/69 Test #31: osquery_utils_aws_tests-test ..................................   Passed    0.16 sec
        Start 32: osquery_utils_caches_tests_lrutests-test
  32/69 Test #32: osquery_utils_caches_tests_lrutests-test ......................   Passed    0.01 sec
        Start 33: osquery_utils_system_errno_errnotests-test
  33/69 Test #33: osquery_utils_system_errno_errnotests-test ....................   Passed    0.01 sec
        Start 34: osquery_utils_system_time_timetest-test
  34/69 Test #34: osquery_utils_system_time_timetest-test .......................   Passed    0.02 sec
        Start 35: osquery_utils_system_linux_proc_proctests-test
  35/69 Test #35: osquery_utils_system_linux_proc_proctests-test ................   Passed    0.02 sec
        Start 36: osquery_utils_status_statustests-test
  36/69 Test #36: osquery_utils_status_statustests-test .........................   Passed    0.01 sec
        Start 37: osquery_utils_json_jsontests-test
  37/69 Test #37: osquery_utils_json_jsontests-test .............................   Passed    0.04 sec
        Start 38: osquery_utils_error_errortests-test
  38/69 Test #38: osquery_utils_error_errortests-test ...........................   Passed    0.01 sec
        Start 39: osquery_utils_debug_debugtests-test
  39/69 Test #39: osquery_utils_debug_debugtests-test ...........................   Passed    0.01 sec
        Start 40: osquery_utils_expected_expectedtests-test
  40/69 Test #40: osquery_utils_expected_expectedtests-test .....................   Passed    0.01 sec
        Start 41: osquery_utils_conversions_conversionstests-test
  41/69 Test #41: osquery_utils_conversions_conversionstests-test ...............   Passed    0.01 sec
        Start 42: osquery_utils_conversions_totests-test
  42/69 Test #42: osquery_utils_conversions_totests-test ........................   Passed    0.01 sec
        Start 43: osquery_utils_versioning_semanticversiontest-test
  43/69 Test #43: osquery_utils_versioning_semanticversiontest-test .............   Passed    0.01 sec
        Start 44: osquery_utils_schemer_tests_schemertests-test
  44/69 Test #44: osquery_utils_schemer_tests_schemertests-test .................   Passed    0.02 sec
        Start 45: osquery_utils_schemer_json_tests_schemerjsontests-test
  45/69 Test #45: osquery_utils_schemer_json_tests_schemerjsontests-test ........   Passed    0.01 sec
        Start 46: osquery_filesystem_filesystemtests-test
  46/69 Test #46: osquery_filesystem_filesystemtests-test .......................   Passed    1.28 sec
        Start 47: osquery_database_tests-test
  47/69 Test #47: osquery_database_tests-test ...................................   Passed    0.05 sec
        Start 48: osquery_database_tests_results-test
  48/69 Test #48: osquery_database_tests_results-test ...........................   Passed    0.05 sec
        Start 49: osquery_devtools_tests_printertests-test
  49/69 Test #49: osquery_devtools_tests_printertests-test ......................   Passed    0.06 sec
        Start 50: osquery_extensions_extensiontests-test
  50/69 Test #50: osquery_extensions_extensiontests-test ........................   Passed    3.25 sec
        Start 51: osquery_events_tests_eventsdatabasetests-test
  51/69 Test #51: osquery_events_tests_eventsdatabasetests-test .................   Passed    0.14 sec
        Start 52: osquery_events_tests_windowseventlogtests-test
  52/69 Test #52: osquery_events_tests_windowseventlogtests-test ................   Passed    0.03 sec
        Start 53: osquery_events_tests-test
  53/69 Test #53: osquery_events_tests-test .....................................   Passed    0.06 sec
        Start 54: osquery_ev2_ev2tests-test
  54/69 Test #54: osquery_ev2_ev2tests-test .....................................   Passed    0.02 sec
        Start 55: osquery_system_network_tests_hostnamehostidentitytests-test
  55/69 Test #55: osquery_system_network_tests_hostnamehostidentitytests-test ...   Passed    0.06 sec
        Start 56: plugins_config_parsers_tests_decoratorstests-test
  56/69 Test #56: plugins_config_parsers_tests_decoratorstests-test .............   Passed    2.19 sec
        Start 57: plugins_config_parsers_tests_eventsparsertests-test
  57/69 Test #57: plugins_config_parsers_tests_eventsparsertests-test ...........   Passed    1.14 sec
        Start 58: plugins_config_parsers_tests_filepathstests-test
  58/69 Test #58: plugins_config_parsers_tests_filepathstests-test ..............   Passed    3.23 sec
        Start 59: plugins_config_parsers_tests_optionstests-test
  59/69 Test #59: plugins_config_parsers_tests_optionstests-test ................   Passed    1.13 sec
        Start 60: plugins_config_parsers_tests_viewstests-test
  60/69 Test #60: plugins_config_parsers_tests_viewstests-test ..................   Passed    1.13 sec
        Start 61: plugins_database_tests_rocksdbtests-test
  61/69 Test #61: plugins_database_tests_rocksdbtests-test ......................   Passed    1.20 sec
        Start 62: plugins_database_tests_sqliteplugintests-test
  62/69 Test #62: plugins_database_tests_sqliteplugintests-test .................   Passed    0.90 sec
        Start 63: plugins_killswitch_killswitchfilesystemplugintests-test
  63/69 Test #63: plugins_killswitch_killswitchfilesystemplugintests-test .......   Passed    0.04 sec
        Start 64: plugins_logger_tests_awskinesisloggertests-test
  64/69 Test #64: plugins_logger_tests_awskinesisloggertests-test ...............   Passed    0.04 sec
        Start 65: plugins_logger_tests_bufferedloggertests-test
  65/69 Test #65: plugins_logger_tests_bufferedloggertests-test .................   Passed    0.05 sec
        Start 66: plugins_logger_tests_filesystemloggertests-test
  66/69 Test #66: plugins_logger_tests_filesystemloggertests-test ...............   Passed    0.08 sec
        Start 67: plugins_logger_tests_tlsloggertests-test
  67/69 Test #67: plugins_logger_tests_tlsloggertests-test ......................   Passed    3.01 sec
        Start 68: plugins_numericmonitoring_tests_filesystem-test
  68/69 Test #68: plugins_numericmonitoring_tests_filesystem-test ...............   Passed    0.04 sec
        Start 69: tests_integration_tables-test
  69/69 Test #69: tests_integration_tables-test .................................   Passed   54.67 sec

  99% tests passed, 1 tests failed out of 69

  Total Test time (real) = 101.46 sec

  The following tests FAILED:
         28 - osquery_config_tests-test (Failed)
  Errors while running CTest
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: The command "setlocal [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: "C:\Program Files\CMake\bin\ctest.exe" --force-new-ctest-process -C RelWithDebInfo [C:\Users\Nicholas\work\repos\osqu
ery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: if %errorlevel% neq 0 goto :cmEnd [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: :cmEnd [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_t
ests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: :cmErrorLevel [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: exit /b %1 [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: :cmDone [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: if %errorlevel% neq 0 goto :VCEnd [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v150\Microsoft.CppCommon.targets(138,5): erro
r MSB3073: :VCEnd" exited with code 8. [C:\Users\Nicholas\work\repos\osquery\build\windows10\run_tests.vcxproj]
```