### PR TITLE
Use function `waitThenShutdown` to wait for the shutdown signal

### DIFF
--- a/tools/codegen/templates/osquery_extension_group_main.cpp.in
+++ b/tools/codegen/templates/osquery_extension_group_main.cpp.in
@@ -25,6 +25,6 @@ int main(int argc, char* argv[]) {
   }
 
   // Finally wait for a signal / interrupt to shutdown.
-  runner.waitForShutdown();
+  runner.waitThenShutdown();
   return 0;
 }


### PR DESCRIPTION
Use function `waitThenShutdown` to wait for the shutdown signal/interrupt before exiting. The function has been renamed after the 4.0.2 release.