### PR TITLE
Refactor and simplify shutdown logic

### DIFF
--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -192,6 +192,14 @@ function(importBoostInterfaceLibrary folder_name)
       BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX)
   endif()
 
+  if(DEFINED PLATFORM_WINDOWS)
+    if("${folder_name}" STREQUAL "asio")
+      target_compile_definitions(${target_name} INTERFACE
+        BOOST_ASIO_WINDOWS
+      )
+    endif()
+  endif()
+
   foreach(additional_dependency ${ARGN})
 
     if(additional_dependency MATCHES "^thirdparty_")

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -158,7 +158,15 @@ void initWorkDirectories() {
 }
 
 void signalHandler(int num) {
-  Initializer::requestShutdown(128 + num);
+  int rc = 0;
+
+  // Expect SIGTERM and SIGINT to gracefully shutdown.
+  // Other signals are unexpected.
+  if (num != SIGTERM && num != SIGINT) {
+    rc = 128 + num;
+  }
+
+  Initializer::requestShutdown(rc);
 }
 } // namespace
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -616,7 +616,7 @@ void Initializer::start() const {
  * This is a small interruptable thread implementation.
  *
  * The goal is to wait until interrupted or an alarm timeout. If the timeout
- * occures then osquery is stuck shutting and and we force-terminate.
+ * occurs then osquery is stuck shutting and we force-terminate.
  */
 class AlarmRunnable : public InterruptableRunnable {
  public:
@@ -646,9 +646,8 @@ std::mutex kShutdownRequestMutex;
 bool kShutdownRequested{false};
 
 void Initializer::waitForShutdown() const {
-  // Attempt to be the only place in code where a join is attempted.
   std::unique_lock<std::mutex> lock(kShutdownRequestMutex);
-  kShutdownRequestCV.wait(lock, []{ return kShutdownRequested; });
+  kShutdownRequestCV.wait(lock, [] { return kShutdownRequested; });
 }
 
 int Initializer::shutdown(int retcode) const {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -692,7 +692,7 @@ void Initializer::requestShutdown(int retcode) {
 
     kExitCode = retcode;
     kShutdownRequested = true;
-    kShutdownRequestCV.notify_one();
+    kShutdownRequestCV.notify_all();
   });
 }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -574,7 +574,7 @@ void WatcherRunner::createWorker() {
   if (worker == nullptr) {
     // Unrecoverable error, cannot create a worker process.
     LOG(ERROR) << "osqueryd could not create a worker process";
-    Initializer::shutdown(EXIT_FAILURE);
+    Initializer::shutdownNow(EXIT_FAILURE);
     return;
   }
 
@@ -621,7 +621,7 @@ void WatcherRunner::createExtension(const std::string& extension) {
   if (ext_process == nullptr) {
     // Unrecoverable error, cannot create an extension process.
     LOG(ERROR) << "Cannot create extension process: " << extension;
-    Initializer::shutdown(EXIT_FAILURE);
+    Initializer::shutdownNow(EXIT_FAILURE);
   }
 
   watcher.setExtension(extension, ext_process);

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -81,6 +81,22 @@ class Initializer : private boost::noncopyable {
   /// Assume initialization finished, start work.
   void start() const;
 
+  /**
+   * @brief Cleanly wait for all services and components to shutdown.
+   *
+   * Enter a join of all services followed by a sync wait for event loops,
+   * then it shuts down all the components.
+   * If the main thread is out of actions it can call #shutdown.
+   */
+  int shutdown(int retcode) const;
+
+  /**
+   * @brief Attempt to join all services.
+   *
+   * If the main thread is out of actions it can call #waitThenShutdown.
+   */
+  void waitForShutdown() const;
+
  public:
   /**
    * @brief Forcefully request the application to stop.
@@ -109,22 +125,6 @@ class Initializer : private boost::noncopyable {
 
   /// Exit immediately without requesting the dispatcher to stop.
   static void shutdownNow(int retcode = EXIT_SUCCESS);
-
-  /**
-   * @brief Cleanly wait for all services and components to shutdown.
-   *
-   * Enter a join of all services followed by a sync wait for event loops,
-   * then it shuts down all the components.
-   * If the main thread is out of actions it can call #waitThenShutdown.
-   */
-  static int waitThenShutdown(int retcode);
-
-  /**
-   * @brief Attempt to join all services.
-   *
-   * If the main thread is out of actions it can call #waitThenShutdown.
-   */
-  static void waitForShutdown();
 
   /**
    * @brief Initialize any platform dependent libraries or objects

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -82,7 +82,7 @@ class Initializer : private boost::noncopyable {
   void start() const;
 
   /**
-   * @brief Cleanly shutdown all services and components to shutdown.
+   * @brief Cleanly shutdown all services and components.
    *
    * Issue interrupt/stop requests to all service threads, join them, then
    * stop the eventing system, database usage, and run any platform-specific

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -82,18 +82,31 @@ class Initializer : private boost::noncopyable {
   void start() const;
 
   /**
-   * @brief Cleanly wait for all services and components to shutdown.
+   * @brief Cleanly shutdown all services and components to shutdown.
    *
-   * Enter a join of all services followed by a sync wait for event loops,
-   * then it shuts down all the components.
+   * Issue interrupt/stop requests to all service threads, join them, then
+   * stop the eventing system, database usage, and run any platform-specific
+   * teardown logic.
+   *
+   * If a request to shutdown stored a non-0 return code, that will override
+   * the input return code if the input is 0. If the caller assumes success
+   * and something else indicated failure we return with the failure code.
+   *
    * If the main thread is out of actions it can call #shutdown.
+   *
+   * @param retcode Caller (main thread's) request return code.
+   * @return The most appropriate return code.
    */
   int shutdown(int retcode) const;
 
   /**
-   * @brief Attempt to join all services.
+   * @brief Wait until a #requestShutdown is issued.
    *
-   * If the main thread is out of actions it can call #waitThenShutdown.
+   * The #requestShutdown method is called in a signal handler or service
+   * stop event. It may also be called by osquery internal components if an
+   * unrecoverable error occurs.
+   *
+   * This method should be called before #shutdown.
    */
   void waitForShutdown() const;
 

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -185,6 +185,6 @@ int startOsquery(int argc, char* argv[]) {
     }
   }
 
-  return runner.waitThenShutdown(retcode);
+  return runner.shutdown(retcode);
 }
 } // namespace osquery

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -94,7 +94,7 @@ int profile(int argc, char* argv[]) {
   return 0;
 }
 
-int startDaemon(Initializer& runner) {
+void startDaemon(Initializer& runner) {
   runner.start();
 
   // Conditionally begin the distributed query service
@@ -108,9 +108,7 @@ int startDaemon(Initializer& runner) {
 
   osquery::events::init_syscall_tracing();
 
-  // Finally wait for a signal / interrupt to shutdown.
-  runner.waitThenShutdown();
-  return 0;
+  runner.waitForShutdown();
 }
 
 int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
@@ -137,12 +135,10 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
   } else {
     retcode = profile(argc, argv);
   }
-  // Finally shutdown.
-  runner.requestShutdown(retcode);
   return retcode;
 }
 
-int startOsquery(int argc, char* argv[], std::function<void()> shutdown) {
+int startOsquery(int argc, char* argv[]) {
   // Parse/apply flags, start registry, load logger/config plugins.
   osquery::Initializer runner(argc, argv, osquery::ToolType::SHELL_DAEMON);
 
@@ -173,16 +169,22 @@ int startOsquery(int argc, char* argv[], std::function<void()> shutdown) {
     }
   }
 
-  runner.installShutdown(shutdown);
+  int retcode = 0;
   runner.initDaemon();
 
   // When a watchdog is used, the current daemon will fork/exec into a worker.
   // In either case the watcher may start optionally loaded extensions.
   runner.initWorkerWatcher(kWatcherWorkerName);
 
-  if (runner.isDaemon()) {
-    return startDaemon(runner);
+  // Only worker processes should start a daemon or shell.
+  if (!runner.isWatcher()) {
+    if (runner.isDaemon()) {
+      startDaemon(runner);
+    } else {
+      retcode = startShell(runner, argc, argv);
+    }
   }
-  return startShell(runner, argc, argv);
+
+  return runner.waitThenShutdown(retcode);
 }
 } // namespace osquery

--- a/osquery/main/main.h
+++ b/osquery/main/main.h
@@ -30,7 +30,5 @@ Status installService(const std::string& path);
 Status uninstallService();
 
 /// Begin the platform-agnostic shell and daemon initialization.
-int startOsquery(int argc,
-                 char* argv[],
-                 std::function<void()> shutdown = nullptr);
+int startOsquery(int argc, char* argv[]);
 } // namespace osquery

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -305,9 +305,6 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
       SLOG("Failed to open handle to main thread of execution with " +
            std::to_string(le));
     }
