### PR TITLE
cpack: Revert renaming com.facebook.plist to com.osquery.plist

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -231,14 +231,10 @@ function(generateInstallTargets)
     install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/certs.pem" COMPONENT osquery DESTINATION /private/var/osquery/certs)
 
     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.conf" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
-    file(RENAME "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.conf" "${CMAKE_BINARY_DIR}/package/pkg/com.osquery.osqueryd.conf")
-    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.osquery.osqueryd.conf" DESTINATION /private/var/osquery COMPONENT osquery)
+    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.conf" DESTINATION /private/var/osquery COMPONENT osquery)
 
-    file(READ "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.plist" osquery_service_plist)
-    string(REPLACE "com.facebook.osqueryd" "com.osquery.osqueryd" osquery_service_plist "${osquery_service_plist}")
-    file(WRITE "${CMAKE_BINARY_DIR}/package/productbuild/com.osquery.osqueryd.plist" "${osquery_service_plist}")
-
-    install(FILES "${CMAKE_BINARY_DIR}/package/productbuild/com.osquery.osqueryd.plist" DESTINATION /private/var/osquery COMPONENT osquery)
+    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.plist" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
+    install(FILES "${CMAKE_BINARY_DIR}/package/pkg/com.facebook.osqueryd.plist" DESTINATION /private/var/osquery COMPONENT osquery)
 
     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf" DESTINATION "${CMAKE_BINARY_DIR}/package/pkg")
     install(FILES "${CMAKE_BINARY_DIR}/package/pkg/osquery.example.conf" DESTINATION /private/var/osquery COMPONENT osquery)


### PR DESCRIPTION
We should avoid renaming files unless we have a migration/cleanup plan. For existing installations this can lead to having two LaunchDaemons installed. Those with tooling to modify LaunchDaemons will need to be notified. We should save these changes until a 5.0 release that includes guidance.