### PR TITLE
cpack: Add RPM and DEB postinstall script

### DIFF
--- a/cmake/CPackConfig.cmake.in
+++ b/cmake/CPackConfig.cmake.in
@@ -5,26 +5,5 @@
 # the LICENSE file found in the root directory of this source tree.
 
 if("${CPACK_GENERATOR}" STREQUAL "")
-	message(FATAL_ERROR "No packaging system selected, cannot create a package. Please configure it through the PACKAGING_SYSTEM variable")
-endif()
-
-if("${CPACK_GENERATOR}" STREQUAL "DEB")
-
-  file(WRITE "@CMAKE_BINARY_DIR@/package/deb/conffiles"
-       "/etc/init.d/osqueryd\n"
-       "/etc/default/osqueryd\n")
-
-  # Patch the EnvironmentFile in the systemd unit
-  file(READ "@CMAKE_BINARY_DIR@/package/linux/osqueryd.service" osqueryd_service_file)
-  string(REPLACE "/etc/sysconfig/osqueryd" "/etc/default/osqueryd" osqueryd_service_file "${osqueryd_service_file}")
-  file(WRITE "@CMAKE_BINARY_DIR@/package/linux/osqueryd.service" "${osqueryd_service_file}")
-
-  # Patch /etc/sysconfig to /etc/default in the initd script
-  file(READ "@CMAKE_BINARY_DIR@/package/linux/osqueryd.initd" osqueryd_initd_file)
-  string(REPLACE "/etc/sysconfig" "/etc/default" osqueryd_initd_file "${osqueryd_initd_file}")
-  file(WRITE "@CMAKE_BINARY_DIR@/package/linux/osqueryd.initd" "${osqueryd_initd_file}")
-
-  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "@CMAKE_BINARY_DIR@/package/deb/conffiles;@CMAKE_BINARY_DIR@/package/deb/postinst")
-elseif("${CPACK_GENERATOR}" STREQUAL "productbuild")
-	set(CPACK_SET_DESTDIR ON)
+  message(FATAL_ERROR "No packaging system selected, cannot create a package. Please configure it through the PACKAGING_SYSTEM variable")
 endif()

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -124,10 +124,8 @@ function(generateInstallTargets)
 
   if(DEFINED PLATFORM_LINUX)
     # .
-    if("${PACKAGING_SYSTEM}" STREQUAL "DEB")
-      file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/deb")
-      file(RENAME "${CMAKE_BINARY_DIR}/package/deb/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/deb/postinst")
-    endif()
+    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/deb")
+    file(RENAME "${CMAKE_BINARY_DIR}/package/deb/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/deb/postinst")
 
     # bin
     install(TARGETS osqueryd DESTINATION bin COMPONENT osquery)
@@ -176,9 +174,6 @@ function(generateInstallTargets)
     # var
     install(DIRECTORY DESTINATION /var/log/osquery COMPONENT osquery)
     install(DIRECTORY DESTINATION /var/osquery COMPONENT osquery)
-
-    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/linux")
-    file(RENAME "${CMAKE_BINARY_DIR}/package/linux/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/linux/postinst")
   elseif(DEFINED PLATFORM_WINDOWS)
     # .
     install(PROGRAMS "$<TARGET_FILE:osqueryd>" DESTINATION . RENAME osqueryi.exe)
@@ -292,7 +287,7 @@ function(generatePackageTarget)
     set(OSQUERY_PACKAGE_RELEASE "1.linux")
 
     if(CPACK_GENERATOR STREQUAL "TGZ")
-      set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}_${OSQUERY_PACKAGE_RELEASE}.x86_64")
+      set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}_${OSQUERY_PACKAGE_RELEASE}_x86_64")
     elseif(CPACK_GENERATOR STREQUAL "DEB")
       set(CPACK_DEBIAN_OSQUERY_PACKAGE_NAME ${CPACK_PACKAGE_NAME})
       set(CPACK_DEBIAN_PACKAGE_RELEASE "${OSQUERY_PACKAGE_RELEASE}")
@@ -303,7 +298,7 @@ function(generatePackageTarget)
       set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE_URL}")
       set(CPACK_DEB_COMPONENT_INSTALL ON)
       set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
-      set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/package/linux/postinst")
+      set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "@CMAKE_BINARY_DIR@/package/deb/conffiles;@CMAKE_BINARY_DIR@/package/deb/postinst")
     elseif(CPACK_GENERATOR STREQUAL "RPM")
       set(CPACK_RPM_PACKAGE_RELEASE_DIST "${OSQUERY_PACKAGE_RELEASE}")
       set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${OSQUERY_PACKAGE_RELEASE}.x86_64")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -177,6 +177,8 @@ function(generateInstallTargets)
     install(DIRECTORY DESTINATION /var/log/osquery COMPONENT osquery)
     install(DIRECTORY DESTINATION /var/osquery COMPONENT osquery)
 
