### PR TITLE
toolchain: Add required includes for azure and ebpf

### DIFF
--- a/osquery/utils/azure/azure_util.cpp
+++ b/osquery/utils/azure/azure_util.cpp
@@ -17,6 +17,8 @@
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/json/json.h>
 
+#include <mutex>
+
 namespace http = osquery::http;
 namespace fs = boost::filesystem;
 

--- a/osquery/utils/system/linux/ebpf/program.h
+++ b/osquery/utils/system/linux/ebpf/program.h
@@ -11,6 +11,11 @@
 #include <osquery/utils/expected/expected.h>
 
 #include <linux/bpf.h>
+#include <linux/version.h>
+
+#if defined(LINUX_VERSION_CODE) && LINUX_VERSION_CODE < 263946
+#define BPF_PROG_TYPE_TRACEPOINT (bpf_prog_type)(BPF_PROG_TYPE_SCHED_ACT + 1)
+#endif
 
 namespace osquery {
 namespace ebpf {


### PR DESCRIPTION
While there may be many implicit includes within the code base,
these specifically show up when trying to use different compilers.

These changes are a nice-to-have.