### PR TITLE
Fix WHERE in(N items) results in table query running N times

### DIFF
--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -205,7 +205,8 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
       "sample", columnDefinition(response, false, false), dbc, false);
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
-  std::string const q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
+  std::string const q =
+      "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
   QueryData results;
   status = queryInternal(q, results, dbc);
   EXPECT_EQ(
@@ -326,7 +327,8 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   for (const auto& test : constraint_tests) {
     QueryData results;
     queryInternal(test.first, results, dbc);
-    EXPECT_EQ(results, test.second) << "Unexpected result for the query: " << test.first;
+    EXPECT_EQ(results, test.second)
+        << "Unexpected result for the query: " << test.first;
   }
 
   std::vector<QueryData> union_results = {

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -299,12 +299,12 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   std::vector<std::pair<std::string, QueryData>> constraint_tests = {
       MP("select k.x from p, k", makeResult("x", {"1", "2", "1", "2"})),
       MP("select k.x from (select * from k) k2, p, k where k.x = p.x",
-         makeResult("x", {"1", "1", "2", "2"})),
+         makeResult("x", {"1", "2", "1", "2"})),
       MP("select k.x from (select * from k where z = 1) k2, p, k where k.x = "
          "p.x",
          makeResult("x", {"1", "2"})),
       MP("select k.x from k k1, (select * from p) p1, k where k.x = p1.x",
-         makeResult("x", {"1", "1", "2", "2"})),
+         makeResult("x", {"1", "2", "1", "2"})),
       MP("select k.x from (select * from p) p1, k, (select * from k) k2 where "
          "k.x = p1.x",
          makeResult("x", {"1", "1", "2", "2"})),

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -1025,12 +1025,14 @@ struct NoConstraintTestTablePlugin : public TablePlugin {
 
   TableRows generate(QueryContext& context) override {
     scans++;
-    QueryData results;
+
+    TableRows tr;
     auto indexes = context.constraints["name"].getAll<int>(EQUALS);
-    results.push_back({{"name", "alpha"}, {"straints", "-1"}});
-    results.push_back(
-        {{"name", "beta"}, {"straints", INTEGER(indexes.size())}});
-    return results;
+
+    tr.push_back(make_table_row({{"name", "alpha"}, {"straints", "-1"}}));
+    tr.push_back(make_table_row(
+        {{"name", "beta"}, {"straints", INTEGER(indexes.size())}}));
+    return tr;
   }
 
   // Here the goal is to expect/assume the number of scans.

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -1023,7 +1023,7 @@ struct NoConstraintTestTablePlugin : public TablePlugin {
     };
   }
 
-  QueryData generate(QueryContext& context) override {
+  TableRows generate(QueryContext& context) override {
     scans++;
     QueryData results;
     auto indexes = context.constraints["name"].getAll<int>(EQUALS);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -695,9 +695,7 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
   double cost = 1000000;
 
   // Tables may have requirements or use indexes.
-  int numIndexedColumns = 0;
   int numRequiredColumns = 0;
-  int numIndexedConstraints = 0;
   int numRequiredConstraints = 0;
 
   // Expressions operating on the same virtual table are loosely identified by
@@ -738,7 +736,6 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
         numRequiredConstraints++;
         cost = 1;
       } else if (options & (ColumnOptions::INDEX | ColumnOptions::ADDITIONAL)) {
-        numIndexedConstraints++;
         cost = 1;
       } else {
         // not indexed, let sqlite filter it
@@ -754,7 +751,7 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
       // important: if we specify an index, it means xFilter will be called
       // once for every row.  So if you have an IN() list with 50 items,
       // xFilter will get called 50 times, once for each item.  If you have
-      // a JOIN with 500 rows, xFilter will get 500 times.  Therefore,
+      // a JOIN with 500 rows, xFilter is called 500 times.  Therefore,
       // when a spec file specifies a column to be required or index, the
       // table implementation must be able to quickly find and return a
       // single row. See issue 5379.
@@ -796,9 +793,6 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
         const auto& options = std::get<2>(columns[i]);
         if (options & ColumnOptions::REQUIRED) {
           numRequiredColumns++;
-        } else if (options &
-                   (ColumnOptions::INDEX | ColumnOptions::ADDITIONAL)) {
-          numIndexedColumns++;
         }
       }
     }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -695,8 +695,8 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
   double cost = 1000000;
 
   // Tables may have requirements or use indexes.
-  int numRequiredColumns = 0;
-  int numRequiredConstraints = 0;
+  size_t numRequiredColumns = 0;
+  size_t numRequiredConstraints = 0;
 
   // Expressions operating on the same virtual table are loosely identified by
   // the consecutive sets of terms each of the constraint sets are applied onto.

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -709,11 +709,11 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
       // Record the term index (this index exists across all expressions).
       const auto& constraint_info = pIdxInfo->aConstraint[i];
       if (FLAGS_planner) {
-        plan("xBestIndex Evaluating constraints for table: " + pVtab->content->name +
-           " [index=" + std::to_string(i) +
-           " column=" + std::to_string(constraint_info.iColumn) +
-           " term=" + std::to_string((int)constraint_info.iTermOffset) +
-           " usable=" + std::to_string((int)constraint_info.usable) + "]");
+        plan("xBestIndex Evaluating constraints for table: " +
+             pVtab->content->name + " [index=" + std::to_string(i) +
+             " column=" + std::to_string(constraint_info.iColumn) +
+             " term=" + std::to_string((int)constraint_info.iTermOffset) +
+             " usable=" + std::to_string((int)constraint_info.usable) + "]");
       }
       if (!constraint_info.usable) {
         continue;
@@ -759,13 +759,13 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
       // table implementation must be able to quickly find and return a
       // single row. See issue 5379.
 
-      pIdxInfo->aConstraintUsage[i].argvIndex =
-          static_cast<int>(++expr_index);
+      pIdxInfo->aConstraintUsage[i].argvIndex = static_cast<int>(++expr_index);
 
       if (FLAGS_planner) {
-            plan("xBestIndex Adding index constraint for table: " + pVtab->content->name +
-                 " [column=" + name + " arg_index=" + std::to_string(expr_index) +
-                 " op=" + std::to_string(constraint_info.op) + "]");
+        plan("xBestIndex Adding index constraint for table: " +
+             pVtab->content->name + " [column=" + name +
+             " arg_index=" + std::to_string(expr_index) +
+             " op=" + std::to_string(constraint_info.op) + "]");
       }
     }
   }
