### PR TITLE
Prefer 7zip when installing Strawberry Perl

### DIFF
--- a/tools/ci/scripts/install_openssl_formula_dependencies.ps1
+++ b/tools/ci/scripts/install_openssl_formula_dependencies.ps1
@@ -11,5 +11,15 @@
 #
 
 # It does not seem that they have HTTPS: https://github.com/StrawberryPerl/strawberryperl.com/issues/11
-Invoke-WebRequest "http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-64bit.zip" -OutFile "$env:TEMP\strawberry_perl.zip"
-Expand-Archive "$env:TEMP\strawberry_perl.zip" -DestinationPath "C:\Strawberry" -Force
+(New-Object System.Net.WebClient).DownloadFile("http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-64bit.zip", "$env:TEMP\strawberry_perl.zip")
+
+# Prefer 7zip if present, which is faster
+if (Get-Command 7z -errorAction SilentlyContinue)
+{
+	7z x -oC:\Strawberry -y "$env:TEMP\strawberry_perl.zip"
+}
+else
+{
+	Write-Host "Couldn't find 7zip, will use the slower Expand-Archive"
+	Expand-Archive -Path "$env:TEMP\strawberry_perl.zip" -DestinationPath "C:\Strawberry" -Force
+}


### PR DESCRIPTION
Use a faster method to download and a faster method to
extract zip archives, when available.
