### PR TITLE
process_open_sockets/windows: add state column

### DIFF
--- a/osquery/tables/networking/windows/process_open_sockets.cpp
+++ b/osquery/tables/networking/windows/process_open_sockets.cpp
@@ -6,6 +6,9 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
+#include <string>
+#include <vector>
+
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
@@ -13,6 +16,27 @@
 
 namespace osquery {
 namespace tables {
+namespace {
+const std::vector<std::string> kWinTcpStates = {
+    "UNKNOWN",
+    "CLOSED",
+    "LISTEN",
+    "SYN_SENT",
+    "SYN_RCVD",
+    "ESTABLISHED",
+    "FIN_WAIT1",
+    "FIN_WAIT2",
+    "CLOSE_WAIT",
+    "CLOSING",
+    "LAST_ACK",
+    "TIME_WAIT",
+    "DELETE_TCB",
+};
+
+std::string tcpStateString(const DWORD state) {
+  return state < kWinTcpStates.size() ? kWinTcpStates[state] : "UNKNOWN";
+}
+} // namespace
 
 WinSockets::WinSockets() {
   auto pSockTable = allocateSocketTable(IPPROTO_TCP, AF_INET);
@@ -117,6 +141,7 @@ void WinSockets::parseSocketTable(WinSockTableType sockType,
           ntohs(static_cast<u_short>(tcpTable_->table[i].dwRemotePort)));
       r["pid"] = INTEGER(tcpTable_->table[i].dwOwningPid);
       r["family"] = INTEGER(AF_INET);
+      r["state"] = tcpStateString(tcpTable_->table[i].dwState);
       break;
     }
 
@@ -143,6 +168,7 @@ void WinSockets::parseSocketTable(WinSockTableType sockType,
           ntohs(static_cast<u_short>(tcp6Table_->table[i].dwRemotePort)));
       r["pid"] = INTEGER(tcp6Table_->table[i].dwOwningPid);
       r["family"] = INTEGER(AF_INET6);
+      r["state"] = tcpStateString(tcp6Table_->table[i].dwState);
       break;
     }
 
@@ -263,5 +289,5 @@ QueryData genOpenSockets(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -12,7 +12,7 @@ schema([
     Column("remote_port", INTEGER, "Socket remote port"),
     Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
 ])
-extended_schema(lambda: LINUX() or DARWIN(), [
+extended_schema(lambda: LINUX() or DARWIN() or WINDOWS(), [
     Column("state", TEXT, "TCP socket state"),
 ])
 extended_schema(LINUX, [


### PR DESCRIPTION
On Windows, the `process_open_sockets` table was missing the `state` column, so I added it for TCP connections.