### PR TITLE
http: Move away from deprecated async_resolve overload

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -131,7 +131,8 @@ void Client::createConnection() {
   }
 
   callNetworkOperation([&]() {
-    r_.async_resolve(boost::asio::ip::tcp::resolver::query{connect_host, port},
+    r_.async_resolve(connect_host,
+                     port,
                      std::bind(&Client::resolveHandler,
                                this,
                                std::placeholders::_1,


### PR DESCRIPTION
Wait for https://github.com/osquery/osquery/pull/5946 to be reviewed and merged.

When testing on IPv6-only hosts, with an IPv4 lo stack, the resolver may not return an IPv4 address. This seems to be an issue with the deprecated overload of async_resolve. Upon inspection, the previous overload would only return 1 result_type.

Migrating to the recommended overload works as expected.

This was referenced in the issue #5883.