### PR TITLE
Print CMake version in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,6 +197,7 @@ jobs:
 
     steps:
     - script: |
+        cmake --version
         brew upgrade
         brew install ccache flex bison
         pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
@@ -331,6 +332,7 @@ jobs:
     - checkout: self
 
     - powershell: |
+        cmake --version
         $python3_path = ((Get-Item C:\hostedtoolcache\windows\Python\3*\x64) | Sort-Object -Descending)[0].FullName
         & $python3_path\python -m pip install setuptools psutil timeout_decorator thrift==0.11.0 osquery pywin32
       displayName: Install tests prerequisites


### PR DESCRIPTION
This helps debugging issues that may arise
between different Azure Pipelines instances.