### PR TITLE
tables: Change atom_packages to use user constraints

### DIFF
--- a/osquery/tables/applications/atom_packages.cpp
+++ b/osquery/tables/applications/atom_packages.cpp
@@ -6,10 +6,8 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <pwd.h>
 #include <set>
 #include <string>
-#include <sys/types.h>
 
 #include <boost/filesystem.hpp>
 
@@ -17,6 +15,7 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/json/json.h>
+#include <osquery/tables/system/system_utils.h>
 
 namespace fs = boost::filesystem;
 
@@ -26,18 +25,18 @@ namespace tables {
 const std::vector<std::string> kPackageKeys{
     "name", "version", "description", "license", "homepage"};
 
-void genReadJSONAndAddRow(const std::string& package, QueryData& results) {
+void genReadJSONAndAddRow(const std::string& uid,
+                          const std::string& package,
+                          QueryData& results) {
   std::string json;
   if (!readFile(package, json).ok()) {
-    LOG(WARNING) << "Could not read Atom's package.json from '" << package
-                 << "'";
+    LOG(WARNING) << "Could not read Atom package.json from '" << package << "'";
     return;
   }
 
   auto doc = JSON::newObject();
   if (!doc.fromString(json) || !doc.doc().IsObject()) {
-    LOG(WARNING) << "Could not parse Atom's package.json from " << package
-                 << "'";
+    LOG(WARNING) << "Could not parse Atom package.json from " << package << "'";
     return;
   }
 
@@ -51,27 +50,31 @@ void genReadJSONAndAddRow(const std::string& package, QueryData& results) {
   }
   // add package path manually
   r["path"] = package;
+  r["uid"] = uid;
   results.push_back(r);
 }
 
 QueryData genAtomPackages(QueryContext& context) {
   QueryData results;
+
   // find atom config directories
-  std::set<fs::path> confDirs;
-  struct passwd* pwd;
-  while ((pwd = getpwent()) != NULL) {
-    fs::path confDir{pwd->pw_dir};
-    confDir /= ".atom";
-    if (isDirectory(confDir)) {
-      confDirs.insert(confDir);
+  std::set<std::pair<std::string, fs::path>> confDirs;
+  auto users = usersFromContext(context);
+  for (const auto& row : users) {
+    auto uid = row.find("uid");
+    auto directory = row.find("directory");
+    if (directory == row.end() || uid == row.end()) {
+      continue;
     }
+    confDirs.insert({uid->second, fs::path(directory->second) / ".atom"});
   }
 
   for (const auto& confDir : confDirs) {
     std::vector<std::string> packages;
-    resolveFilePattern(confDir / "packages" / "%" / "package.json", packages);
+    resolveFilePattern(confDir.second / "packages" / "%" / "package.json",
+                       packages);
     for (const auto& package : packages) {
-      genReadJSONAndAddRow(package, results);
+      genReadJSONAndAddRow(confDir.first, package, results);
     }
   }
 

--- a/osquery/tables/applications/atom_packages.cpp
+++ b/osquery/tables/applications/atom_packages.cpp
@@ -14,8 +14,8 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/utils/json/json.h>
 #include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/json/json.h>
 
 namespace fs = boost::filesystem;
 

--- a/specs/atom_packages.table
+++ b/specs/atom_packages.table
@@ -7,7 +7,10 @@ schema([
     Column("path", TEXT, "Package's package.json path"),
     Column("license", TEXT, "License for package"),
     Column("homepage", TEXT, "Package supplied homepage"),
+    Column("uid", BIGINT, "The local user that owns the plugin",
+      index=True),
 ])
+attributes(user_data=True)
 implementation("applications/atom_packages@genAtomPackages")
 examples([
   "select * from atom_packages",


### PR DESCRIPTION
This addresses #5933. It changes the table API to use common user-based calling conventions. This avoids adding user-enumeration directly in the table implementation.

Fixes: #5933