### PR TITLE
Force git to create symlinks on the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -325,6 +325,7 @@ jobs:
     steps:
     - powershell: |
         git config --global core.autocrlf false
+        git config --global core.symlinks true
 
     - checkout: self
 


### PR DESCRIPTION
git on Windows supports cloning a repository with symlinks
without actually creating them; it will substitute them
with text files containing the target path.
This can potentially break the build of some of osquery
third party libraries.

Moreover this is the default on the CI,
which is different compared to the setup on local machines,
which means that it can hide other kind of issues.