@@ -796,7 +796,8 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
         const auto& options = std::get<2>(columns[i]);
         if (options & ColumnOptions::REQUIRED) {
           numRequiredColumns++;
-        } else if (options & (ColumnOptions::INDEX | ColumnOptions::ADDITIONAL)) {
+        } else if (options &
+                   (ColumnOptions::INDEX | ColumnOptions::ADDITIONAL)) {
           numIndexedColumns++;
         }
       }
@@ -805,10 +806,10 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
 
   pIdxInfo->idxNum = static_cast<int>(kConstraintIndexID++);
   if (FLAGS_planner) {
-    plan("xBestIndex Recording constraint set for table: " + pVtab->content->name +
-       " [cost=" + std::to_string(cost) +
-       " size=" + std::to_string(constraints.size()) +
-       " idx=" + std::to_string(pIdxInfo->idxNum) + "]");
+    plan("xBestIndex Recording constraint set for table: " +
+         pVtab->content->name + " [cost=" + std::to_string(cost) +
+         " size=" + std::to_string(constraints.size()) +
+         " idx=" + std::to_string(pIdxInfo->idxNum) + "]");
   }
   // Add the constraint set to the table's tracked constraints.
   pVtab->content->constraints[pIdxInfo->idxNum] = std::move(constraints);


### PR DESCRIPTION
Attempt to port fix for 5379 to new branch.  Some changes I noticed from v3.3.1 branch:
 - now that there's a colsUsedBitset
 - loop to fill colsUsed set<string> is considering aliases
