### PR TITLE
Fix possible xxhash collision between zstd and rdkafka

### DIFF
--- a/libraries/cmake/source/librdkafka/CMakeLists.txt
+++ b/libraries/cmake/source/librdkafka/CMakeLists.txt
@@ -72,7 +72,6 @@ function(generateLibrdkafka)
     "${library_root}/snappy.c"
     "${library_root}/rdhdrhistogram.c"
     "${library_root}/rdkafka_lz4.c"
-    "${library_root}/xxhash.c"
     "${library_root}/lz4.c"
     "${library_root}/lz4frame.c"
     "${library_root}/lz4hc.c"
@@ -88,6 +87,8 @@ function(generateLibrdkafka)
 
   target_compile_definitions(thirdparty_librdkafka_c PRIVATE
     LIBRDKAFKA_GIT_VERSION=\"v1.0.1\"
+    XXH_NAMESPACE=rdkafka_
+    XXH_PRIVATE_API
   )
 
   target_link_libraries(thirdparty_librdkafka_c PUBLIC

--- a/libraries/cmake/source/zstd/CMakeLists.txt
+++ b/libraries/cmake/source/zstd/CMakeLists.txt
@@ -14,7 +14,6 @@ function(zstdMain)
     "${library_root}/common/pool.c"
     "${library_root}/common/zstd_common.c"
     "${library_root}/common/error_private.c"
-    "${library_root}/common/xxhash.c"
     "${library_root}/compress/hist.c"
     "${library_root}/compress/fse_compress.c"
     "${library_root}/compress/huf_compress.c"
@@ -40,6 +39,8 @@ function(zstdMain)
 
   target_compile_definitions(thirdparty_zstd PRIVATE
     ZSTD_MULTITHREAD
+    XXH_NAMESPACE=zstd_
+    XXH_PRIVATE_API
   )
 
   if(DEFINED PLATFORM_WINDOWS)


### PR DESCRIPTION
Both libraries use the xxhash library,
compiling its source files directly.
The version they use though it's different so to avoid the linker
resolve the collision by removing one of the two implementations,
we prefix the functions with the respective library name.

Moreover we make the xxhash API private, by declaring the static
so that any unused function is not included anymore in the binary
and only the used one are present.

As additional info:
This was the old state of affairs
```
$ nm osquery/osqueryd| grep XXH
00000000017e85b9 t XXH32
00000000017e916b t XXH32_canonicalFromHash
00000000017e8555 t XXH32_copyState
00000000017e89c6 t XXH32_createState
00000000017e8cf3 t XXH32_digest
00000000017e89f2 t XXH32_freeState
00000000017e91bd t XXH32_hashFromCanonical
00000000017e8a74 t XXH32_reset
00000000017e8b30 t XXH32_update
00000000017e8711 t XXH64
00000000017e9193 t XXH64_canonicalFromHash
00000000017e858f t XXH64_copyState
00000000017e8a1d t XXH64_createState
00000000017e8f74 t XXH64_digest
00000000017e8a49 t XXH64_freeState
00000000017e91e5 t XXH64_hashFromCanonical
00000000017e8ac7 t XXH64_reset
00000000017e8db4 t XXH64_update
00000000017e852c t XXH_versionNumber
0000000000dd060b t _ZN7rocksdb10XXH32_initEj
0000000000dd08c2 t _ZN7rocksdb12XXH32_digestEPv
0000000000dd0650 t _ZN7rocksdb12XXH32_updateEPvPKvi
0000000000dd05bc t _ZN7rocksdb16XXH32_resetStateEPvj
0000000000dd0595 t _ZN7rocksdb17XXH32_sizeofStateEv
0000000000dd07f9 t _ZN7rocksdb24XXH32_intermediateDigestEPv
0000000000dd0434 t _ZN7rocksdb5XXH32EPKvij
```
We know that rdkafka was using only the XXH32 symbols and zstd the XXH64 ones, though there's a single set of them both, which means that only one implementation has been chosen, either the one from zstd or rdkafka.
We know that there are two colliding set of symbols because if we set `XXH_NAMESPACE` define on each library, which prefixes every symbol with a given value, we obtain
```
$ nm osquery/osqueryd | grep XXH   
000000000193e1c1 t rdkafka_XXH32
000000000193e681 t rdkafka_XXH32_canonicalFromHash
000000000193e370 t rdkafka_XXH32_copyState
000000000193e319 t rdkafka_XXH32_createState
000000000193e5c0 t rdkafka_XXH32_digest
000000000193e345 t rdkafka_XXH32_freeState
000000000193e6a9 t rdkafka_XXH32_hashFromCanonical
000000000193e3aa t rdkafka_XXH32_reset
000000000193e3fd t rdkafka_XXH32_update
000000000193e6d1 t rdkafka_XXH64
000000000193ee27 t rdkafka_XXH64_canonicalFromHash
000000000193e9dd t rdkafka_XXH64_copyState
000000000193e986 t rdkafka_XXH64_createState
000000000193ec30 t rdkafka_XXH64_digest
000000000193e9b2 t rdkafka_XXH64_freeState
000000000193ee51 t rdkafka_XXH64_hashFromCanonical
000000000193ea07 t rdkafka_XXH64_reset
000000000193ea70 t rdkafka_XXH64_update
000000000193e198 t rdkafka_XXH_versionNumber
0000000000dd060b t _ZN7rocksdb10XXH32_initEj
0000000000dd08c2 t _ZN7rocksdb12XXH32_digestEPv
0000000000dd0650 t _ZN7rocksdb12XXH32_updateEPvPKvi
0000000000dd05bc t _ZN7rocksdb16XXH32_resetStateEPvj
0000000000dd0595 t _ZN7rocksdb17XXH32_sizeofStateEv
0000000000dd07f9 t _ZN7rocksdb24XXH32_intermediateDigestEPv
0000000000dd0434 t _ZN7rocksdb5XXH32EPKvij
00000000017e85b9 t zstd_XXH32
00000000017e916b t zstd_XXH32_canonicalFromHash
00000000017e8555 t zstd_XXH32_copyState
00000000017e89c6 t zstd_XXH32_createState
00000000017e8cf3 t zstd_XXH32_digest
00000000017e89f2 t zstd_XXH32_freeState
00000000017e91bd t zstd_XXH32_hashFromCanonical
00000000017e8a74 t zstd_XXH32_reset
00000000017e8b30 t zstd_XXH32_update
00000000017e8711 t zstd_XXH64
00000000017e9193 t zstd_XXH64_canonicalFromHash
00000000017e858f t zstd_XXH64_copyState
00000000017e8a1d t zstd_XXH64_createState
00000000017e8f74 t zstd_XXH64_digest
00000000017e8a49 t zstd_XXH64_freeState
00000000017e91e5 t zstd_XXH64_hashFromCanonical
00000000017e8ac7 t zstd_XXH64_reset
00000000017e8db4 t zstd_XXH64_update
00000000017e852c t zstd_XXH_versionNumber

```
Though each library actually uses few of them and we don't really need to have them public, so we can define them as "private" with `XXH_PRIVATE_API`.
The result is
```
$ nm osquery/osqueryd | grep XXH
000000000193e224 t rdkafka_XXH32
000000000193f392 t rdkafka_XXH32_digest
000000000193f0dd t rdkafka_XXH32_update
0000000000dd060b t _ZN7rocksdb10XXH32_initEj
0000000000dd08c2 t _ZN7rocksdb12XXH32_digestEPv
0000000000dd0650 t _ZN7rocksdb12XXH32_updateEPvPKvi
0000000000dd05bc t _ZN7rocksdb16XXH32_resetStateEPvj
0000000000dd0595 t _ZN7rocksdb17XXH32_sizeofStateEv
0000000000dd07f9 t _ZN7rocksdb24XXH32_intermediateDigestEPv
0000000000dd0434 t _ZN7rocksdb5XXH32EPKvij
00000000017ec2eb t zstd_XXH64_digest
000000000181cd56 t zstd_XXH64_digest
000000000181cb98 t zstd_XXH64_update
```
