### PR TITLE
windows/bitlocker_info: Fetch WMI method results

### DIFF
--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -11,11 +11,32 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
-#include <osquery/utils/conversions/tryto.h>
 #include "osquery/core/windows/wmi.h"
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
+
+static void fetchMethodResultLong(std::string& result,
+                                  const WmiRequest& req,
+                                  const std::string& method,
+                                  const std::string& param) {
+  WmiMethodArgs args;
+  WmiResultItem out;
+
+  auto status = req.ExecMethod(method, args, out);
+  if (status.ok()) {
+    long value = -1;
+    status = out.GetLong(param, value);
+    if (status.ok()) {
+      result = INTEGER(value);
+    } else {
+      result = INTEGER(-1);
+    }
+  } else {
+    result = INTEGER(-1);
+  }
+}
 
 QueryData genBitlockerInfo(QueryContext& context) {
   Row r;
@@ -58,6 +79,15 @@ QueryData genBitlockerInfo(QueryContext& context) {
       emethod_str = "UNKNOWN";
     }
     r["encryption_method"] = emethod_str;
+
+    fetchMethodResultLong(r["version"], data, "GetVersion", "Version");
+    fetchMethodResultLong(r["percentage_encrypted"],
+                          data,
+                          "GetConversionStatus",
+                          "EncryptionPercentage");
+    fetchMethodResultLong(
+        r["lock_status"], data, "GetLockStatus", "LockStatus");
+
     results.push_back(r);
   }
 

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -19,12 +19,13 @@ namespace tables {
 
 static void fetchMethodResultLong(std::string& result,
                                   const WmiRequest& req,
+                                  const WmiResultItem& object,
                                   const std::string& method,
                                   const std::string& param) {
   WmiMethodArgs args;
   WmiResultItem out;
 
-  auto status = req.ExecMethod(method, args, out);
+  auto status = req.ExecMethod(object, method, args, out);
   if (status.ok()) {
     long value = -1;
     status = out.GetLong(param, value);
@@ -80,13 +81,15 @@ QueryData genBitlockerInfo(QueryContext& context) {
     }
     r["encryption_method"] = emethod_str;
 
-    fetchMethodResultLong(r["version"], data, "GetVersion", "Version");
+    fetchMethodResultLong(
+        r["version"], wmiSystemReq, data, "GetVersion", "Version");
     fetchMethodResultLong(r["percentage_encrypted"],
+                          wmiSystemReq,
                           data,
                           "GetConversionStatus",
                           "EncryptionPercentage");
     fetchMethodResultLong(
-        r["lock_status"], data, "GetLockStatus", "LockStatus");
+        r["lock_status"], wmiSystemReq, data, "GetLockStatus", "LockStatus");
 
     results.push_back(r);
   }

--- a/specs/windows/bitlocker_info.table
+++ b/specs/windows/bitlocker_info.table
@@ -8,5 +8,8 @@ schema([
   Column("conversion_status", INTEGER, "The bitlocker conversion status of the drive."),
   Column("protection_status", INTEGER, "The bitlocker protection status of the drive."),
   Column("encryption_method", TEXT, "The encryption type of the device."),
+  Column("version", INTEGER, "The FVE metadata version of the drive."),
+  Column("percentage_encrypted", INTEGER, "The percentage of the drive that is encrypted."),
+  Column("lock_status", INTEGER, "The accessibility status of the drive from Windows."),
 ])
 implementation("bitlocker_info@genBitlockerInfo")


### PR DESCRIPTION
Retrieves version, in-progress encryption status, and the lock
status for each BitLocker-encrypted volume via WMI methods.

Closes https://github.com/osql/osquery-pr/pull/9.
