### PR TITLE
website: Update the website specs formatting code genapi

### DIFF
--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -16,10 +16,8 @@ import uuid
 import subprocess
 
 from gentable import *
-
-SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
 from osquery_tests.tools.tests import utils
+
 
 # the log format for the logging module
 LOG_FORMAT = "%(levelname)s [Line %(lineno)d]: %(message)s"
@@ -298,5 +296,4 @@ def main(argc, argv):
 
 
 if __name__ == "__main__":
-    SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
     main(len(sys.argv), sys.argv)

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -16,10 +16,10 @@ import uuid
 import subprocess
 
 from gentable import *
-from utils import platform
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(SCRIPT_DIR + "/../tests")
+
+from osquery_tests.tools.tests import utils
 
 # the log format for the logging module
 LOG_FORMAT = "%(levelname)s [Line %(lineno)d]: %(message)s"
@@ -192,7 +192,7 @@ def gen_api(tables_path, profile={}):
             if spec_file[0] == '.' or spec_file.find("example") == 0:
                 continue
             # Exclude blacklist specific file
-            if spec_file == 'blacklist':
+            if spec_file == 'blacklist' or spec_file == 'CMakeLists.txt' or spec_file == 'BUCK':
                 continue
             platform = os.path.basename(base)
             # Exclude kernel tables

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -62,7 +62,7 @@ def url_for_spec(path):
     to the specification on GitHub.
     """
     full_path = os.path.abspath(path)
-    url = "https://github.com/facebook/osquery/blob/master"
+    url = "https://github.com/osquery/osquery/blob/master"
     osquery_found = False
     for part in full_path.split("/"):
         if osquery_found:


### PR DESCRIPTION
This script is used to generate JSON for the osquery website. We might be able to follow up and add a CMake target to run and test the code (we'll need the python testing PRs to land). For now let's update it to work with the recent `gentable` changes.