### PR TITLE
Make AWS kinesis status logging configurable

### DIFF
--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -43,6 +43,11 @@ FLAG(bool,
      false,
      "Enable random kinesis partition keys");
 
+FLAG(bool,
+     aws_kinesis_disable_log_status,
+     false,
+     "Disable status logs processing");
+
 Status KinesisLoggerPlugin::setUp() {
   initAwsSdk();
   forwarder_ = std::make_shared<KinesisLogForwarder>(
@@ -67,6 +72,10 @@ Status KinesisLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
 void KinesisLoggerPlugin::init(const std::string& name,
                                const std::vector<StatusLogLine>& log) {
   logStatus(log);
+}
+
+bool KinesisLoggerPlugin::usesLogStatus() {
+  return !FLAGS_aws_kinesis_disable_log_status;
 }
 
 Status KinesisLogForwarder::internalSetup() {

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -68,9 +68,7 @@ class KinesisLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
-  bool usesLogStatus() override {
-    return true;
-  }
+  bool usesLogStatus() override;
 
  private:
   void init(const std::string& name,


### PR DESCRIPTION
The AWS kineis logger plugin is sent two types of log record: results logs which are produced by scheduled queries and status logs which are produced by glog. When the logger_min_status or verbose options are used the volume of status logs can cause undesirable bandwidth usage.

Logger plugins can opt out of being sent status logs by overriding the base LoggerPlugin usesLogStatus method. The AWS kinesis logger plugin currently opts in for status logs and this cannot be configured.

This PR adds a new configuration option aws_kinesis_disable_log_status that when set to true will prevent status logs being sent to kinesis. The default value of this option is false so when not specified the previous behaviour is retained. The options can be set either as a CLI flag or in the configuration.