### PR TITLE
CMake: Change Python version required to be at least 3.5

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -100,17 +100,7 @@ function(enableLinkWholeArchive target_name)
 endfunction()
 
 function(findPythonExecutablePath)
-  find_package(Python2 COMPONENTS Interpreter REQUIRED)
-  set(EX_TOOL_PYTHON2_EXECUTABLE_PATH "${Python2_EXECUTABLE}" PARENT_SCOPE)
-
-  find_package(Python3 3.7 EXACT COMPONENTS Interpreter)
-
-  if(NOT Python3_FOUND)
-    find_package(Python3 3.6 EXACT COMPONENTS Interpreter)
-    if(NOT Python3_FOUND)
-      message(FATAL_ERROR "Could not find a suitable Python 3 version. Please install a version >= 3.6 but < 3.8")
-    endif()
-  endif()
+  find_package(Python3 3.5 COMPONENTS Interpreter REQUIRED)
 
   set(EX_TOOL_PYTHON3_EXECUTABLE_PATH "${Python3_EXECUTABLE}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Removed the restriction for the Python version to be >= 3.6 but < 3.8.
Now it has to be >=3.5, lower versions are EOL.

Removed the search for Python2 too since nothing uses it anymore.

Fixes osquery/osquery#6079