### PR TITLE
tables: Improve integration test debugging and deb_packages

### DIFF
--- a/osquery/tables/system/linux/deb_packages.cpp
+++ b/osquery/tables/system/linux/deb_packages.cpp
@@ -149,6 +149,11 @@ void extractDebPackageInfo(const struct pkginfo *pkg, QueryData &results) {
   }
   varbuf_destroy(&vb);
 
+  if (r.find("size") == r.end()) {
+    // Possible meta-package without an installed-size.
+    r["size"] = "0";
+  }
+
   results.push_back(r);
 }
 

--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -40,8 +40,9 @@ TEST_F(DebPackages, test_sanity) {
     for (const auto& row : rows) {
       auto pckg_name = row.at("name");
       all_packages.insert(pckg_name);
-      if (pckg_name == "dpkg")
+      if (pckg_name == "dpkg") {
         break;
+      }
     }
 
     ASSERT_EQ(all_packages.count("dpkg"), 1u);

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -39,6 +39,21 @@ namespace table_tests {
 
 namespace fs = boost::filesystem;
 
+std::string rowToString(const Row& x) {
+  std::stringstream o;
+  o << '{';
+  for (Row::const_iterator i = x.begin(); i != x.end(); i++) {
+    if (i != x.begin()) {
+      o << ", ";
+    }
+    o << i->first;
+    o << ": ";
+    o << boost::io::quoted(i->second);
+  }
+  o << '}';
+  return o.str();
+}
+
 bool CronValuesCheck::operator()(const std::string& string) const {
   // Fast asterisk check, its most common
   if (string == "*") {
@@ -159,11 +174,15 @@ void validate_row(const Row& row, const ValidationMap& validation_map) {
       int flags = boost::get<int>(validator);
       ASSERT_TRUE(validate_value_using_flags(value, flags))
           << "Standard validator of the column " << boost::io::quoted(key)
-          << " with value " << boost::io::quoted(value) << " failed";
+          << " with value " << boost::io::quoted(value) << " failed"
+          << std::endl
+          << "Row: " << rowToString(row);
     } else {
       ASSERT_TRUE(boost::get<CustomCheckerType>(validator)(value))
           << "Custom validator of the column " << boost::io::quoted(key)
-          << " with value " << boost::io::quoted(value) << " failed";
+          << " with value " << boost::io::quoted(value) << " failed"
+          << std::endl
+          << "Row: " << rowToString(row);
     }
   }
 }
@@ -183,8 +202,7 @@ bool is_valid_hex(const std::string& value) {
   return true;
 }
 
-bool validate_value_using_flags(const std::string& value,
-                                                      int flags) {
+bool validate_value_using_flags(const std::string& value, int flags) {
   if ((flags & NonEmpty) > 0) {
     if (value.length() == 0) {
       return false;


### PR DESCRIPTION
This fixes the flaky `deb_packages` integration test by improving the `dep_packages` table to return a 0-size if a meta-package has no installed-sized.
