### PR TITLE
Include header files in the test of format-check.py

### DIFF
--- a/tools/formatting/format-test.sh
+++ b/tools/formatting/format-test.sh
@@ -19,8 +19,8 @@ build_dir=${args[1]}
 
 set -e
 
-# List all .cpp files to format, skipping all the ones inside the libraries folder, sort them and save the list on a file
-find . -type d -path ./libraries -prune -o -type f -name "*.cpp" -print | sort > $build_dir/files_to_format.txt
+# List all files to format, skipping all the ones inside the libraries folder, sort them and save the list on a file
+find . -type d -path ./libraries -prune -o -type f -regex ".*\.cpp$\|.*\.h$\|.*\.hpp$" -print | sort > $build_dir/files_to_format.txt
 
 # Read back the list of files, modify them appending two newlines, so that the format_check.py is triggered
 while read line; do echo -e "\n\n" >> $line; done <<< `cat $build_dir/files_to_format.txt`


### PR DESCRIPTION
If we don't include them and if the commit we're on requires formatting
on a header file, the test will fail.
We don't want it to fail because it's not the job of this test
to verify that the commit is properly formatted.
Moreover, it just makes sense to test that the formatting script
can properly reach all files it has to.
