### PR TITLE
tables: Fix column attributes in specfiles

### DIFF
--- a/specs/carves.table
+++ b/specs/carves.table
@@ -4,10 +4,10 @@ schema([
     Column("time", BIGINT, "Time at which the carve was kicked off"),
     Column("sha256", TEXT, "A SHA256 sum of the carved archive"),
     Column("size", INTEGER, "Size of the carved archive"),
-    Column("path", TEXT, "The path of the requested carve"),
+    Column("path", TEXT, "The path of the requested carve", additional=True),
     Column("status", TEXT, "Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED"),
     Column("carve_guid", TEXT, "Identifying value of the carve session"),
-    Column("carve", INTEGER, "Set this value to '1' to start a file carve")
+    Column("carve", INTEGER, "Set this value to '1' to start a file carve", additional=True)
 ])
 attributes(user_data=True)
 implementation("forensic/carves@genCarves")

--- a/specs/darwin/apps.table
+++ b/specs/darwin/apps.table
@@ -2,7 +2,7 @@ table_name("apps")
 description("OS X applications installed in known search paths (e.g., /Applications).")
 schema([
     Column("name", TEXT, "Name of the Name.app folder"),
-    Column("path", TEXT, "Absolute and full Name.app path"),
+    Column("path", TEXT, "Absolute and full Name.app path", additional=True),
     Column("bundle_executable", TEXT,
         "Info properties CFBundleExecutable label"),
     Column("bundle_identifier", TEXT,

--- a/specs/darwin/asl.table
+++ b/specs/darwin/asl.table
@@ -4,19 +4,19 @@ description("Queries the Apple System Log data structure for system events.")
 # Columns pulled from asl.h
 # Descriptions mostly as retrieved from asl.h, some with clarifications
 schema([
-    Column("time", INTEGER, "Unix timestamp.  Set automatically"),
-    Column("time_nano_sec", INTEGER, "Nanosecond time."),
-    Column("host", TEXT, "Sender's address (set by the server)."),
-    Column("sender", TEXT, "Sender's identification string.  Default is process name."),
-    Column("facility", TEXT, "Sender's facility.  Default is 'user'."),
-    Column("pid", INTEGER, "Sending process ID encoded as a string.  Set automatically."),
+    Column("time", INTEGER, "Unix timestamp.  Set automatically", additional=True),
+    Column("time_nano_sec", INTEGER, "Nanosecond time.", additional=True),
+    Column("host", TEXT, "Sender's address (set by the server).", additional=True),
+    Column("sender", TEXT, "Sender's identification string.  Default is process name.", additional=True),
+    Column("facility", TEXT, "Sender's facility.  Default is 'user'.", additional=True),
+    Column("pid", INTEGER, "Sending process ID encoded as a string.  Set automatically.", additional=True),
     # UID and GID of 4294967294 have been encountered
-    Column("gid", BIGINT, "GID that sent the log message (set by the server)."),
-    Column("uid", BIGINT, "UID that sent the log message (set by the server)."),
-    Column("level", INTEGER, "Log level number.  See levels in asl.h."),
-    Column("message", TEXT, "Message text."),
-    Column("ref_pid", INTEGER, "Reference PID for messages proxied by launchd"),
-    Column("ref_proc", TEXT, "Reference process for messages proxied by launchd"),
+    Column("gid", BIGINT, "GID that sent the log message (set by the server).", additional=True),
+    Column("uid", BIGINT, "UID that sent the log message (set by the server).", additional=True),
+    Column("level", INTEGER, "Log level number.  See levels in asl.h.", additional=True),
+    Column("message", TEXT, "Message text.", additional=True),
+    Column("ref_pid", INTEGER, "Reference PID for messages proxied by launchd", additional=True),
+    Column("ref_proc", TEXT, "Reference process for messages proxied by launchd", additional=True),
     # Gather anything extra into the "extra" column
     Column("extra", TEXT, "Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h."),
 ])

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -2,7 +2,7 @@ table_name("browser_plugins")
 description("All C/NPAPI browser plugin details for all users.")
 schema([
     Column("uid", BIGINT, "The local user that owns the plugin",
-      index=True),
+      additional=True),
     Column("name", TEXT, "Plugin display name"),
     Column("identifier", TEXT, "Plugin identifier"),
     Column("version", TEXT, "Plugin short version"),

--- a/specs/darwin/crashes.table
+++ b/specs/darwin/crashes.table
@@ -9,7 +9,7 @@ schema([
     Column("version", TEXT, "Version info of the crashed process"),
     Column("parent", BIGINT, "Parent PID of the crashed process"),
     Column("responsible", TEXT, "Process responsible for the crashed process"),
-    Column("uid", INTEGER, "User ID of the crashed process", index=True),
+    Column("uid", INTEGER, "User ID of the crashed process", additional=True),
     Column("datetime", TEXT, "Date/Time at which the crash occurred"),
     Column("crashed_thread", BIGINT, "Thread ID which crashed"),
     Column("stack_trace", TEXT, "Most recent frame from the stack trace"),

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -7,6 +7,6 @@ schema([
     Column("created", TEXT, "Data item was created"),
     Column("modified", TEXT, "Date of last modification"),
     Column("type", TEXT, "Keychain item type (class)"),
-    Column("path", TEXT, "Path to keychain containing item", index=True),
+    Column("path", TEXT, "Path to keychain containing item", additional=True),
 ])
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/mdfind.table
+++ b/specs/darwin/mdfind.table
@@ -2,7 +2,7 @@ table_name("mdfind")
 description("Run searches against the spotlight database.")
 schema([
     Column("path", TEXT, "Path of the file returned from spotlight"),
-    Column("query", TEXT, "The query that was run to find the file"),
+    Column("query", TEXT, "The query that was run to find the file", required=True),
 ])
 implementation("mdfind@genMdfindResults")
 fuzz_paths([])

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -2,7 +2,7 @@ table_name("preferences")
 description("OS X defaults and managed preferences.")
 schema([
     Column("domain", TEXT, "Application ID usually in com.name.product format",
-      index=True),
+      additional=True),
     Column("key", TEXT, "Preference top-level key", index=True),
     Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),

--- a/specs/darwin/running_apps.table
+++ b/specs/darwin/running_apps.table
@@ -3,9 +3,9 @@ table_name("running_apps")
 description("OSX applications currently running on the host system.")
 
 schema([
-    Column("pid", INTEGER, "The pid of the application"),
+    Column("pid", INTEGER, "The pid of the application", additional=True),
     Column("bundle_identifier", TEXT, "The bundle identifier of the application"),
-    Column("is_active", INTEGER, "1 if the application is in focus, 0 otherwise")
+    Column("is_active", INTEGER, "1 if the application is in focus, 0 otherwise", additional=True)
 ])
 
 implementation("running_apps@genRunningApps")

--- a/specs/linux/rpm_package_files.table
+++ b/specs/linux/rpm_package_files.table
@@ -1,8 +1,8 @@
 table_name("rpm_package_files")
-description("RPM packages that are currently installed on the host system.")
+description("Files within RPM packages that are currently installed on the host system.")
 schema([
-    Column("package", TEXT, "RPM package name", index=True),
-    Column("path", TEXT, "Path name"),
+    Column("package", TEXT, "RPM package name", additional=True),
+    Column("path", TEXT, "Path of file within a package"),
     Column("username", TEXT, "File default username from info DB"),
     Column("groupname", TEXT, "File default groupname from info DB"),
     Column("mode", TEXT, "File permissions mode from info DB"),

--- a/specs/macwin/certificates.table
+++ b/specs/macwin/certificates.table
@@ -15,7 +15,7 @@ schema([
     Column("subject_key_id", TEXT, "SKID an optionally included SHA1"),
     Column("authority_key_id", TEXT, "AKID an optionally included SHA1"),
     Column("sha1", TEXT, "SHA1 hash of the raw certificate contents"),
-    Column("path", TEXT, "Path to Keychain or PEM bundle"),
+    Column("path", TEXT, "Path to Keychain or PEM bundle", additional=True),
     Column("serial", TEXT, "Certificate serial number"),
 
 ])

--- a/specs/posix/docker_container_labels.table
+++ b/specs/posix/docker_container_labels.table
@@ -1,7 +1,7 @@
 table_name("docker_container_labels")
 description("Docker container labels.")
 schema([
-    Column("id", TEXT, "Container ID", index=True),
+    Column("id", TEXT, "Container ID", additional=True),
     Column("key", TEXT, "Label key"),
     Column("value", TEXT, "Optional label value")
 ])

--- a/specs/posix/docker_container_mounts.table
+++ b/specs/posix/docker_container_mounts.table
@@ -1,7 +1,7 @@
 table_name("docker_container_mounts")
 description("Docker container mounts.")
 schema([
-    Column("id", TEXT, "Container ID", index=True),
+    Column("id", TEXT, "Container ID", additional=True),
     Column("type", TEXT, "Type of mount (bind, volume)"),
     Column("name", TEXT, "Optional mount name"),
     Column("source", TEXT, "Source path on host"),

--- a/specs/posix/docker_container_networks.table
+++ b/specs/posix/docker_container_networks.table
@@ -1,7 +1,7 @@
 table_name("docker_container_networks")
 description("Docker container networks.")
 schema([
-    Column("id", TEXT, "Container ID", index=True),
+    Column("id", TEXT, "Container ID", additional=True),
     Column("name", TEXT, "Network name"),
     Column("network_id", TEXT, "Network ID"),
     Column("endpoint_id", TEXT, "Endpoint ID"),

--- a/specs/posix/docker_container_ports.table
+++ b/specs/posix/docker_container_ports.table
@@ -1,7 +1,7 @@
 table_name("docker_container_ports")
 description("Docker container ports.")
 schema([
-    Column("id", TEXT, "Container ID", index=True),
+    Column("id", TEXT, "Container ID", additional=True),
     Column("type", TEXT, "Protocol (tcp, udp)"),
     Column("port", INTEGER, "Port inside the container"),
     Column("host_ip", TEXT, "Host IP address on which public port is listening"),

--- a/specs/posix/docker_container_processes.table
+++ b/specs/posix/docker_container_processes.table
@@ -1,7 +1,7 @@
 table_name("docker_container_processes")
 description("Docker container processes.")
 schema([
-    Column("id", TEXT, "Container ID", index=True, required=True),
+    Column("id", TEXT, "Container ID", required=True),
     Column("pid", BIGINT, "Process ID"),
     Column("name", TEXT, "The process path or shorthand argv[0]"),
     Column("cmdline", TEXT, "Complete argv"),

--- a/specs/posix/docker_container_stats.table
+++ b/specs/posix/docker_container_stats.table
@@ -1,7 +1,7 @@
 table_name("docker_container_stats")
 description("Docker container statistics. Queries on this table take at least one second.")
 schema([
-    Column("id", TEXT, "Container ID", index=True, required=True),
+    Column("id", TEXT, "Container ID", required=True),
     Column("name", TEXT, "Container name"),
     Column("pids", INTEGER, "Number of processes"),
     Column("read", BIGINT, "UNIX time when stats were read"),

--- a/specs/posix/docker_volume_labels.table
+++ b/specs/posix/docker_volume_labels.table
@@ -1,7 +1,7 @@
 table_name("docker_volume_labels")
 description("Docker volume labels.")
 schema([
-    Column("name", TEXT, "Volume name", index=True),
+    Column("name", TEXT, "Volume name", additional=True),
     Column("key", TEXT, "Label key"),
     Column("value", TEXT, "Optional label value")
 ])

--- a/specs/posix/docker_volumes.table
+++ b/specs/posix/docker_volumes.table
@@ -1,7 +1,7 @@
 table_name("docker_volumes")
 description("Docker volumes information.")
 schema([
-    Column("name", TEXT, "Volume name", index=True),
+    Column("name", TEXT, "Volume name", additional=True),
     Column("driver", TEXT, "Volume driver"),
     Column("mount_point", TEXT, "Mount point"),
     Column("type", TEXT, "Volume type")

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -1,7 +1,7 @@
 table_name("process_open_sockets")
 description("Processes which have open network sockets on the system.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID", index=True),
+    Column("pid", INTEGER, "Process (or thread) ID", additional=True),
     Column("fd", BIGINT, "Socket file descriptor number"),
     Column("socket", BIGINT, "Socket handle or inode number"),
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),

--- a/specs/python_packages.table
+++ b/specs/python_packages.table
@@ -7,7 +7,7 @@ schema([
     Column("author", TEXT, "Optional package author"),
     Column("license", TEXT, "License under which package is launched"),
     Column("path", TEXT, "Path at which this module resides"),
-    Column("directory", TEXT, "Directory where Python modules are located", index=True)
+    Column("directory", TEXT, "Directory where Python modules are located", additional=True)
 ])
 implementation("system/linux/python_packages@genPythonPackages")
 examples([

--- a/specs/routes.table
+++ b/specs/routes.table
@@ -9,7 +9,7 @@ schema([
     Column("interface", TEXT, "Route local interface"),
     Column("mtu", INTEGER, "Maximum Transmission Unit for the route"),
     Column("metric", INTEGER, "Cost of route. Lowest is preferred"),
-    Column("type", TEXT, "Type of route"),
+    Column("type", TEXT, "Type of route", additional=True),
 ])
 
 extended_schema(POSIX, [

--- a/specs/windows/ntfs_acl_permissions.table
+++ b/specs/windows/ntfs_acl_permissions.table
@@ -1,7 +1,7 @@
 table_name("ntfs_acl_permissions")
 description("Retrieve NTFS ACL permission information for files and directories.")
 schema([
-  Column("path", TEXT, "Path to the file or directory."),
+  Column("path", TEXT, "Path to the file or directory.", required=True),
   Column("type", TEXT, "Type of access mode for the access control entry."),
   Column("principal", TEXT, "User or group to which the ACE applies."),
   Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -253,13 +253,6 @@ class TableState(Singleton):
                                     column.name, self.table_name))))
                 exit(1)
 
-        if "ADDITIONAL" in all_options and "INDEX" not in all_options:
-            if "no_pkey" not in self.attributes:
-                print(lightred(
-                    "Table cannot have 'additional' columns without an index: %s" %(
-                    path)))
-                exit(1)
-
         path_bits = path.split("/")
         for i in range(1, len(path_bits)):
             dir_path = ""


### PR DESCRIPTION
These changes are fairly significant. Several of these tables may not work correctly in 4.1.1. The next step is adding an integration test for the effected tables.

Fixes #6099.
