### PR TITLE
services, startup_items: More intelligent expansion

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -315,6 +315,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils:utils"),
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/expected:expected"),
+        osquery_target("osquery/utils/system:env"),
         osquery_target("osquery/utils/system:filepath"),
         osquery_target("osquery/utils/system:system_utils"),
         osquery_target("osquery/utils/system:time"),

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -221,6 +221,7 @@ function(generateOsqueryTablesSystemSystemtable)
     osquery_utils
     osquery_utils_conversions
     osquery_utils_expected
+    osquery_utils_system_env
     osquery_utils_system_filepath
     osquery_utils_system_systemutils
     osquery_utils_system_time

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <osquery/utils/system/system.h>
+#include <osquery/utils/system/env.h>
 
 #include <Winsvc.h>
 
@@ -128,7 +129,12 @@ static inline Status getService(const SC_HANDLE& scmHandle,
            regResults);
   for (const auto& aKey : regResults) {
     if (aKey.at("name") == "ServiceDll") {
-      r["module_path"] = SQL_TEXT(aKey.at("data"));
+      auto module_path = aKey.at("data");
+      if (const auto expanded_path = expandEnvString(module_path)) {
+        module_path = *expanded_path;
+      }
+
+      r["module_path"] = SQL_TEXT(module_path);
     }
   }
 

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -6,8 +6,8 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <osquery/utils/system/system.h>
 #include <osquery/utils/system/env.h>