-
-    UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
-
     break;
   }
   default:

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -37,12 +37,6 @@ static SERVICE_STATUS kServiceStatus = {0};
 
 const unsigned long kServiceShutdownWait{100};
 
-/*
- * This event is set when a SERVICE_CONTROL_STOP or SERVICE_CONTROL_SHUTDOWN
- * message is received in the ServiceControlHandler
- */
-static const std::string kStopEventName{"osqueryd-service-stop-event"};
-
 /// Logging for when we need to debug this service
 #define SLOG(s) ::osquery::DebugPrintf(s)
 
@@ -52,32 +46,6 @@ void DebugPrintf(const std::string& s) {
     ::OutputDebugStringA(dbgString.c_str());
   }
   LOG(ERROR) << s;
-}
-
-// A helper function to return a HANDLE to the named Stop Event for child
-// processes
-HANDLE getStopEvent() {
-  auto stopEvent = ::OpenEventA(
-      SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, osquery::kStopEventName.c_str());
-
-  if (stopEvent == nullptr) {
-    return stopEvent;
-  }
-
-  auto ret = WaitForSingleObject(stopEvent, 0);
-
-  // The object has already been signaled
-  if (ret == WAIT_OBJECT_0) {
-    return nullptr;
-  }
-
-  // ERROR_FILE_NOT_FOUND indicates the event was never created.
-  // Likely the process running as the daemon at the command line.
-  if (stopEvent == nullptr && GetLastError() != ERROR_FILE_NOT_FOUND) {
-    SLOG("OpenEventA failed for event name " + osquery::kStopEventName +
-         " (lasterror=" + std::to_string(GetLastError()) + ")");
-  }
-  return stopEvent;
 }
 
 static void UpdateServiceStatus(unsigned long controls,
@@ -96,29 +64,6 @@ static void UpdateServiceStatus(unsigned long controls,
          std::to_string(GetLastError()) + ")");
   }
 }
