### PR TITLE
Add missing validation to fix `last` table

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -35,6 +35,7 @@ osquery_cxx_library(
                 "posix/shell_history.h",
                 "posix/sudoers.h",
                 "posix/sysctl_utils.h",
+                "posix/last.h",
             ],
         ),
         (

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -275,6 +275,7 @@ function(generateOsqueryTablesSystemSystemtable)
       posix/shell_history.h
       posix/sudoers.h
       posix/sysctl_utils.h
+      posix/last.h
     )
   endif()
 

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -17,14 +17,14 @@ namespace tables {
 namespace impl {
 
 void genLastAccessForRow(const utmpx& ut, QueryData& results) {
-  if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
+  if (ut.ut_type == USER_PROCESS || ut.ut_type == DEAD_PROCESS) {
     Row r;
-    r["username"] = TEXT(ut->ut_user);
-    r["tty"] = TEXT(ut->ut_line);
-    r["pid"] = INTEGER(ut->ut_pid);
-    r["type"] = INTEGER(ut->ut_type);
-    r["time"] = INTEGER(ut->ut_tv.tv_sec);
-    r["host"] = TEXT(ut->ut_host);
+    r["username"] = TEXT(ut.ut_user);
+    r["tty"] = TEXT(ut.ut_line);
+    r["pid"] = INTEGER(ut.ut_pid);
+    r["type"] = INTEGER(ut.ut_type);
+    r["time"] = INTEGER(ut.ut_tv.tv_sec);
+    r["host"] = TEXT(ut.ut_host);
     results.push_back(r);
   }
 }

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -16,7 +16,7 @@ namespace tables {
 
 namespace impl {
 
-void genLastAccessForRow(const utmpx* ut, QueryData& results) {
+void genLastAccessForRow(const utmpx& ut, QueryData& results) {
   if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
     Row r;
     r["username"] = TEXT(ut->ut_user);

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -6,17 +6,30 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <vector>
-#include <string>
-
 #include <utmpx.h>
 
 #include <osquery/core.h>
 #include <osquery/tables.h>
-#include <osquery/utils/system/time.h>
 
 namespace osquery {
 namespace tables {
+
+namespace impl {
+
+void genLastAccessForRow(utmpx* ut, QueryData& results) {
+  if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
+    Row r;
+    r["username"] = TEXT(ut->ut_user);
+    r["tty"] = TEXT(ut->ut_line);
+    r["pid"] = INTEGER(ut->ut_pid);
+    r["type"] = INTEGER(ut->ut_type);
+    r["time"] = INTEGER(ut->ut_tv.tv_sec);
+    r["host"] = TEXT(ut->ut_host);
+    results.push_back(r);
+  }
+}
+
+} // namespace impl
 
 QueryData genLastAccess(QueryContext& context) {
   QueryData results;
@@ -28,24 +41,13 @@ QueryData genLastAccess(QueryContext& context) {
 #else
 
 #ifndef __FreeBSD__
-  utmpxname("/var/log/wtmpx");
+  utmpxname(_PATH_WTMP);
 #endif
   setutxent();
 
   while ((ut = getutxent()) != nullptr) {
 #endif
-
-    if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
-      Row r;
-      r["username"] = TEXT(ut->ut_user);
-      r["tty"] = TEXT(ut->ut_line);
-      r["pid"] = INTEGER(ut->ut_pid);
-      r["type"] = INTEGER(ut->ut_type);
-      r["time"] = INTEGER(ut->ut_tv.tv_sec);
-      r["host"] = TEXT(ut->ut_host);
-
-      results.push_back(r);
-    }
+    impl::genLastAccessForRow(ut, results);
   }
 
 #ifdef __APPLE__
@@ -53,7 +55,6 @@ QueryData genLastAccess(QueryContext& context) {
 #else
   endutxent();
 #endif
-
   return results;
 }
 }

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -47,7 +47,7 @@ QueryData genLastAccess(QueryContext& context) {
 
   while ((ut = getutxent()) != nullptr) {
 #endif
-    impl::genLastAccessForRow(ut, results);
+    impl::genLastAccessForRow(*ut, results);
   }
 
 #ifdef __APPLE__

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -16,7 +16,7 @@ namespace tables {
 
 namespace impl {
 
-void genLastAccessForRow(utmpx* ut, QueryData& results) {
+void genLastAccessForRow(const utmpx* ut, QueryData& results) {
   if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
     Row r;
     r["username"] = TEXT(ut->ut_user);

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -35,7 +35,7 @@ QueryData genLastAccess(QueryContext& context) {
   while ((ut = getutxent()) != nullptr) {
 #endif
 
-    if (ut->ut_type == USER_PROCESS) {
+    if (ut->ut_type == USER_PROCESS || ut->ut_type == DEAD_PROCESS) {
       Row r;
       r["username"] = TEXT(ut->ut_user);
       r["tty"] = TEXT(ut->ut_line);

--- a/osquery/tables/system/posix/last.h
+++ b/osquery/tables/system/posix/last.h
@@ -1,0 +1,27 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/query.h>
+#include <osquery/tables.h>
+
+#include <utmpx.h>
+
+namespace osquery {
+namespace tables {
+
+QueryData genLastAccess(QueryContext& context);
+
+namespace impl {
+
+void genLastAccessForRow(utmpx* ut,
+                        QueryData& results);
+
+} // namespace impl
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/last.h
+++ b/osquery/tables/system/posix/last.h
@@ -18,8 +18,7 @@ QueryData genLastAccess(QueryContext& context);
 
 namespace impl {
 
-void genLastAccessForRow(utmpx* ut,
-                        QueryData& results);
+void genLastAccessForRow(utmpx* ut, QueryData& results);
 
 } // namespace impl
 

--- a/osquery/tables/system/posix/last.h
+++ b/osquery/tables/system/posix/last.h
@@ -18,7 +18,7 @@ QueryData genLastAccess(QueryContext& context);
 
 namespace impl {
 
-void genLastAccessForRow(utmpx* ut, QueryData& results);
+void genLastAccessForRow(const utmpx* ut, QueryData& results);
 
 } // namespace impl
 

--- a/osquery/tables/system/posix/last.h
+++ b/osquery/tables/system/posix/last.h
@@ -18,7 +18,7 @@ QueryData genLastAccess(QueryContext& context);
 
 namespace impl {
 
-void genLastAccessForRow(const utmpx* ut, QueryData& results);
+void genLastAccessForRow(const utmpx& ut, QueryData& results);
 
 } // namespace impl
 

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ function(generateOsqueryTablesSystemPosixTests)
     posix/shell_history_tests.cpp
     posix/sudoers_tests.cpp
     posix/yum_sources_tests.cpp
+    posix/last_tests.cpp
   )
 
   target_link_libraries(osquery_tables_system_posix_tests-test PRIVATE

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+
+#include <osquery/tables/system/posix/last.h>
+#include <osquery/utils/scope_guard.h>
+
+#include <utmp.h>
+#include <pwd.h>
+
+namespace osquery {
+namespace tables {
+
+class LastImplTests : public testing::Test {};
+
+TEST_F(LastImplTests, gen_row_from_utmpx) {
+  QueryData results;
+  struct utmpx ut_login;
+  struct utmpx ut_badtype;
+  struct utmpx ut_logout;
+
+  ut_login.ut_user = "osquery";
+  ut_login.ut_line = "line";
+  ut_login.ut_type = USER_PROCESS;
+  ut_login.ut_pid = 1337;
+  ut_login.ut_tv.tv_sec = 1577836800;
+  ut_login.ut_host = "test_host";
+
+  ut_badtype.ut_type = INIT_PROCESS;
+
+  ut_logout.ut_line = "line";
+  ut_logout.ut_type = DEAD_PROCESS;
+  ut_logout.ut_pid = 1337;
+  ut_logout.ut_tv.tv_sec = 1577836900;
+
+  impl::genLastAccessForRow(&ut_login, results);
+  impl::genLastAccessForRow(&ut_badtype, results);
+  impl::genLastAccessForRow(&ut_logout, results);
+
+  ASSERT_EQ(results.size(), 2);
+
+  const auto& first_row = results[0];
+  EXPECT_EQ(first_row.at("username"), ut_login.ut_user);
+  EXPECT_EQ(first_row.at("tty"), ut_login.ut_user);
+  EXPECT_EQ(first_row.at("pid"), ut_login.ut_pid);
+  EXPECT_EQ(first_row.at("type"), ut_login.ut_type);
+  EXPECT_EQ(first_row.at("host"), ut_login.ut_host);
+
+  const auto& second_row = results[1];
+  EXPECT_EQ(second_row.at("username"), "");
+  EXPECT_EQ(second_row.at("tty"), ut_logout.ut_user);
+  EXPECT_EQ(second_row.at("pid"), ut_logout.ut_pid);
+  EXPECT_EQ(second_row.at("type"), ut_logout.ut_type);
+  EXPECT_EQ(second_row.at("host"), "");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -6,16 +6,12 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <fstream>
-
-#include <boost/filesystem.hpp>
+#include <string>
 #include <gtest/gtest.h>
 
 #include <osquery/tables/system/posix/last.h>
-#include <osquery/utils/scope_guard.h>
 
 #include <utmp.h>
-#include <pwd.h>
 
 namespace osquery {
 namespace tables {
@@ -28,16 +24,16 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
   struct utmpx ut_badtype;
   struct utmpx ut_logout;
 
-  ut_login.ut_user = "osquery";
-  ut_login.ut_line = "line";
+  strcpy(ut_login.ut_user, "osquery");
+  strcpy(ut_login.ut_line, "line");
   ut_login.ut_type = USER_PROCESS;
   ut_login.ut_pid = 1337;
   ut_login.ut_tv.tv_sec = 1577836800;
-  ut_login.ut_host = "test_host";
+  strcpy(ut_login.ut_host,"test_host");
 
   ut_badtype.ut_type = INIT_PROCESS;
 
-  ut_logout.ut_line = "line";
+  strcpy(ut_logout.ut_line, "line");
   ut_logout.ut_type = DEAD_PROCESS;
   ut_logout.ut_pid = 1337;
   ut_logout.ut_tv.tv_sec = 1577836900;
@@ -50,16 +46,16 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
 
   const auto& first_row = results[0];
   EXPECT_EQ(first_row.at("username"), ut_login.ut_user);
-  EXPECT_EQ(first_row.at("tty"), ut_login.ut_user);
-  EXPECT_EQ(first_row.at("pid"), ut_login.ut_pid);
-  EXPECT_EQ(first_row.at("type"), ut_login.ut_type);
+  EXPECT_EQ(first_row.at("tty"), ut_login.ut_line);
+  ASSERT_EQ(std::stoi(first_row.at("pid")), ut_login.ut_pid);
+  ASSERT_EQ(std::stoi(first_row.at("type")), ut_login.ut_type);
   EXPECT_EQ(first_row.at("host"), ut_login.ut_host);
 
   const auto& second_row = results[1];
   EXPECT_EQ(second_row.at("username"), "");
-  EXPECT_EQ(second_row.at("tty"), ut_logout.ut_user);
-  EXPECT_EQ(second_row.at("pid"), ut_logout.ut_pid);
-  EXPECT_EQ(second_row.at("type"), ut_logout.ut_type);
+  EXPECT_EQ(second_row.at("tty"), ut_logout.ut_line);
+  ASSERT_EQ(std::stoi(second_row.at("pid")), ut_logout.ut_pid);
+  EXPECT_EQ(std::stoi(second_row.at("type")), ut_logout.ut_type);
   EXPECT_EQ(second_row.at("host"), "");
 }
 

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -6,8 +6,8 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <string>
 #include <gtest/gtest.h>
+#include <string>
 
 #include <osquery/tables/system/posix/last.h>
 
@@ -29,7 +29,7 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
   ut_login.ut_type = USER_PROCESS;
   ut_login.ut_pid = 1337;
   ut_login.ut_tv.tv_sec = 1577836800;
-  strcpy(ut_login.ut_host,"test_host");
+  strcpy(ut_login.ut_host, "test_host");
 
   ut_badtype.ut_type = INIT_PROCESS;
 
@@ -38,7 +38,7 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
   ut_logout.ut_type = DEAD_PROCESS;
   ut_logout.ut_pid = 1337;
   ut_logout.ut_tv.tv_sec = 1577836900;
-  strcpy(ut_logout.ut_host,"");
+  strcpy(ut_logout.ut_host, "");
 
   impl::genLastAccessForRow(&ut_login, results);
   impl::genLastAccessForRow(&ut_badtype, results);

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -39,7 +39,7 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
   ut_logout.ut_tv.tv_sec = 1577836900;
 
   impl::genLastAccessForRow(&ut_login, results);
-  impl::genLastAccessForRow(&ut_badtype, results);
+  impl::genLastAccessForRow(ut_badtype, results);
   impl::genLastAccessForRow(&ut_logout, results);
 
   ASSERT_EQ(results.size(), 2);

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -38,7 +38,7 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
   ut_logout.ut_pid = 1337;
   ut_logout.ut_tv.tv_sec = 1577836900;
 
-  impl::genLastAccessForRow(&ut_login, results);
+  impl::genLastAccessForRow(ut_login, results);
   impl::genLastAccessForRow(ut_badtype, results);
   impl::genLastAccessForRow(&ut_logout, results);
 

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -40,7 +40,7 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
 
   impl::genLastAccessForRow(ut_login, results);
   impl::genLastAccessForRow(ut_badtype, results);
-  impl::genLastAccessForRow(&ut_logout, results);
+  impl::genLastAccessForRow(ut_logout, results);
 
   ASSERT_EQ(results.size(), 2);
 

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -33,10 +33,12 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
 
   ut_badtype.ut_type = INIT_PROCESS;
 
+  strcpy(ut_logout.ut_user, "");
   strcpy(ut_logout.ut_line, "line");
   ut_logout.ut_type = DEAD_PROCESS;
   ut_logout.ut_pid = 1337;
   ut_logout.ut_tv.tv_sec = 1577836900;
+  strcpy(ut_logout.ut_host,"");
 
   impl::genLastAccessForRow(&ut_login, results);
   impl::genLastAccessForRow(&ut_badtype, results);

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -20,9 +20,9 @@ class LastImplTests : public testing::Test {};
 
 TEST_F(LastImplTests, gen_row_from_utmpx) {
   QueryData results;
-  struct utmpx ut_login{};
-  struct utmpx ut_badtype{};
-  struct utmpx ut_logout{};
+  struct utmpx ut_login {};
+  struct utmpx ut_badtype {};
+  struct utmpx ut_logout {};
 
   strcpy(ut_login.ut_user, "osquery");
   strcpy(ut_login.ut_line, "line");

--- a/osquery/tables/system/tests/posix/last_tests.cpp
+++ b/osquery/tables/system/tests/posix/last_tests.cpp
@@ -11,7 +11,7 @@
 
 #include <osquery/tables/system/posix/last.h>
 
-#include <utmp.h>
+#include <utmpx.h>
 
 namespace osquery {
 namespace tables {
@@ -20,9 +20,9 @@ class LastImplTests : public testing::Test {};
 
 TEST_F(LastImplTests, gen_row_from_utmpx) {
   QueryData results;
-  struct utmpx ut_login;
-  struct utmpx ut_badtype;
-  struct utmpx ut_logout;
+  struct utmpx ut_login{};
+  struct utmpx ut_badtype{};
+  struct utmpx ut_logout{};
 
   strcpy(ut_login.ut_user, "osquery");
   strcpy(ut_login.ut_line, "line");
@@ -33,12 +33,10 @@ TEST_F(LastImplTests, gen_row_from_utmpx) {
 
   ut_badtype.ut_type = INIT_PROCESS;
 
-  strcpy(ut_logout.ut_user, "");
   strcpy(ut_logout.ut_line, "line");
   ut_logout.ut_type = DEAD_PROCESS;
   ut_logout.ut_pid = 1337;
   ut_logout.ut_tv.tv_sec = 1577836900;
-  strcpy(ut_logout.ut_host, "");
 
   impl::genLastAccessForRow(&ut_login, results);
   impl::genLastAccessForRow(&ut_badtype, results);

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -25,22 +25,18 @@ TEST_F(last, test_sanity) {
   // 1. Query data
   auto const data = execute_query("select * from last");
   // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
+  ASSERT_FALSE(data.empty());
   // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"username", NormalType}
-  //      {"tty", NormalType}
-  //      {"pid", IntType}
-  //      {"type", IntType}
-  //      {"time", IntType}
-  //      {"host", NormalType}
-  //}
+   ValidationMap row_map = {
+        {"username", NormalType}
+        {"tty", NormalType}
+        {"pid", NonNegativeInt}
+        {"type", IntMinMaxCheck(7, 8)}
+        {"time", NonNegativeInt}
+        {"host", verifyEmptyStringOrIpAddress}
+  }
   // 4. Perform validation
-  // validate_rows(data, row_map);
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -27,9 +27,14 @@ TEST_F(last, test_sanity) {
   // 2. Check size before validation
   ASSERT_FALSE(data.empty());
   // 3. Build validation map
-  ValidationMap row_map = {{"username", NormalType} {"tty", NormalType} {
-      "pid", NonNegativeInt} {"type", IntMinMaxCheck(7, 8)} {
-      "time", NonNegativeInt} {"host", verifyEmptyStringOrIpAddress}};
+  ValidationMap row_map = {
+    {"username", NormalType},
+    {"tty", NormalType},
+    {"pid", NonNegativeInt},
+    {"type", IntMinMaxCheck(7, 8)},
+    {"time", NonNegativeInt},
+    {"host", verifyEmptyStringOrIpAddress}
+  };
   // 4. Perform validation
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -9,8 +9,8 @@
 // Sanity check integration test for last
 // Spec file: specs/posix/last.table
 
-#include <osquery/tests/integration/tables/helper.h>
 #include <osquery/logger.h>
+#include <osquery/tests/integration/tables/helper.h>
 
 namespace osquery {
 namespace table_tests {

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -27,14 +27,14 @@ TEST_F(last, test_sanity) {
   // 2. Check size before validation
   ASSERT_FALSE(data.empty());
   // 3. Build validation map
-   ValidationMap row_map = {
-        {"username", NormalType}
-        {"tty", NormalType}
-        {"pid", NonNegativeInt}
-        {"type", IntMinMaxCheck(7, 8)}
-        {"time", NonNegativeInt}
-        {"host", verifyEmptyStringOrIpAddress}
-  }
+  ValidationMap row_map = {
+      {"username", NormalType}
+      {"tty", NormalType}
+      {"pid", NonNegativeInt}
+      {"type", IntMinMaxCheck(7, 8)}
+      {"time", NonNegativeInt}
+      {"host", verifyEmptyStringOrIpAddress}
+  };
   // 4. Perform validation
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -10,6 +10,7 @@
 // Spec file: specs/posix/last.table
 
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/logger.h>
 
 namespace osquery {
 namespace table_tests {
@@ -25,15 +26,18 @@ TEST_F(last, test_sanity) {
   // 1. Query data
   auto const data = execute_query("select * from last");
   // 2. Check size before validation
-  ASSERT_FALSE(data.empty());
+  if (data.empty()) {
+    LOG(WARNING) << "No entries in wtmp, skipping test";
+    return;
+  }
   // 3. Build validation map
   ValidationMap row_map = {
-    {"username", NormalType},
-    {"tty", NormalType},
-    {"pid", NonNegativeInt},
-    {"type", IntMinMaxCheck(7, 8)},
-    {"time", NonNegativeInt},
-    {"host", verifyEmptyStringOrIpAddress},
+      {"username", NormalType},
+      {"tty", NormalType},
+      {"pid", NonNegativeInt},
+      {"type", IntMinMaxCheck(7, 8)},
+      {"time", NonNegativeInt},
+      {"host", verifyEmptyStringOrIpAddress},
   };
   // 4. Perform validation
   validate_rows(data, row_map);

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -33,7 +33,7 @@ TEST_F(last, test_sanity) {
     {"pid", NonNegativeInt},
     {"type", IntMinMaxCheck(7, 8)},
     {"time", NonNegativeInt},
-    {"host", verifyEmptyStringOrIpAddress}
+    {"host", verifyEmptyStringOrIpAddress},
   };
   // 4. Perform validation
   validate_rows(data, row_map);

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -27,14 +27,9 @@ TEST_F(last, test_sanity) {
   // 2. Check size before validation
   ASSERT_FALSE(data.empty());
   // 3. Build validation map
-  ValidationMap row_map = {
-      {"username", NormalType}
-      {"tty", NormalType}
-      {"pid", NonNegativeInt}
-      {"type", IntMinMaxCheck(7, 8)}
-      {"time", NonNegativeInt}
-      {"host", verifyEmptyStringOrIpAddress}
-  };
+  ValidationMap row_map = {{"username", NormalType} {"tty", NormalType} {
+      "pid", NonNegativeInt} {"type", IntMinMaxCheck(7, 8)} {
+      "time", NonNegativeInt} {"host", verifyEmptyStringOrIpAddress}};
   // 4. Perform validation
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -37,7 +37,7 @@ TEST_F(last, test_sanity) {
       {"pid", NonNegativeInt},
       {"type", IntMinMaxCheck(7, 8)},
       {"time", NonNegativeInt},
-      {"host", verifyEmptyStringOrIpAddress},
+      {"host", NormalType},
   };
   // 4. Perform validation
   validate_rows(data, row_map);


### PR DESCRIPTION
A validation was added to the `genLastAccess` function (https://github.com/osquery/osquery/pull/5274) which would filter for login events only (`USER_PROCESS`). This change breaks the intent of the `last` table, which should show logins and logouts.

This PR updates extracts the `last` implementation to its own function, which is OS independent, enabling tests to be made to the implementation, as well as adding a test for the content (if existing) of the `last` table.

The reasoning for the validation in the first place is to remove information unrelated to user login/logout (check `man wtmp` for more info).