### PR TITLE
tables: Remove INDEX requirement for ADDITIONAL option

### DIFF
--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -117,6 +117,33 @@ TEST_F(VirtualTableTests, test_tableplugin_moreoptions) {
   EXPECT_EQ(expected_statement, columnDefinition(response, true, false));
 }
 
+class additionalOnlyTablePlugin : public TablePlugin {
+ private:
+  TableColumns columns() const override {
+    return {
+        std::make_tuple("id", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("username", TEXT_TYPE, ColumnOptions::ADDITIONAL),
+        std::make_tuple("name", TEXT_TYPE, ColumnOptions::DEFAULT),
+    };
+  }
+
+ private:
+  FRIEND_TEST(VirtualTableTests, test_tableplugin_additionalonly);
+};
+
+TEST_F(VirtualTableTests, test_tableplugin_additionalonly) {
+  auto table = std::make_shared<additionalOnlyTablePlugin>();
+
+  PluginResponse response;
+  PluginRequest request = {{"action", "columns"}};
+  EXPECT_TRUE(table->call(request, response).ok());
+
+  std::string expected_statement =
+      "(`id` INTEGER, `username` TEXT, `name` TEXT, PRIMARY KEY (`id`, "
+      "`username`, `name`)) WITHOUT ROWID";
+  EXPECT_EQ(expected_statement, columnDefinition(response, true, false));
+}
+
 class aliasesTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -253,13 +253,6 @@ class TableState(Singleton):
                                     column.name, self.table_name))))
                 exit(1)
 
-        if "ADDITIONAL" in all_options and "INDEX" not in all_options:
-            if "no_pkey" not in self.attributes:
-                print(lightred(
-                    "Table cannot have 'additional' columns without an index: %s" %(
-                    path)))
-                exit(1)
-
         path_bits = path.split("/")
         for i in range(1, len(path_bits)):
             dir_path = ""


### PR DESCRIPTION
We do not need an explicit INDEX column for ADDITIONAL to work. If the ADDITIONAL option is set the constraint should be passed into the virtual table context.