### PR TITLE
Fix python3 deprecation warning

### DIFF
--- a/tools/codegen/amalgamate.py
+++ b/tools/codegen/amalgamate.py
@@ -18,7 +18,7 @@ END_LINE = "/// END[GENTABLE]"
 
 
 def genTableData(filename):
-    with open(filename, "rU") as fh:
+    with open(filename, "r") as fh:
         data = fh.read()
     begin_table = False
     table_data = []
@@ -50,7 +50,7 @@ def main(argc, argv):
     tables = []
     # Discover the output template, usually a black cpp file with includes.
     template = os.path.join(args.templates, TEMPLATE_NAME)
-    with open(template, "rU") as fh:
+    with open(template, "r") as fh:
         template_data = fh.read()
 
     for base, _, filenames in os.walk(args.sources):

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -202,7 +202,7 @@ def gen_api(tables_path, profile={}):
             name = spec_file.split(".table", 1)[0]
             if platform not in categories.keys():
                 categories[platform] = {"name": platform_name, "tables": []}
-            with open(os.path.join(base, spec_file), "rU") as fh:
+            with open(os.path.join(base, spec_file), "r") as fh:
                 tree = ast.parse(fh.read())
                 table_spec = gen_spec(tree)
                 table_profile = profile.get("%s.%s" % (platform, name), {})

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -76,7 +76,7 @@ def url_for_spec(path):
 def generate_table_metadata(full_path):
     """This function generates a dictionary of table metadata for a spec file
     found at a given path."""
-    with open(full_path, "rU") as file_handle:
+    with open(full_path, "r") as file_handle:
         # Each osquery table specification is a syntactically correct python file
         # because we imported `from gentable import *`, we imported all of the
         # functions that you use in an osquery specification. a global "table"


### PR DESCRIPTION
In python 3, open was changed to enable universal newlines by default, and 'U' mode was deprecated.

This PR replaces instances of `open(filename, 'rU')` with `open(filename, 'r')` to remove the DeprecationWarning.

Example:

```
[100%] Generating amalgamation file for the native tables...
/home/user/src/github.com/osquery/osquery/tools/codegen/amalgamate.py:53: DeprecationWarning: 'U' mode is deprecated
  with open(template, "rU") as fh:
```