### PR TITLE
Added return code to requestShutdown call

### DIFF
--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -138,7 +138,7 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
     retcode = profile(argc, argv);
   }
   // Finally shutdown.
-  runner.requestShutdown();
+  runner.requestShutdown(retcode);
   return retcode;
 }
 


### PR DESCRIPTION
* When calling osquery in interactive mode with a single query as argument `(osqueryd -S  "SELECT * FROM bogus_table;")` would exit with a 0 return code when expectation is an exit with a 1 return code

* This change adds the return code back to the requestShutdown call in startShell, which will allow exiting with the proper return codes, this error was reported by and will fix #5853  
