### PR TITLE
Add docs to show that config_dump flag exits

### DIFF
--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -67,6 +67,8 @@ osqueryi --config_path ./build/testing/invalid_osquery.conf --config_dump
 }
 ```
 
+Osqueryd will exit after printing the config.
+
 This example contains a C-style comment which was allowed in boost 1.58, but is deprecated and removed in 1.59. To be future-proof, stick to the JSON specification and do not include comments.
 
 ### Scheduled query failures and the watchdog

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -65,7 +65,7 @@ Check the format of an osquery config and exit. Arbitrary config plugins may be 
 
 `--config_dump=false`
 
-Request that the configuration JSON be printed to standard out before it is updated. In this case "updated" means applied to the active config. When osquery starts it performs an initial update from the config plugin. To quickly debug the content retrieved by custom config plugins use this in tandem with `--config_check`.
+Request that the configuration JSON be printed to standard out before it is updated, then exit the process. In this case "updated" means applied to the active config. When osquery starts it performs an initial update from the config plugin. To quickly debug the content retrieved by custom config plugins use this in tandem with `--config_check`.
 
 ### Daemon control flags
 

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -70,7 +70,10 @@ CLI_FLAG(bool,
          false,
          "Check the format of an osquery config and exit");
 
-CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration, then exit");
+CLI_FLAG(bool,
+         config_dump,
+         false,
+         "Dump the contents of the configuration, then exit");
 
 CLI_FLAG(uint64,
          config_refresh,

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -504,7 +504,7 @@ Status Config::refresh() {
                 content.first.c_str(),
                 content.second.c_str());
       }
-      LOG(INFO) << "Requesting shutdown after dumping config";
+      VLOG(1) << "Requesting shutdown after dumping config";
       // Don't force because the config plugin may have started services.
       Initializer::requestShutdown();
       return Status::success();

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -70,7 +70,7 @@ CLI_FLAG(bool,
          false,
          "Check the format of an osquery config and exit");
 
-CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration");
+CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration, then exit");
 
 CLI_FLAG(uint64,
          config_refresh,
@@ -501,6 +501,7 @@ Status Config::refresh() {
                 content.first.c_str(),
                 content.second.c_str());
       }
+      LOG(INFO) << "Requesting shutdown after dumping config";
       // Don't force because the config plugin may have started services.
       Initializer::requestShutdown();
       return Status::success();


### PR DESCRIPTION
* Add documentation and logging to show that config_dump flag will exit the
  process after printing the config.