### PR TITLE
linux: Update systemd service to use KillMode=control-group

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/osqueryd \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE
 Restart=on-failure
-KillMode=process
+KillMode=control-group
 KillSignal=SIGTERM
 
 [Install]


### PR DESCRIPTION
This updates the systemd service to use the default `KillMode`, `control-group`. This is needed due to removing the custom `signal` handlers within the osquery watchdog process -- the watchdog had been propagating signals to the worker processes.

Fixes #6092.