### PR TITLE
http: Minor fixups to Client

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -9,6 +9,8 @@
 #include <osquery/logger.h>
 #include <osquery/remote/http_client.h>
 
+#include <boost/asio/connect.hpp>
+
 namespace osquery {
 namespace http {
 
@@ -64,8 +66,8 @@ void Client::timeoutHandler(boost::system::error_code const& ec) {
   }
 }
 
-void Client::connectHandler(const boost::system::error_code& ec,
-                            const boost::asio::ip::tcp::endpoint&) {
+void Client::connectHandler(boost::system::error_code const & ec,
+                            boost::asio::ip::tcp::endpoint const&) {
   if (client_options_.timeout_) {
     timer_.cancel();
   }
@@ -76,7 +78,7 @@ void Client::connectHandler(const boost::system::error_code& ec,
 }
 
 void Client::resolveHandler(
-    const boost::system::error_code& ec,
+    boost::system::error_code const& ec,
     boost::asio::ip::tcp::resolver::results_type results) {
   if (!ec) {
     boost::asio::async_connect(sock_,
@@ -96,7 +98,7 @@ void Client::resolveHandler(
   }
 }
 
-void Client::handshakeHandler(const boost::system::error_code& ec) {
+void Client::handshakeHandler(boost::system::error_code const& ec) {
   if (client_options_.timeout_) {
     timer_.cancel();
   }

--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -6,19 +6,8 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-// TODO(5591) Remove this when addressed by Boost's ASIO config.
-// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
-// Standard library support for std::string_view.
-#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
-
-// clang-format off
-// Keep it on top of all other includes to fix double include WinSock.h header file
-// which is windows specific boost build problem
-#include <boost/asio.hpp>
-#include <osquery/remote/http_client.h>
-// clang-format on
-
 #include <osquery/logger.h>
+#include <osquery/remote/http_client.h>
 
 namespace osquery {
 namespace http {
@@ -38,7 +27,7 @@ void Client::callNetworkOperation(std::function<void()> callback) {
   callback();
 
   {
-    boost_system::error_code rc;
+    boost::system::error_code rc;
     ioc_.run(rc);
     ioc_.reset();
     if (rc) {
@@ -47,8 +36,8 @@ void Client::callNetworkOperation(std::function<void()> callback) {
   }
 }
 
-void Client::postResponseHandler(boost_system::error_code const& ec) {
-  if ((ec.category() == boost_asio::error::ssl_category) &&
+void Client::postResponseHandler(boost::system::error_code const& ec) {
+  if ((ec.category() == boost::asio::error::ssl_category) &&
       (ec.value() == kSSLShortReadError)) {
     // Ignoring short read error, set ec_ to success.
     ec_.clear();
@@ -62,13 +51,13 @@ void Client::postResponseHandler(boost_system::error_code const& ec) {
 
 void Client::closeSocket() {
   if (sock_.is_open()) {
-    boost_system::error_code rc;
-    sock_.shutdown(boost_asio::ip::tcp::socket::shutdown_both, rc);
+    boost::system::error_code rc;
+    sock_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, rc);
     sock_.close(rc);
   }
 }
 
-void Client::timeoutHandler(boost_system::error_code const& ec) {
+void Client::timeoutHandler(boost::system::error_code const& ec) {
   if (!ec) {
     closeSocket();
     ec_ = boost::asio::error::make_error_code(boost::asio::error::timed_out);
@@ -76,7 +65,7 @@ void Client::timeoutHandler(boost_system::error_code const& ec) {
 }
 
 void Client::connectHandler(const boost::system::error_code& ec,
-                            const boost_asio::ip::tcp::endpoint&) {
+                            const boost::asio::ip::tcp::endpoint&) {
   if (client_options_.timeout_) {
     timer_.cancel();
   }
@@ -88,7 +77,7 @@ void Client::connectHandler(const boost::system::error_code& ec,
 
 void Client::resolveHandler(
     const boost::system::error_code& ec,
-    boost_asio::ip::tcp::resolver::results_type results) {
+    boost::asio::ip::tcp::resolver::results_type results) {
   if (!ec) {
     boost::asio::async_connect(sock_,
                                results,
@@ -117,7 +106,7 @@ void Client::handshakeHandler(const boost::system::error_code& ec) {
   }
 }
 
-void Client::writeHandler(boost_system::error_code const& ec, size_t) {
+void Client::writeHandler(boost::system::error_code const& ec, size_t) {
   if (client_options_.timeout_) {
     timer_.cancel();
   }
@@ -127,7 +116,7 @@ void Client::writeHandler(boost_system::error_code const& ec, size_t) {
   }
 }
 
-void Client::readHandler(boost_system::error_code const& ec, size_t) {
+void Client::readHandler(boost::system::error_code const& ec, size_t) {
   if (client_options_.timeout_) {
     timer_.cancel();
   }
@@ -150,7 +139,7 @@ void Client::createConnection() {
   }
 
   callNetworkOperation([&]() {
-    r_.async_resolve(boost_asio::ip::tcp::resolver::query{connect_host, port},
+    r_.async_resolve(boost::asio::ip::tcp::resolver::query{connect_host, port},
                      std::bind(&Client::resolveHandler,
                                this,
                                std::placeholders::_1,
@@ -162,12 +151,12 @@ void Client::createConnection() {
     if (client_options_.proxy_hostname_) {
       error += "proxy host ";
     }
-    error += connect_host + ":" + port;
+    error += connect_host + ':' + port;
     throw std::system_error(ec_, error);
   }
 
   if (client_options_.keep_alive_) {
-    boost_asio::socket_base::keep_alive option(true);
+    boost::asio::socket_base::keep_alive option(true);
     sock_.set_option(option);
   }
 
@@ -177,7 +166,7 @@ void Client::createConnection() {
 
     beast_http_request req;
     req.method(beast_http::verb::connect);
-    req.target(remote_host + ":" + remote_port);
+    req.target(remote_host + ':' + remote_port);
     req.version(11);
     req.prepare_payload();
 
@@ -220,21 +209,21 @@ void Client::createConnection() {
 }
 
 void Client::encryptConnection() {
-  boost_asio::ssl::context ctx{boost_asio::ssl::context::sslv23};
+  boost::asio::ssl::context ctx{boost::asio::ssl::context::sslv23};
 
   if (client_options_.always_verify_peer_) {
-    ctx.set_verify_mode(boost_asio::ssl::verify_peer);
+    ctx.set_verify_mode(boost::asio::ssl::verify_peer);
   } else {
-    ctx.set_verify_mode(boost_asio::ssl::verify_none);
+    ctx.set_verify_mode(boost::asio::ssl::verify_none);
   }
 
   if (client_options_.server_certificate_) {
-    ctx.set_verify_mode(boost_asio::ssl::verify_peer);
+    ctx.set_verify_mode(boost::asio::ssl::verify_peer);
     ctx.load_verify_file(*client_options_.server_certificate_);
   }
 
   if (client_options_.verify_path_) {
-    ctx.set_verify_mode(boost_asio::ssl::verify_peer);
+    ctx.set_verify_mode(boost::asio::ssl::verify_peer);
     ctx.add_verify_path(*client_options_.verify_path_);
   }
 
@@ -249,12 +238,12 @@ void Client::encryptConnection() {
 
   if (client_options_.client_certificate_file_) {
     ctx.use_certificate_file(*client_options_.client_certificate_file_,
-                             boost_asio::ssl::context::pem);
+                             boost::asio::ssl::context::pem);
   }
 
   if (client_options_.client_private_key_file_) {
     ctx.use_private_key_file(*client_options_.client_private_key_file_,
-                             boost_asio::ssl::context::pem);
+                             boost::asio::ssl::context::pem);
   }
 
   ssl_sock_ = std::make_shared<ssl_stream>(sock_, ctx);
@@ -265,7 +254,7 @@ void Client::encryptConnection() {
 
   callNetworkOperation([&]() {
     ssl_sock_->async_handshake(
-        boost_asio::ssl::stream_base::client,
+        boost::asio::ssl::stream_base::client,
         std::bind(&Client::handshakeHandler, this, std::placeholders::_1));
   });
 
@@ -287,7 +276,7 @@ void Client::sendRequest(STREAM_TYPE& stream,
         (kHTTPSDefaultPort != *client_options_.remote_port_)) {
       host_header_value += ':' + *client_options_.remote_port_;
     } else if (!client_options_.ssl_connection_ &&
-        kHTTPDefaultPort != *client_options_.remote_port_) {
+               kHTTPDefaultPort != *client_options_.remote_port_) {
       host_header_value += ':' + *client_options_.remote_port_;
     }
     req.set(beast_http::field::host, host_header_value);
@@ -298,7 +287,7 @@ void Client::sendRequest(STREAM_TYPE& stream,
 
   if (client_options_.timeout_) {
     timer_.async_wait(
-        [=](boost_system::error_code const& ec) { timeoutHandler(ec); });
+        [=](boost::system::error_code const& ec) { timeoutHandler(ec); });
   }
 
   beast_http_request_serializer sr{req};
@@ -513,5 +502,5 @@ Response Client::delete_(Request& req) {
   req.method(beast_http::verb::delete_);
   return sendHTTPRequest(req);
 }
-}
-}
+} // namespace http
+} // namespace osquery

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -47,14 +47,12 @@
 
 #include <osquery/remote/uri.h>
 
-namespace boost_system = boost::system;
-namespace boost_asio = boost::asio;
 namespace beast_http = boost::beast::http;
 
 namespace osquery {
 namespace http {
 
-typedef boost_asio::ssl::stream<boost_asio::ip::tcp::socket&> ssl_stream;
+typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> ssl_stream;
 typedef beast_http::request<beast_http::string_body> beast_http_request;
 typedef beast_http::response<beast_http::string_body> beast_http_response;
 typedef beast_http::response_parser<beast_http::string_body>
@@ -181,10 +179,15 @@ class Client {
              (client_private_key_file_ == ropts.client_private_key_file_) &&
              (ciphers_ == ropts.ciphers_) &&
              (sni_hostname_ == ropts.sni_hostname_) &&
-             (ssl_options_ == ropts.ssl_options_) &&
-             (always_verify_peer_ == ropts.always_verify_peer_) &&
              (proxy_hostname_ == ropts.proxy_hostname_) &&
-             (keep_alive_ == ropts.keep_alive_);
+             (remote_hostname_ == ropts.remote_hostname_) &&
+             (remote_port_ == ropts.remote_port_) &&
+             (ssl_options_ == ropts.ssl_options_) &&
+             (timeout_ == ropts.timeout_) &&
+             (always_verify_peer_ == ropts.always_verify_peer_) &&
+             (follow_redirects_ == ropts.follow_redirects_) &&
+             (keep_alive_ == ropts.keep_alive_) &&
+             (ssl_connection_ == ropts.ssl_connection_);
     }
 
    private:
@@ -276,7 +279,7 @@ class Client {
   Response sendHTTPRequest(Request& req);
 
   /// Handles HTTP request timeout.
-  void timeoutHandler(boost_system::error_code const& ec);
+  void timeoutHandler(boost::system::error_code const& ec);
 
   /**
    * @brief Handles response if requests completes or aborted due to timeout.
@@ -285,24 +288,24 @@ class Client {
    * connections. This can happen if a remote server did not call shutdown on
    * the TLS connection.
    */
-  void postResponseHandler(boost_system::error_code const& ec);
+  void postResponseHandler(boost::system::error_code const& ec);
 
   /// Callback to be provided during async_resolve call.
   void resolveHandler(const boost::system::error_code& ec,
-                      boost_asio::ip::tcp::resolver::results_type results);
+                      boost::asio::ip::tcp::resolver::results_type results);
 
   /// Callback to be provided during async_connect call.
   void connectHandler(const boost::system::error_code& ec,
-                      const boost_asio::ip::tcp::endpoint&);
+                      const boost::asio::ip::tcp::endpoint&);
 
   /// Callback to be provided during async_handshake call.
   void handshakeHandler(const boost::system::error_code& ec);
 
   /// Callback to be provided during async_write call.
-  void writeHandler(boost_system::error_code const& ec, size_t);
+  void writeHandler(boost::system::error_code const& ec, size_t);
 
   /// Callback to be provided during async_read call.
-  void readHandler(boost_system::error_code const& ec, size_t);
+  void readHandler(boost::system::error_code const& ec, size_t);
 
   bool isSocketOpen() {
     return sock_.is_open();
@@ -324,12 +327,12 @@ class Client {
 
  private:
   Options client_options_;
-  boost_asio::io_context ioc_;
-  boost_asio::ip::tcp::resolver r_;
-  boost_asio::ip::tcp::socket sock_;
-  boost_asio::deadline_timer timer_;
+  boost::asio::io_context ioc_;
+  boost::asio::ip::tcp::resolver r_;
+  boost::asio::ip::tcp::socket sock_;
+  boost::asio::deadline_timer timer_;
   std::shared_ptr<ssl_stream> ssl_sock_;
-  boost_system::error_code ec_;
+  boost::system::error_code ec_;
   bool new_client_options_{true};
 };
 
@@ -523,5 +526,5 @@ class HTTP_Response<T>::Headers {
  private:
   T* resp_;
 };
-}
-}
+} // namespace http
+} // namespace osquery

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -307,14 +307,14 @@ class Client {
   /// Callback to be provided during async_read call.
   void readHandler(boost::system::error_code const& ec, size_t);
 
-  bool isSocketOpen() {
-    return sock_.is_open();
-  }
+  /// Check if the socket is open.
+  bool isSocketOpen();
 
+  /// If the socket is open, request a shutdown and close.
   void closeSocket();
 
   /**
-   * @brief Wrap actual network call.
+   * @brief Wrap calls to boost::beast async functions.
    *
    * callNetworkOperation is a wrapper function which wraps following tasks
    * 1. Start the timer for network call timeout.
@@ -324,6 +324,13 @@ class Client {
    * This function sets ec_ in case of boost io service returns with an error.
    */
   void callNetworkOperation(std::function<void()> callback);
+
+  /**
+   * @brief Used in callbacks to cancel timers and set ec_.
+   *
+   * Note that one side-effect is ec_ will be overwritten.
+   */
+  void cancelTimerAndSetError(boost::system::error_code const& ec);
 
  private:
   Options client_options_;

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -291,15 +291,15 @@ class Client {
   void postResponseHandler(boost::system::error_code const& ec);
 
   /// Callback to be provided during async_resolve call.
-  void resolveHandler(const boost::system::error_code& ec,
+  void resolveHandler(boost::system::error_code const& ec,
                       boost::asio::ip::tcp::resolver::results_type results);
 
   /// Callback to be provided during async_connect call.
-  void connectHandler(const boost::system::error_code& ec,
-                      const boost::asio::ip::tcp::endpoint&);
+  void connectHandler(boost::system::error_code const& ec,
+                      boost::asio::ip::tcp::endpoint const&);
 
   /// Callback to be provided during async_handshake call.
-  void handshakeHandler(const boost::system::error_code& ec);
+  void handshakeHandler(boost::system::error_code const& ec);
 
   /// Callback to be provided during async_write call.
   void writeHandler(boost::system::error_code const& ec, size_t);

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -11,9 +11,9 @@
 #include <chrono>
 #include <osquery/core.h>
 #include <osquery/filesystem/filesystem.h>
-#include <osquery/utils/info/version.h>
-#include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/config/default_paths.h>
+#include <osquery/utils/info/platform_type.h>
+#include <osquery/utils/info/version.h>
 
 #include <boost/filesystem.hpp>
 
@@ -73,7 +73,7 @@ HIDDEN_FLAG(bool, tls_node_api, false, "Use node key as TLS endpoints");
 
 DECLARE_bool(verbose);
 
-TLSTransport::TLSTransport() : verify_peer_(true) {
+TLSTransport::TLSTransport() {
   if (FLAGS_tls_server_certs.size() > 0) {
     server_certificate_file_ = FLAGS_tls_server_certs;
   }
@@ -109,7 +109,7 @@ http::Client::Options TLSTransport::getOptions() {
                    << server_certificate_file_;
     } else {
       // There is a non-default server certificate set.
-      boost_system::error_code ec;
+      boost::system::error_code ec;
 
       auto status = fs::status(server_certificate_file_, ec);
 
@@ -277,4 +277,4 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
   }
   return response_status_;
 }
-}
+} // namespace osquery

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -71,7 +71,7 @@ class TLSTransport : public Transport {
   /**
    * @brief Class destructor
    */
-  virtual ~TLSTransport() {}
+  virtual ~TLSTransport() = default;
 
  public:
   TLSTransport();
@@ -107,7 +107,7 @@ class TLSTransport : public Transport {
   std::string server_certificate_file_;
 
   /// Testing-only, disable peer verification.
-  bool verify_peer_;
+  bool verify_peer_{true};
 
  protected:
   /**
@@ -130,6 +130,5 @@ class TLSTransport : public Transport {
   FRIEND_TEST(TLSTransportsTests, test_call_http);
 
   friend class TestDistributedPlugin;
-
 };
-}
+} // namespace osquery


### PR DESCRIPTION
This is a quick review of the HTTP Client class. I noticed the Options
comparison does not include all members. The namespace alias seemed
unneeded so I removed boost_system and boost_asio.

