### PR TITLE
Use cert bundle in repo for make_windows_package script

### DIFF
--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -664,7 +664,7 @@ function Main() {
   if ($InstallType.ToLower() -eq 'msi') {
     Write-Host '[*] Building osquery MSI' -ForegroundColor Cyan
     $chocoPath = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'Machine')
-    $certs = $(Join-Path $chocoPath 'lib\openssl\local\certs')
+    $certs = $(Join-Path $osqRoot 'tools\deployment\certs.pem')
     if ($ConfigFilePath -eq '') {
       $ConfigFilePath = $(Join-Path $osqRoot 'tools\deployment\osquery.example.conf')
     }


### PR DESCRIPTION
Instead of using the path to an openssl provided cert bundle (which no
longer exists in recent installs of openssl from Chocolatey), use the
cert bundle already stored in the repo.

Fixes #6109