### PR TITLE
fuzzing: Minify logic required for new harnesses

### DIFF
--- a/osquery/main/harnesses/CMakeLists.txt
+++ b/osquery/main/harnesses/CMakeLists.txt
@@ -9,16 +9,16 @@ function(osqueryMainHarnesses)
     message( FATAL_ERROR "If fuzzing is enabled, a sanitizer must be chosen. (Currently only OSQUERY_ENABLE_ADDRESS_SANITIZER is available.)" )
   endif()
 
-  if(OSQUERY_ENABLE_FUZZER_SANITIZERS AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
+  if(OSQUERY_ENABLE_FUZZER_SANITIZERS AND
+      (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
     message( FATAL_ERROR "If fuzzing is enabled, it must be built in Release or RelWithDebInfo" )
   endif()
 
-  generateOsqueryFuzzHarnesses()
+  add_osquery_library(osquery_harnesses EXCLUDE_FROM_ALL
+    fuzz_utils.cpp
+  )
 
-endfunction()
-
-function(generateOsqueryFuzzHarnesses)
-  set(fuzzing_libraries
+  target_link_libraries(osquery_harnesses PUBLIC
     osquery_cxx_settings
     osquery_headers
     osquery_core
@@ -58,15 +58,21 @@ function(generateOsqueryFuzzHarnesses)
     specs_tables
   )
 
-  add_osquery_executable(osqueryfuzz-config fuzz_config.cpp)
-  set_target_properties(osqueryfuzz-config PROPERTIES POSITION_INDEPENDENT_CODE true)
-  target_link_libraries(osqueryfuzz-config PRIVATE ${fuzzing_libraries})
-  target_link_options(osqueryfuzz-config PRIVATE -fsanitize=fuzzer)
+  set(public_header_files
+    fuzz_utils.h
+  )
 
-  add_osquery_executable(osqueryfuzz-sqlquery fuzz_sqlquery.cpp)
-  set_target_properties(osqueryfuzz-sqlquery PROPERTIES POSITION_INDEPENDENT_CODE true)
-  target_link_libraries(osqueryfuzz-sqlquery PRIVATE ${fuzzing_libraries})
-  target_link_options(osqueryfuzz-sqlquery PRIVATE -fsanitize=fuzzer)
+  generateIncludeNamespace(osquery_harnesses "osquery/main/harnesses" "FILE_ONLY" ${public_header_files})
+
+  generateOsqueryFuzzHarness(osqueryfuzz-config fuzz_config.cpp)
+  generateOsqueryFuzzHarness(osqueryfuzz-sqlquery fuzz_sqlquery.cpp)
+endfunction()
+
+function(generateOsqueryFuzzHarness harness_name source_files)
+  add_osquery_executable(${harness_name} ${source_files})
+  set_target_properties(${harness_name} PROPERTIES POSITION_INDEPENDENT_CODE true)
+  target_link_libraries(${harness_name} PRIVATE osquery_harnesses)
+  target_link_options(${harness_name} PRIVATE -fsanitize=fuzzer)
 endfunction()
 
 osqueryMainHarnesses()

--- a/osquery/main/harnesses/fuzz_config.cpp
+++ b/osquery/main/harnesses/fuzz_config.cpp
@@ -7,26 +7,11 @@
  */
 
 #include <osquery/config/config.h>
-#include <osquery/database.h>
-#include <osquery/logger.h>
-#include <osquery/registry.h>
-#include <osquery/sql.h>
+
+#include <osquery/main/harnesses/fuzz_utils.h>
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
-  osquery::registryAndPluginInit();
-  osquery::DatabasePlugin::setAllowOpen(true);
-  osquery::Registry::get().setActive("database", "ephemeral");
-  osquery::DatabasePlugin::initPlugin().ok();
-
-  osquery::PluginRequest r;
-  r["action"] = "detach";
-  r["table"] = "file";
-
-  osquery::PluginResponse rsp;
-  osquery::Registry::get().call("sql", r, rsp);
-  FLAGS_minloglevel = 4;
-
-  return 0;
+  return osquery::osqueryFuzzerInitialize(argc, argv);
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/osquery/main/harnesses/fuzz_sqlquery.cpp
+++ b/osquery/main/harnesses/fuzz_sqlquery.cpp
@@ -6,31 +6,12 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <osquery/config/config.h>
-#include <osquery/core.h>
-#include <osquery/database.h>
-#include <osquery/logger.h>
-#include <osquery/registry.h>
 #include <osquery/sql.h>
-#include <osquery/sql/dynamic_table_row.h>
-#include <osquery/system.h>
-#include <osquery/tables.h>
+
+#include <osquery/main/harnesses/fuzz_utils.h>
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
-  osquery::registryAndPluginInit();
-  osquery::DatabasePlugin::setAllowOpen(true);
-  osquery::Registry::get().setActive("database", "ephemeral");
-  osquery::DatabasePlugin::initPlugin().ok();
-
-  osquery::PluginRequest r;
-  r["action"] = "detach";
-  r["table"] = "file";
-
-  osquery::PluginResponse rsp;
-  osquery::Registry::get().call("sql", r, rsp);
-  FLAGS_minloglevel = 4;
-
-  return 0;
+  return osquery::osqueryFuzzerInitialize(argc, argv);
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/osquery/main/harnesses/fuzz_utils.cpp
+++ b/osquery/main/harnesses/fuzz_utils.cpp
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/database.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+namespace osquery {
+
+int osqueryFuzzerInitialize(int* argc, char*** argv) {
+  osquery::registryAndPluginInit();
+  osquery::DatabasePlugin::setAllowOpen(true);
+  osquery::Registry::get().setActive("database", "ephemeral");
+  osquery::DatabasePlugin::initPlugin().ok();
+
+  osquery::PluginRequest r;
+  r["action"] = "detach";
+  r["table"] = "file";
+
+  osquery::PluginResponse rsp;
+  osquery::Registry::get().call("sql", r, rsp);
+  FLAGS_minloglevel = 4;
+
+  return 0;
+}
+} // namespace osquery

--- a/osquery/main/harnesses/fuzz_utils.cpp
+++ b/osquery/main/harnesses/fuzz_utils.cpp
@@ -16,7 +16,7 @@ int osqueryFuzzerInitialize(int* argc, char*** argv) {
   osquery::registryAndPluginInit();
   osquery::DatabasePlugin::setAllowOpen(true);
   osquery::Registry::get().setActive("database", "ephemeral");
-  osquery::DatabasePlugin::initPlugin().ok();
+  osquery::DatabasePlugin::initPlugin();
 
   osquery::PluginRequest r;
   r["action"] = "detach";

--- a/osquery/main/harnesses/fuzz_utils.h
+++ b/osquery/main/harnesses/fuzz_utils.h
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+namespace osquery {
+
+/**
+ * Generic initialize function that 'disables' core features.
+ *
+ * The goal of this logic is to reduce statefulness.
+ * Call this within LLVMFuzzerInitialize.
+ */
+int osqueryFuzzerInitialize(int* argc, char*** argv);
+
+} // namespace osquery


### PR DESCRIPTION
I wanted to reduce code-reuse and make new harnesses easy to add. Now this should be a line in CMake and a new harness source file with only the harness logic.