### PR TITLE
docs: Recommend macOS 10.11 deployment target

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,7 +210,7 @@ jobs:
       displayName: "Configure osquery"
       inputs:
         workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DOSQUERY_BUILD_TESTS=ON $(EXTRA_CMAKE_ARGS) $(Build.SourcesDirectory)
+        cmakeArgs: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DOSQUERY_BUILD_TESTS=ON $(EXTRA_CMAKE_ARGS) $(Build.SourcesDirectory)
 
     - task: CacheBeta@0
       inputs:

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -16,7 +16,7 @@ Note: the recommended system memory for building osquery is at least 8GB, or Cla
 
 ## Linux
 
-The root folder is assumed to be `/home/<user>`
+The root folder is assumed to be `/home/<user>`.
 
 **Ubuntu 18.04/18.10**
 
@@ -59,6 +59,8 @@ brew install git cmake python@2 python
 
 **Step 2: Download and build**
 
+A macOS 10.11 deployment target is selected in this example.
+
 ```bash
 # Download source
 git clone https://github.com/osquery/osquery
@@ -66,7 +68,7 @@ cd osquery
 
 # Configure
 mkdir build; cd build
-cmake ..
+cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..
 
 # Build
 cmake --build .


### PR DESCRIPTION
This is an attempt to maintain backwards compatibility for macOS. We should not add this directly to CMake due to recommendations in the CMake documentation, but we can test older deployment targets and recommend it in documentation.

The most significant effect this has for compatibility is on compile-time linking. 

This addresses #5993.