### PR TITLE
Explicitly select Xcode version 10.3 in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,6 +193,7 @@ jobs:
     - script: |
         brew upgrade
         brew install ccache flex bison
+        sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20
 
@@ -257,6 +258,7 @@ jobs:
         brew upgrade
         brew cask install adoptopenjdk
         brew install buck watchman
+        sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20
 


### PR DESCRIPTION
Some Agents configuration is being updated and the default Xcode version is now 11.1 which we don't support yet.
