### PR TITLE
http_client: Handle relative redirects

### DIFF
--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -79,7 +79,7 @@ QueryData genCurl(QueryContext& context) {
 
     auto status = processRequest(r);
     if (!status.ok()) {
-      LOG(WARNING) << status.getMessage();
+      LOG(WARNING) << "Error making request: " << status.getMessage();
     }
 
     results.push_back(r);


### PR DESCRIPTION
This should fix #6043, where I think the root cause is the URI parsing. If there is no protocol/host/port then the URI is parsed incorrectly. We missed this due to the rarity of relative-redirects and due to the HTTP client being difficult to test.

This also adds a max of 10 redirects before the client gives up.