### PR TITLE
tables: Improve nvram to use input variable names

### DIFF
--- a/osquery/tables/system/darwin/nvram.cpp
+++ b/osquery/tables/system/darwin/nvram.cpp
@@ -19,47 +19,93 @@
 namespace osquery {
 namespace tables {
 
-#define kIODTOptionsPath_ "IODeviceTree:/options"
+const std::string kIODTOptionsPath = "IODeviceTree:/options";
 
-void genVariable(const void *key, const void *value, void *results) {
+Status stringFromNVRAM(const void* value,
+                       std::string& type_name,
+                       std::string& output) {
+  // Variable type will be defined by the CF type.
+  CFTypeID type_id = CFGetTypeID(value);
+  CFStringRef type_description = CFCopyTypeIDDescription(type_id);
+  type_name = stringFromCFString(type_description);
+
+  CFRelease(type_description);
+
+  // Based on the type, get a texual representation of the variable.
+  if (type_id == CFBooleanGetTypeID()) {
+    output = (CFBooleanGetValue((CFBooleanRef)value)) ? "true" : "false";
+  } else if (type_id == CFNumberGetTypeID()) {
+    output = stringFromCFNumber((CFDataRef)value);
+  } else if (type_id == CFStringGetTypeID()) {
+    output = stringFromCFString((CFStringRef)value);
+  } else if (type_id == CFDataGetTypeID()) {
+    output = stringFromCFData((CFDataRef)value);
+  } else {
+    // Unknown result type, do not attempt to decode/format.
+    return Status::failure("Unknown variable type");
+  }
+  return Status::success();
+}
+
+void genVariable(const void* key, const void* value, void* results) {
   if (key == nullptr || value == nullptr || results == nullptr) {
     // Paranoia: don't expect the callback application to yield nullptrs.
     return;
   }
 
   // Variable name is the dictionary key.
-  Row nvram_row;
-  nvram_row["name"] = stringFromCFString((CFStringRef)key);
+  Row r;
+  auto name = stringFromCFString((CFStringRef)key);
 
-  // Variable type will be defined by the CF type.
-  CFTypeID type_id = CFGetTypeID(value);
-  CFStringRef type_description = CFCopyTypeIDDescription(type_id);
-  nvram_row["type"] = stringFromCFString(type_description);
-  CFRelease(type_description);
-
-  // Based on the type, get a texual representation of the variable.
+  std::string type_name;
   std::string value_string;
-  if (type_id == CFBooleanGetTypeID()) {
-    value_string = (CFBooleanGetValue((CFBooleanRef)value)) ? "true" : "false";
-  } else if (type_id == CFNumberGetTypeID()) {
-    value_string = stringFromCFNumber((CFDataRef)value);
-  } else if (type_id == CFStringGetTypeID()) {
-    value_string = stringFromCFString((CFStringRef)value);
-  } else if (type_id == CFDataGetTypeID()) {
-    value_string = stringFromCFData((CFDataRef)value);
+  auto status = stringFromNVRAM(value, type_name, value_string);
+  if (!status.ok()) {
+    VLOG(1) << "Failed to convert NVRAM variable: " << name;
   } else {
-    // Unknown result type, do not attempt to decode/format.
-    value_string = "<INVALID>";
+    r["value"] = std::move(value_string);
   }
 
-  // Finally, add the variable value to the row.
-  nvram_row["value"] = value_string;
-  ((QueryData *)results)->push_back(nvram_row);
+  r["name"] = std::move(name);
+  r["type"] = std::move(type_name);
+  ((QueryData*)results)->push_back(r);
 }
 
-QueryData genNVRAM(QueryContext &context) {
-  QueryData results;
+void genSingleVariable(const io_registry_entry_t& options,
+                       const std::string& key,
+                       QueryData& results) {
+  auto name = CFStringCreateWithCString(
+      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
+  if (name == nullptr) {
+    VLOG(1) << "Cannot create CFString for NVRAM name";
+    return;
+  }
 
+  auto value = IORegistryEntryCreateCFProperty(options, name, 0, 0);
+  CFRelease(name);
+  if (value == nullptr) {
+    LOG(INFO) << "Cannot find NVRAM variable: " << key;
+    return;
+  }
+
+  Row r;
+  std::string type_name;
+  std::string value_string;
+  auto status = stringFromNVRAM(value, type_name, value_string);
+  CFRelease(value);
+
+  if (!status.ok()) {
+    VLOG(1) << "Failed to convert NVRAM variable: " << key;
+  } else {
+    r["value"] = std::move(value_string);
+  }
+
+  r["name"] = key;
+  r["type"] = std::move(type_name);
+  results.push_back(r);
+}
+
+QueryData genNVRAM(QueryContext& context) {
   mach_port_t master_port;
   auto kr = IOMasterPort(bootstrap_port, &master_port);
   if (kr != KERN_SUCCESS) {
@@ -68,22 +114,32 @@ QueryData genNVRAM(QueryContext &context) {
   }
 
   // NVRAM registry entry is :/options.
-  auto options = IORegistryEntryFromPath(master_port, kIODTOptionsPath_);
+  auto options = IORegistryEntryFromPath(master_port, kIODTOptionsPath.c_str());
   if (options == 0) {
     VLOG(1) << "NVRAM is not supported on this system";
     return {};
   }
 
-  CFMutableDictionaryRef options_dict;
-  kr = IORegistryEntryCreateCFProperties(options, &options_dict, 0, 0);
-  if (kr != KERN_SUCCESS) {
-    VLOG(1) << "Could not get NVRAM properties";
+  QueryData results;
+  // If the query is requesting an SMC key by name within the predicate.
+  if (context.hasConstraint("name", EQUALS)) {
+    context.iteritems(
+        "name", EQUALS, ([&options, &results](const std::string& key) {
+          genSingleVariable(options, key, results);
+        }));
   } else {
-    CFDictionaryApplyFunction(options_dict, &genVariable, &results);
+    CFMutableDictionaryRef options_dict;
+    kr = IORegistryEntryCreateCFProperties(options, &options_dict, 0, 0);
+    if (kr != KERN_SUCCESS) {
+      VLOG(1) << "Could not get NVRAM properties";
+    } else {
+      CFDictionaryApplyFunction(options_dict, &genVariable, &results);
+    }
+
+    // Cleanup (registry entry context).
+    CFRelease(options_dict);
   }
 
-  // Cleanup (registry entry context).
-  CFRelease(options_dict);
   IOObjectRelease(options);
   return results;
 }

--- a/osquery/tables/system/darwin/nvram.cpp
+++ b/osquery/tables/system/darwin/nvram.cpp
@@ -81,7 +81,8 @@ void genSingleVariable(const io_registry_entry_t& options,
     return;
   }
 
-  auto value = IORegistryEntryCreateCFProperty(options, name, 0, 0);
+  auto value =
+      IORegistryEntryCreateCFProperty(options, name, kCFAllocatorDefault, 0);
   CFRelease(name);
   if (value == nullptr) {
     LOG(INFO) << "Cannot find NVRAM variable: " << key;
@@ -115,7 +116,7 @@ QueryData genNVRAM(QueryContext& context) {
 
   // NVRAM registry entry is :/options.
   auto options = IORegistryEntryFromPath(master_port, kIODTOptionsPath.c_str());
-  if (options == 0) {
+  if (options == MACH_PORT_NULL) {
     VLOG(1) << "NVRAM is not supported on this system";
     return {};
   }
@@ -129,7 +130,8 @@ QueryData genNVRAM(QueryContext& context) {
         }));
   } else {
     CFMutableDictionaryRef options_dict;
-    kr = IORegistryEntryCreateCFProperties(options, &options_dict, 0, 0);
+    kr = IORegistryEntryCreateCFProperties(
+        options, &options_dict, kCFAllocatorDefault, 0);
     if (kr != KERN_SUCCESS) {
       VLOG(1) << "Could not get NVRAM properties";
     } else {

--- a/osquery/utils/conversions/darwin/cfdata.cpp
+++ b/osquery/utils/conversions/darwin/cfdata.cpp
@@ -28,7 +28,7 @@ std::string stringFromCFData(const CFDataRef& cf_data) {
     uint8_t byte = buffer[i];
     if (isprint(byte)) {
       result << byte;
-    } else if (buffer[i] == 0) {
+    } else if (range.length > 1 && buffer[i] == 0) {
       result << ' ';
     } else {
       result << '%' << std::setfill('0') << std::setw(2) << std::hex

--- a/specs/darwin/nvram.table
+++ b/specs/darwin/nvram.table
@@ -1,7 +1,7 @@
 table_name("nvram")
 description("Apple NVRAM variable listing.")
 schema([
-    Column("name", TEXT, "Variable name"),
+    Column("name", TEXT, "Variable name", additional=True, index=True),
     Column("type", TEXT, "Data type (CFData, CFString, etc)"),
     Column("value", TEXT, "Raw variable data"),
 ])


### PR DESCRIPTION
This improves the `nvram` table to use optional `name` constraints as lookups for non-advertised NVRAM variables.

An example includes:
```sql
select name, type, value from nvram where
  name = '94b73556-2197-4702-82a8-3e1337dafbfb:AppleSecureBootPolicy';
```

The result on my laptop:
```
+------------------------------------------------------------+--------+-------+
| name                                                       | type   | value |
+------------------------------------------------------------+--------+-------+
| 94b73556-2197-4702-82a8-3e1337dafbfb:AppleSecureBootPolicy | CFData | %02   |
+------------------------------------------------------------+--------+-------+
```