### PR TITLE
Fix a race condition during the shutdown of the worker process

### DIFF
--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -104,6 +104,6 @@ int main(int argc, char* argv[]) {
   }
 
   // Finally wait for a signal / interrupt to shutdown.
-  runner.waitForShutdown();
+  runner.waitThenShutdown();
   return 0;
 }

--- a/osquery/examples/example_writable_table.cpp
+++ b/osquery/examples/example_writable_table.cpp
@@ -293,6 +293,6 @@ int main(int argc, char* argv[]) {
   }
 
   // Finally wait for a signal / interrupt to shutdown.
-  runner.waitForShutdown();
+  runner.waitThenShutdown();
   return 0;
 }

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -131,10 +131,11 @@ class Initializer : private boost::noncopyable {
   /**
    * @brief Cleanly wait for all services and components to shutdown.
    *
-   * Enter a join of all services followed by a sync wait for event loops.
-   * If the main thread is out of actions it can call #waitForShutdown.
+   * Enter a join of all services followed by a sync wait for event loops,
+   * then it shuts down all the components.
+   * If the main thread is out of actions it can call #waitThenShutdown.
    */
-  static void waitForShutdown();
+  static void waitThenShutdown();
 
   /**
    * @brief Initialize any platform dependent libraries or objects

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -109,7 +109,7 @@ int startDaemon(Initializer& runner) {
   osquery::events::init_syscall_tracing();
 
   // Finally wait for a signal / interrupt to shutdown.
-  runner.waitForShutdown();
+  runner.waitThenShutdown();
   return 0;
 }
 


### PR DESCRIPTION
When a thread different from the main requests a shutdown
through Initializer::requestShutdown, it should not call
waitForShutdown; there's no reason to wait, moreover the function
doesn't only wait, but also actually stops other components and then
finally calls exit().

Since the main thread is already inside the waitForShutdown call
waiting on Dispatcher::joinServices or inside the shutdown() callable
on Windows, having a secondary thread do
the same work potentially at the same time is wrong.
Moreover calling exit() from a secondary thread is most of the time
incorrect.

The waitForShutdown function has been renamed to waitThenShutdown
to better represent what it's actually doing.