### PR TITLE
audit: Allow configuring audit_backlog_wait_time

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -53,6 +53,9 @@ FLAG(bool,
      false,
      "Configure the audit subsystem from scratch");
 
+/// This value is passed directly to the audit API.
+FLAG(int32, audit_backlog_wait_time, 0, "Set the audit backlog wait time");
+
 // External flags; they are used to determine which rules need to be installed
 DECLARE_bool(audit_allow_fim_events);
 DECLARE_bool(audit_allow_process_events);
@@ -61,14 +64,16 @@ DECLARE_bool(audit_allow_sockets);
 DECLARE_bool(audit_allow_user_events);
 DECLARE_bool(audit_allow_selinux_events);
 
-// user messages should be filtered
-// also, we should handle the 2nd user message type
 namespace {
 bool IsSELinuxRecord(const audit_reply& reply) noexcept {
   static const auto& selinux_event_set = kSELinuxEventList;
   return (selinux_event_set.find(reply.type) != selinux_event_set.end());
 }
 
+/**
+ * User messages should be filtered. Also, we should handle the 2nd user
+ * message type.
+ */
 bool ShouldHandle(const audit_reply& reply) noexcept {
   if (IsSELinuxRecord(reply)) {
     return FLAGS_audit_allow_selinux_events;
@@ -146,7 +151,7 @@ void AuditdNetlinkReader::start() {
   while (!interrupted()) {
     if (auditd_context_->acquire_handle) {
       if (FLAGS_audit_debug) {
-        std::cout << "(re)acquiring the audit handle.." << std::endl;
+        VLOG(1) << "(Re)acquiring the audit handle";
       }
 
       NetlinkStatus netlink_status = acquireHandle();
@@ -196,7 +201,10 @@ void AuditdNetlinkReader::stop() {
   VLOG(1) << "Releasing the audit handle...";
 
   auditd_context_->unprocessed_records_cv.notify_all();
-  restoreAuditServiceConfiguration();
+
+  if (FLAGS_audit_allow_config) {
+    restoreAuditServiceConfiguration();
+  }
 
   audit_close(audit_netlink_handle_);
   audit_netlink_handle_ = -1;
@@ -304,7 +312,8 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
   // Want to set a min sane buffer and maximum number of events/second min.
   // This is normally controlled through the audit config, but we must
   // enforce sane minimums: -b 8192 -e 100
-  audit_set_backlog_wait_time(audit_netlink_handle_, 1);
+  audit_set_backlog_wait_time(audit_netlink_handle_,
+                              FLAGS_audit_backlog_wait_time);
   audit_set_backlog_limit(audit_netlink_handle_, 4096);
   audit_set_failure(audit_netlink_handle_, AUDIT_FAIL_SILENT);
 
@@ -371,8 +380,7 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
     // we have been asked to
     if (rule_add_error >= 0) {
       if (FLAGS_audit_debug) {
-        std::cout << "Audit rule installed for syscall " << syscall_number
-                  << std::endl;
+        VLOG(1) << "Audit rule installed for syscall " << syscall_number;
       }
 
       installed_rule_list_.push_back(rule);
@@ -380,8 +388,8 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
     }
 
     if (FLAGS_audit_debug) {
-      std::cout << "Audit rule for syscall " << syscall_number
-                << " could not be installed. Errno: " << (-errno) << std::endl;
+      VLOG(1) << "Audit rule for syscall " << syscall_number
+              << " could not be installed: " << (-errno);
     }
 
     if (FLAGS_audit_force_unconfigure) {
@@ -548,10 +556,6 @@ bool AuditdNetlinkReader::deleteAuditRule(
 }
 
 void AuditdNetlinkReader::restoreAuditServiceConfiguration() noexcept {
-  if (FLAGS_audit_debug) {
-    std::cout << "Uninstalling audit rules" << std::endl;
-  }
-
   // Remove the rules we have added
   VLOG(1) << "Uninstalling the audit rules we have installed";
 
@@ -562,14 +566,7 @@ void AuditdNetlinkReader::restoreAuditServiceConfiguration() noexcept {
 
   installed_rule_list_.clear();
 
-  // Restore audit configuration defaults.
-  if (FLAGS_audit_debug) {
-    std::cout << "Restoring default settings and disabling the service"
-              << std::endl;
-  }
-
   VLOG(1) << "Restoring the default configuration for the audit service";
-
   audit_set_backlog_limit(audit_netlink_handle_, 0);
   audit_set_backlog_wait_time(audit_netlink_handle_, 60000);
   audit_set_failure(audit_netlink_handle_, AUDIT_FAIL_PRINTK);
@@ -640,10 +637,6 @@ NetlinkStatus AuditdNetlinkReader::acquireHandle() noexcept {
 
       return NetlinkStatus::Error;
     }
-
-    if (FLAGS_audit_debug) {
-      std::cout << "Audit service enabled" << std::endl;
-    }
   }
 
   if (FLAGS_audit_allow_config) {
@@ -656,10 +649,6 @@ NetlinkStatus AuditdNetlinkReader::acquireHandle() noexcept {
 
     if (!configureAuditService()) {
       return NetlinkStatus::ActiveImmutable;
-    }
-
-    if (FLAGS_audit_debug) {
-      std::cout << "Audit service configured" << std::endl;
     }
   }
 
@@ -758,8 +747,7 @@ bool AuditdNetlinkParser::ParseAuditReply(
   event_record = {};
 
   if (FLAGS_audit_debug) {
-    std::cout << reply.type << ", " << std::string(reply.message, reply.len)
-              << std::endl;
+    VLOG(1) << reply.type << ", " << std::string(reply.message, reply.len);
   }
 
   // Parse the record header

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -54,7 +54,10 @@ FLAG(bool,
      "Configure the audit subsystem from scratch");
 
 /// This value is passed directly to the audit API.
-FLAG(int32, audit_backlog_wait_time, 0, "Set the audit backlog wait time");
+FLAG(int32, audit_backlog_wait_time, 0, "The audit backlog wait time");
+
+/// This value is passed directly to the audit API.
+FLAG(int32, audit_backlog_limit, 4096, "The audit backlog limit");
 
 // External flags; they are used to determine which rules need to be installed
 DECLARE_bool(audit_allow_fim_events);
@@ -314,7 +317,7 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
   // enforce sane minimums: -b 8192 -e 100
   audit_set_backlog_wait_time(audit_netlink_handle_,
                               FLAGS_audit_backlog_wait_time);
-  audit_set_backlog_limit(audit_netlink_handle_, 4096);
+  audit_set_backlog_limit(audit_netlink_handle_, FLAGS_audit_backlog_limit);
   audit_set_failure(audit_netlink_handle_, AUDIT_FAIL_SILENT);
 
   // Request only the highest priority of audit status messages.


### PR DESCRIPTION
Read the analysis within #5952.

There are multiple sources suggesting an optimal value is 0. Our implementation previously hardcoded the value to 1. It is now 0 and can be configured to a different value using the `audit_backlog_wait_time` option or command line flag.