-
-static auto kShutdownCallable = ([]() {
-  // To prevent invalid access to the stop event, we return if running as shell
-  if (Initializer::isShell()) {
-    return;
-  }
-  // The event only gets initialized in the entry point of the service. Child
-  // processes and those run from the commandline will not have a stop event.
-  auto stopEvent = osquery::getStopEvent();
-  if (stopEvent != nullptr) {
-    // Wait forever, until the service handler signals us
-    ::WaitForSingleObject(stopEvent, INFINITE);
-
-    // Interrupt the worker service threads before joining
-    Dispatcher::stopServices();
-
-    auto ret = ::CloseHandle(stopEvent);
-    if (ret != TRUE) {
-      SLOG("kShutdownCallable failed to call CloseHandle with (" +
-           std::to_string(GetLastError()) + ")");
-    }
-  }
-});
 
 /*
  * Parses arguments for the Windows service. Arguments to the Windows service
@@ -342,35 +287,28 @@ Status uninstallService() {
 void WINAPI ServiceControlHandler(DWORD control_code) {
   switch (control_code) {
   case SERVICE_CONTROL_STOP:
-  case SERVICE_CONTROL_SHUTDOWN:
+  case SERVICE_CONTROL_SHUTDOWN: {
     if (kServiceStatus.dwCurrentState != SERVICE_RUNNING) {
       break;
     }
 
     // Give the main thread a chance to shutdown gracefully before exiting
     UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 3, kServiceShutdownWait);
-    {
-      auto stopEvent = osquery::getStopEvent();
-      if (stopEvent != nullptr) {
-        auto ret = SetEvent(stopEvent);
-        if (ret != TRUE) {
-          SLOG("SetEvent failed (lasterror=" + std::to_string(GetLastError()) +
-               ")");
-        }
-        CloseHandle(stopEvent);
-      }
-      auto thread = OpenThread(SYNCHRONIZE, false, kLegacyThreadId);
-      if (thread != nullptr) {
-        WaitForSingleObjectEx(thread, INFINITE, FALSE);
-        CloseHandle(thread);
-      } else {
-        SLOG("Failed to open handle to main thread of execution with " +
-             std::to_string(GetLastError()));
-      }
+
+    Initializer::requestShutdown();
+    auto thread = OpenThread(SYNCHRONIZE, false, kLegacyThreadId);
+    if (thread != nullptr) {
+      WaitForSingleObjectEx(thread, INFINITE, FALSE);
+      CloseHandle(thread);
+    } else {
+      SLOG("Failed to open handle to main thread of execution with " +
+           std::to_string(GetLastError()));
     }
+
     UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 
     break;
+  }
   default:
     break;
   }
@@ -384,26 +322,15 @@ void WINAPI ServiceMain(DWORD argc, LPSTR* argv) {
     kServiceStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
     kServiceStatus.dwServiceSpecificExitCode = 0;
     UpdateServiceStatus(0, SERVICE_START_PENDING, 0, 0);
+    UpdateServiceStatus(
+        SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN, SERVICE_RUNNING, 0, 0);
 
-    auto stopEvent =
-        ::CreateEventA(nullptr, TRUE, FALSE, kStopEventName.c_str());
-    if (stopEvent != nullptr) {
-      UpdateServiceStatus(
-          SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN, SERVICE_RUNNING, 0, 0);
-
-      ServiceArgumentParser parser(argc, argv);
-      if (parser.count() == 0) {
-        SLOG("ServiceArgumentParser failed (cmdline=" +
-             std::string(GetCommandLineA()) + ")");
-      } else {
-        osquery::startOsquery(
-            parser.count(), parser.arguments(), kShutdownCallable);
-      }
-
-      ::CloseHandle(stopEvent);
+    ServiceArgumentParser parser(argc, argv);
+    if (parser.count() == 0) {
+      SLOG("ServiceArgumentParser failed (cmdline=" +
+           std::string(GetCommandLineA()) + ")");
     } else {
-      SLOG("CreateEventA failed (lasterror=" + std::to_string(GetLastError()) +
-           ")");
+      osquery::startOsquery(parser.count(), parser.arguments());
     }
   } else {
     SLOG("RegisterServiceCtrlHandlerA failed (lasterror=" +
@@ -420,6 +347,7 @@ int main(int argc, char* argv[]) {
        static_cast<LPSERVICE_MAIN_FUNCTION>(osquery::ServiceMain)},
       {nullptr, nullptr}};
 
+  int retcode = 0;
   if (!StartServiceCtrlDispatcherA(serviceTable)) {
     DWORD last_error = ::GetLastError();
     if (last_error == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
@@ -427,12 +355,12 @@ int main(int argc, char* argv[]) {
       // usually indicates that the process was not started as a service.
       // Therefore, it must've been started from the commandline or as a child
       // process
-      osquery::startOsquery(argc, argv, osquery::kShutdownCallable);
+      retcode = osquery::startOsquery(argc, argv);
     } else {
       // An actual error has occurred at this point
       SLOG("StartServiceCtrlDispatcherA error (lasterror=" +
            std::to_string(last_error) + ")");
     }
   }
-  return 0;
+  return retcode;
 }

--- a/osquery/process/posix/process_ops.cpp
+++ b/osquery/process/posix/process_ops.cpp
@@ -70,8 +70,4 @@ int platformGetPid() {
 uint64_t platformGetTid() {
   return std::hash<std::thread::id>()(std::this_thread::get_id());
 }
-
-void platformMainThreadExit(int excode) {
-  exit(excode);
-}
 }

--- a/osquery/process/process.h
+++ b/osquery/process/process.h
@@ -268,14 +268,4 @@ int platformGetPid();
  * and on posix platforms returns gettid()
  */
 uint64_t platformGetTid();
