### PR TITLE
build: Pin Linux builds to use libc++

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -58,6 +58,7 @@ function(setupBuildFlags)
       -Woverloaded-virtual
       -Wnon-virtual-dtor
       -Weffc++
+      -stdlib=libc++
     )
 
     set(posix_cxx_link_options
@@ -108,7 +109,7 @@ function(setupBuildFlags)
       )
 
       set(linux_cxx_link_libraries
-        libc++abi.a
+        c++abi
         rt
         dl
       )
@@ -131,7 +132,6 @@ function(setupBuildFlags)
         -x objective-c++
         -fobjc-arc
         -Wabi-tag
-        -stdlib=libc++
       )
 
       set(macos_cxx_link_options

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -44,7 +44,7 @@ function(opensslMain)
 
         -fPIC
         --sysroot=${CMAKE_SYSROOT}
-        -l:libunwind.a
+        -lunwind
         -lpthread
     )
 


### PR DESCRIPTION
This supersedes several of the changes included in #6112.

The goal is to pin Linux builds to libc++, which our toolchain does implicitly. 