### PR TITLE
source migration: Add low hanging fruit (easy) libraries

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -79,8 +79,8 @@ set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,
 overwrite_cache_variable("BUILD_TESTING" "BOOL" "OFF")
 
 # Linux can use source and formula modules to link dependencies; this
-# feature is not yet available on Windows and macOS
-if(DEFINED PLATFORM_LINUX)
+# feature is not yet available on Windows.
+if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
   set(third_party_source_list "source;formula;facebook")
 else()
   set(third_party_source_list "source_migration;facebook")

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -620,15 +620,23 @@ endfunction()
 function(generateBoostContext)
   set(library_root "${BOOST_ROOT}/libs/context")
 
-  set(asm_source_file_list
-    "${library_root}/src/asm/jump_x86_64_sysv_elf_gas.S"
-    "${library_root}/src/asm/make_x86_64_sysv_elf_gas.S"
-    "${library_root}/src/asm/ontop_x86_64_sysv_elf_gas.S"
-  )
+  if(DEFINED PLATFORM_LINUX)
+    set(asm_source_file_list
+      "${library_root}/src/asm/jump_x86_64_sysv_elf_gas.S"
+      "${library_root}/src/asm/make_x86_64_sysv_elf_gas.S"
+      "${library_root}/src/asm/ontop_x86_64_sysv_elf_gas.S"
+    )
 
-  foreach(asm_source_file ${asm_source_file_list})
-    set_property(SOURCE "${asm_source_file}" PROPERTY LANGUAGE C)
-  endforeach()
+    foreach(asm_source_file ${asm_source_file_list})
+      set_property(SOURCE "${asm_source_file}" PROPERTY LANGUAGE C)
+    endforeach()
+  elseif(DEFINED PLATFORM_MACOS)
+    set(asm_source_file_list
+      "${library_root}/src/asm/jump_x86_64_sysv_macho_gas.S"
+      "${library_root}/src/asm/make_x86_64_sysv_macho_gas.S"
+      "${library_root}/src/asm/ontop_x86_64_sysv_macho_gas.S"
+    )
+  endif()
 
   add_library(thirdparty_boost_context STATIC
     "${library_root}/src/execution_context.cpp"


### PR DESCRIPTION
This is a set of migrations from the `facebook` to `source_migration` layer.