+#include <osquery/utils/system/system.h>
 
 #include <Winsvc.h>
 

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -58,17 +58,19 @@ const std::set<std::string> kStartupStatusRegKeys = {
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
 static inline void parseStartupPath(const std::string& path, Row& r) {
+  std::string expandedPath = path;
+
   if (path.find('%') != std::string::npos) {
     if (auto expanded = expandEnvString(path)) {
-      path = *expanded;
+      expandedPath = *expanded;
     }
   }
 
   if (path.find('\"') == std::string::npos) {
-    r["path"] = path;
+    r["path"] = expandedPath;
   } else {
     boost::tokenizer<boost::escaped_list_separator<TCHAR>> tokens(
-        path,
+        expandedPath,
         boost::escaped_list_separator<TCHAR>(
             std::string(""), std::string(" "), std::string("\"\'")));
     for (auto&& tok = tokens.begin(); tok != tokens.end(); ++tok) {

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -24,6 +24,7 @@
 #include <osquery/process/process.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/system/env.h>
 
 namespace osquery {
 namespace tables {
@@ -57,6 +58,12 @@ const std::set<std::string> kStartupStatusRegKeys = {
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
 static inline void parseStartupPath(const std::string& path, Row& r) {
+  if (path.find('%') != std::string::npos) {
+    if (auto expanded = expandEnvString(path)) {
+      path = *expanded;
+    }
+  }
+
   if (path.find('\"') == std::string::npos) {
     r["path"] = path;
   } else {

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -26,6 +26,8 @@
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/system/env.h>
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 namespace tables {
 
@@ -66,17 +68,21 @@ static inline void parseStartupPath(const std::string& path, Row& r) {
     }
   }
 
-  if (const auto argsp = splitArgs(expandedPath)) {
-    const auto args = *argsp;
-
-    r["path"] = args[0];
-
-    if (args.size() > 1) {
-      args.erase(args.begin());
-      r["args"] = boost::join(args, " ");
-    }
-  } else {
+  if (pathExists(fs::path(expandedPath)).ok()) {
     r["path"] = expandedPath;
+  } else {
+    if (const auto argsp = splitArgs(expandedPath)) {
+      auto args = *argsp;
+
+      r["path"] = args[0];
+
+      if (args.size() > 1) {
+        args.erase(args.begin());
+        r["args"] = boost::join(args, " ");
+      }
+    } else {
+      r["path"] = expandedPath;
+    }
   }
 }
 

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -61,27 +61,22 @@ static inline void parseStartupPath(const std::string& path, Row& r) {
   std::string expandedPath = path;
 
   if (path.find('%') != std::string::npos) {
-    if (auto expanded = expandEnvString(path)) {
+    if (const auto expanded = expandEnvString(path)) {
       expandedPath = *expanded;
     }
   }
 
-  if (path.find('\"') == std::string::npos) {
-    r["path"] = expandedPath;
-  } else {
-    boost::tokenizer<boost::escaped_list_separator<TCHAR>> tokens(
-        expandedPath,
-        boost::escaped_list_separator<TCHAR>(
-            std::string(""), std::string(" "), std::string("\"\'")));
-    for (auto&& tok = tokens.begin(); tok != tokens.end(); ++tok) {
-      if (tok == tokens.begin()) {
-        r["path"] = *tok;
-      } else if (r.count("args") == 0) {
-        r["args"] = *tok;
-      } else {
-        r["args"].append(" " + *tok);
-      }
+  if (const auto argsp = splitArgs(expandedPath)) {
+    const auto args = *argsp;
+
+    r["path"] = args[0];
+
+    if (args.size() > 1) {
+      args.erase(args.begin());
+      r["args"] = boost::join(args, " ");
     }
+  } else {
+    r["path"] = expandedPath;
   }
 }
 

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -62,6 +62,9 @@ const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 static inline void parseStartupPath(const std::string& path, Row& r) {
   std::string expandedPath = path;
 
+  // NOTE(ww): This is a pretty dumb expansion test, but the query that feeds
+  // us these paths doesn't pass us REG_EXPAND_SZ or any other hint
+  // that we could use instead.
   if (path.find('%') != std::string::npos) {
     if (const auto expanded = expandEnvString(path)) {
       expandedPath = *expanded;

--- a/osquery/utils/BUCK
+++ b/osquery/utils/BUCK
@@ -6,7 +6,7 @@
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
-load("//tools/build_defs/oss/osquery:platforms.bzl", "FREEBSD", "MACOSX")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "FREEBSD", "MACOSX", "WINDOWS")
 load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
 
 osquery_cxx_library(
@@ -75,9 +75,18 @@ osquery_cxx_test(
         "tests/map_take.cpp",
         "tests/scope_guard.cpp",
     ],
+    platform_srcs = [
+        (
+            WINDOWS,
+            [
+                "tests/windows/env.cpp",
+            ],
+        ),
+    ],
     visibility = ["PUBLIC"],
     deps = [
-        ":utils",
+        osquery_target("osquery/utils:utils"),
+        osquery_target("osquery/utils/system:env"),
     ],
 )
 

--- a/osquery/utils/CMakeLists.txt
+++ b/osquery/utils/CMakeLists.txt
@@ -99,11 +99,18 @@ function(generateOsqueryUtilsUtilstestsTest)
     tests/scope_guard.cpp
   )
 
+  if(DEFINED PLATFORM_WINDOWS)
+    list(APPEND source_files
+      tests/windows/env.cpp
+    )
+  endif()
+
   add_osquery_executable(osquery_utils_utilstests-test ${source_files})
 
   target_link_libraries(osquery_utils_utilstests-test PRIVATE
     osquery_cxx_settings
     osquery_utils
+    osquery_utils_system_env
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -82,6 +82,7 @@ osquery_cxx_library(
         ),
     ],
     deps = [
+        osquery_target("osquery/logger:logger"),
         osquery_target("osquery/utils/status:status"),
     ],
     tests = [

--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -32,6 +32,7 @@ osquery_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         osquery_tp_target("boost"),
+        osquery_target("osquery/utils/conversions:conversions"),
     ],
 )
 

--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -33,6 +33,7 @@ osquery_cxx_library(
     deps = [
         osquery_tp_target("boost"),
         osquery_target("osquery/utils/conversions:conversions"),
+        ":errno",
     ],
 )
 

--- a/osquery/utils/system/CMakeLists.txt
+++ b/osquery/utils/system/CMakeLists.txt
@@ -44,6 +44,7 @@ function(generateOsqueryUtilsSystemEnv)
     osquery_cxx_settings
     thirdparty_boost
     osquery_utils_conversions
+    osquery_utils_system_errno
   )
 
   set(public_header_files

--- a/osquery/utils/system/CMakeLists.txt
+++ b/osquery/utils/system/CMakeLists.txt
@@ -43,6 +43,7 @@ function(generateOsqueryUtilsSystemEnv)
   target_link_libraries(osquery_utils_system_env PUBLIC
     osquery_cxx_settings
     thirdparty_boost
+    osquery_utils_conversions
   )
 
   set(public_header_files

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -27,4 +27,13 @@ bool unsetEnvVar(const std::string& name);
  */
 boost::optional<std::string> getEnvVar(const std::string& name);
 
+#ifdef WINDOWS
+/**
+ * @brief Returns the input, with any environment variables present expanded.
+ *
+ * Returns boost::none on failure.
+ */
+boost::optional<std::string> expandEnvString(const std::string& input);
+#endif
+
 } // namespace osquery

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <boost/optional.hpp>
 
 

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -8,10 +8,9 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
-
 
 namespace osquery {
 
@@ -37,7 +36,8 @@ boost::optional<std::string> getEnvVar(const std::string& name);
 boost::optional<std::string> expandEnvString(const std::string& input);
 
 /**
- * Splits the input into command line arguments, according to the system's rules.
+ * Splits the input into command line arguments, according to the system's
+ * rules.
  *
  * Returns boost::none on failure.
  */

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -34,6 +34,13 @@ boost::optional<std::string> getEnvVar(const std::string& name);
  * Returns boost::none on failure.
  */
 boost::optional<std::string> expandEnvString(const std::string& input);
+
+/**
+ * Splits the input into command line arguments, according to the system's rules.
+ *
+ * Returns boost::none on failure.
+ */
+boost::optional<std::vector<std::string>> splitArgs(const std::string& args);
 #endif
 
 } // namespace osquery

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -6,7 +6,7 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <osquery/core.h>
+#include <osquery/logger.h>
 #include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/utils/system/env.h>
 #include <osquery/utils/system/errno.h>

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -60,7 +60,7 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
   buf.assign(kInitialBufferSize, '\0');
 
   // ExpandEnvironmentStrings doesn't support inputs larger than 32k.
-  if (input.size > 32768) {
+  if (input.size() > 32768) {
     return boost::none;
   }
 
@@ -78,7 +78,7 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
     return boost::none;
   }
 
-  return std::string(buf.data(), value_len);
+  return std::string(buf.data(), len);
 }
 
 } // namespace osquery

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -6,15 +6,18 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <osquery/utils/system/env.h>
 #include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/system/env.h>
 
 #include <string>
 #include <vector>
 
 #include <boost/optional.hpp>
 
+// clang-format off
 #include <windows.h>
+#include <shellapi.h>
+// clang-format on
 
 namespace osquery {
 
@@ -65,7 +68,8 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
     return boost::none;
   }
 
-  auto len = ::ExpandEnvironmentStrings(input.c_str(), buf.data(), kInitialBufferSize);
+  auto len =
+      ::ExpandEnvironmentStrings(input.c_str(), buf.data(), kInitialBufferSize);
   if (len == 0) {
     return boost::none;
   }
@@ -79,13 +83,15 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
     return boost::none;
   }
 
-  return std::string(buf.data(), len);
+  // Unlike GetEnvironmentVariableA, the length returned by
+  // ExpandEnvironmentStrings does include the terminating null.
+  return std::string(buf.data(), len - 1);
 }
 
 boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
   int argc = 0;
 
-  auto argv = CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
+  auto argv = ::CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
   if (argv == nullptr) {
     return boost::none;
   }

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <osquery/utils/system/env.h>
+#include <osquery/utils/conversions/windows/strings.h>
 
 #include <string>
 #include <vector>
@@ -79,6 +80,24 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
   }
 
   return std::string(buf.data(), len);
+}
+
+boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
+  int argc;
+
+  auto argv = CommandLineToArgvW(stringToWstring(args), &argc);
+  if (argv == nullptr) {
+    return boost::none;
+  }
+
+  std::vector<std::string> argvec;
+  for (int i = 0; i < argc; ++i) {
+    argvec.push_back(wstringToString(std::wstring(argv[i])));
+  }
+
+  LocalFree(argv);
+
+  return argvec;
 }
 
 } // namespace osquery

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -85,7 +85,7 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
 boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
   int argc;
 
-  auto argv = CommandLineToArgvW(stringToWstring(args), &argc);
+  auto argv = CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
   if (argv == nullptr) {
     return boost::none;
   }

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -83,7 +83,7 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
 }
 
 boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
-  int argc;
+  int argc = 0;
 
   auto argv = CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
   if (argv == nullptr) {

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -92,7 +92,7 @@ boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
 
   std::vector<std::string> argvec;
   for (int i = 0; i < argc; ++i) {
-    argvec.push_back(wstringToString(std::wstring(argv[i])));
+    argvec.push_back(wstringToString(argv[i]));
   }
 
   LocalFree(argv);

--- a/osquery/utils/tests/windows/env.cpp
+++ b/osquery/utils/tests/windows/env.cpp
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <boost/optional.hpp>
+#include <gtest/gtest.h>
+
+#include <osquery/utils/system/env.h>
+
+namespace osquery {
+
+class WindowsEnvTests : public testing::Test {};
+
+TEST_F(WindowsEnvTests, test_expandEnvString) {
+  // Environment strings larger than 32K can't be expanded by the Windows API.
+  const auto& big = std::string(32769, 'A');
+  EXPECT_EQ(expandEnvString(big), boost::none);
+
+  const auto& windir = getEnvVar("WINDIR");
+  EXPECT_TRUE(windir);
+  EXPECT_EQ(*expandEnvString("%WINDIR%"), *windir);
+
+  // Multiple expansions are handled correctly
+  EXPECT_EQ(*expandEnvString("%WINDIR% %WINDIR%"), *windir + " " + *windir);
+}
+
+TEST_F(WindowsEnvTests, test_splitArgs) {
+  const auto& args = splitArgs("\"C:\\Program Files\\Foo\" bar baz");
+  EXPECT_TRUE(args);
+
+  EXPECT_EQ(args.get().size(), 3);
+  EXPECT_EQ(args.get().at(0), "C:\\Program Files\\Foo");
+  EXPECT_EQ(args.get().at(1), "bar");
+  EXPECT_EQ(args.get().at(2), "baz");
+}
+
+} // namespace osquery


### PR DESCRIPTION
Adds support for expanding (`%`-style) environment variables in the paths of the `services` and `startup_items` tables.