-
-/**
- * @brief Allows for platform specific exit logic
- *
- * On Windows this makes use of a thread specific exit APIs
- * to ensure that our main threads shutdown and notify the SCM
- * thread so we can close the service cleanly. On posix this is
- * just a stub to exit()
- */
-void platformMainThreadExit(int excode);
 } // namespace osquery

--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -251,8 +251,4 @@ int platformGetPid() {
 uint64_t platformGetTid() {
   return GetCurrentThreadId();
 }
-
-void platformMainThreadExit(int excode) {
-  ExitThread(static_cast<DWORD>(excode));
-}
 }

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -145,7 +145,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         os.kill(daemon.pid, signal.SIGINT)
         self.assertTrue(daemon.isDead(daemon.pid, 10))
         if os.name != "nt":
-            self.assertTrue(daemon.retcode in [128 + signal.SIGINT, -2])
+            self.assertTrue(daemon.retcode in [0])
 
     @test_base.flaky
     def test_6_logger_mode(self):


### PR DESCRIPTION
The windows documentation mentions that ExitThread should not be used in C++ code. When debugging these exit flows I saw exceptions when running dtors.

> I think this is related to the `test_osqueryd.py`'s `test_3_daemon_lost_worker` hang. I have this test running in a loop now to verify.

As a follow up to the investigation referenced above, I reviewed how osquery shuts down gracefully and attempted to simplify the code.

