### PR TITLE
yara memory management

### DIFF
--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -41,8 +41,8 @@ FLAG(bool,
 FLAG(uint32,
      yara_intrafile_sleep,
      50,
-     "Time in ms to sleep after scan of each file (default 50). Helps reduce "
-     "memory spikes.");
+     "Time in ms to sleep after scan of each file (default 50) to reduce "
+     "memory spikes");
 
 namespace tables {
 

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -39,7 +39,7 @@ FLAG(bool,
      "Call malloc_trim() after YARA scans (linux)");
 #endif
 FLAG(uint32,
-     yara_intrafile_sleep,
+     yara_delay,
      50,
      "Time in ms to sleep after scan of each file (default 50) to reduce "
      "memory spikes");
@@ -155,7 +155,7 @@ QueryData genYara(QueryContext& context) {
 
         // sleep between each file to help smooth out malloc spikes
         std::this_thread::sleep_for(
-            std::chrono::milliseconds(FLAGS_yara_intrafile_sleep));
+            std::chrono::milliseconds(FLAGS_yara_delay));
       }
     }
   }

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -36,7 +36,7 @@ namespace osquery {
 FLAG(bool,
      yara_malloc_trim,
      true,
-     "Call malloc_trim() after yara scans (linux)");
+     "Call malloc_trim() after YARA scans (linux)");
 #endif
 
 namespace tables {

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -38,6 +38,11 @@ FLAG(bool,
      true,
      "Call malloc_trim() after YARA scans (linux)");
 #endif
+FLAG(uint32,
+     yara_intrafile_sleep,
+     50,
+     "Time in ms to sleep after scan of each file (default 50). Helps reduce "
+     "memory spikes.");
 
 namespace tables {
 
@@ -149,7 +154,8 @@ QueryData genYara(QueryContext& context) {
         doYARAScan(rules[group], path.c_str(), results, group, group);
 
         // sleep between each file to help smooth out malloc spikes
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(FLAGS_yara_intrafile_sleep));
       }
     }
   }


### PR DESCRIPTION
Watchdog will kill the osquery process if the memory usage is too high for too long.  Doing a decent size yara scan will likely trigger watchdog.  The yara library makes use of malloc(), and it has been observed that calling free() will not necessarily free that memory if the malloc subsystem thinks it will just need to reallocate that memory again soon.  The memory allocation increases more gradually, it's more likely that malloc will return free() memory back to the system.  This fix has two parts:
- a 50 microsecond delay after a file scan to make memory spike more gradual.  It accounted for about 30% less memory profile over a large scan.
- call to malloc_trim() on Linux to ask for malloc to cleanup and return freed memory.
