### PR TITLE
logging: Change logNumericsAsNumbers to numerics and add docs

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -163,7 +163,8 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
   "epoch": "314159265",
-  "counter": "1"
+  "counter": "1",
+  "numerics": false
 }
 ```
 
@@ -180,7 +181,8 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
   "epoch": "314159265",
-  "counter": "1"
+  "counter": "1",
+  "numerics": false
 }
 ```
 
@@ -221,7 +223,8 @@ Consider the following example:
   "calendarTime": "Mon May  2 22:27:32 2016 UTC",
   "unixTime": "1462228052",
   "epoch": "314159265",
-  "counter": "1"
+  "counter": "1",
+  "numerics": false
 }
 ```
 
@@ -256,23 +259,30 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
   "epoch": "314159265",
-  "counter": "1"
+  "counter": "1",
+  "numerics": false
 }
 ```
 
 Most of the time the **Event format** is the most appropriate. The next section in the deployment guide describes [log aggregation](log-aggregation.md) methods. The aggregation methods describe collecting, searching, and alerting on the results from a query schedule.
 
-## Schedule epoch
+## Special top-level fields
+
+### Schedule epoch
 
 When [differential logs](#differential-logs) were described above, we mentioned that after the initial execution of a scheduled query, only differential results are logged. While this is very efficient from a size-of-logs perspective, it introduces some challenges. To begin with, if the logs are stored in a log management system of some kind, it becomes difficult or impossible to identify which log results are from the initial run of the query, and which ones are differentials to the initial results. In some situations, this becomes problematic - for example, for some tables like the users table that don't change very often at all and so don't generate differential results very often, one would have to search far into historical logs to find the last results returned by osquery; conversely, for some tables like processes that change frequently, one would have to do a fair amount of logic applying the effects of added and removed rows to reconstruct the current state of running processes.
 
 To aid with this, osquery maintains an **epoch** marker along with each scheduled query execution, and calculates differentials only if the epoch of the last run matches the current epoch. If it doesn't, then it treats the current execution of the query as an initial run. You can set the epoch marker by starting osquery with the --schedule_epoch=<some 64bit int> flag or by updating the schedule_epoch flag remotely from a TLS backend. The epoch is transmitted with each log result, so that it is easy to identify which results belong to which execution of the scheduled query.
 
-## Schedule counter
+### Schedule counter
 
 When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial **added** records. **counter** can be used to identify if the added records are all records from initial query of if they are new records. For initial query results that includes all records counter will be **"0"**. For subsequent query executions counter will be incremented by **1**. When **epoch** changes, counter will be reset back to "0".
 
-## Unique host identification
+### Numerics
+
+This is an indicator for all results, `true` if osquery attempted to log numerics as numbers, otherwise `false` indicates they were logged as strings.
+
+### Unique host identification
 
 If you need a way to uniquely identify hosts embedded into **osqueryd**'s results log, then the `--host_identifier` flag is what you're looking for.
 By default, **host_identifier** is set to "hostname". The host's hostname will be used as the host identifier in results logs. If hostnames are not unique or consistent in your environment, you can launch osqueryd with `--host_identifier=uuid`.

--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -114,7 +114,8 @@ A sample log entry from process_events may look something like this:
   },
   "unixTime": 1527895550,
   "hostIdentifier": "vagrant",