### How osquery starts

There are essentially two entry points to osquery code, from `main` or as a Windows service `ServiceMain`. These should flow and spend all execution time in `osquery::startOsquery`.

### How osquery waits to stop

The process then makes two decisions:
- If it is a daemon (using the CLI flag or named `osqueryd`) it becomes a daemon (execute a schedule) otherwise a shell (and execute a REPL).
- If the watchdog is used the process forks and the parent becomes a watchdog and the child becomes a worker.

If a watchdog is not used then "watchdog-like" features still run for example auto-load extensions are searched, executed, and watched in another thread. So there are important distinctions to clarify about startup action:
- Is a watchdog used and is the process a watchdog
- Is a watchdog used and is the process a worker
- Is a watchdog not used

A daemon worker, and a daemon watchdog process should eventually wait using `waitForShutdown`.

### How osquery stops

There are two categories of stoppage.
- The process is requested to stop by a Windows service control handler (using `RegisterServiceCtrlHandlerA`), by a POSIX SIGTERM or SIGINT. On Linux a SIGTERM is used to stop the service.
- An internal error state occurs and osquery cannot recover.

In the former case where the OS's service management requests a stop, anywhere in osquery code a call to `requestShutdown` can be made (from any thread). This notifies a conditional variable being waited in `waitForShutdown` such that the main thread can begin termination, join all threads, and exit from `main` or `ServiceMain`.

In the later case osquery may also request shutdown gracefully using `requestShutdown` or exit immediately with `shutdownNow`. Exiting immediately has undefined behavior and should only be used rarely. (Auditing this usage is outside the scope of this PR.)

When a graceful shutdown is attempted an alarm thread is created to force shutdown after a reasonable timeout.

### Assertions

- osquery should try to return from `main` or `ServiceMain` in most cases
- [...] must only stop service threads from the main thread in a single location


NB: This is a good first step towards decoupling osquery internal components. Right now extensions rely on `Initializer` (which has a lot of dependencies) for the `::requestShutdown` method. In a follow up PR we can move the shutdown-request logic out of `Initializer` and into a smaller independent target.