### PR TITLE
Fix build with Ninja on Windows

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -292,6 +292,26 @@ function(setupBuildFlags)
     )
 
     list(APPEND osquery_defines ${osquery_windows_common_defines})
+
+    # Remove some flags from the default ones to avoid "overriding" warnings or unwanted results.
+    if(OSQUERY_WINDOWS AND "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+      string(REPLACE "/MD" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+      string(REPLACE "/MD" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "/MD" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+      string(REPLACE "/MD" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+
+      string(REPLACE "/Zi" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "/Zi" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+
+      # This must be removed, because passing /EHs doesn't override it
+      string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+      overwrite_cache_variable("CMAKE_C_FLAGS_RELEASE" STRING "${CMAKE_C_FLAGS_RELEASE}")
+      overwrite_cache_variable("CMAKE_C_FLAGS_RELWITHDEBINFO" STRING "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+      overwrite_cache_variable("CMAKE_CXX_FLAGS_RELEASE" STRING "${CMAKE_CXX_FLAGS_RELEASE}")
+      overwrite_cache_variable("CMAKE_CXX_FLAGS_RELWITHDEBINFO" STRING "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      overwrite_cache_variable("CMAKE_CXX_FLAGS" STRING "${CMAKE_CXX_FLAGS}")
+    endif()
   else()
     message(FATAL_ERROR "Platform not supported!")
   endif()

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -294,7 +294,7 @@ function(setupBuildFlags)
     list(APPEND osquery_defines ${osquery_windows_common_defines})
 
     # Remove some flags from the default ones to avoid "overriding" warnings or unwanted results.
-    if(OSQUERY_WINDOWS AND "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if(DEFINED PLATFORM_WINDOWS AND "${CMAKE_GENERATOR}" STREQUAL "Ninja")
       string(REPLACE "/MD" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
       string(REPLACE "/MD" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
       string(REPLACE "/MD" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -87,19 +87,22 @@ function(opensslMain)
     )
 
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    set(CMAKE_PREFIX_PATH "C:\\Strawberry\\perl\\bin")
     find_package(Perl REQUIRED)
 
     set(configure_command
       "${CMAKE_COMMAND}" -E env
       "${PERL_EXECUTABLE}" Configure VC-WIN64A
-        ${common_options}
+      ${common_options}
     )
 
     get_filename_component(perl_bin_path "${PERL_EXECUTABLE}" DIRECTORY)
 
+    string(REPLACE "/" "\\\\" perl_executable_path "${PERL_EXECUTABLE}")
+
     set(build_command
       cmake -E env "PATH=${perl_bin_path}" "cmd.exe" "/C" "ms\\do_nt.bat" &&
-      "cmd.exe" "/C" "nmake /f ms\\nt.mak"
+      "cmd.exe" "/C" "nmake /f ms\\nt.mak PERL=${perl_executable_path}"
     )
 
     set(install_command


### PR DESCRIPTION
- Remove the /EHsc compiler flag from the default flags
  coming from CMake. Boost coroutine needs /EHs and
  passing that after /EHsc does not override it.

- Remove other flags from the default ones,
  to avoid the "overriding" warning.

- Give a suggested path to find Perl using CMAKE_PREFIX_PATH.

- openssl Makefile needs Perl to be passed explicitly through
  the PERL variable, otherwise it won't properly find it.

Enables https://github.com/osquery/osquery/issues/5968