### PR TITLE
tables: Use basic TLS options within the curl table

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -240,10 +240,8 @@ void Client::encryptConnection() {
   }
 
   ssl_sock_ = std::make_shared<ssl_stream>(sock_, ctx);
-  if (client_options_.sni_hostname_) {
-    ::SSL_set_tlsext_host_name(ssl_sock_->native_handle(),
-                               client_options_.sni_hostname_->c_str());
-  }
+  ::SSL_set_tlsext_host_name(ssl_sock_->native_handle(),
+                             client_options_.remote_hostname_->c_str());
 
   callNetworkOperation([&]() {
     ssl_sock_->async_handshake(

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -152,11 +152,6 @@ class Client {
       return *this;
     }
 
-    Options& openssl_sni_hostname(std::string const& sni_h) {
-      sni_hostname_ = sni_h;
-      return *this;
-    }
-
     Options& proxy_hostname(std::string const& prxy_h) {
       proxy_hostname_ = prxy_h;
       return *this;
@@ -178,7 +173,6 @@ class Client {
              (client_certificate_file_ == ropts.client_certificate_file_) &&
              (client_private_key_file_ == ropts.client_private_key_file_) &&
              (ciphers_ == ropts.ciphers_) &&
-             (sni_hostname_ == ropts.sni_hostname_) &&
              (proxy_hostname_ == ropts.proxy_hostname_) &&
              (remote_hostname_ == ropts.remote_hostname_) &&
              (remote_port_ == ropts.remote_port_) &&
@@ -196,7 +190,6 @@ class Client {
     boost::optional<std::string> client_certificate_file_;
     boost::optional<std::string> client_private_key_file_;
     boost::optional<std::string> ciphers_;
-    boost::optional<std::string> sni_hostname_;
     boost::optional<std::string> proxy_hostname_;
     boost::optional<std::string> remote_hostname_;
     boost::optional<std::string> remote_port_;

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -76,6 +76,22 @@ class TLSTransport : public Transport {
  public:
   TLSTransport();
 
+  /**
+   * This returns the restrictive (best practice) set of options.
+   * They include a limited cipher suite as well as the potential client
+   * certificates.
+   *
+   * Use these options with a TLS client communicating with osquery-related
+   * infrastructure.
+   */
+  http::Client::Options getInternalOptions();
+
+  /**
+   * This returns basic/generial options.
+   *
+   * Use these options if you are communicating with AWS or generic Internet
+   * infrastrucutre.
+   */
   http::Client::Options getOptions();
 
  private:

--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -10,6 +10,7 @@
 // Keep it on top of all other includes to fix double include WinSock.h header file
 // which is windows specific boost build problem
 #include <osquery/remote/http_client.h>
+#include <osquery/remote/transports/tls.h>
 // clang-format on
 
 #include <chrono>
@@ -27,17 +28,17 @@ const std::string kOsqueryUserAgent{"osquery"};
 
 Status processRequest(Row& r) {
   try {
-    osquery::http::Client client_;
-    osquery::http::Response response_;
-    osquery::http::Request request_(r["url"]);
+    osquery::http::Client client(TLSTransport().getOptions());
+    osquery::http::Response response;
+    osquery::http::Request request(r["url"]);
 
     // Change the user-agent for the request to be osquery
-    request_ << osquery::http::Request::Header("User-Agent", r["user_agent"]);
+    request << osquery::http::Request::Header("User-Agent", r["user_agent"]);
 
     // Measure the rtt using the system clock
     std::chrono::time_point<std::chrono::system_clock> start =
         std::chrono::system_clock::now();
-    response_ = client_.get(request_);
+    response = client_.get(request);
     std::chrono::time_point<std::chrono::system_clock> end =
         std::chrono::system_clock::now();
 

--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -36,20 +36,19 @@ Status processRequest(Row& r) {
     request << osquery::http::Request::Header("User-Agent", r["user_agent"]);
 
     // Measure the rtt using the system clock
-    std::chrono::time_point<std::chrono::system_clock> start =
-        std::chrono::system_clock::now();
-    response = client_.get(request);
-    std::chrono::time_point<std::chrono::system_clock> end =
-        std::chrono::system_clock::now();
+    auto time_start = std::chrono::system_clock::now();
+    response = client.get(request);
+    auto time_end = std::chrono::system_clock::now();
 
-    r["response_code"] = INTEGER(static_cast<int>(response_.status()));
-    r["round_trip_time"] = BIGINT(
-        std::chrono::duration_cast<std::chrono::microseconds>(end - start)
-            .count());
-    r["result"] = response_.body();
+    r["response_code"] = INTEGER(static_cast<int>(response.status()));
+    r["round_trip_time"] =
+        BIGINT(std::chrono::duration_cast<std::chrono::microseconds>(time_end -
+                                                                     time_start)
+                   .count());
+    r["result"] = response.body();
     r["bytes"] = BIGINT(r["result"].size());
   } catch (const std::exception& e) {
-    return Status(1, e.what());
+    return Status::failure(e.what());
   }
 
   return Status::success();

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -138,7 +138,7 @@ std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
   uri.SetPath(Aws::Http::URI::URLEncodePath(uri.GetPath()));
   Aws::String url = uri.GetURIString();
 
-  http::Client client(TLSTransport().getOptions());
+  http::Client client(TLSTransport().getInternalOptions());
   http::Request req(url);
 
   for (const auto& requestHeader : request.GetHeaders()) {


### PR DESCRIPTION
This creates two sets of common TLS options. One is for osquery-internal infra, the other is for everything else. This updates the curl table implementation to use the generic TLS options. This prevents using outdated CA files on macOS/etc.

Fixes: #6034
Fixes: #6162
