### PR TITLE
bug: Fix race in Dispatcher adding and stopping

### DIFF
--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -37,7 +37,6 @@
 #include <thread>
 #include <vector>
 
-
 namespace osquery {
 
 DECLARE_uint64(config_refresh);
@@ -80,6 +79,13 @@ class ConfigTests : public testing::Test {
   void TearDown() {
     fs::remove_all(fake_directory_);
     FLAGS_config_refresh = refresh_;
+  }
+
+  void resetDispatcher() {
+    auto& dispatcher = Dispatcher::instance();
+    dispatcher.stopServices();
+    dispatcher.joinServices();
+    dispatcher.resetStopping();
   }
 
  protected:
@@ -560,8 +566,7 @@ TEST_F(ConfigTests, test_config_refresh) {
   get().reset();
 
   // Stop the existing refresh runner thread.
-  Dispatcher::stopServices();
-  Dispatcher::joinServices();
+  resetDispatcher();
 
   // Set a config_refresh value to convince the Config to start the thread.
   FLAGS_config_refresh = 2;
@@ -603,8 +608,7 @@ TEST_F(ConfigTests, test_config_refresh) {
   EXPECT_EQ(get().getRefresh(), FLAGS_config_refresh);
 
   // Stop the new refresh runner thread.
-  Dispatcher::stopServices();
-  Dispatcher::joinServices();
+  resetDispatcher();
 
   FLAGS_config_refresh = refresh;
   FLAGS_config_accelerated_refresh = refresh_acceleratred;

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -85,6 +85,11 @@ Status Dispatcher::addService(InternalRunnableRef service) {
   return Status::success();
 }
 
+void Dispatcher::resetStopping() {
+  WriteLock lock(mutex_);
+  stopping_ = false;
+}
+
 void Dispatcher::removeService(const InternalRunnable* service) {
   auto& self = Dispatcher::instance();
   WriteLock lock(self.mutex_);
@@ -137,7 +142,6 @@ void Dispatcher::joinServices() {
     }
   }
 
-  self.stopping_ = false;
   DLOG(INFO) << "Services and threads have been cleared";
 }
 

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -76,8 +76,8 @@ Status Dispatcher::addService(InternalRunnableRef service) {
     auto thread = std::make_unique<std::thread>(
         std::bind(&InternalRunnable::run, &*service));
     DLOG(INFO) << "Adding new service: " << service->name() << " ("
-              << service.get() << ") to thread: " << thread->get_id() << " ("
-              << thread.get() << ") in process " << platformGetPid();
+               << service.get() << ") to thread: " << thread->get_id() << " ("
+               << thread.get() << ") in process " << platformGetPid();
 
     self.service_threads_.push_back(std::move(thread));
     self.services_.push_back(std::move(service));

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -65,20 +65,19 @@ Status Dispatcher::addService(InternalRunnableRef service) {
   }
 
   auto& self = instance();
-  if (self.stopping_) {
-    // Cannot add a service while the dispatcher is stopping and no joins
-    // have been requested.
-    return Status(1, "Cannot add service, dispatcher is stopping");
-  }
-
-  auto thread = std::make_unique<std::thread>(
-      std::bind(&InternalRunnable::run, &*service));
-
-  DLOG(INFO) << "Adding new service: " << service->name() << " ("
-             << service.get() << ") to thread: " << thread->get_id() << " ("
-             << thread.get() << ") in process " << platformGetPid();
   {
     WriteLock lock(self.mutex_);
+    if (self.stopping_) {
+      // Cannot add a service while the dispatcher is stopping and no joins
+      // have been requested.
+      return Status(1, "Cannot add service, dispatcher is stopping");
+    }
+
+    auto thread = std::make_unique<std::thread>(
+        std::bind(&InternalRunnable::run, &*service));
+    DLOG(INFO) << "Adding new service: " << service->name() << " ("
+              << service.get() << ") to thread: " << thread->get_id() << " ("
+              << thread.get() << ") in process " << platformGetPid();
 
     self.service_threads_.push_back(std::move(thread));
     self.services_.push_back(std::move(service));
@@ -144,11 +143,11 @@ void Dispatcher::joinServices() {
 
 void Dispatcher::stopServices() {
   auto& self = instance();
-  self.stopping_ = true;
-
-  WriteLock lock(self.mutex_);
   DLOG(INFO) << "Thread: " << std::this_thread::get_id()
              << " requesting a stop";
+
+  WriteLock lock(self.mutex_);
+  self.stopping_ = true;
   for (const auto& service : self.services_) {
     assureRun(service);
     service->interrupt();

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -65,11 +65,18 @@ class ExtensionsTest : public testing::Test {
   }
 
   void TearDown() override {
-    Dispatcher::stopServices();
-    Dispatcher::joinServices();
+    resetDispatcher();
+
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
       fs::remove(fs::path(socket_path));
     }
+  }
+
+  void resetDispatcher() {
+    auto& dispatcher = Dispatcher::instance();
+    dispatcher.stopServices();
+    dispatcher.joinServices();
+    dispatcher.resetStopping();
   }
 
   bool ping(int attempts = 3) {

--- a/osquery/include/osquery/dispatcher.h
+++ b/osquery/include/osquery/dispatcher.h
@@ -161,9 +161,7 @@ class Dispatcher : private boost::noncopyable {
 
  private:
   /// For testing only, reset the stopping status for unittests.
-  void resetStopping() {
-    stopping_ = false;
-  }
+  void resetStopping();
 
  private:
   /// The set of shared osquery service threads.
@@ -187,11 +185,14 @@ class Dispatcher : private boost::noncopyable {
    * A future join will be requested AFTER all services were expected to have
    * been interrupted.
    */
-  std::atomic<bool> stopping_{false};
+  bool stopping_{false};
 
  private:
   friend class InternalRunnable;
-  friend class ExtensionsTests;
+
+  // Tests
+  friend class ConfigTests;
   friend class DispatcherTests;
+  friend class ExtensionsTest;
 };
 } // namespace osquery


### PR DESCRIPTION
Fixes #6139.

We do not want to add any services after the dispatcher enters the stopping state. To accomplish this we first acquire a lock in both places then check or set the stopping state.