### PR TITLE
Fix regression in oss-fuzz after moving the test config files

### DIFF
--- a/tools/harnesses/osqueryfuzz_config_corpus.sh
+++ b/tools/harnesses/osqueryfuzz_config_corpus.sh
@@ -20,7 +20,7 @@ function main() {
     exit 1
   fi
 
-  zip -j $1 $SCRIPT_DIR/../tests/*.conf
+  zip -j $1 $SCRIPT_DIR/../tests/configs/*.conf
 }
 
 main $@

--- a/tools/harnesses/osqueryfuzz_config_dict.sh
+++ b/tools/harnesses/osqueryfuzz_config_dict.sh
@@ -23,7 +23,7 @@ function main() {
   # dict format is keyword="value" or just "value" - so we need to make sure our output is quoted.
 
   egrep -h -R -o "HasMember\\(\"([^\"]+)\"\\)" ./  | sed 's/HasMember(//' | sed 's/)//' > tmp
-  egrep -h -o -e "\"([^\"]+)\"" $SCRIPT_DIR/../tests/*.conf >> tmp
+  egrep -h -o -e "\"([^\"]+)\"" $SCRIPT_DIR/../tests/configs/*.conf >> tmp
   egrep -h -o -e "\"([^\"]+)\"" $SCRIPT_DIR/../../packs/*.conf >> tmp
 
   sort tmp | uniq > $1


### PR DESCRIPTION
For a possibly longer-term solution, please look at https://github.com/osquery/osquery/issues/6131
