### PR TITLE
extensions compatibility : default columns to INDEX

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -175,6 +175,10 @@ Extensions are loaded as processes. They are expected to start a thrift service 
 
 Optional comma-delimited set of extension names to require before **osqueryi** or **osqueryd** will start. The tool will fail if the extension has not started according to the interval and timeout.
 
+`--extensions_default_index=true`
+
+Enable INDEX (and thereby constraints) on all extension table columns.  Provides backwards compatiblity for extensions (or SDKs) that don't correctly define indexes in column options. See issue 6006 for more details.
+
 ### Remote settings flags (optional)
 
 When using non-default [remote](../deployment/remote.md) plugins such as the **tls** config, logger and distributed plugins, there are process-wide settings applied to every plugin.

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -18,6 +18,10 @@
 namespace osquery {
 
 FLAG(bool, disable_caching, false, "Disable scheduled query caching");
+FLAG(bool,
+     compat_index_all_extension_columns,
+     true,
+     "Enable INDEX (and thereby constraints) on all extension tables");
 
 CREATE_LAZY_REGISTRY(TablePlugin, "table");
 
@@ -335,6 +339,9 @@ std::string columnDefinition(const PluginResponse& response,
         auto op = tryTo<int>(cop->second);
         if (op) {
           options = static_cast<ColumnOptions>(op.take());
+          if (FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
+            options = ColumnOptions::INDEX;
+          }
         }
       }
       auto column_type = columnTypeName(ctype->second);

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -339,11 +339,13 @@ std::string columnDefinition(const PluginResponse& response,
         auto op = tryTo<int>(cop->second);
         if (op) {
           options = static_cast<ColumnOptions>(op.take());
-          if (FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
-            options = ColumnOptions::INDEX;
-          }
         }
       }
+
+      if (is_extension && FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
+        options = ColumnOptions::INDEX;
+      }
+
       auto column_type = columnTypeName(ctype->second);
       columns.push_back(make_tuple(cname->second, column_type, options));
       if (aliases) {

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -337,7 +337,6 @@ std::string columnDefinition(const PluginResponse& response,
           options = static_cast<ColumnOptions>(op.take());
         }
       }
-
       auto column_type = columnTypeName(ctype->second);
       columns.push_back(make_tuple(cname->second, column_type, options));
       if (aliases) {

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -18,10 +18,6 @@
 namespace osquery {
 
 FLAG(bool, disable_caching, false, "Disable scheduled query caching");
-FLAG(bool,
-     compat_index_all_extension_columns,
-     true,
-     "Enable INDEX (and thereby constraints) on all extension tables");
 
 CREATE_LAZY_REGISTRY(TablePlugin, "table");
 
@@ -340,10 +336,6 @@ std::string columnDefinition(const PluginResponse& response,
         if (op) {
           options = static_cast<ColumnOptions>(op.take());
         }
-      }
-
-      if (is_extension && FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
-        options = ColumnOptions::INDEX;
       }
 
       auto column_type = columnTypeName(ctype->second);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -29,9 +29,12 @@ FLAG(uint64,
      "Add an optional microsecond delay between table scans");
 
 FLAG(bool,
-     compat_index_all_extension_columns,
+     extensions_default_index,
      true,
-     "Enable INDEX (and thereby constraints) on all extension tables");
+     "Enable INDEX (and thereby constraints) on all extension table columns. "
+     "Provides backwards compatiblity for extensions (or SDKs) that don't "
+     "correctly define indexes in column options. (default true)"
+   );
 
 SHELL_FLAG(bool, planner, false, "Enable osquery runtime planner output");
 
@@ -609,8 +612,8 @@ int xCreate(sqlite3* db,
         }
       }
 
-      if (is_extension && FLAGS_compat_index_all_extension_columns &&
-          0 == (int)options) {
+      if (is_extension && FLAGS_extensions_default_index &&
+          ColumnOptions::DEFAULT == options) {
         options = ColumnOptions::INDEX;
       }
 

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -32,6 +32,8 @@ SHELL_FLAG(bool, planner, false, "Enable osquery runtime planner output");
 
 DECLARE_bool(disable_events);
 
+DECLARE_bool(compat_index_all_extension_columns);
+
 RecursiveMutex kAttachMutex;
 
 namespace tables {
@@ -602,6 +604,10 @@ int xCreate(sqlite3* db,
         if (op) {
           options = static_cast<ColumnOptions>(op.take());
         }
+      }
+
+      if (is_extension && FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
+        options = ColumnOptions::INDEX;
       }
 
       pVtab->content->columns.push_back(std::make_tuple(

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -28,11 +28,14 @@ FLAG(uint64,
      0,
      "Add an optional microsecond delay between table scans");
 
+FLAG(bool,
+     compat_index_all_extension_columns,
+     true,
+     "Enable INDEX (and thereby constraints) on all extension tables");
+
 SHELL_FLAG(bool, planner, false, "Enable osquery runtime planner output");
 
 DECLARE_bool(disable_events);
-
-DECLARE_bool(compat_index_all_extension_columns);
 
 RecursiveMutex kAttachMutex;
 
@@ -606,7 +609,8 @@ int xCreate(sqlite3* db,
         }
       }
 
-      if (is_extension && FLAGS_compat_index_all_extension_columns && 0 == (int)options) {
+      if (is_extension && FLAGS_compat_index_all_extension_columns &&
+          0 == (int)options) {
         options = ColumnOptions::INDEX;
       }
 

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -584,7 +584,6 @@ int xCreate(sqlite3* db,
 
   // Tables may request aliases as views.
   std::set<std::string> views;
-  bool extensionSetsOptionColumn = false;
 
   // Keep a local copy of the column details in the VirtualTableContent struct.
   // This allows introspection into the column type without additional calls.
@@ -614,7 +613,8 @@ int xCreate(sqlite3* db,
         if (ColumnOptions::DEFAULT == options) {
           options = ColumnOptions::INDEX;
         } else {
-          extensionSetsOptionColumn = true;
+          // The extension is effected by extensions_default_index.
+          // Consider adding a deprecation warning (#6035).
         }
       }
 
@@ -658,13 +658,6 @@ int xCreate(sqlite3* db,
         }
       }
     }
-  }
-
-  if (is_extension && FLAGS_extensions_default_index &&
-      !extensionSetsOptionColumn) {
-    LOG(INFO) << "Deprecation warning: extension table " << name
-              << " does not set any column options and will not receive any "
-                 "INDEX constraints when --extensions_default_index=false";
   }
 
   // Create the requested 'aliases'.

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -33,8 +33,7 @@ FLAG(bool,
      true,
      "Enable INDEX (and thereby constraints) on all extension table columns. "
      "Provides backwards compatiblity for extensions (or SDKs) that don't "
-     "correctly define indexes in column options. (default true)"
-   );
+     "correctly define indexes in column options. (default true)");
 
 SHELL_FLAG(bool, planner, false, "Enable osquery runtime planner output");
 


### PR DESCRIPTION
@directionless and @terracatta found this issue with go-sdk extension in response to the recent INDEX enforcements fix.

This fix adds a compatibility flag that defaults to the old behavior of INDEX on all columns.
This only affects extension virtual tables, all built in tables have index constraints enforced.

 From Slack:

```
When run with 4.0.2:
dover:simple-osquery-test-extension seph$ ./osqueryd-4.0.2 -S --allow-unsafe --extension /tmp/simple.ext 
Using a virtual database. Need help, type '.help'
osquery> select * from test_table where input = "sdf";
generate called
Starting on constraint #0 -- sdf
Done. Processed 1 constraints
+-------+-----+--------+
| input | num | output |
+-------+-----+--------+
| sdf   | 0   | sdf    |
+-------+-----+--------+
When run with 4.1.0:
dover:simple-osquery-test-extension seph$ ./osqueryd-4.1.0 -S --allow-unsafe --extension /tmp/simple.ext 
Using a virtual database. Need help, type '.help'
osquery> select * from test_table where input = "sdf";
generate called
no in constraints
That’s the same resultant binary. I don’t know if this represents a bug in the go sdk, or if something changed in the thrift. I’m not sure if there’s an easy way to sniff that socket
```