### PR TITLE
CMake: Prefer Python 3.7 then 3.6

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -101,9 +101,17 @@ endfunction()
 
 function(findPythonExecutablePath)
   find_package(Python2 COMPONENTS Interpreter REQUIRED)
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
-
   set(EX_TOOL_PYTHON2_EXECUTABLE_PATH "${Python2_EXECUTABLE}" PARENT_SCOPE)
+
+  find_package(Python3 3.7 EXACT COMPONENTS Interpreter)
+
+  if(NOT Python3_FOUND)
+    find_package(Python3 3.6 EXACT COMPONENTS Interpreter)
+    if(NOT Python3_FOUND)
+      message(FATAL_ERROR "Could not find a suitable Python 3 version. Please install a version >= 3.6 but < 3.8")
+    endif()
+  endif()
+
   set(EX_TOOL_PYTHON3_EXECUTABLE_PATH "${Python3_EXECUTABLE}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
We are not currently ready for Python 3.8,
so we prefer either the newest 3.7 or 3.6.