### PR TITLE
CMake: Future proof Python finding mechanism

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -101,6 +101,8 @@ endfunction()
 
 function(findPythonExecutablePath)
   find_package(Python3 3.5 COMPONENTS Interpreter REQUIRED)
+
+  set(OSQUERY_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}" CACHE INTERNAL "" FORCE)
 endfunction()
 
 function(generateBuildTimeSourceFile file_path content)
@@ -274,12 +276,12 @@ function(generateSpecialTargets)
   endif()
 
   add_custom_target(format_check
-    COMMAND ${command_prefix} "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py --exclude-folders ${excluded_folders} origin/master
+    COMMAND ${command_prefix} "${OSQUERY_PYTHON_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py --exclude-folders ${excluded_folders} origin/master
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     VERBATIM
   )
   add_custom_target(format
-    COMMAND ${command_prefix} "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py --exclude-folders ${excluded_folders} -f --style=file
+    COMMAND ${command_prefix} "${OSQUERY_PYTHON_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py --exclude-folders ${excluded_folders} -f --style=file
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     VERBATIM
   )

--- a/libraries/cmake/facebook/modules/api.cmake
+++ b/libraries/cmake/facebook/modules/api.cmake
@@ -10,11 +10,11 @@ function(downloadRemoteFile identifier base_url file_name hash)
   set(destination "${CMAKE_CURRENT_BINARY_DIR}/${file_name}")
   set(url "${base_url}/${file_name}")
 
-  set(command_prefix "${Python3_EXECUTABLE}")
+  set(command_prefix "${OSQUERY_PYTHON_EXECUTABLE}")
 
   add_custom_command(
     OUTPUT "${destination}"
-    COMMAND ${command_prefix} "${CMAKE_SOURCE_DIR}/tools/cmake/downloader.py" "${base_url}/${file_name}" "${destination}" "${hash}"
+    COMMAND "${command_prefix}" "${CMAKE_SOURCE_DIR}/tools/cmake/downloader.py" "${base_url}/${file_name}" "${destination}" "${hash}"
     COMMENT "Downloading: ${url}"
     VERBATIM
   )

--- a/tools/codegen/CMakeLists.txt
+++ b/tools/codegen/CMakeLists.txt
@@ -131,7 +131,7 @@ function(generateTables category)
     add_custom_command(
       OUTPUT "${generated_source_code}"
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${source_code_intermediate_directories}"
-      COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${Python3_EXECUTABLE}" "${gentable_file_path}" --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${optional_foreign_parameter} "${table_spec}" "${generated_source_code}"
+      COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${OSQUERY_PYTHON_EXECUTABLE}" "${gentable_file_path}" --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${optional_foreign_parameter} "${table_spec}" "${generated_source_code}"
       WORKING_DIRECTORY "${gentable_working_directory}"
       DEPENDS codegen_gentable "${table_spec}"
       COMMENT "Generating code for table ${category}/${table_name}..."
@@ -141,7 +141,7 @@ function(generateTables category)
     add_custom_command(
       OUTPUT "${generated_header_code}"
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${generated_headers_folder}"
-      COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${Python3_EXECUTABLE}" "${gentable_file_path}" --header --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${optional_foreign_parameter} "${table_spec}" "${generated_header_code}"
+      COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${OSQUERY_PYTHON_EXECUTABLE}" "${gentable_file_path}" --header --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${optional_foreign_parameter} "${table_spec}" "${generated_header_code}"
       WORKING_DIRECTORY "${gentable_working_directory}"
       DEPENDS codegen_gentable "${table_spec}"
       COMMENT "Generating header for table ${category}/${table_name}..."
@@ -192,7 +192,7 @@ function(generateTableCategoryAmalgamation category_name)
 
   add_custom_command(
     OUTPUT "${amalgamation_file}"
-    COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/codegen/amalgamate.py" --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${amalgamation_type} --sources "${generateTables_output}" --output "${amalgamation_file}"
+    COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${OSQUERY_PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/codegen/amalgamate.py" --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${amalgamation_type} --sources "${generateTables_output}" --output "${amalgamation_file}"
     COMMENT "Generating amalgamation file for the ${category_name} tables..."
     DEPENDS "${category_spec_files}" ${generateTables_targetList} "thirdparty_python_modules"
   )

--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ function(addPythonTest)
 
   set(python_test_command
     "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}"
-    "${Python3_EXECUTABLE}" -u ${script_name}
+    "${OSQUERY_PYTHON_EXECUTABLE}" -u ${script_name}
     --verbose --build "${CMAKE_BINARY_DIR}"
     --test-configs-dir "${TEST_CONFIGS_DIR}"
     "${osquery_test_EXTRA_ARGS}"


### PR DESCRIPTION
CMake 3.16 doesn't set Python3_EXECUTABLE as cache variable anymore,
it has changed to _Python3_EXECUTABLE which is for internal use.
The module returns Python3_EXECUTABLE as a local variable,
so we share that value through a new custom cache variable,
OSQUERY_PYTHON_EXECUTABLE.