### PR TITLE
CMake: explicitly enable ASM_MASM language on Windows

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -56,3 +56,7 @@ set(PACKAGING_SYSTEM "" CACHE STRING "Packaging system to generate when building
 if(DEFINED PLATFORM_WINDOWS)
   set(WIX_ROOT_FOLDER_PATH "" CACHE STRING "Root folder of the WIX installation")
 endif()
+
+if(DEFINED PLATFORM_WINDOWS)
+  enable_language(ASM_MASM)
+endif()

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -693,8 +693,6 @@ function(generateBoostContext)
     )
 
   elseif(DEFINED PLATFORM_WINDOWS)
-    enable_language(ASM_MASM)
-
     target_sources(thirdparty_boost_context PRIVATE
       "${library_root}/src/windows/stack_traits.cpp"
     )


### PR DESCRIPTION
This is needed by some third party libraries and
when using Ninja on Windows.
CMake complains that it cannot find the internal variable
for CMAKE_ASM_MASM_COMPILE_OBJECT otherwise.