### PR TITLE
selinux_settings: New table that presents effective SELinux settings

### DIFF
--- a/osquery/filesystem/BUCK
+++ b/osquery/filesystem/BUCK
@@ -25,6 +25,7 @@ osquery_cxx_library(
             LINUX,
             [
                 "linux/proc.h",
+                "linux/mounts.h",
             ],
         ),
     ],
@@ -55,6 +56,7 @@ osquery_cxx_library(
             [
                 "linux/mem.cpp",
                 "linux/proc.cpp",
+                "linux/mounts.cpp",
             ],
         ),
         (
@@ -74,6 +76,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/status:status"),
         osquery_target("osquery/utils/system:env"),
+        osquery_target("osquery/utils/system:filepath"),
         osquery_tp_target("boost"),
         osquery_tp_target("libarchive"),
         osquery_tp_target("zstd"),

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -36,6 +36,7 @@ function(generateOsqueryFilesystem)
     list(APPEND source_files
       linux/mem.cpp
       linux/proc.cpp
+      linux/mounts.cpp
     )
 
   elseif(DEFINED PLATFORM_WINDOWS)
@@ -55,6 +56,7 @@ function(generateOsqueryFilesystem)
     osquery_utils_conversions
     osquery_utils_status
     osquery_utils_system_env
+    osquery_utils_system_filepath
     thirdparty_boost
     thirdparty_libarchive
     thirdparty_zstd
@@ -68,6 +70,7 @@ function(generateOsqueryFilesystem)
   if(DEFINED PLATFORM_LINUX)
     list(APPEND public_header_files
       linux/proc.h
+      linux/mounts.h
     )
   endif()
 

--- a/osquery/filesystem/linux/mounts.cpp
+++ b/osquery/filesystem/linux/mounts.cpp
@@ -1,0 +1,113 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <mntent.h>
+#include <sys/vfs.h>
+
+#include <osquery/filesystem/linux/mounts.h>
+#include <osquery/logger.h>
+#include <osquery/utils/system/filepath.h>
+
+namespace osquery {
+namespace {
+const std::string kMountsPseudoFile{"/proc/mounts"};
+
+struct MountDataDeleter final {
+  void operator()(FILE* ptr) {
+    if (ptr == nullptr) {
+      return;
+    }
+
+    endmntent(ptr);
+  }
+};
+
+using MountData = std::unique_ptr<FILE, MountDataDeleter>;
+
+Status getMountData(MountData& obj) {
+  obj = {};
+
+  auto mount_data = setmntent(kMountsPseudoFile.c_str(), "r");
+  if (mount_data == nullptr) {
+    return Status::failure("Failed to open the '" + kMountsPseudoFile +
+                           "' pseudo file");
+  }
+
+  obj.reset(mount_data);
+  return Status::success();
+}
+} // namespace
+
+Status getMountedFilesystemMap(MountedFilesystemMap& mounted_fs_info) {
+  mounted_fs_info = {};
+
+  MountData mount_data;
+  auto status = getMountData(mount_data);
+  if (!status.ok()) {
+    return status;
+  }
+
+  std::vector<char> string_buffer(4096);
+
+  for (;;) {
+    mntent ent = {};
+    if (getmntent_r(mount_data.get(),
+                    &ent,
+                    string_buffer.data(),
+                    string_buffer.size()) == nullptr) {
+      if (errno != ENOENT) {
+        LOG(ERROR) << "getmntent_r failed with errno " << std::to_string(errno);
+      }
+
+      break;
+    }
+
+    MountInformation mount_info = {};
+    mount_info.type = ent.mnt_type;
+    mount_info.device = ent.mnt_fsname;
+    mount_info.device_alias = canonicalize_file_name(ent.mnt_fsname);
+    mount_info.path = ent.mnt_dir;
+    mount_info.flags = ent.mnt_opts;
+
+    if (mount_info.type == "autofs") {
+      VLOG(1) << "Skipping statfs information for autofs mount: "
+              << mount_info.path;
+
+    } else {
+      struct statfs stats = {};
+      if (statfs(mount_info.path.c_str(), &stats) == 0) {
+        MountInformation::StatFsInfo statfs_info = {};
+
+        statfs_info.block_size = static_cast<std::uint32_t>(stats.f_bsize);
+        statfs_info.block_count = static_cast<std::uint32_t>(stats.f_blocks);
+
+        statfs_info.free_block_count =
+            static_cast<std::uint32_t>(stats.f_bfree);
+
+        statfs_info.unprivileged_free_block_count =
+            static_cast<std::uint32_t>(stats.f_bavail);
+
+        statfs_info.inode_count = static_cast<std::uint32_t>(stats.f_files);
+
+        statfs_info.free_inode_count =
+            static_cast<std::uint32_t>(stats.f_ffree);
+
+        mount_info.optional_statfs_info = std::move(statfs_info);
+
+      } else {
+        LOG(ERROR) << "statfs failed with errno " << std::to_string(errno)
+                   << " on path " << mount_info.path;
+      }
+    }
+
+    mounted_fs_info.insert({mount_info.path, std::move(mount_info)});
+  }
+
+  return Status::success();
+}
+} // namespace osquery

--- a/osquery/filesystem/linux/mounts.h
+++ b/osquery/filesystem/linux/mounts.h
@@ -1,0 +1,62 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <boost/optional.hpp>
+#include <unordered_map>
+
+#include <osquery/core.h>
+#include <osquery/filesystem/filesystem.h>
+
+namespace osquery {
+// Information about a single mounted filesystem
+struct MountInformation final {
+  struct StatFsInfo final {
+    // Optimal transfer block size (statfs::f_bsize)
+    std::uint32_t block_size{0U};
+
+    // Total data blocks in file system (statfs::f_blocks)
+    std::uint32_t block_count{0U};
+
+    // Free blocks in filesystem (statfs::f_bfree)
+    std::uint32_t free_block_count{0U};
+
+    // Free blocks available to unprivileged user (statfs::f_bavail)
+    std::uint32_t unprivileged_free_block_count{0U};
+
+    // Total file nodes in filesystem (statfs::f_files)
+    std::uint32_t inode_count{0U};
+
+    // Free file nodes in filesystem (statfs::f_ffree)
+    std::uint32_t free_inode_count{0U};
+  };
+
+  // Filesystem type
+  std::string type;
+
+  // Device path
+  std::string device;
+
+  // Canonicalized device path
+  std::string device_alias;
+
+  // Mount path
+  std::string path;
+
+  // Mount options
+  std::string flags;
+
+  // statfs information; may not be set if the statfs operation
+  // has failed
+  boost::optional<StatFsInfo> optional_statfs_info;
+};
+
+// Information about all mounted filesystems
+using MountedFilesystemMap = std::unordered_map<std::string, MountInformation>;
+
+Status getMountedFilesystemMap(MountedFilesystemMap& mounted_fs_info);
+} // namespace osquery

--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -157,6 +157,7 @@ osquery_cxx_library(
                 "linux/process_open_files.cpp",
                 "linux/processes.cpp",
                 "linux/rpm_packages.cpp",
+                "linux/selinux_settings.cpp",
                 "linux/shadow.cpp",
                 "linux/shared_memory.cpp",
                 "linux/smbios_tables.cpp",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -78,6 +78,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/usb_devices.cpp
       linux/user_groups.cpp
       linux/users.cpp
+      linux/selinux_settings.cpp
     )
 
   elseif(DEFINED PLATFORM_MACOS)

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -6,57 +6,58 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <mntent.h>
-#include <sys/vfs.h>
-
-#include <set>
-
-#include <osquery/core.h>
-#include <osquery/filesystem/filesystem.h>
+#include <osquery/filesystem/linux/mounts.h>
+#include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/utils/system/filepath.h>
 
 namespace osquery {
 namespace tables {
-
-std::set<std::string> kMountStatBlacklist = {
-    "autofs",
-};
-
 QueryData genMounts(QueryContext& context) {
-  QueryData results;
-
-  FILE* mounts = setmntent("/proc/mounts", "r");
-  if (mounts == nullptr) {
+  MountedFilesystemMap mounted_fs_map{};
+  auto status = getMountedFilesystemMap(mounted_fs_map);
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to list the system mounts: " << status.getMessage();
     return {};
   }
 
-  struct mntent* ent = nullptr;
-  while ((ent = getmntent(mounts))) {
-    Row r;
+  QueryData results;
 
-    r["type"] = std::string(ent->mnt_type);
-    r["device"] = std::string(ent->mnt_fsname);
-    r["device_alias"] = canonicalize_file_name(ent->mnt_fsname);
-    r["path"] = std::string(ent->mnt_dir);
-    r["flags"] = std::string(ent->mnt_opts);
+  for (const auto& p : mounted_fs_map) {
+    Row r = {};
 
-    // Check type against blacklist before running statfs.
-    if (kMountStatBlacklist.find(r["type"]) == kMountStatBlacklist.end()) {
-      struct statfs st;
-      if (!statfs(ent->mnt_dir, &st)) {
-        r["blocks_size"] = BIGINT(st.f_bsize);
-        r["blocks"] = BIGINT(st.f_blocks);
-        r["blocks_free"] = BIGINT(st.f_bfree);
-        r["blocks_available"] = BIGINT(st.f_bavail);
-        r["inodes"] = BIGINT(st.f_files);
-        r["inodes_free"] = BIGINT(st.f_ffree);
-      }
+    const auto& mount_info = p.second;
+
+    r["type"] = mount_info.type;
+    r["device"] = mount_info.device;
+    r["device_alias"] = mount_info.device_alias;
+    r["path"] = mount_info.path;
+    r["flags"] = mount_info.flags;
+
+    // optional::has_value is not present in Boost 1.66 (which is
+    // what we have when compiling with BUCK)
+    if (mount_info.optional_statfs_info != boost::none) {
+      const auto& statfs_info = mount_info.optional_statfs_info.value();
+
+      r["blocks_size"] = BIGINT(statfs_info.block_size);
+      r["blocks"] = BIGINT(statfs_info.block_count);
+      r["blocks_free"] = BIGINT(statfs_info.free_block_count);
+
+      r["blocks_available"] = BIGINT(statfs_info.unprivileged_free_block_count);
+
+      r["inodes"] = BIGINT(statfs_info.inode_count);
+      r["inodes_free"] = BIGINT(statfs_info.free_inode_count);
+
+    } else {
+      r["blocks_size"] = BIGINT(0);
+      r["blocks"] = BIGINT(0);
+      r["blocks_free"] = BIGINT(0);
+      r["blocks_available"] = BIGINT(0);
+      r["inodes"] = BIGINT(0);
+      r["inodes_free"] = BIGINT(0);
     }
 
     results.push_back(std::move(r));
   }
-  endmntent(mounts);
 
   return results;
 }

--- a/osquery/tables/system/linux/selinux_settings.cpp
+++ b/osquery/tables/system/linux/selinux_settings.cpp
@@ -1,0 +1,235 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include <boost/algorithm/string.hpp>
+
+namespace osquery {
+namespace tables {
+Status keyNameFromFilePath(std::string& key_name, const std::string& file_path);
+
+Status translateBooleanKeyValue(std::string& value,
+                                const std::string& raw_value);
+
+namespace {
+const std::string kSELinuxSysPath{"/sys/fs/selinux"};
+
+const std::vector<std::string> kRootKeyList = {"checkreqprot",
+                                               "deny_unknown",
+                                               "enforce",
+                                               "mls",
+                                               "policyvers",
+                                               "reject_unknown"};
+
+const std::vector<std::string> kScopeList = {
+    "booleans", "policy_capabilities", "initial_contexts"};
+
+Status generateScopeKey(Row& row,
+                        const std::string& scope,
+                        const std::string& key,
+                        const std::string& path) {
+  row = {};
+
+  row["scope"] = scope;
+  row["key"] = key;
+
+  std::string raw_value;
+  auto status = readFile(path, raw_value);
+  if (!status.ok()) {
+    return Status::failure("Failed to retrieve SELinux key value: " + path +
+                           ". Error: " + status.getMessage());
+  }
+
+  std::string value;
+  if (scope == "booleans") {
+    status = translateBooleanKeyValue(value, raw_value);
+    if (!status.ok()) {
+      return Status::failure("Failed to retrieve SELinux key value: " + path +
+                             ". Error: " + status.getMessage());
+    }
+
+  } else {
+    value = std::move(raw_value);
+  }
+
+  row["value"] = std::move(value);
+  return Status::success();
+}
+
+Status generateScope(QueryData& row_list, const std::string& scope) {
+  auto scope_directory_path = kSELinuxSysPath + "/" + scope;
+
+  std::vector<std::string> path_list;
+  auto status = listFilesInDirectory(scope_directory_path, path_list, true);
+  if (!status.ok()) {
+    return Status::failure("Failed to enumerate the files in '" +
+                           scope_directory_path + "': " + status.getMessage());
+  }
+
+  for (const auto& path : path_list) {
+    if (isDirectory(path).ok()) {
+      continue;
+    }
+
+    std::string key_name = {};
+    status = keyNameFromFilePath(key_name, path);
+    if (!status.ok()) {
+      LOG(ERROR) << "Invalid SELinux key path '" + path
+                 << "'. Error: " << status.getMessage();
+      continue;
+    }
+
+    Row row;
+    status = generateScopeKey(row, scope, key_name, path);
+    if (!status.ok()) {
+      LOG(ERROR) << status.getMessage();
+      continue;
+    }
+
+    row_list.push_back(std::move(row));
+  }
+
+  return Status::success();
+}
+
+Status generateClasses(QueryData& row_list) {
+  auto class_root_path = kSELinuxSysPath + "/class";
+
+  std::vector<std::string> path_list;
+  auto status = listFilesInDirectory(class_root_path, path_list, true);
+  if (!status.ok()) {
+    return Status::failure(
+        "Failed to enumerate the SELinux settings from under '" +
+        class_root_path + "': " + status.getMessage());
+  }
+
+  for (const auto& path : path_list) {
+    if (isDirectory(path).ok()) {
+      continue;
+    }
+
+    auto value_index = path.find_last_of('/');
+    if (value_index == std::string::npos) {
+      continue;
+    }
+
+    ++value_index;
+    if (value_index >= path.size()) {
+      continue;
+    }
+
+    auto value = path.substr(value_index);
+    if (value == "index") {
+      continue;
+    }
+
+    auto key_index = class_root_path.size() + 1U;
+    auto key_length = value_index - key_index - 1U;
+    auto key = path.substr(key_index, key_length);
+
+    Row row = {};
+    row["scope"] = "class";
+    row["key"] = key;
+    row["value"] = value;
+
+    row_list.push_back(std::move(row));
+  }
+
+  return Status::success();
+}
+} // namespace
+
+Status keyNameFromFilePath(std::string& key_name,
+                           const std::string& file_path) {
+  // This limit only applies to this specific case and not to the
+  // items in the 'class' scope
+  static const std::size_t kMinimumPathSize = kSELinuxSysPath.size() + 2U;
+
+  key_name = {};
+
+  if (file_path.find(kSELinuxSysPath) != 0) {
+    return Status::failure("The given path is outside the SELinux folder");
+  }
+
+  if (file_path.size() <= kMinimumPathSize) {
+    return Status::failure("The given path is too small");
+  }
+
+  auto key_name_index = file_path.find_last_of('/');
+  if (key_name_index == std::string::npos ||
+      key_name_index + 1 >= file_path.size()) {
+    return Status::failure("Invalid path specified");
+  }
+
+  ++key_name_index;
+
+  key_name = file_path.substr(key_name_index);
+  if (key_name.empty()) {
+    return Status::failure("Key name is empty");
+  }
+
+  return Status::success();
+}
+
+Status translateBooleanKeyValue(std::string& value,
+                                const std::string& raw_value) {
+  value = {};
+
+  if (raw_value == "0 0") {
+    value = "off";
+
+  } else if (raw_value == "1 1") {
+    value = "on";
+
+  } else {
+    return Status::failure("Invalid raw value for boolean key");
+  }
+
+  return Status::success();
+}
+
+QueryData genSELinuxSettings(QueryContext& context) {
+  QueryData row_list;
+
+  for (const auto& root_key : kRootKeyList) {
+    auto path = kSELinuxSysPath + "/" + root_key;
+
+    if (!pathExists(path).ok()) {
+      continue;
+    }
+
+    Row row;
+    auto status = generateScopeKey(row, "", root_key, path);
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed to generate SELinux root key: "
+                 << status.getMessage();
+    }
+
+    row_list.push_back(std::move(row));
+  }
+
+  for (const auto& scope : kScopeList) {
+    auto status = generateScope(row_list, scope);
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed to generate SELinux scope: " << status.getMessage();
+    }
+  }
+
+  auto status = generateClasses(row_list);
+  if (!status.ok()) {
+    LOG(ERROR) << "failed to bla bla";
+  }
+
+  return row_list;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -18,6 +18,7 @@ osquery_cxx_test(
                 "linux/pci_devices_tests.cpp",
                 "linux/pcidb_tests.cpp",
                 "linux/portage_tests.cpp",
+                "linux/selinux_settings_tests.cpp"
             ],
         ),
     ],

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ function(generateOsqueryTablesSystemLinuxTests)
     linux/pci_devices_tests.cpp
     linux/pcidb_tests.cpp
     linux/portage_tests.cpp
+    linux/selinux_settings_tests.cpp
   )
 
   target_link_libraries(osquery_tables_system_linux_tests-test PRIVATE

--- a/osquery/tables/system/tests/linux/selinux_settings_tests.cpp
+++ b/osquery/tables/system/tests/linux/selinux_settings_tests.cpp
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <pwd.h>
+
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/system.h>
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+namespace tables {
+Status keyNameFromFilePath(std::string& key_name, const std::string& file_path);
+
+bool isBooleanKey(const std::string& key_name);
+
+Status translateBooleanKeyValue(std::string& value,
+                                const std::string& raw_value);
+
+class SELinuxSettingsTests : public testing::Test {};
+
+TEST_F(SELinuxSettingsTests, keyNameFromFilePath) {
+  struct TestCase final {
+    bool expected_status{false};
+    std::string expected_key_name;
+    std::string file_path;
+  };
+
+  const std::vector<TestCase> test_case_list = {
+      {false, "", "/sys/fs/selinux"},
+      {false, "", "/sys/fs/selinux/"},
+      {true, "devnull", "/sys/fs/selinux/initial_contexts/devnull"},
+      {true, "name_bind", "/sys/fs/selinux/class/smc_socket/perms/name_bind"},
+      {true,
+       "nnp_nosuid_transition",
+       "/sys/fs/selinux/policy_capabilities/nnp_nosuid_transition"}};
+
+  for (const auto& test_case : test_case_list) {
+    std::string key_name;
+    auto status = keyNameFromFilePath(key_name, test_case.file_path);
+
+    CHECK_EQ(key_name, test_case.expected_key_name);
+    ASSERT_EQ(status.ok(), test_case.expected_status);
+  }
+}
+
+TEST_F(SELinuxSettingsTests, translateBooleanKeyValue) {
+  struct TestCase final {
+    bool expected_status{false};
+    std::string expected_value;
+    std::string raw_value;
+  };
+
+  const std::vector<TestCase> test_case_list = {
+      {true, "on", "1 1"}, {true, "off", "0 0"}, {false, "", "0"}};
+
+  for (const auto& test_case : test_case_list) {
+    std::string translated_value;
+    auto status =
+        translateBooleanKeyValue(translated_value, test_case.raw_value);
+
+    ASSERT_EQ(status.ok(), test_case.expected_status);
+    ASSERT_EQ(translated_value, test_case.expected_value);
+  }
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -162,6 +162,7 @@ function(generateNativeTables)
     "linux/elf_dynamic.table:linux"
     "linux/ec2_instance_metadata.table:linux"
     "linux/elf_sections.table:linux"
+    "linux/selinux_settings.table:linux"
     "linwin/intel_me_info.table:linux,windows"
     "lldpd/lldp_neighbors.table:linux,macos,freebsd"
     "kernel_info.table:linux,macos,windows"

--- a/specs/linux/selinux_settings.table
+++ b/specs/linux/selinux_settings.table
@@ -1,0 +1,11 @@
+table_name("selinux_settings")
+description("Track active SELinux settings.")
+schema([
+    Column("scope", TEXT, "Where the key is located inside the SELinuxFS mount point.", index=True),
+    Column("key", TEXT, "Key or class name.", index=True),
+    Column("value", TEXT, "Active value."),
+])
+implementation("system/selinux_settings@genSELinuxSettings")
+examples([
+  "SELECT * FROM selinux_settings WHERE key = 'enforce'",
+])


### PR DESCRIPTION
# Example output

```
osquery> SELECT * FROM selinux_settings WHERE key = "enforce";
+-------+---------+-------+
| scope | key     | value |
+-------+---------+-------+
|       | enforce | 1     |
+-------+---------+-------+
```
```
osquery> SELECT value AS 'process_permissions' FROM selinux_settings WHERE key = "process/perms";
+---------------------+
| process_permissions |
+---------------------+
| dyntransition       |
| execheap            |
| execmem             |
| execstack           |
| fork                |
| getattr             |
| getcap              |
| getpgid             |
| getrlimit           |
| getsched            |
| getsession          |
| noatsecure          |
| ptrace              |
| rlimitinh           |
| setcap              |
| setcurrent          |
| setexec             |
| setfscreate         |
| setkeycreate        |
| setpgid             |
| setrlimit           |
| setsched            |
| setsockcreate       |
| share               |
| sigchld             |
| siginh              |
| sigkill             |
| signal              |
| signull             |
| sigstop             |
| transition          |
+---------------------+
```
```
osquery> SELECT * FROM selinux_settings WHERE scope = "booleans";
+----------+---------------------------------------------+-------+
| scope    | key                                         | value |
+----------+---------------------------------------------+-------+
| booleans | abrt_anon_write                             | off   |
| booleans | abrt_handle_event                           | off   |
| booleans | abrt_upload_watch_anon_write                | on    |
| booleans | antivirus_can_scan_system                   | off   |
| booleans | antivirus_use_jit                           | off   |
| booleans | auditadm_exec_content                       | on    |
| booleans | authlogin_nsswitch_use_ldap                 | off   |
| booleans | authlogin_radius                            | off   |
| booleans | authlogin_yubikey                           | off   |
| booleans | awstats_purge_apache_log_files              | off   |
| booleans | boinc_execmem                               | on    |
| booleans | cdrecord_read_content                       | off   |
| booleans | cluster_can_network_connect                 | off   |
| booleans | cluster_manage_all_files                    | off   |
| booleans | cluster_use_execmem                         | off   |
| booleans | cobbler_anon_write                          | off   |
| booleans | cobbler_can_network_connect                 | off   |
| booleans | cobbler_use_cifs                            | off   |
| booleans | cobbler_use_nfs                             | off   |
| booleans | collectd_tcp_network_connect                | off   |
| booleans | colord_use_nfs                              | off   |
| booleans | condor_tcp_network_connect                  | off   |
| booleans | conman_can_network                          | off   |
| booleans | conman_use_nfs                              | off   |
| booleans | cron_can_relabel                            | off   |
| booleans | cron_system_cronjob_use_shares              | off   |
| booleans | cron_userdomain_transition                  | on    |
| booleans | cups_execmem                                | off   |
| booleans | cvs_read_shadow                             | off   |
| booleans | daemons_dump_core                           | off   |
| booleans | daemons_enable_cluster_mode                 | off   |
| booleans | daemons_use_tcp_wrapper                     | off   |
| booleans | daemons_use_tty                             | off   |
| booleans | dbadm_exec_content                          | on    |
| booleans | dbadm_manage_user_files                     | off   |
| booleans | dbadm_read_user_files                       | off   |
| booleans | deny_execmem                                | off   |
| booleans | deny_ptrace                                 | off   |
| booleans | dhcpc_exec_iptables                         | off   |
| booleans | dhcpd_use_ldap                              | off   |
| booleans | domain_can_mmap_files                       | off   |
| booleans | domain_can_write_kmsg                       | off   |
| booleans | domain_fd_use                               | on    |
| booleans | domain_kernel_load_modules                  | off   |
| booleans | entropyd_use_audio                          | on    |
| booleans | exim_can_connect_db                         | off   |
| booleans | exim_manage_user_files                      | off   |
| booleans | exim_read_user_files                        | off   |
| booleans | fcron_crond                                 | off   |
| booleans | fenced_can_network_connect                  | off   |
| booleans | fenced_can_ssh                              | off   |
| booleans | fips_mode                                   | on    |
| booleans | ftpd_anon_write                             | off   |
| booleans | ftpd_connect_all_unreserved                 | off   |
| booleans | ftpd_connect_db                             | off   |
| booleans | ftpd_full_access                            | off   |
| booleans | ftpd_use_cifs                               | off   |
| booleans | ftpd_use_fusefs                             | off   |
| booleans | ftpd_use_nfs                                | off   |
| booleans | ftpd_use_passive_mode                       | off   |
| booleans | git_cgi_enable_homedirs                     | off   |
| booleans | git_cgi_use_cifs                            | off   |
| booleans | git_cgi_use_nfs                             | off   |
| booleans | git_session_bind_all_unreserved_ports       | off   |
| booleans | git_session_users                           | off   |
| booleans | git_system_enable_homedirs                  | off   |
| booleans | git_system_use_cifs                         | off   |
| booleans | git_system_use_nfs                          | off   |
| booleans | gitosis_can_sendmail                        | off   |
| booleans | glance_api_can_network                      | off   |
| booleans | glance_use_execmem                          | off   |
| booleans | glance_use_fusefs                           | off   |
| booleans | global_ssp                                  | off   |
| booleans | gluster_anon_write                          | off   |
| booleans | gluster_export_all_ro                       | off   |
| booleans | gluster_export_all_rw                       | on    |
| booleans | gluster_use_execmem                         | off   |
| booleans | gpg_web_anon_write                          | off   |
| booleans | gssd_read_tmp                               | on    |
| booleans | guest_exec_content                          | on    |
| booleans | haproxy_connect_any                         | off   |
| booleans | httpd_anon_write                            | off   |
| booleans | httpd_builtin_scripting                     | on    |
| booleans | httpd_can_check_spam                        | off   |
| booleans | httpd_can_connect_ftp                       | off   |
| booleans | httpd_can_connect_ldap                      | off   |
| booleans | httpd_can_connect_mythtv                    | off   |
| booleans | httpd_can_connect_zabbix                    | off   |
| booleans | httpd_can_network_connect                   | off   |
| booleans | httpd_can_network_connect_cobbler           | off   |
| booleans | httpd_can_network_connect_db                | off   |
| booleans | httpd_can_network_memcache                  | off   |
| booleans | httpd_can_network_relay                     | off   |
| booleans | httpd_can_sendmail                          | off   |
| booleans | httpd_dbus_avahi                            | off   |
| booleans | httpd_dbus_sssd                             | off   |
| booleans | httpd_dontaudit_search_dirs                 | off   |
| booleans | httpd_enable_cgi                            | on    |
| booleans | httpd_enable_ftp_server                     | off   |
| booleans | httpd_enable_homedirs                       | off   |
| booleans | httpd_execmem                               | off   |
| booleans | httpd_graceful_shutdown                     | off   |
| booleans | httpd_manage_ipa                            | off   |
| booleans | httpd_mod_auth_ntlm_winbind                 | off   |
| booleans | httpd_mod_auth_pam                          | off   |
| booleans | httpd_read_user_content                     | off   |
| booleans | httpd_run_ipa                               | off   |
| booleans | httpd_run_preupgrade                        | off   |
| booleans | httpd_run_stickshift                        | off   |
| booleans | httpd_serve_cobbler_files                   | off   |
| booleans | httpd_setrlimit                             | off   |
| booleans | httpd_ssi_exec                              | off   |
| booleans | httpd_sys_script_anon_write                 | off   |
| booleans | httpd_tmp_exec                              | off   |
| booleans | httpd_tty_comm                              | off   |
| booleans | httpd_unified                               | off   |
| booleans | httpd_use_cifs                              | off   |
| booleans | httpd_use_fusefs                            | off   |
| booleans | httpd_use_gpg                               | off   |
| booleans | httpd_use_nfs                               | off   |
| booleans | httpd_use_openstack                         | off   |
| booleans | httpd_use_sasl                              | off   |
| booleans | httpd_verify_dns                            | off   |
| booleans | icecast_use_any_tcp_ports                   | off   |
| booleans | irc_use_any_tcp_ports                       | off   |
| booleans | irssi_use_full_network                      | off   |
| booleans | kdumpgui_run_bootloader                     | off   |
| booleans | keepalived_connect_any                      | off   |
| booleans | kerberos_enabled                            | on    |
| booleans | ksmtuned_use_cifs                           | off   |
| booleans | ksmtuned_use_nfs                            | off   |
| booleans | logadm_exec_content                         | on    |
| booleans | logging_syslogd_can_sendmail                | off   |
| booleans | logging_syslogd_run_nagios_plugins          | off   |
| booleans | logging_syslogd_use_tty                     | on    |
| booleans | login_console_enabled                       | on    |
| booleans | logrotate_read_inside_containers            | off   |
| booleans | logrotate_use_nfs                           | off   |
| booleans | logwatch_can_network_connect_mail           | off   |
| booleans | lsmd_plugin_connect_any                     | off   |
| booleans | mailman_use_fusefs                          | off   |
| booleans | mcelog_client                               | off   |
| booleans | mcelog_exec_scripts                         | on    |
| booleans | mcelog_foreground                           | off   |
| booleans | mcelog_server                               | off   |
| booleans | minidlna_read_generic_user_content          | off   |
| booleans | mmap_low_allowed                            | off   |
| booleans | mock_enable_homedirs                        | off   |
| booleans | mount_anyfile                               | on    |
| booleans | mozilla_plugin_bind_unreserved_ports        | off   |
| booleans | mozilla_plugin_can_network_connect          | on    |
| booleans | mozilla_plugin_use_bluejeans                | off   |
| booleans | mozilla_plugin_use_gps                      | off   |
| booleans | mozilla_plugin_use_spice                    | off   |
| booleans | mozilla_read_content                        | off   |
| booleans | mpd_enable_homedirs                         | off   |
| booleans | mpd_use_cifs                                | off   |
| booleans | mpd_use_nfs                                 | off   |
| booleans | mplayer_execstack                           | off   |
| booleans | mysql_connect_any                           | off   |
| booleans | mysql_connect_http                          | off   |
| booleans | nagios_run_pnp4nagios                       | off   |
| booleans | nagios_run_sudo                             | off   |
| booleans | nagios_use_nfs                              | off   |
| booleans | named_tcp_bind_http_port                    | off   |
| booleans | named_write_master_zones                    | on    |
| booleans | neutron_can_network                         | off   |
| booleans | nfs_export_all_ro                           | on    |
| booleans | nfs_export_all_rw                           | on    |
| booleans | nfsd_anon_write                             | off   |
| booleans | nis_enabled                                 | off   |
| booleans | nscd_use_shm                                | on    |
| booleans | openshift_use_nfs                           | off   |
| booleans | openvpn_can_network_connect                 | on    |
| booleans | openvpn_enable_homedirs                     | on    |
| booleans | openvpn_run_unconfined                      | off   |
| booleans | pcp_bind_all_unreserved_ports               | off   |
| booleans | pcp_read_generic_logs                       | off   |
| booleans | pdns_can_network_connect_db                 | off   |
| booleans | piranha_lvs_can_network_connect             | off   |
| booleans | polipo_connect_all_unreserved               | off   |
| booleans | polipo_session_bind_all_unreserved_ports    | off   |
| booleans | polipo_session_users                        | off   |
| booleans | polipo_use_cifs                             | off   |
| booleans | polipo_use_nfs                              | off   |
| booleans | polyinstantiation_enabled                   | off   |
| booleans | postfix_local_write_mail_spool              | on    |
| booleans | postgresql_can_rsync                        | off   |
| booleans | postgresql_selinux_transmit_client_label    | off   |
| booleans | postgresql_selinux_unconfined_dbadm         | on    |
| booleans | postgresql_selinux_users_ddl                | on    |
| booleans | pppd_can_insmod                             | off   |
| booleans | pppd_for_user                               | off   |
| booleans | privoxy_connect_any                         | on    |
| booleans | prosody_bind_http_port                      | off   |
| booleans | puppetagent_manage_all_files                | off   |
| booleans | puppetmaster_use_db                         | off   |
| booleans | racoon_read_shadow                          | off   |
| booleans | radius_use_jit                              | off   |
| booleans | redis_enable_notify                         | off   |
| booleans | rpcd_use_fusefs                             | off   |
| booleans | rsync_anon_write                            | off   |
| booleans | rsync_client                                | off   |
| booleans | rsync_export_all_ro                         | off   |
| booleans | rsync_full_access                           | off   |
| booleans | samba_create_home_dirs                      | off   |
| booleans | samba_domain_controller                     | off   |
| booleans | samba_enable_home_dirs                      | off   |
| booleans | samba_export_all_ro                         | off   |
| booleans | samba_export_all_rw                         | off   |
| booleans | samba_load_libgfapi                         | off   |
| booleans | samba_portmapper                            | off   |
| booleans | samba_run_unconfined                        | off   |
| booleans | samba_share_fusefs                          | off   |
| booleans | samba_share_nfs                             | off   |
| booleans | sanlock_enable_home_dirs                    | off   |
| booleans | sanlock_use_fusefs                          | off   |
| booleans | sanlock_use_nfs                             | off   |
| booleans | sanlock_use_samba                           | off   |
| booleans | saslauthd_read_shadow                       | off   |
| booleans | secadm_exec_content                         | on    |
| booleans | secure_mode                                 | off   |
| booleans | secure_mode_insmod                          | off   |
| booleans | secure_mode_policyload                      | off   |
| booleans | selinuxuser_direct_dri_enabled              | on    |
| booleans | selinuxuser_execheap                        | off   |
| booleans | selinuxuser_execmod                         | on    |
| booleans | selinuxuser_execstack                       | on    |
| booleans | selinuxuser_mysql_connect_enabled           | off   |
| booleans | selinuxuser_ping                            | on    |
| booleans | selinuxuser_postgresql_connect_enabled      | off   |
| booleans | selinuxuser_rw_noexattrfile                 | on    |
| booleans | selinuxuser_share_music                     | off   |
| booleans | selinuxuser_tcp_server                      | off   |
| booleans | selinuxuser_udp_server                      | off   |
| booleans | selinuxuser_use_ssh_chroot                  | off   |
| booleans | sge_domain_can_network_connect              | off   |
| booleans | sge_use_nfs                                 | off   |
| booleans | smartmon_3ware                              | off   |
| booleans | smbd_anon_write                             | off   |
| booleans | spamassassin_can_network                    | off   |
| booleans | spamd_enable_home_dirs                      | on    |
| booleans | spamd_update_can_network                    | off   |
| booleans | squid_connect_any                           | on    |
| booleans | squid_use_tproxy                            | off   |
| booleans | ssh_chroot_rw_homedirs                      | off   |
| booleans | ssh_keysign                                 | off   |
| booleans | ssh_sysadm_login                            | off   |
| booleans | ssh_use_tcpd                                | off   |
| booleans | sslh_can_bind_any_port                      | off   |
| booleans | sslh_can_connect_any_port                   | off   |
| booleans | staff_exec_content                          | on    |
| booleans | staff_use_svirt                             | off   |
| booleans | swift_can_network                           | off   |
| booleans | sysadm_exec_content                         | on    |
| booleans | telepathy_connect_all_ports                 | off   |
| booleans | telepathy_tcp_connect_generic_network_ports | on    |
| booleans | tftp_anon_write                             | off   |
| booleans | tftp_home_dir                               | off   |
| booleans | tmpreaper_use_cifs                          | off   |
| booleans | tmpreaper_use_nfs                           | off   |
| booleans | tmpreaper_use_samba                         | off   |
| booleans | tomcat_can_network_connect_db               | off   |
| booleans | tomcat_read_rpm_db                          | off   |
| booleans | tomcat_use_execmem                          | off   |
| booleans | tor_bind_all_unreserved_ports               | off   |
| booleans | tor_can_network_relay                       | off   |
| booleans | tor_can_onion_services                      | off   |
| booleans | unconfined_chrome_sandbox_transition        | on    |
| booleans | unconfined_login                            | on    |
| booleans | unconfined_mozilla_plugin_transition        | on    |
| booleans | unprivuser_use_svirt                        | off   |
| booleans | use_ecryptfs_home_dirs                      | off   |
| booleans | use_fusefs_home_dirs                        | off   |
| booleans | use_lpd_server                              | off   |
| booleans | use_nfs_home_dirs                           | off   |
| booleans | use_samba_home_dirs                         | off   |
| booleans | use_virtualbox                              | off   |
| booleans | user_exec_content                           | on    |
| booleans | varnishd_connect_any                        | off   |
| booleans | virt_read_qemu_ga_data                      | off   |
| booleans | virt_rw_qemu_ga_data                        | off   |
| booleans | virt_sandbox_share_apache_content           | off   |
| booleans | virt_sandbox_use_all_caps                   | on    |
| booleans | virt_sandbox_use_audit                      | on    |
| booleans | virt_sandbox_use_fusefs                     | off   |
| booleans | virt_sandbox_use_mknod                      | off   |
| booleans | virt_sandbox_use_netlink                    | off   |
| booleans | virt_sandbox_use_sys_admin                  | off   |
| booleans | virt_transition_userdomain                  | off   |
| booleans | virt_use_comm                               | off   |
| booleans | virt_use_execmem                            | off   |
| booleans | virt_use_fusefs                             | off   |
| booleans | virt_use_glusterd                           | off   |
| booleans | virt_use_nfs                                | off   |
| booleans | virt_use_pcscd                              | off   |
| booleans | virt_use_rawip                              | off   |
| booleans | virt_use_samba                              | off   |
| booleans | virt_use_sanlock                            | off   |
| booleans | virt_use_usb                                | on    |
| booleans | virt_use_xserver                            | off   |
| booleans | webadm_manage_user_files                    | off   |
| booleans | webadm_read_user_files                      | off   |
| booleans | wine_mmap_zero_ignore                       | off   |
| booleans | xdm_bind_vnc_tcp_port                       | off   |
| booleans | xdm_exec_bootloader                         | off   |
| booleans | xdm_sysadm_login                            | off   |
| booleans | xdm_write_home                              | off   |
| booleans | xen_use_nfs                                 | off   |
| booleans | xend_run_blktap                             | on    |
| booleans | xend_run_qemu                               | on    |
| booleans | xguest_connect_network                      | on    |
| booleans | xguest_exec_content                         | on    |
| booleans | xguest_mount_media                          | on    |
| booleans | xguest_use_bluetooth                        | on    |
| booleans | xserver_clients_write_xshm                  | off   |
| booleans | xserver_execmem                             | off   |
| booleans | xserver_object_manager                      | off   |
| booleans | zabbix_can_network                          | off   |
| booleans | zabbix_run_sudo                             | off   |
| booleans | zarafa_setrlimit                            | off   |
| booleans | zebra_write_config                          | off   |
| booleans | zoneminder_anon_write                       | off   |
| booleans | zoneminder_run_sudo                         | off   |
+----------+---------------------------------------------+-------+
```
