### PR TITLE
remove the value_max flag

### DIFF
--- a/osquery/include/osquery/sql.h
+++ b/osquery/include/osquery/sql.h
@@ -18,7 +18,6 @@
 
 namespace osquery {
 
-DECLARE_int32(value_max);
 
 /**
  * @brief The core interface to executing osquery SQL commands.

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -21,7 +21,6 @@
 
 namespace osquery {
 
-FLAG(int32, value_max, 512, "Maximum returned row value size");
 
 CREATE_LAZY_REGISTRY(SQLPlugin, "sql");
 


### PR DESCRIPTION
The value_max flag is not needed, as described in #5705. @zwass @theopolis

Fixes https://github.com/osquery/osquery/issues/5705