### PR TITLE
Restore specific Visual Studio generator selection in building.md

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -100,7 +100,7 @@ cd osquery
 
 # Configure
 mkdir build; cd build
-cmake -A x64 -T v141 ..
+cmake -G "Visual Studio 16 2019" -A x64 -T v141 ..
 
 # Build
 cmake --build . --config RelWithDebInfo -j10 # Number of projects to build in parallel


### PR DESCRIPTION
Passing the generator is needed because one can have
multiple installations of Visual Studio and Build Tools.

Moreover the documentation is written for Visual Studio 2019 and
the subsequent arguments passed to CMake are not fully valid for
earlier versions.