### PR TITLE
Update plist.table description

### DIFF
--- a/specs/darwin/plist.table
+++ b/specs/darwin/plist.table
@@ -2,7 +2,7 @@ table_name("plist")
 description("Read and parse a plist file.")
 schema([
     Column("key", TEXT, "Preference top-level key"),
-    Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
+    Column("subkey", TEXT, "Intermediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),
     Column("path", TEXT, "(required) read preferences from a plist",
       required=True),


### PR DESCRIPTION
Fixed typo in plist schema description

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- The code is formatted correctly, considering using `make format_check`.
- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- Support for both CMake and BUCK (we are happy to help).
- The code mostly looks and feels similar to the existing codebase.

-->
