### PR TITLE
new cached_logger based aws kinesis forwarder

### DIFF
--- a/plugins/logger/BUCK
+++ b/plugins/logger/BUCK
@@ -131,6 +131,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils/json:json"),
         osquery_target("osquery/utils/system:time"),
         osquery_target("plugins/config/parsers:parsers"),
+        osquery_tp_target("boost"),
     ],
 )
 

--- a/plugins/logger/BUCK
+++ b/plugins/logger/BUCK
@@ -74,6 +74,7 @@ osquery_cxx_library(
         osquery_target("osquery/process:process"),
         osquery_target("osquery/registry:registry"),
         osquery_target("osquery/filesystem:osquery_filesystem"),
+        osquery_tp_target("boost", "boost"),
         ":aws_log_forwarder",
     ],
 )

--- a/plugins/logger/BUCK
+++ b/plugins/logger/BUCK
@@ -104,10 +104,12 @@ osquery_cxx_library(
     name = "buffered",
     srcs = [
         "buffered.cpp",
+        "cached_logger.cpp"
     ],
     header_namespace = "plugins/logger",
     exported_headers = [
         "buffered.h",
+        "cached_logger.h",
     ],
     exported_post_platform_linker_flags = [
         (
@@ -121,6 +123,7 @@ osquery_cxx_library(
     link_whole = True,
     tests = [
         osquery_target("plugins/logger/tests:buffered_logger_tests"),
+        osquery_target("plugins/logger/tests:cached_logger_tests"),
     ],
     visibility = ["PUBLIC"],
     deps = common_deps + [

--- a/plugins/logger/BUCK
+++ b/plugins/logger/BUCK
@@ -73,6 +73,7 @@ osquery_cxx_library(
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/process:process"),
         osquery_target("osquery/registry:registry"),
+        osquery_target("osquery/filesystem:osquery_filesystem"),
         ":aws_log_forwarder",
     ],
 )

--- a/plugins/logger/BUCK
+++ b/plugins/logger/BUCK
@@ -123,7 +123,6 @@ osquery_cxx_library(
     link_whole = True,
     tests = [
         osquery_target("plugins/logger/tests:buffered_logger_tests"),
-        osquery_target("plugins/logger/tests:cached_logger_tests"),
     ],
     visibility = ["PUBLIC"],
     deps = common_deps + [

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -96,6 +96,7 @@ endfunction()
 function(generatePluginsLoggerBuffered)
   add_osquery_library(plugins_logger_buffered EXCLUDE_FROM_ALL
     buffered.cpp
+    cached_logger.cpp
   )
 
   enableLinkWholeArchive(plugins_logger_buffered)
@@ -111,6 +112,7 @@ function(generatePluginsLoggerBuffered)
 
   set(public_header_files
     buffered.h
+    cached_logger.h
   )
 
   generateIncludeNamespace(plugins_logger_buffered "plugins/logger" "FILE_ONLY" ${public_header_files})

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -108,6 +108,7 @@ function(generatePluginsLoggerBuffered)
     osquery_utils_json
     osquery_utils_system_time
     plugins_config_parsers
+    osquery_filesystem
   )
 
   set(public_header_files

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -23,18 +23,36 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include <osquery/flags.h>
+#include <osquery/logger.h>
 #include <osquery/process/process.h>
 #include <osquery/registry.h>
 #include <osquery/system.h>
 
+#include <osquery/utils/aws/aws_util.h>
+
+namespace fs = boost::filesystem;
+
+#ifdef WIN32
+#undef GetMessage
+#endif
+
+// If there are AWS errors, refresh the handle, which may pull in newer
+// FLAGS_aws_xx config such as the sts token.  But not more often than
+// AWS_HANDLE_REFRESH_SECONDS
+
+#define AWS_HANDLE_REFRESH_SECONDS 450 // 7.5 minutes (config refresh 5 mins)
+
 namespace osquery {
+
+DECLARE_string(aws_access_key_id);  // from aws_util.cpp
+DECLARE_string(aws_session_token);
 
 REGISTER(KinesisLoggerPlugin, "logger", "aws_kinesis");
 
 FLAG(uint64,
      aws_kinesis_period,
-     10,
-     "Seconds between flushing logs to Kinesis (default 10)");
+     8,
+     "Seconds between flushing logs to Kinesis (default 8)");
 
 FLAG(string, aws_kinesis_stream, "", "Name of Kinesis stream for logging")
 
@@ -43,25 +61,280 @@ FLAG(bool,
      false,
      "Enable random kinesis partition keys");
 
-Status KinesisLoggerPlugin::setUp() {
-  initAwsSdk();
-  forwarder_ = std::make_shared<KinesisLogForwarder>(
-      "aws_kinesis", FLAGS_aws_kinesis_period, 500);
-  Status s = forwarder_->setUp();
-  if (!s.ok()) {
-    LOG(ERROR) << "Error initializing Kinesis logger: " << s.getMessage();
-    return s;
+// Kinesis stream limit of 1000 records per second
+FLAG(uint64,
+     aws_kinesis_batch_max_records,
+     500U,
+     "Number of records per period");
+
+FLAG(uint64, aws_kinesis_batch_max_bytes, 5000000U, "Max bytes per batch");
+
+static bool gHaveSetup = false;
+
+class KinesisForwarder : public Forwarder {
+ public:
+  KinesisForwarder(const LoggerBounds bounds)
+      : Forwarder(bounds), linebuf_(bounds.max_bytes_per_record), _condition_lock(), _condition() {
+    partition_key_ = getHostIdentifier();
   }
-  Dispatcher::addService(forwarder_);
+  virtual ~KinesisForwarder() {}
+
+  Status send(std::string file_path) override {
+    Aws::Vector<Aws::Kinesis::Model::PutRecordsRequestEntry> records;
+
+    if (aws_id_changed() || client_ == nullptr) {
+      if (!shouldResetAwsHandle()) {
+        return Status(FORWARDER_STATUS_NO_CONNECTION);
+      }
+    }
+
+    // parse file into records
+
+    int readerr = _load(file_path, records);
+    if (readerr != 0) {
+      return Status(readerr, "Error reading file");
+    }
+
+    // build request
+
+    Aws::Kinesis::Model::PutRecordsRequest request;
+    request.WithStreamName(FLAGS_aws_kinesis_stream).SetRecords(records);
+
+    // do the send, with some retries
+
+    int retry;
+    for (retry = 0; retry < 3; retry++) {
+      if (retry > 0) {
+	    _pause(std::chrono::milliseconds(100));
+      }
+      auto outcome = client_->PutRecords(request);
+
+      if (outcome.IsSuccess()) {
+        break;
+      }
+
+      int failedCount = outcome.GetResult().GetFailedRecordCount();
+      if (failedCount > 0 && failedCount < (int)records.size()) {
+        LOG(WARNING) << "partial failure: " << failedCount << " of " << records.size();
+
+        // remove successful entries
+        const std::vector<Aws::Kinesis::Model::PutRecordsResultEntry> &refResults = outcome.GetResult().GetRecords();
+        auto it = records.begin();
+        int numRecords = (int)records.size();
+        for (int i = 0; i < numRecords; i++) {
+          if (i >= (int)refResults.size()) {
+            break; // just in case. results should match records.size
+          }
+          const Aws::Kinesis::Model::PutRecordsResultEntry &entry = refResults[i];
+          const Aws::String & refEntryErrCode = entry.GetErrorCode();
+          if (refEntryErrCode.empty()) {
+            records.erase(it++);  // remove successful
+          } else {
+            it++;
+          }
+        }
+
+        continue; // will retry
+      }
+
+      const Aws::Kinesis::KinesisErrors code = outcome.GetError().GetErrorType();
+
+      // network connection down?
+
+      if (code == Aws::Kinesis::KinesisErrors::NETWORK_CONNECTION) {
+        return Status(FORWARDER_STATUS_NO_CONNECTION);
+      }
+      if (code == Aws::Kinesis::KinesisErrors::SLOW_DOWN) {
+        LOG(WARNING) << "Received Kinesis SLOW_DOWN";
+        _pause(std::chrono::milliseconds(500));
+        return Status(FORWARDER_STATUS_NO_CONNECTION);
+      }
+
+      if (code == Aws::Kinesis::KinesisErrors::ACCESS_DENIED
+          || code == Aws::Kinesis::KinesisErrors::MISSING_AUTHENTICATION_TOKEN) {
+        client_ = nullptr;
+        LOG(WARNING) << "kinesis access denied. clearing handle";
+        return Status(FORWARDER_STATUS_NO_CONNECTION);
+      }
+
+      // anything we can retry?
+
+      if (code == Aws::Kinesis::KinesisErrors::REQUEST_EXPIRED
+          || code == Aws::Kinesis::KinesisErrors::INTERNAL_FAILURE) {
+        LOG(WARNING) << "kinesis failed with code:" << std::to_string((uint32_t)code);
+        continue;
+      }
+
+      // any other error probably can't be fixed by retry
+      LOG(ERROR) << "send fail. Code:" << (uint32_t)code << " msg:" << outcome.GetError().GetMessage();
+
+      // invalidate handle because:
+      //   Sometimes get code==UNKNOWN error with ExpiredTokenException in the
+      //   message string rather than code == ACCESS_DENIED
+
+      client_ = nullptr;
+
+      return Status((int)code, "error in send");
+    }
+
+    if (retry >= 3) {
+      return Status(1, "Failed with retries");
+    }
+
+    return Status();
+  }
+
+  /**
+   * keeps track of FLAGS_aws_access_key_id, return true if changed.
+   */
+  bool aws_id_changed() {
+    static std::string last_aws_access_key;
+    static std::string last_aws_session_token;
+
+    if (last_aws_access_key != FLAGS_aws_access_key_id
+        || last_aws_session_token != FLAGS_aws_session_token ) {
+      VLOG(1) << "using new aws access key:" << FLAGS_aws_access_key_id;
+      last_aws_access_key = FLAGS_aws_access_key_id;
+      last_aws_session_token = FLAGS_aws_session_token;
+      return true;
+    }
+
+    return false;
+  }
+
+  /*
+   * This should only be called when there was a send error.
+   * This will call makeAWSClient(client_) to obtain a new
+   * handle with latest FLAGS , in case there was a config change
+   * for IAM role, etc.
+   */
+  bool shouldResetAwsHandle() {
+    static time_t tLastReset = 0;
+    time_t now = time(NULL);
+    if ((now - tLastReset) >= AWS_HANDLE_REFRESH_SECONDS) {
+      tLastReset = now;
+      VLOG(1) << "obtaining new AWS client handle.";
+      Status s = makeAWSClient<Aws::Kinesis::KinesisClient>(client_);
+      return s.ok();
+    }
+    return false;
+  }
+
+  /*
+   * read file lines, populate records.
+   * returns false on success, true on error.
+   */
+  int _load(
+      std::string file_path,
+      Aws::Vector<Aws::Kinesis::Model::PutRecordsRequestEntry>& records) {
+    file_path = fs::path(file_path).make_preferred().string();
+
+    FILE* fp = FOPEN(file_path.c_str(), "r");
+    if (fp == nullptr) {
+      LOG(ERROR) << "unable to open cached log:" << file_path;
+      return FORWARDER_STATUS_READ_ERROR;
+    }
+
+    while (nullptr != fgets(linebuf_.data(), (int)linebuf_.size(), fp)) {
+      size_t len = strlen(linebuf_.data());
+      if (len <= 1)
+        continue;
+
+      if (linebuf_.data()[0] == '#') {
+        // metadata (TODO: check against MD5 of previous file)
+        continue;
+      }
+
+      // adjust len to ignore trailing newline
+      len--;
+
+      // check for truncated msgs - expect valid JSON object
+      if (linebuf_[len-1] != '}') {
+        LOG(WARNING) << "Drop Truncated : (possibly due to watchdog kill):" << std::string(linebuf_.data());
+        continue;
+      }
+
+      // Initialize and store the new log record
+      auto buffer = Aws::Utils::ByteBuffer(
+          reinterpret_cast<unsigned char*>(linebuf_.data()), len);
+
+      auto idx = records.size();
+      if (idx > bounds_.max_records_per_batch) {
+        LOG(ERROR) << "cached log file failed bounds check idx:" << idx
+                   << " max_records:" << bounds_.max_records_per_batch;
+        break;
+      }
+
+      Aws::Kinesis::Model::PutRecordsRequestEntry aws_record;
+      initializeRecord(aws_record, buffer);
+      records.emplace_back(std::move(aws_record));
+    }
+
+    fclose(fp);
+
+    if (records.empty()) {
+      VLOG(1) << "no records in cached file? " << file_path;
+      return FORWARDER_STATUS_EMPTY_FILE;
+    }
+
+    return 0;
+  }
+
+  Status setUp() {
+    return Status();
+  }
+
+ protected:
+  void initializeRecord(Aws::Kinesis::Model::PutRecordsRequestEntry& record,
+                        Aws::Utils::ByteBuffer& buffer) const {
+    std::string record_partition_key;
+    if (FLAGS_aws_kinesis_random_partition_key) {
+      // Generate a random partition key for each record, ensuring that
+      // records are spread evenly across shards.
+      boost::uuids::uuid uuid = boost::uuids::random_generator()();
+      record_partition_key = boost::uuids::to_string(uuid);
+    } else {
+      record_partition_key = partition_key_;
+    }
+
+    record.WithPartitionKey(record_partition_key).WithData(buffer);
+  }
+
+  void _pause(std::chrono::milliseconds milli) {
+	  std::unique_lock<std::mutex> lock(_condition_lock);
+	  _condition.wait_for(lock, milli);
+  }
+
+  std::vector<char> linebuf_;
+  std::shared_ptr<Aws::Kinesis::KinesisClient> client_{nullptr};
+  std::mutex _condition_lock;
+  std::condition_variable _condition;
+  std::string partition_key_;
+};
+
+Status KinesisLoggerPlugin::setUp() {
+  if (!gHaveSetup) {
+    gHaveSetup = true;
+    LoggerBounds bounds;
+    bounds.max_records_per_batch = FLAGS_aws_kinesis_batch_max_records;
+    bounds.max_bytes_per_record = 1000000 - 256;
+    bounds.max_bytes_per_batch = FLAGS_aws_kinesis_batch_max_bytes;
+
+    setProps("aws_kinesis", true, bounds);
+
+    initAwsSdk();
+
+    auto forwarder = std::make_shared<KinesisForwarder>(bounds);
+    Status s = forwarder->setUp();
+    if (!s.ok()) {
+      LOG(ERROR) << "Error initializing Kinesis logger: " << s.getMessage();
+      return s;
+    }
+
+    start(forwarder, (uint32_t)FLAGS_aws_kinesis_period, 4, 1250);
+  }
+
   return Status(0, "OK");
-}
-
-Status KinesisLoggerPlugin::logString(const std::string& s) {
-  return forwarder_->logString(s);
-}
-
-Status KinesisLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
-  return forwarder_->logStatus(log);
 }
 
 void KinesisLoggerPlugin::init(const std::string& name,
@@ -69,72 +342,4 @@ void KinesisLoggerPlugin::init(const std::string& name,
   logStatus(log);
 }
 
-Status KinesisLogForwarder::internalSetup() {
-  partition_key_ = getHostIdentifier();
-
-  if (FLAGS_aws_kinesis_stream.empty()) {
-    return Status(1, "Stream name must be specified with --aws_kinesis_stream");
-  }
-
-  VLOG(1) << "Kinesis logging initialized with stream: "
-          << FLAGS_aws_kinesis_stream;
-
-  return Status(0, "OK");
-}
-
-KinesisLogForwarder::Outcome KinesisLogForwarder::internalSend(
-    const Batch& batch) {
-  Aws::Kinesis::Model::PutRecordsRequest request;
-  request.WithStreamName(FLAGS_aws_kinesis_stream).SetRecords(batch);
-  return client_->PutRecords(request);
-}
-
-void KinesisLogForwarder::initializeRecord(
-    Record& record, Aws::Utils::ByteBuffer& buffer) const {
-  std::string record_partition_key;
-  if (FLAGS_aws_kinesis_random_partition_key) {
-    // Generate a random partition key for each record, ensuring that
-    // records are spread evenly across shards.
-    boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    record_partition_key = boost::uuids::to_string(uuid);
-  } else {
-    record_partition_key = partition_key_;
-  }
-
-  record.WithPartitionKey(record_partition_key).WithData(buffer);
-}
-
-size_t KinesisLogForwarder::getMaxBytesPerRecord() const {
-  // Max size of log + partition key is 1MB. Max size of partition key is 256B.
-  return (1000000U - 256U);
-}
-
-size_t KinesisLogForwarder::getMaxRecordsPerBatch() const {
-  return 500U;
-}
-
-size_t KinesisLogForwarder::getMaxBytesPerBatch() const {
-  return 5000000U;
-}
-
-size_t KinesisLogForwarder::getMaxRetryCount() const {
-  return 100U;
-}
-
-size_t KinesisLogForwarder::getInitialRetryDelay() const {
-  return 3000U;
-}
-
-bool KinesisLogForwarder::appendNewlineSeparators() const {
-  return false;
-}
-
-size_t KinesisLogForwarder::getFailedRecordCount(Outcome& outcome) const {
-  return static_cast<size_t>(outcome.GetResult().GetFailedRecordCount());
-}
-
-KinesisLogForwarder::Result KinesisLogForwarder::getResult(
-    Outcome& outcome) const {
-  return outcome.GetResult().GetRecords();
-}
-}
+} // namespace osquery

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -19,6 +19,7 @@
 #include <aws/kinesis/model/PutRecordsResult.h>
 
 #include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <chrono>
+#include <gflags/gflags.h>
 #include <memory>
 #include <vector>
-#include <gflags/gflags.h>
 
 #include <aws/kinesis/KinesisClient.h>
 #include <aws/kinesis/model/PutRecordsRequestEntry.h>
@@ -39,4 +39,4 @@ class KinesisLoggerPlugin : public CachedLoggerPlugin {
  private:
 };
 
-}
+} // namespace osquery

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "aws_log_forwarder.h"
-
 #include <chrono>
 #include <memory>
 #include <vector>
@@ -21,50 +19,13 @@
 #include <osquery/core.h>
 #include <osquery/dispatcher.h>
 #include <osquery/plugins/logger.h>
-
+#include <plugins/logger/cached_logger.h>
 
 namespace osquery {
-DECLARE_uint64(aws_kinesis_period);
 
-using IKinesisLogForwarder =
-    AwsLogForwarder<Aws::Kinesis::Model::PutRecordsRequestEntry,
-                    Aws::Kinesis::KinesisClient,
-                    Aws::Kinesis::Model::PutRecordsOutcome,
-                    Aws::Vector<Aws::Kinesis::Model::PutRecordsResultEntry>>;
-
-class KinesisLogForwarder final : public IKinesisLogForwarder {
+class KinesisLoggerPlugin : public CachedLoggerPlugin {
  public:
-  KinesisLogForwarder(const std::string& name,
-                      size_t log_period,
-                      size_t max_lines)
-      : IKinesisLogForwarder(name, log_period, max_lines) {}
-
- protected:
-  Status internalSetup() override;
-  Outcome internalSend(const Batch& batch) override;
-  void initializeRecord(Record& record,
-                        Aws::Utils::ByteBuffer& buffer) const override;
-
-  size_t getMaxBytesPerRecord() const override;
-  size_t getMaxRecordsPerBatch() const override;
-  size_t getMaxBytesPerBatch() const override;
-  size_t getMaxRetryCount() const override;
-  size_t getInitialRetryDelay() const override;
-  bool appendNewlineSeparators() const override;
-
-  size_t getFailedRecordCount(Outcome& outcome) const override;
-  Result getResult(Outcome& outcome) const override;
-
- private:
-  /// The partition key; ignored if aws_kinesis_random_partition_key is set
-  std::string partition_key_;
-
-  FRIEND_TEST(KinesisTests, test_send);
-};
-
-class KinesisLoggerPlugin : public LoggerPlugin {
- public:
-  KinesisLoggerPlugin() : LoggerPlugin() {}
+  KinesisLoggerPlugin() : CachedLoggerPlugin() {}
 
   Status setUp() override;
 
@@ -72,16 +33,10 @@ class KinesisLoggerPlugin : public LoggerPlugin {
     return true;
   }
 
- private:
   void init(const std::string& name,
             const std::vector<StatusLogLine>& log) override;
 
-  Status logString(const std::string& s) override;
-
-  /// Log a status (ERROR/WARNING/INFO) message.
-  Status logStatus(const std::vector<StatusLogLine>& log) override;
-
  private:
-  std::shared_ptr<KinesisLogForwarder> forwarder_{nullptr};
 };
+
 }

--- a/plugins/logger/cached_logger.cpp
+++ b/plugins/logger/cached_logger.cpp
@@ -1,0 +1,577 @@
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/dispatcher.h>
+#include <osquery/utils/info/version.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/system/time.h>
+#include <plugins/config/parsers/decorators.h>
+
+#include <plugins/logger/cached_logger.h>
+//#include "osquery/logger/plugins/cached_logger.h"
+#include <osquery/hashing/hashing.h>
+
+// How often to check for files to send (default only)
+#define DEFAULT_INTERVAL_SEC 30
+
+#define STAT_REPORT_INTERVAL_SEC 300 // 5 minutes
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+FLAG(bool,
+     cached_logger_stats,
+     false,
+     "Enable WARNING status logging of stats every 5-minutes.");
+
+FLAG(bool,
+    cached_logger_audit_trail,
+    false,
+    "Enable saving a local copy of all results logs for QA");
+
+FLAG(uint64,
+    cached_logger_max_files,
+    7500,
+    "In case of connectivity issue, will stop logging if number of files reaches limit.");
+
+// this should be part of CachedLoggerPlugin, but didn't want to muddy up
+// header file.
+static RecursiveMutex mutex_;
+
+static const std::string LOGGER_AUDIT_TRAIL_DIR = "z_cached_logger_audit";
+static const std::string LOGGER_FAILED_DIR = "z_cached_logger_failed";
+static const std::string LOGGER_CACHE_DIR = "z_cached_logs";
+
+DECLARE_string(database_path);
+
+  struct LoggerStats {
+    uint64_t results_records_written;
+    uint64_t results_records_sent;
+    uint64_t results_files_written;
+    uint64_t results_files_sent;
+    uint64_t status_records_written;
+    uint64_t status_records_sent;
+    uint64_t status_files_written;
+    uint64_t status_files_sent;
+    uint64_t results_log_errors;
+    uint64_t status_log_errors;
+    uint64_t num_files_failed_to_send;
+  };
+
+  static LoggerStats gStats;
+  static LoggerStats gStatsLast;
+  static time_t gLastStatTime = 0;
+
+
+class ForwarderThread : public InternalRunnable {
+ public:
+  ForwarderThread(CachedLoggerPlugin& logger,
+                  std::shared_ptr<Forwarder> forwarder,
+                  uint32_t interval_seconds,
+                  uint32_t burst_file_count,
+                  uint32_t burst_sleep_millis)
+      : InternalRunnable(logger.name()),
+        logger_(logger),
+        forwarder_(forwarder),
+        interval_seconds_(interval_seconds),
+        burst_file_count_(burst_file_count),
+        burst_sleep_millis_(burst_sleep_millis) {
+    if (interval_seconds_ < 8 || interval_seconds_ > 3600) {
+      interval_seconds_ = DEFAULT_INTERVAL_SEC;
+    }
+    interval_duration_ = std::chrono::seconds(interval_seconds_);
+  }
+  ~ForwarderThread() {}
+
+ protected:
+  virtual void start() override {
+
+    while (!interrupted()) {
+      std::vector<std::string> file_paths;
+      logger_.getCachedFiles(file_paths, burst_file_count_);
+      for (int i = 0; i < (int)file_paths.size(); i++) {
+        if (i > 0) {
+          pause(std::chrono::milliseconds(burst_sleep_millis_));
+        }
+        Status status = forwarder_->send(file_paths[i]);
+        if (!status.ok() &&
+            status.getCode() == FORWARDER_STATUS_NO_CONNECTION) {
+          LOG(WARNING) << "network connection down or need to reauth";
+          pause(std::chrono::seconds(30));
+          break;
+        }
+        logger_.removeCachedFile(file_paths[i],
+          status.ok() || status.getCode() == FORWARDER_STATUS_EMPTY_FILE);
+      }
+
+      // Cool off and time wait the configured period.
+      pause(interval_duration_);
+    }
+  }
+
+  CachedLoggerPlugin& logger_;
+  std::shared_ptr<Forwarder> forwarder_;
+  uint32_t interval_seconds_;
+  uint32_t burst_file_count_;
+  uint32_t burst_sleep_millis_;
+  std::chrono::seconds interval_duration_;
+};
+
+/**
+ * Call this at end of setUp() in any inherited classes.
+ */
+void CachedLoggerPlugin::start(std::shared_ptr<Forwarder> forwarder,
+                               uint32_t interval_seconds,
+                               uint32_t burst_file_count,
+                               uint32_t burst_sleep_millis) {
+
+  // make sure deadletter director exists
+
+  createDirectory((fs::path(cache_path_) / LOGGER_CACHE_DIR).make_preferred(), false, true);
+  createDirectory((fs::path(cache_path_) / LOGGER_FAILED_DIR).make_preferred(), false, true);
+
+  if (FLAGS_cached_logger_audit_trail) {
+    createDirectory((fs::path(cache_path_) / LOGGER_AUDIT_TRAIL_DIR).make_preferred(), false, true);
+  }
+
+  // start forwarder thread
+
+  auto fthread = new ForwarderThread(
+      *this, forwarder, interval_seconds, burst_file_count, burst_sleep_millis);
+  forwarderThread_ = std::shared_ptr<InternalRunnable>(fthread);
+  Dispatcher::addService(forwarderThread_);
+}
+
+/**
+ * important : override tearDown so forwarderThread_ can be interrupted.
+ * Otherwise, agent may not exit.  Also closes channel file handles.
+ */
+void CachedLoggerPlugin::tearDown() {
+  if (forwarderThread_ != nullptr) {
+    forwarderThread_->interrupt();
+  }
+  if (results_channel_.fp != nullptr) {
+    fclose(results_channel_.fp);
+    if (results_channel_.num_lines == 0) {
+      removePath(fs::path(results_channel_.filepath).make_preferred());
+    }
+  }
+  if (status_channel_.fp != nullptr) {
+    fclose(status_channel_.fp);
+    if (status_channel_.num_lines == 0) {
+      removePath(fs::path(status_channel_.filepath).make_preferred());
+    }
+  }
+}
+
+/**
+ * Call this first from from setUp() of any inherited classes.
+ * If useSeparateStatusChannel == true, status log entries will be
+ * cached and sent separately from results.
+ */
+void CachedLoggerPlugin::setProps(std::string logname,
+                                  bool useSeparateStatusChannel,
+                                  const LoggerBounds bounds) {
+  bounds_ = bounds;
+  results_channel_.prefix = "z_R_" + logname + "_";
+  status_channel_.prefix = "z_S_" + logname + "_";
+  results_channel_.isResult = true;
+  status_channel_.isResult = false;
+
+  cache_path_ = fs::path(FLAGS_database_path).make_preferred().string();
+
+  if (pathExists(cache_path_).ok() && !isReadable(cache_path_).ok()) {
+    LOG(ERROR) << "ERROR: Cannot read cache path: " << cache_path_;
+    cache_path_ = "";
+    return;
+  }
+
+  createDirectory((fs::path(cache_path_) / LOGGER_CACHE_DIR).make_preferred(), false, true);
+
+  _enumerateExistingFiles();
+
+  useSeparateStatusChannel_ = useSeparateStatusChannel;
+
+  _rotateLog(results_channel_);
+  if (useSeparateStatusChannel) {
+    _rotateLog(status_channel_);
+  }
+}
+
+/**
+ * @returns true if the channel file should be closed, and a new file started.
+ * Considers:
+ *   - channel.num_bytes + line_length > bounds.max_bytes_per_batch
+ *   - channel.num_lines + 1 > bounds.max_records_per_batch
+ *   - (now - channel.ts > ROTATE_INTERVAL_SEC) and num_files_queued < 6
+ * This function should be treated as private. (static + public for unit test)
+ */
+bool CachedLoggerPlugin::_needsRotate(LoggerBounds bounds,
+                                      LogChannel& channel,
+                                      time_t now,
+                                      size_t line_length,
+                                      size_t num_files_queued) {
+  if (channel.num_lines == 0) {
+    return false;
+  }
+
+  // if we are backed-up in sending, rely on bounds.
+  // Otherwise, send every ROTATE_INTERVAL_SEC
+  if (num_files_queued < 6 && (now - channel.ts) > ROTATE_INTERVAL_SEC) {
+    return true;
+  }
+
+  if ((channel.num_bytes + line_length) >= bounds.max_bytes_per_batch ||
+      ((channel.num_lines + 1) > bounds.max_records_per_batch)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * _logStringInternal() is used by logString() and logStatus().
+ * It holds the mutex, checks bounds, does _rotateLog if needed,
+ * increments channel counters, and writes to file.
+ */
+Status CachedLoggerPlugin::_logStringInternal(LogChannel& channel,
+                                              const std::string& s,
+                                              bool isResult) {
+  RecursiveLock lock(mutex_);
+  if (nullptr == channel.fp || cacheLimitReached_ ) {
+    return Status();
+  }
+
+  if (s.size() >= bounds_.max_bytes_per_record) {
+    LOG(ERROR) << "unable to log. size: " << s.size()
+               << " transport max:" << bounds_.max_bytes_per_record;
+    if (isResult) {
+      gStats.results_log_errors++;
+    } else {
+      gStats.status_log_errors++;
+    }
+    return Status();
+  }
+
+  bool didRotate = false;
+  if (_needsRotate(
+          bounds_, channel, time(NULL), s.size(), files_to_forward_.size())) {
+    _rotateLog(channel);
+    didRotate = true;
+    if (channel.fp == nullptr) {
+      return Status();
+    }
+  }
+
+  channel.num_lines++;
+  channel.num_bytes += s.size();
+
+  if (isResult) {
+    gStats.results_records_written++;
+  } else {
+    gStats.status_records_written++;
+  }
+
+  fputs(s.c_str(), channel.fp);
+  fputs("\n", channel.fp);
+
+  // With normal config (WARNING and ERROR status only), status lines are
+  // infrequent.  So when we rotate results, also rotate status if needed.
+
+  if (isResult && didRotate && useSeparateStatusChannel_ && status_channel_.num_bytes > 0) {
+      _rotateLog(status_channel_);
+  }
+
+  return Status();
+}
+
+// standard logger entrypoint overrides
+
+Status CachedLoggerPlugin::logString(const std::string& s) {
+  return _logStringInternal(results_channel_, s, true);
+}
+
+/*
+Status CachedLoggerPlugin::logStringBatch(std::vector<std::string>& items) {
+  for (const auto& s : items) {
+    logString(s);
+  }
+  return Status();
+}*/
+
+Status CachedLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
+  // Append decorations to status
+  // Assemble a decorations tree to append to each status buffer line.
+  pt::ptree dtree;
+  std::map<std::string, std::string> decorations;
+  getDecorations(decorations);
+  for (const auto& decoration : decorations) {
+    dtree.put(decoration.first, decoration.second);
+  }
+
+  for (const auto& item : log) {
+    // Convert the StatusLogLine into ptree format, to convert to JSON.
+    pt::ptree buffer;
+    buffer.put("hostIdentifier", item.identifier);
+    buffer.put("calendarTime", item.calendar_time);
+    buffer.put("unixTime", item.time);
+    buffer.put("severity", (google::LogSeverity)item.severity);
+    buffer.put("filename", item.filename);
+    buffer.put("line", item.line);
+    buffer.put("message", item.message);
+    buffer.put("version", kVersion);
+    if (decorations.size() > 0) {
+      buffer.put_child("decorations", dtree);
+    }
+    buffer.put("log_type", "status");
+
+    // Convert to JSON, for storing a string-representation in the database.
+    std::string json;
+    try {
+      std::stringstream json_output;
+      pt::write_json(json_output, buffer, false);
+      json = json_output.str();
+    } catch (const pt::json_parser::json_parser_error& e) {
+      // The log could not be represented as JSON.
+      return Status(1, e.what());
+    }
+
+    _logStringInternal(
+        (useSeparateStatusChannel_ ? status_channel_ : results_channel_), json, false);
+  }
+
+  return Status();
+}
+
+static void fallOnSword()
+{
+  LOG(WARNING) << "\n*******************************************************\n"
+  "The number of cached log files has reached limit:"
+  << FLAGS_cached_logger_max_files
+  << "\nLogging will sent to /dev/null\n"
+  "1. Fix connectivity issue with log forwarding.\n"
+  "2. Delete some or all z_*.json files in DB directory\n"
+  "*******************************************************";
+}
+
+/**
+ * _enumerateExistingFiles is called from setProps()
+ * to populate files_to_forward_ with any cached log
+ * files in cache directory.
+ */
+void CachedLoggerPlugin::_enumerateExistingFiles() {
+  auto dir = fs::path(cache_path_);
+  std::vector<std::string> items;
+  // Get list of all cached log files
+  Status status = listFilesInDirectory((dir / LOGGER_CACHE_DIR).string(), items, false);
+  // also add cached files in DB/ dir (legacy support)
+  status = listFilesInDirectory(cache_path_, items, false);
+  for (std::string filename : items) {
+    // assume all our cached log files are in DB dir, prefixed with "z_"
+    if (fs::path(filename).filename().string().find(CACHE_FILE_PREFIX) != 0) {
+      continue;
+    }
+    // TODO: are these sorted?
+
+    CacheFileInfo info(filename);
+
+    // TODO: count lines and md5?
+
+    files_to_forward_.push_back(info);
+  }
+  if (files_to_forward_.size() >= FLAGS_cached_logger_max_files) {
+    fallOnSword();
+    cacheLimitReached_ = true;
+  }
+}
+
+/**
+ * Resets counters, sets ts=now, updates filepath with timestamp.
+ */
+void CachedLoggerPlugin::_clearAndNameLog(LogChannel& channel, time_t now) {
+  if (now == channel.ts) {
+    // must be tons of results, if rotating in same second
+    channel.subid++;
+  } else {
+    channel.subid = 0;
+  }
+
+  channel.num_bytes = 0;
+  channel.num_lines = 0;
+  channel.ts = now;
+
+  // build name and path
+
+  std::string suffix = "";
+  if (channel.subid > 0) {
+    suffix = "_" + std::to_string(channel.subid);
+  }
+  std::string name = channel.prefix + std::to_string(now) + suffix + ".json";
+  auto path = fs::path(cache_path_) / LOGGER_CACHE_DIR / name;
+  channel.filepath = path.make_preferred().string();
+}
+
+#define DIFF(NAME) { \
+  diff.NAME = gStats.NAME - gStatsLast.NAME; \
+s += std::string(#NAME) + ":" + std::to_string(diff.NAME) + " "; \
+}
+
+static void _reportStats(time_t now) {
+  if (gLastStatTime == 0) {
+    gLastStatTime = now;
+    return;
+  }
+
+  if ((now - gLastStatTime) < STAT_REPORT_INTERVAL_SEC) {
+    return;
+  }
+
+  std::string s = "period:" + std::to_string(now-gLastStatTime) + "s ";
+  gLastStatTime = now;
+  LoggerStats diff;
+
+  DIFF(results_records_written);
+  DIFF(results_records_sent);
+  DIFF(results_files_written);
+  DIFF(results_files_sent);
+  DIFF(status_records_written);
+  DIFF(status_records_sent);
+  DIFF(status_files_written);
+  DIFF(status_files_sent);
+  DIFF(results_log_errors);
+  DIFF(status_log_errors);
+  DIFF(num_files_failed_to_send);
+
+  if (FLAGS_cached_logger_stats) {
+    LOG(WARNING) << s;
+  }
+}
+
+/**
+ * Does a fclose(channel.fp), adds channel.filepath to files_to_forward_[],
+ * calls _clearAndNameLog(),
+ * And does fopen(channel.filepath,"w"), and adds
+ */
+void CachedLoggerPlugin::_rotateLog(LogChannel& channel) {
+  RecursiveLock lock(mutex_);
+
+  // close existing
+  if (!channel.filepath.empty() && channel.fp != nullptr) {
+    CacheFileInfo info(channel.filepath, channel.num_lines);
+    info.isResult = channel.isResult;
+    // NOTE: 'status' counters will go to 'result' if !separate channel.
+    // TODO: md5?
+    files_to_forward_.push_back(info);
+    fclose(channel.fp);
+  }
+
+  // no write if directory is not writable (see setProps)
+  if (cache_path_.empty()) {
+    channel.fp = nullptr;
+    return;
+  }
+
+  time_t now = time(NULL);
+
+  _reportStats(now);
+
+  _clearAndNameLog(channel, now);
+
+  if (files_to_forward_.size() >= FLAGS_cached_logger_max_files) {
+    fallOnSword();
+    cacheLimitReached_ = true;
+  } else {
+    cacheLimitReached_ = false;
+  }
+
+  channel.fp = FOPEN(channel.filepath.c_str(), "w");
+  if (channel.fp == nullptr) {
+    LOG(ERROR) << "unable to create log cache:" << channel.filepath;
+  } else {
+    if (channel.isResult) {
+      gStats.results_files_written++;
+    } else {
+      gStats.status_files_written++;
+    }
+  }
+}
+
+static inline void updateSentStats(CacheFileInfo &info, bool wasSentSuccessfully){
+  if (wasSentSuccessfully) {
+    if (info.isResult) {
+      gStats.results_files_sent ++;
+      gStats.results_records_sent += info.num_lines;
+    } else {
+      gStats.status_files_sent++;
+      gStats.status_records_sent += info.num_lines;
+    }
+  } else {
+    gStats.num_files_failed_to_send ++;
+  }
+}
+
+/*
+ * When subclass has finished sending file, call this to delete it.
+ * If (wasSentSuccessfully == false and
+ *  FLAGS_cached_logger_keep_dead_letters == true)
+ * then logs that failed to send will be written to ${DBDIR}/deadletter/
+ * and will remain there for up to 7 days.
+ */
+void CachedLoggerPlugin::removeCachedFile(std::string& file_path,
+                                          bool wasSentSuccessfully) {
+  RecursiveLock lock(mutex_);
+  VLOG(1) << "removeCachedFile " << file_path;
+
+  // remove from list
+
+  for (auto it = files_to_forward_.begin(); it != files_to_forward_.end();
+       it++) {
+    if (it->filepath == file_path) {
+      updateSentStats(*it, wasSentSuccessfully);
+      files_to_forward_.erase(it);
+      break;
+    }
+  }
+  // delete or move
+
+  if (!wasSentSuccessfully) {
+    LOG(ERROR) << "unable to send cached log file:" << file_path;
+
+    // copy to dead_letter dir if !wasSentSuccessfully
+
+    fs::path deadFile = (fs::path(cache_path_) / LOGGER_FAILED_DIR / fs::path(file_path).filename()).make_preferred();
+    movePath(fs::path(file_path), deadFile);
+  } else {
+    if (FLAGS_cached_logger_audit_trail) {
+      fs::path dest = (fs::path(cache_path_) / LOGGER_AUDIT_TRAIL_DIR / fs::path(file_path).filename()).make_preferred();
+      movePath(fs::path(file_path), dest);
+    } else {
+      removePath(fs::path(file_path));
+    }
+  }
+}
+
+/*
+ * Returns one or more log cache files waiting to be sent
+ */
+void CachedLoggerPlugin::getCachedFiles(
+    std::vector<std::string>& cached_file_paths, int count) {
+  RecursiveLock lock(mutex_);
+  for (int i = 0; i < count && i < (int)files_to_forward_.size(); i++) {
+    //VLOG(1) << i << "] getCachedFiles " << files_to_forward_[i].filepath;
+    cached_file_paths.push_back(files_to_forward_[i].filepath);
+  }
+}
+
+} // namespace osquery

--- a/plugins/logger/cached_logger.h
+++ b/plugins/logger/cached_logger.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <osquery/plugins/logger.h>
+
+namespace osquery {
+
+/*
+ * All files for this logger reside in database_path and are named
+ * starting with CACHE_FILE_PREFIX.  Includes an 'S_' or 'R_',
+ * depending on status or results files, includes the epoch timestamp
+ * and logger name. e.g. 'z_R_aws_kinesis_1553117765.json'.
+ *
+ * The cache files are newline-delimited text-files.  Each line containing
+ * one JSON status or result record.
+ *
+ * Each forwarder may have it's own limits on now many lines or records
+ * and bytes it can handle.  The goal is to package each cache file
+ * according to the LoggerBounds, so that it's ready for sending.
+ */
+
+#define CACHE_FILE_PREFIX "z_"
+
+struct LoggerBounds {
+  uint64_t max_records_per_batch;
+  uint64_t max_bytes_per_record;
+  uint64_t max_bytes_per_batch;
+};
+
+#define FORWARDER_STATUS_NO_CONNECTION 999
+#define FORWARDER_STATUS_EMPTY_FILE    998
+#define FORWARDER_STATUS_READ_ERROR    997
+
+class Forwarder {
+ public:
+  /*
+   * Even though CachedLoggerPlugin checks the bounds when files are
+   * written, the bounds are supplied so send() can double-check them
+   * if desired.
+   */
+  Forwarder(const LoggerBounds bounds) : bounds_(bounds) {}
+  virtual ~Forwarder() {}
+
+  /*
+   * Seconds between checking for cached logs to send.
+   */
+  virtual uint32_t getIntervalSeconds() {
+    return 10;
+  }
+
+  /*
+   * Max number of files to send per interval.
+   */
+  virtual uint32_t getMaxFilesPerInterval() {
+    return 2;
+  }
+
+  /*
+   * If multiple files per interval, delay between each.
+   */
+  virtual uint32_t getBurstDelayMillis() {
+    return 1500;
+  }
+
+  /*
+   * Perform actual send.
+   * Implementation is responsible for retries.
+   * If unable to connect to server, return FORWARDER_STATUS_NO_CONNECTION.
+   * The file will be deleted after return, unless
+   *   status == FORWARDER_STATUS_NO_CONNECTION.
+   */
+  virtual Status send(std::string file_path) = 0;
+
+ protected:
+  const LoggerBounds bounds_;
+};
+
+// How long to wait before closing a file and adding to send queue
+#define ROTATE_INTERVAL_SEC 25
+
+struct LogChannel {
+  FILE* fp;
+  std::string filepath;
+  time_t ts;
+  uint32_t subid;
+
+  uint64_t num_bytes;
+  uint32_t num_lines;
+
+  std::string prefix;
+  std::string last_md5;
+  bool isResult;
+};
+
+struct CacheFileInfo {
+  std::string filepath;
+  uint32_t num_lines;
+  std::string md5;
+  bool isResult;
+  CacheFileInfo(std::string path, uint32_t num = 0, std::string filemd5 = "")
+      : filepath(path), num_lines(num), md5(filemd5), isResult(false) {}
+};
+
+/**
+ * This logger writes result and status into newline-delimited text files.
+ * Cached Format:
+ *  - Every line beginning with a '{' is a JSON object
+ *  - Lines beginning with '#' include metadata, and should be ignored by
+ *    forwarder or application ingesting logs.
+ * This is designed to be subclassed, and used in conjunction with a forwarder.
+ * Subclass can call configure() to set the cache file parameters specific
+ * to the transport.  For example, aws kinesis has 1000 records per second
+ * limit, and record size of 1MB.
+ *
+ * The subclasses of CachedLoggerPlugin should call start() from setUp() with
+ * an instance of the Forwarder.  The start() method will create a
+ * dispatcher thread and call Forwarder.send() at the desired interval.
+ *
+ */
+class CachedLoggerPlugin : public LoggerPlugin {
+ public:
+  /**
+   * Call this first from from setUp() of any inherited classes.
+   * If useSeparateStatusChannel == true, status log entries will be
+   * cached and sent separately from results.
+   */
+  void setProps(std::string logname,
+                bool useSeparateStatusChannel,
+                const LoggerBounds bounds);
+
+  /**
+   * Call this at end of setUp() in any inherited classes.
+   */
+  void start(std::shared_ptr<Forwarder> spForwarder,
+             uint32_t interval_seconds,
+             uint32_t burst_file_count,
+             uint32_t burst_sleep_millis);
+
+  /*
+   * Returns one or more log cache files waiting to be sent.
+   * Called internally by ForwarderThread.  Consider this private.
+   */
+  void getCachedFiles(std::vector<std::string>& cached_file_paths, int count);
+
+  /*
+   * Called internally by ForwarderThread.  Consider this private.
+   */
+  void removeCachedFile(std::string& file_path, bool wasSentSuccessfully);
+
+  // override standard logger entrypoints ... writes to cached text files
+
+  Status logString(const std::string& s) override;
+
+  Status logStatus(const std::vector<StatusLogLine>& log) override;
+
+  /**
+   * Internally, this just calls logString() for each.
+   */
+  //Status logStringBatch(std::vector<std::string>& items) override;
+
+  /**
+   * important : override tearDown so forwarderThread_ can be interrupted.
+   * Otherwise, agent may not exit.  Also closes channel file handles.
+   */
+  void tearDown() override;
+
+  /**
+   * @returns true if the channel file should be closed, and a new file started.
+   * Considers:
+   *   - channel.num_bytes + line_length > bounds.max_bytes_per_batch
+   *   - channel.num_lines + 1 > bounds.max_records_per_batch
+   *   - (now - channel.ts > ROTATE_INTERVAL_SEC) and num_files_queued < 6
+   * This function should be treated as private. (static + public for unit test)
+   */
+  static bool _needsRotate(LoggerBounds bounds,
+                           LogChannel& channel,
+                           time_t now,
+                           size_t line_length,
+                           size_t num_files_queued);
+
+ protected:
+  /**
+   * _logStringInternal() is used by logString() and logStatus().
+   * It holds the mutex, checks bounds, does _rotateLog if needed,
+   * increments channel counters, and writes to file.
+   */
+  Status _logStringInternal(LogChannel& channel, const std::string& s, bool isResult);
+
+  /**
+   * _enumerateExistingFiles is called from setProps()
+   * to populate files_to_forward_ with any cached log
+   * files in cache directory.
+   */
+  void _enumerateExistingFiles();
+
+  /**
+   * Does a fclose(channel.fp), adds channel.filepath to files_to_forward_[],
+   * calls _clearAndNameLog(),
+   * And does fopen(channel.filepath,"w"), and adds
+   */
+  void _rotateLog(LogChannel& channel);
+
+  /**
+   * Resets counters, sets ts=now, updates filepath with timestamp.
+   */
+  void _clearAndNameLog(LogChannel& channel, time_t now);
+
+  bool useSeparateStatusChannel_;
+  LoggerBounds bounds_;
+  std::shared_ptr<InternalRunnable> forwarderThread_;
+  std::string cache_path_;
+  LogChannel results_channel_;
+  LogChannel status_channel_;
+  std::vector<CacheFileInfo> files_to_forward_;
+  bool cacheLimitReached_ {false};
+};
+
+#ifdef WIN32
+inline FILE* FOPEN(const char *FILEPATH, const char *MODE) {
+  FILE* fp;
+  if (0 != fopen_s(&fp, FILEPATH, MODE)) {
+    return nullptr;
+  }
+  return fp;
+}
+#else
+#define FOPEN(FILEPATH, MODE) fopen(FILEPATH, MODE)
+#endif
+
+} // namespace osquery

--- a/plugins/logger/cached_logger.h
+++ b/plugins/logger/cached_logger.h
@@ -27,8 +27,8 @@ struct LoggerBounds {
 };
 
 #define FORWARDER_STATUS_NO_CONNECTION 999
-#define FORWARDER_STATUS_EMPTY_FILE    998
-#define FORWARDER_STATUS_READ_ERROR    997
+#define FORWARDER_STATUS_EMPTY_FILE 998
+#define FORWARDER_STATUS_READ_ERROR 997
 
 class Forwarder {
  public:
@@ -155,7 +155,7 @@ class CachedLoggerPlugin : public LoggerPlugin {
   /**
    * Internally, this just calls logString() for each.
    */
-  //Status logStringBatch(std::vector<std::string>& items) override;
+  // Status logStringBatch(std::vector<std::string>& items) override;
 
   /**
    * important : override tearDown so forwarderThread_ can be interrupted.
@@ -183,7 +183,9 @@ class CachedLoggerPlugin : public LoggerPlugin {
    * It holds the mutex, checks bounds, does _rotateLog if needed,
    * increments channel counters, and writes to file.
    */
-  Status _logStringInternal(LogChannel& channel, const std::string& s, bool isResult);
+  Status _logStringInternal(LogChannel& channel,
+                            const std::string& s,
+                            bool isResult);
 
   /**
    * _enumerateExistingFiles is called from setProps()
@@ -211,11 +213,11 @@ class CachedLoggerPlugin : public LoggerPlugin {
   LogChannel results_channel_;
   LogChannel status_channel_;
   std::vector<CacheFileInfo> files_to_forward_;
-  bool cacheLimitReached_ {false};
+  bool cacheLimitReached_{false};
 };
 
 #ifdef WIN32
-inline FILE* FOPEN(const char *FILEPATH, const char *MODE) {
+inline FILE* FOPEN(const char* FILEPATH, const char* MODE) {
   FILE* fp;
   if (0 != fopen_s(&fp, FILEPATH, MODE)) {
     return nullptr;

--- a/plugins/logger/tests/BUCK
+++ b/plugins/logger/tests/BUCK
@@ -38,6 +38,7 @@ osquery_cxx_test(
     name = "buffered_logger_tests",
     srcs = [
         "buffered_tests.cpp",
+        "cached_logger_tests.cpp",
     ],
     visibility = ["PUBLIC"],
     deps = [

--- a/plugins/logger/tests/CMakeLists.txt
+++ b/plugins/logger/tests/CMakeLists.txt
@@ -7,6 +7,7 @@
 function(pluginsLoggerTestsMain)
   generatePluginsLoggerTestsFilesystemloggertestsTest()
   generatePluginsLoggerTestsBufferedloggertestsTest()
+  generatePluginsLoggerTestsCachedloggertestsTest()
 
   if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
     generatePluginsLoggerTestsKafkaproducerloggertestsTest()
@@ -48,6 +49,30 @@ function(generatePluginsLoggerTestsBufferedloggertestsTest)
   add_osquery_executable(plugins_logger_tests_bufferedloggertests-test buffered_tests.cpp)
 
   target_link_libraries(plugins_logger_tests_bufferedloggertests-test PRIVATE
+    osquery_cxx_settings
+    osquery_core
+    osquery_core_plugins
+    osquery_distributed
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_logger_datalogger
+    osquery_registry
+    osquery_remote_enroll_tlsenroll
+    osquery_utils_conversions
+    osquery_utils_info
+    osquery_utils_system_time
+    plugins_config_tlsconfig
+    plugins_database_ephemeral
+    plugins_logger_buffered
+    specs_tables
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generatePluginsLoggerTestsCachedloggertestsTest)
+  add_osquery_executable(plugins_logger_tests_cachedloggertests-test cached_logger_tests.cpp)
+
+  target_link_libraries(plugins_logger_tests_cachedloggertests-test PRIVATE
     osquery_cxx_settings
     osquery_core
     osquery_core_plugins

--- a/plugins/logger/tests/cached_logger_tests.cpp
+++ b/plugins/logger/tests/cached_logger_tests.cpp
@@ -21,7 +21,6 @@ namespace osquery {
 
 class CachedLoggerTests : public Test {
  public:
-
 };
 
 TEST_F(CachedLoggerTests, rotate_logic) {
@@ -39,7 +38,7 @@ TEST_F(CachedLoggerTests, rotate_logic) {
 
   // the following would be true, but file is empty. e.g. channel.num_lines==0
   EXPECT_FALSE(CachedLoggerPlugin::_needsRotate(
-	  bounds, channel, minute_from_now, 256, num_files_queued));
+      bounds, channel, minute_from_now, 256, num_files_queued));
 
   channel.num_lines = 1;
   EXPECT_TRUE(CachedLoggerPlugin::_needsRotate(

--- a/plugins/logger/tests/cached_logger_tests.cpp
+++ b/plugins/logger/tests/cached_logger_tests.cpp
@@ -1,0 +1,56 @@
+#include <chrono>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/dispatcher.h>
+#include <osquery/logger.h>
+#include <osquery/system.h>
+
+#include <osquery/utils/json/json.h>
+#include <plugins/logger/cached_logger.h>
+
+using namespace testing;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+class CachedLoggerTests : public Test {
+ public:
+
+};
+
+TEST_F(CachedLoggerTests, rotate_logic) {
+  LoggerBounds bounds = {500 /* records */, 1024 /* record bytes */, 50000};
+  LogChannel channel;
+  time_t now = time(NULL);
+  time_t minute_from_now = now + 60;
+  time_t ten_seconds_ago = now - 10;
+  channel.ts = ten_seconds_ago;
+  channel.num_bytes = 4000;
+  channel.num_lines = 0;
+  size_t num_files_queued = 3;
+  EXPECT_FALSE(CachedLoggerPlugin::_needsRotate(
+      bounds, channel, now, 256, num_files_queued));
+
+  // the following would be true, but file is empty. e.g. channel.num_lines==0
+  EXPECT_FALSE(CachedLoggerPlugin::_needsRotate(
+	  bounds, channel, minute_from_now, 256, num_files_queued));
+
+  channel.num_lines = 1;
+  EXPECT_TRUE(CachedLoggerPlugin::_needsRotate(
+      bounds, channel, minute_from_now, 256, num_files_queued));
+
+  channel.num_lines = 499;
+  EXPECT_FALSE(CachedLoggerPlugin::_needsRotate(
+      bounds, channel, now, 256, num_files_queued));
+  channel.num_lines = 500;
+  EXPECT_TRUE(CachedLoggerPlugin::_needsRotate(
+      bounds, channel, now, 256, num_files_queued));
+}
+
+} // namespace osquery


### PR DESCRIPTION
*Sorry, this was PR 5939, but moved it here after branch got messed up.*

The new cached_logger plugin is a replacement for the buffered_logger, and it works in tandem with a 'forwarder' such as aws_kinesis to actually send the records. The TLS logger can be ported to use this cached_logger approach as well in the future. The main problem with buffered_logger was it's use of the rocksdb database and unnecessary complexity. Rocksdb also does a sync after each save unless the source is events.

The new cached_logger operates as follows:

- for each logString(item) call, it will generate JSON string and write it to a newline delimited plain-text file named z_R__.json in the osquery db directory.
- for each logStatus(msg) call, it will generate JSON string and write it to a newline delimited plain-text file named z_S__.json in the osquery db directory.
- At the start of logString() and logStatus(), it will check to see if it should close the current results or status file and open a new one. The decision will start a new file if there's at least one record, and it's been 20 seconds since creation, and if the sending mechanism is not backed up (number of files waiting to be sent). Additionally, forwarders such as kinesis have strict limits on the bytes per record, number of records, and total bytes per batch, all which shape the limits of each file, so that the forwarder can easily parse the file, package, and send the records.
- The forwarder is run in a dedicated thread, and will sleep for a forwarder defined number of seconds, send a batch of files, and go back to sleep. The kinesis logger, for example will sleep 8 seconds, send up to 4 files, with a 1.2 second pause in between each file, then back to sleep.
- If network connection is down, the sending thread pauses for 30 seconds.
- If aws kinesis forwarder gets an authentication error, it will invalidate the handle and reconnect. If the authentication error persists, it will wait for 7.5 minutes to refresh config and reconnect, doing this perpetually, until successfully sends data.

With old buffered logger on windows, sending a burst of 20,000 windows events will yield a forwarding patter of a spike and tail. This is a result of buffering not being fast enough.

![](https://user-images.githubusercontent.com/20775507/67627902-01dc2e80-f82b-11e9-9594-9e3c39da57da.png)

With the new logger, the pattern is more what you would expect:

![](https://user-images.githubusercontent.com/20775507/67627912-26380b00-f82b-11e9-8738-323f854d7cab.png)
