### PR TITLE
Use a custom defined manifest for executables on Windows

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -191,6 +191,20 @@ function(add_osquery_executable)
 
   add_executable(${osquery_exe_name} ${osquery_exe_args})
 
+  if(DEFINED PLATFORM_WINDOWS)
+    set(OSQUERY_MANIFEST_TARGET_NAME "${osquery_exe_name}")
+
+    string(REGEX MATCH "^[0-9]+\.[0-9]+\.[0-9]+" osquery_cleaned_version "${OSQUERY_VERSION_INTERNAL}")
+    set(OSQUERY_MANIFEST_VERSION "${osquery_cleaned_version}")
+
+    configure_file(
+      "${CMAKE_SOURCE_DIR}/tools/osquery.manifest.in"
+      "${osquery_exe_name}.manifest"
+      @ONLY NEWLINE_STYLE WIN32
+    )
+    target_sources(${osquery_exe_name} PRIVATE "${osquery_exe_name}.manifest")
+  endif()
+
   if("${osquery_exe_name}" MATCHES "-test$" AND DEFINED PLATFORM_POSIX)
     target_link_options("${osquery_exe_name}" PRIVATE -Wno-sign-compare)
   endif()

--- a/tools/osquery.manifest.in
+++ b/tools/osquery.manifest.in
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity
+        type="win32"
+        name="@OSQUERY_MANIFEST_TARGET_NAME@"
+        version="@OSQUERY_MANIFEST_VERSION@.0"
+        processorArchitecture="ia64"
+    />
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+</assembly>


### PR DESCRIPTION
This uniforms the manifest that gets embedded using msbuild
or Ninja, while also letting us customize it if necessary.

Depends on https://github.com/osquery/osquery/pull/6007 to test with Ninja.
