### PR TITLE
Don't always link to all AWS libraries

### DIFF
--- a/libraries/cmake/source/aws-sdk-cpp/CMakeLists.txt
+++ b/libraries/cmake/source/aws-sdk-cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ function(generateAwsCcommonTarget)
   set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/aws-c-common_src")
   set(binary_root "${CMAKE_CURRENT_BINARY_DIR}/aws-c-common")
 
-  add_library(thirdparty_aws_c_common STATIC
+  add_library(thirdparty_aws_c_common STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/array_list.c"
     "${library_root}/source/assert.c"
     "${library_root}/source/byte_buf.c"
@@ -109,7 +109,7 @@ endfunction()
 function(generateAwsChecksumsTarget)
   set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/aws-checksums_src")
 
-  add_library(thirdparty_aws_checksums STATIC
+  add_library(thirdparty_aws_checksums STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/cpuid_generic.c"
     "${library_root}/source/crc.c"
     "${library_root}/source/crc_jni.c"
@@ -148,7 +148,7 @@ endfunction()
 function(generateAwsCeventStreamTarget)
   set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/aws-c-event-stream_src")
 
-  add_library(thirdparty_aws_c_event_stream STATIC
+  add_library(thirdparty_aws_c_event_stream STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/event_stream.c"
   )
 
@@ -210,7 +210,7 @@ function(generateAwsCore)
     "${binary_root}/include/aws/core/SDKConfig.h"
    )
 
-  add_library(thirdparty_aws_core STATIC
+  add_library(thirdparty_aws_core STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/AmazonSerializableWebServiceRequest.cpp"
     "${library_root}/source/AmazonStreamingWebServiceRequest.cpp"
     "${library_root}/source/AmazonWebServiceRequest.cpp"
@@ -352,7 +352,7 @@ endfunction()
 function(generateAwsFirehose)
   set(library_root "${AWS_SDK_CPP_ROOT}/aws-cpp-sdk-firehose")
 
-  add_library(thirdparty_aws_firehose STATIC
+  add_library(thirdparty_aws_firehose STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/FirehoseClient.cpp"
     "${library_root}/source/FirehoseEndpoint.cpp"
     "${library_root}/source/FirehoseErrorMarshaller.cpp"
@@ -462,7 +462,7 @@ endfunction()
 function(generateAwsKinesis)
   set(library_root "${AWS_SDK_CPP_ROOT}/aws-cpp-sdk-kinesis")
 
-  add_library(thirdparty_aws_kinesis STATIC
+  add_library(thirdparty_aws_kinesis STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/KinesisClient.cpp"
     "${library_root}/source/KinesisEndpoint.cpp"
     "${library_root}/source/KinesisErrorMarshaller.cpp"
@@ -550,7 +550,7 @@ endfunction()
 function(generateAwsEc2)
   set(library_root "${AWS_SDK_CPP_ROOT}/aws-cpp-sdk-ec2")
 
-  add_library(thirdparty_aws_ec2 STATIC
+  add_library(thirdparty_aws_ec2 STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/EC2Client.cpp"
     "${library_root}/source/EC2Endpoint.cpp"
     "${library_root}/source/EC2ErrorMarshaller.cpp"
@@ -1770,7 +1770,7 @@ endfunction()
 function(generateAwsSts)
   set(library_root "${AWS_SDK_CPP_ROOT}/aws-cpp-sdk-sts")
 
-  add_library(thirdparty_aws_sts STATIC
+  add_library(thirdparty_aws_sts STATIC EXCLUDE_FROM_ALL
     "${library_root}/source/STSClient.cpp"
     "${library_root}/source/STSEndpoint.cpp"
     "${library_root}/source/STSErrorMarshaller.cpp"

--- a/osquery/tables/cloud/CMakeLists.txt
+++ b/osquery/tables/cloud/CMakeLists.txt
@@ -22,6 +22,8 @@ function(generateOsqueryTablesCloud)
     osquery_logger
     osquery_utils_aws
     thirdparty_boost
+    thirdparty_aws_core
+    thirdparty_aws_ec2
   )
 endfunction()
 

--- a/osquery/utils/aws/CMakeLists.txt
+++ b/osquery/utils/aws/CMakeLists.txt
@@ -24,7 +24,8 @@ function(generateOsqueryUtilsAws)
     osquery_remote_transports_transportstls
     osquery_utils_json
     osquery_utils_status
-    thirdparty_aws-sdk-cpp
+    thirdparty_aws_core
+    thirdparty_aws_sts
   )
 
   set(public_header_files

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -44,6 +44,8 @@ function(generatePluginsLoggerAwsfirehose)
     osquery_cxx_settings
     osquery_dispatcher
     plugins_logger_awslogforwarder
+    thirdparty_aws_core
+    thirdparty_aws_firehose
   )
 
   set(public_header_files
@@ -67,6 +69,8 @@ function(generatePluginsLoggerAwskinesis)
     osquery_process
     osquery_registry
     plugins_logger_awslogforwarder
+    thirdparty_aws_core
+    thirdparty_aws_kinesis
   )
 
   set(public_header_files


### PR DESCRIPTION
While in the end the osqueryd binary will require almost all libraries
built and linked, having each intermediate library depend on the whole
set of AWS libraries might result in higher compiling time.
Especially since on some platforms not all libraries are used.

This should speed up the compilation speed on Windows.