### PR TITLE
powershell/config: Add checks for character_frequencies

### DIFF
--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -108,8 +108,8 @@ void PowershellEventSubscriber::addScriptResult(Row& results) {
 
   const auto& doc = parser->getData().doc();
   if (!doc.IsObject() || !doc.HasMember("feature_vectors") ||
-      !doc["feature_vectors"].HasMember("chracter_frequencies") ||
-      !doc["feature_vectors"]["chracter_frequencies"].IsArray()) {
+      !doc["feature_vectors"].HasMember("character_frequencies") ||
+      !doc["feature_vectors"]["character_frequencies"].IsArray()) {
     VLOG(1) << "No character frequency map found, skipping computation";
     add(r);
     return;

--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -106,6 +106,22 @@ void PowershellEventSubscriber::addScriptResult(Row& results) {
     return;
   }
 
+  const auto& doc = parser->getData().doc();
+  if (!doc.IsObject() || !doc.HasMember("feature_vectors") ||
+      !doc["feature_vectors"].HasMember("chracter_frequencies") ||
+      !doc["feature_vectors"]["chracter_frequencies"].IsArray()) {
+    VLOG(1) << "No character frequency map found, skipping computation";
+    add(r);
+    return;
+  }
+
+  const auto& cf = doc["feature_vectors"]["character_frequencies"];
+  if (cf.Empty() || cf.Size() != kCharFreqVectorLen) {
+    VLOG(1) << "Invalid character frequency map found, skipping computation";
+    add(r);
+    return;
+  }
+
   // Get the reassembled powershell scripts character frequency vector
   std::vector<double> freqs(kCharFreqVectorLen, 0.0);
   for (const auto chr : r["script_text"]) {
@@ -114,17 +130,11 @@ void PowershellEventSubscriber::addScriptResult(Row& results) {
     }
   }
 
-  const auto& cf =
-      parser->getData().doc()["feature_vectors"]["character_frequencies"];
-  if (cf.Empty() || cf.Size() != kCharFreqVectorLen) {
-    VLOG(1) << "Invalid character frequency map found, skipping computation";
-    add(r);
-    return;
-  }
-
   std::vector<double> cfg_freqs(kCharFreqVectorLen, 0.0);
   for (unsigned int i = 0; i < cf.Size(); i++) {
-    cfg_freqs[i] = cf[i].GetDouble();
+    if (cf[i].IsDouble()) {
+      cfg_freqs[i] = cf[i].GetDouble();
+    }
   }
   r["cosine_similarity"] = DOUBLE(cosineSimilarity(freqs, cfg_freqs));
   add(r);

--- a/plugins/config/parsers/feature_vectors.cpp
+++ b/plugins/config/parsers/feature_vectors.cpp
@@ -6,9 +6,9 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <plugins/config/parsers/feature_vectors.h>
 #include <osquery/config/config.h>
 #include <osquery/registry_factory.h>
+#include <plugins/config/parsers/feature_vectors.h>
 
 namespace osquery {
 
@@ -22,13 +22,19 @@ Status FeatureVectorsConfigParserPlugin::update(const std::string& source,
                                                 const ParserConfig& config) {
   auto fv = config.find(kFeatureVectorsRootKey);
   if (fv == config.end()) {
-    return Status();
+    // No feature_vectors key.
+    return Status::success();
+  }
+
+  if (!fv->second.doc().IsObject()) {
+    // Expect feature_vectors to be an object.
+    return Status::success();
   }
 
   auto obj = data_.getObject();
   data_.copyFrom(fv->second.doc(), obj);
   data_.add(kFeatureVectorsRootKey, obj);
-  return Status();
+  return Status::success();
 }
 
 REGISTER_INTERNAL(FeatureVectorsConfigParserPlugin,


### PR DESCRIPTION
This fixes #5929.

I am not sure what this functionality provides and it is not tested. 

But this PR adds basic checks for the expectations for the format of the configuration JSON.