### PR TITLE
Do not use dllimport in glog on Windows

### DIFF
--- a/osquery/utils/conversions/BUCK
+++ b/osquery/utils/conversions/BUCK
@@ -62,6 +62,7 @@ osquery_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         ":to",
+        osquery_target("osquery/logger:logger"),
         osquery_target("osquery/utils/expected:expected"),
         osquery_tp_target("boost"),
         osquery_tp_target("glog"),

--- a/osquery/utils/conversions/CMakeLists.txt
+++ b/osquery/utils/conversions/CMakeLists.txt
@@ -41,6 +41,7 @@ function(generateOsqueryUtilsConversions)
 
   target_link_libraries(osquery_utils_conversions PUBLIC
     osquery_cxx_settings
+    osquery_logger
     osquery_utils_conversions_to
     osquery_utils_expected
     thirdparty_boost

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -9,8 +9,7 @@
 #include <codecvt>
 #include <string>
 
-#include <glog/logging.h>
-
+#include <osquery/logger.h>
 #include <osquery/utils/conversions/windows/strings.h>
 
 namespace osquery {


### PR DESCRIPTION
Reproduce what we already have in osquery/logger.h,
since we are compiling everything static.

Reduce warnings about locally defined and imported symbols.