### PR TITLE
apparmor_profiles: New table that presents active AppArmor profiles

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -137,6 +137,7 @@ osquery_cxx_library(
             [
                 "freenux/cpu_time.cpp",
                 "linux/acpi_tables.cpp",
+                "linux/apparmor_profiles.cpp",
                 "linux/block_devices.cpp",
                 "linux/deb_packages.cpp",
                 "linux/disk_encryption.cpp",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -79,6 +79,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/user_groups.cpp
       linux/users.cpp
       linux/selinux_settings.cpp
+      linux/apparmor_profiles.cpp
     )
 
   elseif(DEFINED PLATFORM_MACOS)

--- a/osquery/tables/system/linux/apparmor_profiles.cpp
+++ b/osquery/tables/system/linux/apparmor_profiles.cpp
@@ -1,0 +1,182 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include <boost/algorithm/string.hpp>
+
+namespace osquery {
+namespace tables {
+namespace {
+struct AppArmorProfile final {
+  std::string path;
+  std::string name;
+  std::string attach;
+  std::string mode;
+  std::string sha1;
+};
+
+using AppArmorProfileList = std::vector<AppArmorProfile>;
+using ProfilePathQueueEntry = std::pair<std::string, std::string>;
+using ProfilePathQueue = std::vector<ProfilePathQueueEntry>;
+
+const std::string kAppArmorProfilesPath{
+    "/sys/kernel/security/apparmor/policy/profiles"};
+
+Status generateProfile(AppArmorProfile& profile,
+                       const std::string& profile_path,
+                       const std::string& parent_name) {
+  profile = {};
+
+  auto status = readFile(profile_path + "/attach", profile.attach);
+  if (!status.ok()) {
+    return status;
+  }
+
+  boost::trim(profile.attach);
+
+  status = readFile(profile_path + "/mode", profile.mode);
+  if (!status.ok()) {
+    return status;
+  }
+
+  boost::trim(profile.mode);
+
+  status = readFile(profile_path + "/name", profile.name);
+  if (!status.ok()) {
+    return status;
+  }
+
+  boost::trim(profile.name);
+
+  status = readFile(profile_path + "/sha1", profile.sha1);
+  if (!status.ok()) {
+    return status;
+  }
+
+  boost::trim(profile.sha1);
+
+  profile.path = parent_name;
+  if (!profile.path.empty()) {
+    profile.path += "//";
+  }
+
+  profile.path += profile.name;
+  return Status::success();
+}
+
+Status generateProfilePathQueue(ProfilePathQueue& queue,
+                                const std::string& parent_name,
+                                const std::string& path) {
+  std::vector<std::string> path_list;
+
+  auto status = listDirectoriesInDirectory(path, path_list, false);
+  if (!status.ok()) {
+    return status;
+  }
+
+  for (auto& p : path_list) {
+    queue.push_back(std::make_pair(parent_name, std::move(p)));
+  }
+
+  return Status::success();
+}
+
+Status generateProfileList(AppArmorProfileList& profile_list) {
+  profile_list = {};
+
+  ProfilePathQueue profile_path_queue;
+
+  auto status =
+      generateProfilePathQueue(profile_path_queue, "", kAppArmorProfilesPath);
+
+  if (!status.ok()) {
+    return Status::failure("Failed to access AppArmor's \"profiles\" folder");
+  }
+
+  while (!profile_path_queue.empty()) {
+    auto queue_entry = profile_path_queue.back();
+    profile_path_queue.pop_back();
+
+    const auto& parent_name = queue_entry.first;
+    const auto& profile_path = queue_entry.second;
+
+    if (!isDirectory(profile_path).ok()) {
+      continue;
+    }
+
+    AppArmorProfile apparmor_profile;
+    status = generateProfile(apparmor_profile, profile_path, parent_name);
+
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed to open the following AppArmor profile: "
+                 << profile_path << ". " << status.getMessage();
+
+      continue;
+    }
+
+    auto subprofiles_folder = profile_path + "/profiles";
+    if (pathExists(subprofiles_folder).ok()) {
+      ProfilePathQueue additional_queue_items;
+
+      status = generateProfilePathQueue(
+          additional_queue_items, apparmor_profile.name, subprofiles_folder);
+
+      if (!status.ok()) {
+        LOG(ERROR) << "Failed to list the subprofiles of the following "
+                      "AppArmor profile: "
+                   << profile_path << ". " << status.getMessage();
+
+        continue;
+      }
+
+      profile_path_queue.insert(
+          profile_path_queue.end(),
+          std::make_move_iterator(additional_queue_items.begin()),
+          std::make_move_iterator(additional_queue_items.end()));
+    }
+
+    profile_list.push_back(std::move(apparmor_profile));
+  }
+
+  return Status::success();
+}
+} // namespace
+
+QueryData genAppArmorProfiles(QueryContext& context) {
+  if (!pathExists(kAppArmorProfilesPath).ok()) {
+    return {};
+  }
+
+  AppArmorProfileList profile_list;
+  auto status = generateProfileList(profile_list);
+  if (!status.ok()) {
+    LOG(ERROR) << status.getMessage();
+    return {};
+  }
+
+  QueryData row_list;
+
+  for (const auto& profile : profile_list) {
+    Row row = {};
+    row["name"] = profile.name;
+    row["mode"] = profile.mode;
+    row["attach"] = profile.attach;
+    row["sha1"] = profile.sha1;
+    row["path"] = profile.path;
+
+    row_list.push_back(std::move(row));
+  }
+
+  return row_list;
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -163,6 +163,7 @@ function(generateNativeTables)
     "linux/ec2_instance_metadata.table:linux"
     "linux/elf_sections.table:linux"
     "linux/selinux_settings.table:linux"
+    "linux/apparmor_profiles.table:linux"
     "linwin/intel_me_info.table:linux,windows"
     "lldpd/lldp_neighbors.table:linux,macos,freebsd"
     "kernel_info.table:linux,macos,windows"

--- a/specs/linux/apparmor_profiles.table
+++ b/specs/linux/apparmor_profiles.table
@@ -1,0 +1,13 @@
+table_name("apparmor_profiles")
+description("Track active AppArmor profiles.")
+schema([
+    Column("path", TEXT, "Unique, aa-status compatible, policy identifier.", index=True),
+    Column("name", TEXT, "Policy name."),
+    Column("attach", TEXT, "Which executable(s) a profile will attach to."),
+    Column("mode", TEXT, "How the policy is applied."),
+    Column("sha1", TEXT, "A unique hash that identifies this policy."),
+])
+implementation("system/apparmor_profiles@genAppArmorProfiles")
+examples([
+  "SELECT * FROM apparmor_profiles WHERE mode = 'complain'",
+])


### PR DESCRIPTION
This table provides output similar to the `apparmor_status` command

```
osquery> SELECT * FROM apparmor_profiles;
+----------------------------------------------------------------------------+-----------------------------------------------+-----------------------------------------------+----------+------------------------------------------+
| path                                                                       | name                                          | attach                                        | mode     | sha1                                     |
+----------------------------------------------------------------------------+-----------------------------------------------+-----------------------------------------------+----------+------------------------------------------+
| /usr/sbin/tcpdump                                                          | /usr/sbin/tcpdump                             | /usr/sbin/tcpdump                             | enforce  | 1fc61ebb9ca148c6f9a2260b4f97183213e90dcb |
| /usr/sbin/ippusbxd                                                         | /usr/sbin/ippusbxd                            | /usr/sbin/ippusbxd                            | enforce  | c72542a81c0450339e3fd2d1f889039ea058a287 |
| /usr/sbin/cupsd                                                            | /usr/sbin/cupsd                               | /usr/sbin/cupsd                               | enforce  | 7fa6ce9c07905f63cd3ff9079ddab8d6b312dc92 |
| /usr/sbin/cupsd//third_party                                               | third_party                                   | third_party                                   | enforce  | 350aa2c2bff09e0a7c64e76f1fcec67c066155dd |
| /usr/sbin/cups-browsed                                                     | /usr/sbin/cups-browsed                        | /usr/sbin/cups-browsed                        | enforce  | 307e7712ab17a7a681b827274f8a648bf71b5cd4 |
| /usr/lib/snapd/snap-confine                                                | /usr/lib/snapd/snap-confine                   | /usr/lib/snapd/snap-confine                   | enforce  | f41321418b4f4aff23a73bd26c601981177e089d |
| /usr/lib/snapd/snap-confine//mount-namespace-capture-helper                | mount-namespace-capture-helper                | mount-namespace-capture-helper                | enforce  | ef65bb11e3bc902d0e8a0ffd1a2aef20863498c2 |
| /usr/lib/cups/backend/cups-pdf                                             | /usr/lib/cups/backend/cups-pdf                | /usr/lib/cups/backend/cups-pdf                | enforce  | 5cbf285b0be1901e117264e0eb8178af488ce642 |
| /usr/lib/connman/scripts/dhclient-script                                   | /usr/lib/connman/scripts/dhclient-script      | /usr/lib/connman/scripts/dhclient-script      | enforce  | f596e7466ed73953c636cbbe451cc4adb2b1a9b8 |
| /usr/lib/NetworkManager/nm-dhcp-helper                                     | /usr/lib/NetworkManager/nm-dhcp-helper        | /usr/lib/NetworkManager/nm-dhcp-helper        | enforce  | 6ad196eac459e6aab3c3fa1c598bf8fe0192facd |
| /usr/lib/NetworkManager/nm-dhcp-client.action                              | /usr/lib/NetworkManager/nm-dhcp-client.action | /usr/lib/NetworkManager/nm-dhcp-client.action | enforce  | 80ab2eb917bfcb1efd788b16fe7374982c0ab935 |
| /usr/bin/man                                                               | /usr/bin/man                                  | /usr/bin/man                                  | enforce  | 9d8e9f4106474484ccac9951bf9c908f74967c30 |
| /usr/bin/evince                                                            | /usr/bin/evince                               | /usr/bin/evince                               | enforce  | d7abf46cf2589a8e58e1c6b8033694066b6a6b98 |
| /usr/bin/evince//sanitized_helper                                          | sanitized_helper                              | sanitized_helper                              | enforce  | b4e3f2d373bbff78336872316012f3767fde2857 |
| /usr/bin/evince-thumbnailer                                                | /usr/bin/evince-thumbnailer                   | /usr/bin/evince-thumbnailer                   | enforce  | d0b1e7c501e33ef9c93f6b1707ea4767f68c69cb |
| /usr/bin/evince-previewer                                                  | /usr/bin/evince-previewer                     | /usr/bin/evince-previewer                     | enforce  | 8d75a793afcde998d0bccc45701b57e59dcec76a |
| /usr/bin/evince-previewer//sanitized_helper                                | sanitized_helper                              | sanitized_helper                              | enforce  | 39e30b5422cb4d10e3b66dd879cef82f08434275 |
| snap.lxd.migrate                                                           | snap.lxd.migrate                              | snap.lxd.migrate                              | enforce  | a39c75f7b15ab76f9e19d60dad68006414fe2b18 |
| snap.lxd.lxd                                                               | snap.lxd.lxd                                  | snap.lxd.lxd                                  | enforce  | c85500632b986beff4dd79d7cbb0f1f29ac66da2 |
| snap.lxd.lxc                                                               | snap.lxd.lxc                                  | snap.lxd.lxc                                  | enforce  | 3ef300998ac569492cd9f413a60aa50d16030c22 |
| snap.lxd.hook.install                                                      | snap.lxd.hook.install                         | snap.lxd.hook.install                         | enforce  | 35514015d5c468068bb64299a99e043a46432172 |
| snap.lxd.hook.configure                                                    | snap.lxd.hook.configure                       | snap.lxd.hook.configure                       | enforce  | eaaa42fba769880190a5fa3a8baac3880465340f |
| snap.lxd.daemon                                                            | snap.lxd.daemon                               | snap.lxd.daemon                               | enforce  | 4f7237532b8a6ee1ff543aa335899cad1d2d311f |
| snap.lxd.check-kernel                                                      | snap.lxd.check-kernel                         | snap.lxd.check-kernel                         | enforce  | 219670ea5d00433ad7dce1c7e224a919d3ee95f7 |
| snap.lxd.buginfo                                                           | snap.lxd.buginfo                              | snap.lxd.buginfo                              | enforce  | 230ebf72475543843f46e42a7cef0d5a0d11ac9c |
| snap.lxd.benchmark                                                         | snap.lxd.benchmark                            | snap.lxd.benchmark                            | enforce  | 6950a832a1ba0bd2b92536f501fba7dcea5cf2b5 |
| snap.lxd.activate                                                          | snap.lxd.activate                             | snap.lxd.activate                             | enforce  | ab2366845fc8c68ddbf44e63c06f8bbef69da5aa |
| snap.core.hook.configure                                                   | snap.core.hook.configure                      | snap.core.hook.configure                      | enforce  | d9a899a47791a512c60237adc6f5c00658b82e45 |
| /snap/core/7917/usr/lib/snapd/snap-confine                                 | /snap/core/7917/usr/lib/snapd/snap-confine    | /snap/core/7917/usr/lib/snapd/snap-confine    | enforce  | 55f60bb86e4e632b00fa338896359d8ccb693c73 |
| /snap/core/7917/usr/lib/snapd/snap-confine//mount-namespace-capture-helper | mount-namespace-capture-helper                | mount-namespace-capture-helper                | enforce  | f5722704bab5a67f4437d2f50a92510769bd80df |
| snap-update-ns.lxd                                                         | snap-update-ns.lxd                            | snap-update-ns.lxd                            | enforce  | 14086c3a01a21acf5ee592920784b764816fbf89 |
| snap-update-ns.core                                                        | snap-update-ns.core                           | snap-update-ns.core                           | enforce  | 81723698cfb055fa903a6ae5be62e5aa188892e3 |
| /sbin/dhclient                                                             | /sbin/dhclient                                | /sbin/dhclient                                | enforce  | fddf65ed5b7b54240dcd535eab9b1bcba44ef44f |
| nvidia_modprobe                                                            | nvidia_modprobe                               | nvidia_modprobe                               | enforce  | d59fffe999243781cf95ff5be5b244d86baa51aa |
| nvidia_modprobe//kmod                                                      | kmod                                          | kmod                                          | enforce  | a8b79bf25311bcfb79d0bb45ce8ce6296ed174be |
| man_groff                                                                  | man_groff                                     | man_groff                                     | enforce  | 1413bf0ad2fa17af898efff5be73583913ae2023 |
| man_filter                                                                 | man_filter                                    | man_filter                                    | enforce  | c6805bd01c75f687b782945c196842407485ceb7 |
| lsb_release                                                                | lsb_release                                   | lsb_release                                   | enforce  | cda3e992e8a024e0b3a12bba6c99e4e0138512a6 |
| libreoffice-xpdfimport                                                     | libreoffice-xpdfimport                        | <unknown>                                     | enforce  | 5c6281a50320c44eb7c07f5140eb92be6bbca6e9 |
| libreoffice-soffice                                                        | libreoffice-soffice                           | <unknown>                                     | complain | 6a79f9b1dfa329439cb87e509c00b9e6b4a0c395 |
| libreoffice-soffice//gpg                                                   | gpg                                           | gpg                                           | enforce  | 9b70748f46691c45f764a43d684be16d1466c716 |
| libreoffice-senddoc                                                        | libreoffice-senddoc                           | <unknown>                                     | enforce  | 9d08b199f4bb084e6a9562d5125eb40c81e7105d |
| libreoffice-oopslash                                                       | libreoffice-oopslash                          | <unknown>                                     | complain | 2c334ed709b2af025ce2ab12686f5a87a2ca1fb6 |
+----------------------------------------------------------------------------+-----------------------------------------------+-----------------------------------------------+----------+------------------------------------------+
```