+    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/linux")
+    file(RENAME "${CMAKE_BINARY_DIR}/package/linux/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/linux/postinst")
   elseif(DEFINED PLATFORM_WINDOWS)
     # .
     install(PROGRAMS "$<TARGET_FILE:osqueryd>" DESTINATION . RENAME osqueryi.exe)
@@ -301,6 +303,7 @@ function(generatePackageTarget)
       set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE_URL}")
       set(CPACK_DEB_COMPONENT_INSTALL ON)
       set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
+      set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/package/linux/postinst")
     elseif(CPACK_GENERATOR STREQUAL "RPM")
       set(CPACK_RPM_PACKAGE_RELEASE_DIST "${OSQUERY_PACKAGE_RELEASE}")
       set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${OSQUERY_PACKAGE_RELEASE}.x86_64")
@@ -308,6 +311,7 @@ function(generatePackageTarget)
       set(CPACK_RPM_PACKAGE_GROUP "default")
       set(CPACK_RPM_PACKAGE_LICENSE "Apache 2.0 or GPL 2.0")
       set(CPACK_RPM_PACKAGE_REQUIRES "glibc >= 2.12, zlib")
+      set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/package/linux/postinst")
       list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
         /etc/sysconfig
         /var

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -142,6 +142,12 @@ function(generateInstallTargets)
 
     # lib
     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/osqueryd.service" DESTINATION "${CMAKE_BINARY_DIR}/package/linux")
+    if("${PACKAGING_SYSTEM}"  STREQUAL "DEB")
+      # Patch the EnvironmentFile in the systemd unit
+      file(READ "${CMAKE_BINARY_DIR}/package/linux/osqueryd.service" osqueryd_service_file)
+      string(REPLACE "/etc/sysconfig/osqueryd" "/etc/default/osqueryd" osqueryd_service_file "${osqueryd_service_file}")
+      file(WRITE "${CMAKE_BINARY_DIR}/package/linux/osqueryd.service" "${osqueryd_service_file}")
+    endif()
     install(FILES "${CMAKE_BINARY_DIR}/package/linux/osqueryd.service" DESTINATION lib/systemd/system COMPONENT osquery)
 
     # share
@@ -169,10 +175,6 @@ function(generateInstallTargets)
     # etc
     file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/osqueryd.sysconfig" DESTINATION "${CMAKE_BINARY_DIR}/package/linux")
     if("${PACKAGING_SYSTEM}"  STREQUAL "DEB")
-      # Patch the EnvironmentFile in the systemd unit
-      file(READ "${CMAKE_BINARY_DIR}/package/linux/osqueryd.service" osqueryd_service_file)
-      string(REPLACE "/etc/sysconfig/osqueryd" "/etc/default/osqueryd" osqueryd_service_file "${osqueryd_service_file}")
-      file(WRITE "${CMAKE_BINARY_DIR}/package/linux/osqueryd.service" "${osqueryd_service_file}")
       install(FILES "${CMAKE_BINARY_DIR}/package/linux/osqueryd.sysconfig" DESTINATION /etc/default RENAME osqueryd COMPONENT osquery)
     else()
       install(FILES "${CMAKE_BINARY_DIR}/package/linux/osqueryd.sysconfig" DESTINATION /etc/sysconfig RENAME osqueryd COMPONENT osquery)

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -124,8 +124,8 @@ function(generateInstallTargets)
 
   if(DEFINED PLATFORM_LINUX)
     # .
-    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/deb")
-    file(RENAME "${CMAKE_BINARY_DIR}/package/deb/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/deb/postinst")
+    file(COPY "${CMAKE_SOURCE_DIR}/tools/deployment/linux_postinstall.sh" DESTINATION "${CMAKE_BINARY_DIR}/package/linux")
+    file(RENAME "${CMAKE_BINARY_DIR}/package/linux/linux_postinstall.sh" "${CMAKE_BINARY_DIR}/package/linux/postinst")
 
     # bin
     install(TARGETS osqueryd DESTINATION bin COMPONENT osquery)
@@ -298,7 +298,7 @@ function(generatePackageTarget)
       set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE_URL}")
       set(CPACK_DEB_COMPONENT_INSTALL ON)
       set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
-      set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "@CMAKE_BINARY_DIR@/package/deb/conffiles;@CMAKE_BINARY_DIR@/package/deb/postinst")
+      set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/package/linux/conffiles;${CMAKE_BINARY_DIR}/package/linux/postinst")
     elseif(CPACK_GENERATOR STREQUAL "RPM")
       set(CPACK_RPM_PACKAGE_RELEASE_DIST "${OSQUERY_PACKAGE_RELEASE}")
       set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${OSQUERY_PACKAGE_RELEASE}.x86_64")


### PR DESCRIPTION
This fixes a regression between `make_linux_package.sh` and `CPack`'s logic. The post-install script will restart `osqueryd` when the package is updated.