### PR TITLE
Add optional_permissions column to chrome_extensions table

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -71,6 +71,32 @@ Status getChromeProfileName(std::string& name, const fs::path& path) {
 }
 } // namespace
 
+const std::string genPermissions(const std::string& permissionTypeKey,
+                                 pt::ptree tree) {
+  std::string permission_list;
+
+  const auto& perm_array_obj = tree.get_child_optional(permissionTypeKey);
+  if (perm_array_obj) {
+    const auto& perm_array_contents = perm_array_obj.get();
+
+    std::vector<std::string> perm_vector;
+    perm_vector.reserve(perm_array_contents.size());
+
+    for (auto it = perm_array_contents.begin(); it != perm_array_contents.end();
+         ++it) {
+      const auto& perm_obj = *it;
+      const auto& permission =
+          perm_obj.second.get_value_optional<std::string>();
+      if (permission) {
+        perm_vector.emplace_back(*permission);
+      }
+    }
+
+    permission_list = boost::algorithm::join(perm_vector, ", ");
+  }
+  return permission_list;
+}
+
 void genExtension(const std::string& uid,
                   const std::string& path,
                   const std::string& profile_name,
@@ -115,60 +141,12 @@ void genExtension(const std::string& uid,
     }
   }
 
-  // Fetch the permission array from the manifest file
-  std::string permission_list;
-
-  const auto& perm_array_obj = tree.get_child_optional(kExtensionPermissionKey);
-  if (perm_array_obj) {
-    const auto& perm_array_contents = perm_array_obj.get();
-
-    std::vector<std::string> perm_vector;
-    perm_vector.reserve(perm_array_contents.size());
-
-    for (auto it = perm_array_contents.begin(); it != perm_array_contents.end();
-         ++it) {
-      const auto& perm_obj = *it;
-      const auto& permission =
-          perm_obj.second.get_value_optional<std::string>();
-      if (permission) {
-        perm_vector.emplace_back(*permission);
-      }
-    }
-
-    permission_list = boost::algorithm::join(perm_vector, ", ");
-  }
-
-  // Fetch the optional permission array from the manifest file
-  std::string optional_permission_list;
-
-  const auto& optional_perm_array_obj =
-      tree.get_child_optional(kExtensionOptionalPermissionKey);
-  if (optional_perm_array_obj) {
-    const auto& optional_perm_array_contents = optional_perm_array_obj.get();
-
-    std::vector<std::string> optional_perm_vector;
-    optional_perm_vector.reserve(optional_perm_array_contents.size());
-
-    for (auto it = optional_perm_array_contents.begin();
-         it != optional_perm_array_contents.end();
-         ++it) {
-      const auto& optional_perm_obj = *it;
-      const auto& optional_permission =
-          optional_perm_obj.second.get_value_optional<std::string>();
-      if (optional_permission) {
-        optional_perm_vector.emplace_back(*optional_permission);
-      }
-    }
-
-    optional_permission_list =
-        boost::algorithm::join(optional_perm_vector, ", ");
-  }
-
   std::string localized_prefix = "__MSG_";
   Row r;
   r["uid"] = uid;
-  r[kExtensionPermissionKey] = permission_list;
-  r[kExtensionOptionalPermissionKey] = optional_permission_list;
+  r[kExtensionPermissionKey] = genPermissions(kExtensionPermissionKey, tree);
+  r[kExtensionOptionalPermissionKey] =
+      genPermissions(kExtensionOptionalPermissionKey, tree);
   r["profile"] = profile_name;
   // Most of the keys are in the top-level JSON dictionary.
   for (const auto& it : kExtensionKeys) {

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -72,7 +72,7 @@ Status getChromeProfileName(std::string& name, const fs::path& path) {
 } // namespace
 
 const std::string genPermissions(const std::string& permissionTypeKey,
-                                 pt::ptree tree) {
+                                 const pt::ptree& tree) {
   std::string permission_list;
 
   const auto& perm_array_obj = tree.get_child_optional(permissionTypeKey);

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -15,6 +15,7 @@ schema([
         "1 If extension is persistent across all tabs else 0"),
     Column("path", TEXT, "Path to extension folder"),
     Column("permissions", TEXT, "The permissions required by the extension"),
+    Column("optional_permissions", TEXT, "The permissions optionally required by the extensions"),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)


### PR DESCRIPTION
Chrome extensions have optional permissions which are defined in the extension manifest file along the required permissions. This PR will add an additional column to the chrome_extensions table to include optional_permissions.
