### PR TITLE
improve etc_protocols test

### DIFF
--- a/tests/integration/tables/etc_protocols.cpp
+++ b/tests/integration/tables/etc_protocols.cpp
@@ -26,7 +26,7 @@ TEST_F(EtcProtocolsTest, test_sanity) {
   auto const row_map = ValidationMap{
       {"name", NonEmptyString},
       {"number", NonNegativeInt},
-      {"alias", NonEmptyString},
+      {"alias", NonNull},
       {"comment", NormalType},
   };
   validate_rows(rows, row_map);


### PR DESCRIPTION
In the etc_protocols test, the `alias` field in the etc_protocols table was not  allowed to be empty, this caused the test on some machine to fail as  described in #5805. Now it's allowed to be empty.

