### PR TITLE
flags: Implement enable_tables

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -508,3 +508,14 @@ Time period in _seconds_ for numeric monitoring pre-aggreagation buffer. During 
 `--numeric_monitoring_filesystem_path=OSQUERY_LOG_HOME/numeric_monitoring.log`
 
 File to dump numeric monitoring records one per line. The format of the line is `<PATH><TAB><VALUE><TAB><TIMESTAMP>`. File will be opened in append mode.
+
+
+### Whitelisting and blacklisting flags
+
+`--disable_tables=table1,table2`
+
+Comma separated list of tables to blacklist. By default no tables are disabled.
+
+`--enable_tables=table1,table2`
+
+Comma separated list of tables to whitelist. By default every tables are enabled. If a specific table is set in both `--enable_tables` and `--disable_tables`, blacklisting take precedence and the table is disabled. If `--enable_tables` is defined and `--disable_tables` is not set, every tables but the one defined in `-enable_tables` are disabled.

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -27,12 +27,12 @@ namespace osquery {
 
 FLAG(string,
      disable_tables,
-     "Not Specified",
+     "",
      "Comma-delimited list of table names to be disabled");
 
 FLAG(string,
      enable_tables,
-     "Not Specified",
+     "",
      "Comma-delimited list of table names to be enabled");
 
 FLAG(string, nullvalue, "", "Set string for NULL values, default ''");
@@ -370,10 +370,8 @@ SQLiteDBManager::SQLiteDBManager() : db_(nullptr) {
 }
 
 bool SQLiteDBManager::isDisabled(const std::string& table_name) {
-  bool disabled_set = !(instance().disabled_tables_.find("Not Specified") !=
-                        instance().disabled_tables_.end());
-  bool enabled_set = !(instance().enabled_tables_.find("Not Specified") !=
-                       instance().enabled_tables_.end());
+  bool disabled_set = !Flag::isDefault("disable_tables");
+  bool enabled_set = !Flag::isDefault("enable_tables");
   if (!disabled_set && !enabled_set) {
     // We have zero enabled tables and zero disabled tables.
     // As a result, no tables are disabled.

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -188,24 +188,14 @@ class SQLiteDBManager : private boost::noncopyable {
   /**
    * @brief Check if `table_name` is disabled.
    *
-   * Check if `table_name` is in the list of tables passed in to the
-   * `--disable_tables` flag.
+   * `table_name` is disabled if it's in the list of tables passed in to the
+   * `--disable_tables` flag or if the `--enable_tables` flag is set and
+   * `table_name` is not specified.
    *
    * @param The name of the Table to check.
    * @return If `table_name` is disabled.
    */
   static bool isDisabled(const std::string& table_name);
-
-  /**
-   * @brief Check if `table_name` is enabled.
-   *
-   * Check if `table_name` is in the list of tables passed in to the
-   * `--enable_tables` flag.
-   *
-   * @param The name of the Table to check.
-   * @return If `table_name` is enabled.
-   */
-  static bool isEnabled(const std::string& table_name);
 
  protected:
   SQLiteDBManager();

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -196,6 +196,17 @@ class SQLiteDBManager : private boost::noncopyable {
    */
   static bool isDisabled(const std::string& table_name);
 
+  /**
+   * @brief Check if `table_name` is enabled.
+   *
+   * Check if `table_name` is in the list of tables passed in to the
+   * `--enable_tables` flag.
+   *
+   * @param The name of the Table to check.
+   * @return If `table_name` is enabled.
+   */
+  static bool isEnabled(const std::string& table_name);
+
  protected:
   SQLiteDBManager();
   virtual ~SQLiteDBManager();
@@ -220,8 +231,14 @@ class SQLiteDBManager : private boost::noncopyable {
   /// Member variable to hold set of disabled tables.
   std::unordered_set<std::string> disabled_tables_;
 
+  /// Member variable to hold set of enabled tables.
+  std::unordered_set<std::string> enabled_tables_;
+
   /// Parse a comma-delimited set of tables names, passed in as a flag.
   void setDisabledTables(const std::string& s);
+
+  /// Parse a comma-delimited set of tables names, passed in as a flag.
+  void setEnabledTables(const std::string& s);
 
   /// Request a connection, optionally request the primary connection.
   static SQLiteDBInstanceRef getConnection(bool primary = false);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -1059,7 +1059,7 @@ Status attachTableInternal(const std::string& name,
                            const std::string& statement,
                            const SQLiteDBInstanceRef& instance,
                            bool is_extension) {
-  if (SQLiteDBManager::isDisabled(name)) {
+  if (SQLiteDBManager::isDisabled(name) or !SQLiteDBManager::isEnabled(name)) {
     VLOG(1) << "Table " << name << " is disabled, not attaching";
     return Status(0, getStringForSQLiteReturnCode(0));
   }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -1059,7 +1059,7 @@ Status attachTableInternal(const std::string& name,
                            const std::string& statement,
                            const SQLiteDBInstanceRef& instance,
                            bool is_extension) {
-  if (SQLiteDBManager::isDisabled(name) or !SQLiteDBManager::isEnabled(name)) {
+  if (SQLiteDBManager::isDisabled(name)) {
     VLOG(1) << "Table " << name << " is disabled, not attaching";
     return Status(0, getStringForSQLiteReturnCode(0));
   }

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -29,6 +29,10 @@
     // This allows osquery to be launched without certain tables.
     //"disable_tables": "foo_bar,time",
 
+    // Comma-delimited list of table names to be enabled.
+    // This allows osquery to be launched with certain tables only.
+    //"enable_tables": "foo_bar,time",
+
     "utc": "true"
   },
 


### PR DESCRIPTION
Adds an ``--enable_tables`` CLI flags to specify a limited set of
tables to expose. This is the contrary of ``--disable_tables``.

Ref https://github.com/osquery/osquery/issues/5513