-  "name": "process_events"
+  "name": "process_events",
+  "numerics": false
 }
 ```
 
@@ -151,7 +152,8 @@ A sample socket_event log entry looks like this:
   },
   "unixTime": 1527895545,
   "hostIdentifier": "vagrant",
-  "name": "socket_events"
+  "name": "socket_events",
+  "numerics": false
 }
 ```
 

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -22,7 +22,8 @@
 namespace osquery {
 
 DECLARE_bool(disable_database);
-DECLARE_bool(log_numerics_as_numbers);
+DECLARE_bool(logger_numerics);
+
 class QueryTests : public testing::Test {
  public:
   QueryTests() {
@@ -40,7 +41,7 @@ TEST_F(QueryTests, test_private_members) {
 }
 
 TEST_F(QueryTests, test_add_and_get_current_results) {
-  FLAGS_log_numerics_as_numbers = true;
+  FLAGS_logger_numerics = true;
   // Test adding a "current" set of results to a scheduled query instance.
   auto query = getOsqueryScheduledQuery();
   auto cf = Query("foobar", query);

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -29,7 +29,7 @@ DECLARE_bool(logger_status_sync);
 DECLARE_bool(logger_event_type);
 DECLARE_bool(logger_snapshot_event_type);
 DECLARE_bool(disable_logging);
-DECLARE_bool(log_numerics_as_numbers);
+DECLARE_bool(logger_numerics);
 
 class LoggerTests : public testing::Test {
  public:
@@ -371,8 +371,8 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
       "\"calendarTime\":\"no_time\",\"unixTime\":0,\"epoch\":0,"
-      "\"counter\":0,\"logNumericsAsNumbers\":" +
-      std::string(FLAGS_log_numerics_as_numbers ? "true" : "false") +
+      "\"counter\":0,\"numerics\":" +
+      std::string(FLAGS_logger_numerics ? "true" : "false") +
       ",\"columns\":{\"test_column\":\"test_value\"},\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }
@@ -389,27 +389,27 @@ TEST_F(LoggerTests, test_logger_numeric_flag) {
   item.epoch = 0L;
   item.counter = 0L;
   item.results.added.push_back({{"test_double_column", 2.000}});
-  FLAGS_log_numerics_as_numbers = true;
+  FLAGS_logger_numerics = true;
   logQueryLogItem(item);
   EXPECT_EQ(1U, LoggerTests::log_lines.size());
 
   // Make sure the JSON output serializes the double as a double when the flag
-  // FLAGS_log_numerics_as_numbers is true (as we set it, above)
+  // FLAGS_logger_numerics is true (as we set it, above)
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
       "\"calendarTime\":\"no_time\",\"unixTime\":0,\"epoch\":0,"
-      "\"counter\":0,\"logNumericsAsNumbers\":true,\"columns\":{\"test_double_"
+      "\"counter\":0,\"numerics\":true,\"columns\":{\"test_double_"
       "column\":2.0},\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 
-  FLAGS_log_numerics_as_numbers = false;
+  FLAGS_logger_numerics = false;
   logQueryLogItem(item);
   // Make sure the JSON output serializes the double as a double within a string
-  // when FLAGS_log_numerics_as_numbers is false (as we set it, above)
+  // when FLAGS_logger_numerics is false (as we set it, above)
   expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
       "\"calendarTime\":\"no_time\",\"unixTime\":0,\"epoch\":0,"
-      "\"counter\":0,\"logNumericsAsNumbers\":false,\"columns\":{\"test_double_"
+      "\"counter\":0,\"numerics\":false,\"columns\":{\"test_double_"
       "column\":\"2.0\"},\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }

--- a/osquery/sql/tests/sql_test_utils.cpp
+++ b/osquery/sql/tests/sql_test_utils.cpp
@@ -3,7 +3,7 @@
 
 namespace osquery {
 
-DECLARE_bool(log_numerics_as_numbers);
+DECLARE_bool(logger_numerics);
 
 QueryDataTyped getTestDBExpectedResults() {
   QueryDataTyped d;
@@ -153,7 +153,7 @@ std::pair<JSON, QueryLogItem> getSerializedQueryLogItem() {
   doc.add("unixTime", 1408993857);
   doc.add("epoch", std::size_t{0});
   doc.add("counter", std::size_t{0});
-  doc.add("logNumericsAsNumbers", FLAGS_log_numerics_as_numbers);
+  doc.add("numerics", FLAGS_logger_numerics);
 
   return std::make_pair(std::move(doc), std::move(i));
 }

--- a/plugins/config/parsers/tests/decorators_tests.cpp
+++ b/plugins/config/parsers/tests/decorators_tests.cpp
@@ -21,7 +21,7 @@ namespace osquery {
 DECLARE_bool(disable_decorators);
 DECLARE_bool(decorations_top_level);
 DECLARE_bool(disable_database);
-DECLARE_bool(log_numerics_as_numbers);
+DECLARE_bool(logger_numerics);
 
 class DecoratorsConfigParserPluginTests : public testing::Test {
  public:
@@ -103,8 +103,8 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   std::string expected =
       "{\"snapshot\":[],\"action\":\"snapshot\",\"name\":\"\","
       "\"hostIdentifier\":\"\",\"calendarTime\":\"\",\"unixTime\":0,"
-      "\"epoch\":0,\"counter\":0,\"logNumericsAsNumbers\":" +
-      std::string(FLAGS_log_numerics_as_numbers ? "true" : "false") +
+      "\"epoch\":0,\"counter\":0,\"numerics\":" +
+      std::string(FLAGS_logger_numerics ? "true" : "false") +
       ",\"decorations\":{\"internal_60_test\":\"test\",\"one\":\"1\"}}";
   EXPECT_EQ(log_line, expected);
 

--- a/plugins/logger/tests/filesystem_logger.cpp
+++ b/plugins/logger/tests/filesystem_logger.cpp
@@ -32,7 +32,7 @@ namespace osquery {
 DECLARE_bool(disable_database);
 DECLARE_string(logger_path);
 DECLARE_bool(disable_logging);
-DECLARE_bool(log_numerics_as_numbers);
+DECLARE_bool(logger_numerics);
 
 class FilesystemLoggerTests : public testing::Test {
  public:
@@ -171,12 +171,12 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   std::string expected =
       "{\"snapshot\":[],\"action\":\"snapshot\",\"name\":\"test\","
       "\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":0,\"epoch\":0,\"counter\":0,\"logNumericsAsNumbers\":" +
-      std::string(FLAGS_log_numerics_as_numbers ? "true" : "false") +
+      "\"unixTime\":0,\"epoch\":0,\"counter\":0,\"numerics\":" +
+      std::string(FLAGS_logger_numerics ? "true" : "false") +
       "}\n{\"snapshot\":[],\"action\":\"snapshot\","
       "\"name\":\"test\",\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":0,\"epoch\":0,\"counter\":0,\"logNumericsAsNumbers\":" +
-      std::string(FLAGS_log_numerics_as_numbers ? "true" : "false") + "}\n";
+      "\"unixTime\":0,\"epoch\":0,\"counter\":0,\"numerics\":" +
+      std::string(FLAGS_logger_numerics ? "true" : "false") + "}\n";
   EXPECT_EQ(content, expected);
 }
 } // namespace osquery


### PR DESCRIPTION
This is an API change for the format of logged events. The top-level log field "logNumericsAsNumbers" was introduced to help migrate from string-encoded numerics to JSON numbers.

This change updates the field to be "numerics", updates the flag to conform to flag naming conventions, and documents the expectation.
