### PR TITLE
Add scripts to generate a dictionary and seed corpus for the config fuzzing

### DIFF
--- a/tools/harnesses/osqueryfuzz_config_corpus.sh
+++ b/tools/harnesses/osqueryfuzz_config_corpus.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage() {
+  echo "${BASH_SOURCE[0]} destination-file"
+}
+
+function main() {
+  if [[ $# < 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  zip -j $1 $SCRIPT_DIR/../../../tools/tests/*.conf
+}
+
+main $@

--- a/tools/harnesses/osqueryfuzz_config_dict.sh
+++ b/tools/harnesses/osqueryfuzz_config_dict.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage() {
+  echo "${BASH_SOURCE[0]} destination-file"
+}
+
+function main() {
+  if [[ $# < 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  # dict format is keyword="value" or just "value" - so we need to make sure our output is quoted.
+
+  egrep -h -R -o "HasMember\\(\"([^\"]+)\"\\)" ./  | sed 's/HasMember(//' | sed 's/)//' > tmp
+  egrep -h -o -e "\"([^\"]+)\"" $SCRIPT_DIR/../../../tools/tests/*.conf >> tmp
+  egrep -h -o -e "\"([^\"]+)\"" $SCRIPT_DIR/../../../packs/*.conf >> tmp
+
+  sort tmp | uniq > $1
+  rm tmp
+}
+
+main $@


### PR DESCRIPTION
This is partly a straw-man PR.  

The dictionary should list keywords for the config file. Rather than make a hard-coded list that will eventually get out of date, I grab them from the sample config files and from keywords inside HasMember() in the source code.

The seed corpus is a set of interesting config files for the fuzzer to start with. Again, I grab the sample config files.


I'd love more/better suggestions for how to identify config keywords in the codebase; or config files that are interesting but not represented in the existing test configs.

If these techniques are decent; but some hardcoded suggestions are also valuable, we can add them into the script (for the dict) or in a sub-directory of harnesses (for seed files).

Finally, if no one has any ideas, we can always add these to the tree, update oss-fuzz, and see if the code coverage improves.