### PR TITLE
Update SQL For getDriverImagePath

### DIFF
--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -168,7 +168,7 @@ Status getDeviceProperty(const device_infoset_t& infoset,
 }
 
 std::string getDriverImagePath(const std::string& service_key) {
-  SQL sql("SELECT data FROM registry WHERE path = '" + service_key + 
+  SQL sql("SELECT data FROM registry WHERE key = '" + service_key + 
           "' AND name = 'ImagePath'");
 
   if (sql.rows().empty() || sql.rows().at(0).count("data") == 0) {

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -168,8 +168,8 @@ Status getDeviceProperty(const device_infoset_t& infoset,
 }
 
 std::string getDriverImagePath(const std::string& service_key) {
-  SQL sql("SELECT data FROM registry WHERE path = '" + service_key +
-          "\\ImagePath'");
+  SQL sql("SELECT data FROM registry WHERE path = '" + service_key + 
+          "' AND name = 'ImagePath'");
 
   if (sql.rows().empty() || sql.rows().at(0).count("data") == 0) {
     return "";


### PR DESCRIPTION
Fix retrieves the ImagePath value from the service_key value:
```
C:\Users\user\Desktop>osqueryi "SELECT data FROM registry WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\atapi' AND name = 'ImagePath'" --json
[
  {"data":"system32\\drivers\\atapi.sys"}
]
```

Old logic always returns empty set as the key being specified does not exist (ImagePath should be the name of the registry value, not concatenated to the key):
```
C:\Users\user\Desktop>osqueryi "SELECT data FROM registry WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\atapi\ImagePath'" --json
[

]
```

It may be a good idea to also prefix the result with `%SYSTEMDRIVE%` or to enumerate that value and prefix it to the result i.e:
```
[
  {"data":"%SYSTEMDRIVE%\\system32\\drivers\\atapi.sys"}
]
```

Or lookup that environment variable and normalize the path:
```
[
  {"data":"C:\\system32\\drivers\\atapi.sys"}
]
```

I haven't tried compiling this, apologies if I missed something silly.