### PR TITLE
adding docker image layers table

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -990,12 +990,8 @@ void getImageLayers(std::string image_id, QueryData& results) {
     return;
   }
 
-  if (layers.empty()) {
-    return;
-  }
-
-  Row r;
-  for (int index = 0; index < layers.size(); index++) {
+  for (size_t index = 0; index < layers.size(); index++) {
+    Row r;
     r["id"] = image_id;
     r["layer_order"] = std::to_string(index + 1);
     r["layer_id"] = layers[index];

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -184,6 +184,7 @@ function(generateNativeTables)
     "posix/docker_container_stats.table:linux,macos,freebsd"
     "posix/docker_containers.table:linux,macos,freebsd"
     "posix/docker_image_labels.table:linux,macos,freebsd"
+    "posix/docker_image_layers.table:linux,macos,freebsd"
     "posix/docker_images.table:linux,macos,freebsd"
     "posix/docker_info.table:linux,macos,freebsd"
     "posix/docker_network_labels.table:linux,macos,freebsd"

--- a/specs/posix/docker_image_layers.table
+++ b/specs/posix/docker_image_layers.table
@@ -1,0 +1,12 @@
+table_name("docker_image_layers")
+description("Docker image layers information.")
+schema([
+    Column("id", TEXT, "Image ID"),
+    Column("layer_id", TEXT, "Layer ID"),
+    Column("layer_order", INTEGER, "Layer Order (0 = base layer)")
+])
+implementation("applications/docker@genImageLayers")
+examples([
+  "select * from docker_images",
+  "select * from docker_images where id = '6a2f32de169d14e6f8a84538eaa28f2629872d7d4f580a303b296c60db36fbd7'"
+])

--- a/specs/posix/docker_image_layers.table
+++ b/specs/posix/docker_image_layers.table
@@ -1,12 +1,13 @@
 table_name("docker_image_layers")
 description("Docker image layers information.")
 schema([
-    Column("id", TEXT, "Image ID"),
+    Column("id", TEXT, "Image ID", index=True),
     Column("layer_id", TEXT, "Layer ID"),
-    Column("layer_order", INTEGER, "Layer Order (0 = base layer)")
+    Column("layer_order", INTEGER, "Layer Order (1 = base layer)")
 ])
 implementation("applications/docker@genImageLayers")
 examples([
   "select * from docker_images",
+  "select * from docker_images where id = '6a2f32de169d'",
   "select * from docker_images where id = '6a2f32de169d14e6f8a84538eaa28f2629872d7d4f580a303b296c60db36fbd7'"
 ])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -90,6 +90,7 @@ function(generateTestsIntegrationTablesTestsTest)
       docker_container_stats.cpp
       docker_containers.cpp
       docker_image_labels.cpp
+      docker_image_layers.cpp
       docker_images.cpp
       docker_info.cpp
       docker_network_labels.cpp

--- a/tests/integration/tables/docker_image_layers.cpp
+++ b/tests/integration/tables/docker_image_layers.cpp
@@ -1,0 +1,40 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+// Sanity check integration test for docker_image_layers
+// Spec file: specs/posix/docker_image_layers.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class dockerImageLayersTest : public testing::Test {
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(dockerImageLayersTest, test_sanity) {
+  QueryData data = execute_query("select * from docker_images");
+  if (data.size() <= 0) { // docker not installed, or issues talking to dockerd,
+                          // or no images present
+    return;
+  }
+
+  data = execute_query("select * from docker_image_layers");
+  ASSERT_GT(data.size(), 0ul);
+  ValidationMap row_map = {
+      {"id", NonEmptyString},
+      {"layer_id", NonEmptyString},
+      {"layer_order", NonNegativeInt},
+  };
+  validate_rows(data, row_map);
+}
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
This table lists constituent layers of a docker image.

Example output: 
```
osquery> select * from docker_image_layers where id = 'bcb0317';
+---------+------------------------------------------------------------------+-------------+
| id      | layer_id                                                         | layer_order |
+---------+------------------------------------------------------------------+-------------+
| bcb0317 | cc967c529ced563b7746b663d98248bc571afdb3c012019d7f54d6c092793b8b | 1           |
| bcb0317 | 2c6ac8e5063e35e91ab79dfb7330c6154b82f3a7e4724fb1b4475c0a95dfdd33 | 2           |
| bcb0317 | 6c01b5a53aac53c66f02ea711295c7586061cbe083b110d54dafbeb6cf7636bf | 3           |
| bcb0317 | e0b3afb09dc386786d49d6443bdfb20bc74d77dcf68e152db7e5bb36b1cca638 | 4           |
| bcb0317 | f702eabea3b99cb38d912fa018a2692cedf0367101cfe4a002da31b1836e6909 | 5           |
| bcb0317 | ab11d8128d1eb55778e2906f09d63a800dde4bf61ef7be5ac0c206ba866aa3d9 | 6           |
| bcb0317 | 95ec16cce2bdccb7372f9d187c551122721d6bbbfb731df4449e8e5a284e972c | 7           |
| bcb0317 | ca830ef3a3f312d38bc36c87a807890fd333a6ad2b69ad6de9008f741318c7b5 | 8           |
+---------+------------------------------------------------------------------+-------------+

```