### PR TITLE
config: Fix JSON format assumptions in file_paths parser

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -920,6 +920,7 @@ void Config::reset() {
       continue;
     }
     parser->reset();
+    parser->setUp();
   }
 }
 
@@ -1082,7 +1083,7 @@ Status ConfigPlugin::call(const PluginRequest& request,
   }
 
   if (action->second == "genConfig") {
-    std::map<std::string, std::string> config;
+    ConfigMap config;
     auto stat = genConfig(config);
     response.push_back(config);
     return stat;

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -305,7 +305,7 @@ TEST_F(ConfigTests, test_content_update) {
   // Update, then clear, packs should have been cleared.
   get().update(config_data);
   auto source_hash = get().getHash(source);
-  EXPECT_EQ("fb0973b39c70db16655effbca532d4aa93381e59", source_hash);
+  EXPECT_EQ("dfae832a62a3e3a51760334184364b7d66468ccc", source_hash);
 
   size_t count = 0;
   auto packCounter = [&count](const Pack& pack) { count++; };

--- a/tools/tests/configs/test_parse_items.conf
+++ b/tools/tests/configs/test_parse_items.conf
@@ -39,17 +39,34 @@
     ],
     "config_files": [
       "/dev",
-      "/dev/zero"
+      "/dev/zero",
+      1,
+      ["error", "invalid"],
+      {"error": "invalid"}
     ]
   },
   "file_paths_query": {
     "config_files_query": [
-      "select '/dev/urandom' as path;"
+      "select '/dev/urandom' as path;",
+      1,
+      ["error", "invalid"],
+      {"error": "invalid"}
     ]
   },
   "file_accesses": [
-    "logs"
+    "logs",
+    1,
+    ["error", "invalid"],
+    {"error": "invalid"}
   ],
+  "exclude_paths": {
+    "example": [
+      "/dev/null",
+      1,
+      ["error", "invalid"],
+      {"error": "invalid"}
+    ]
+  },
   "events": {
     "environment_variables": [
       "foo",


### PR DESCRIPTION
I may have gotten carried away with a refactor here.

I wanted to correct some of the format assumptions and noticed there were no tests for `exclude_paths`. 