### PR TITLE
Fix boost process basic_ipstream build

### DIFF
--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -171,7 +171,11 @@ function(generateBoostRandom)
 endfunction()
 
 function(importBoostInterfaceLibrary folder_name)
-  set(library_root "${BOOST_ROOT}/libs/${folder_name}")
+  if(folder_name STREQUAL "process")
+    set(library_root "${OSQUERY_boost_src_libs_process_ROOT_DIR}")
+  else()
+    set(library_root "${BOOST_ROOT}/libs/${folder_name}")
+  endif()
 
   string(REPLACE "_" "" target_name "${folder_name}")
   set(target_name "thirdparty_boost_${target_name}")

--- a/libraries/cmake/source/boost/patches/src/libs/process/ipstream_move_assignment.patch
+++ b/libraries/cmake/source/boost/patches/src/libs/process/ipstream_move_assignment.patch
@@ -1,0 +1,37 @@
+diff --git a/include/boost/process/pipe.hpp b/include/boost/process/pipe.hpp
+index dd4af09..a44a910 100644
+--- a/include/boost/process/pipe.hpp
++++ b/include/boost/process/pipe.hpp
+@@ -295,8 +295,9 @@ public:
+     basic_ipstream& operator=(basic_ipstream && lhs)
+     {
+         std::basic_istream<CharT, Traits>::operator=(std::move(lhs));
+-        _buf = std::move(lhs);
++        _buf = std::move(lhs._buf);
+         std::basic_istream<CharT, Traits>::rdbuf(&_buf);
++        return *this;
+     };
+     ///Move assignment of a pipe.
+     basic_ipstream& operator=(pipe_type && p)
+@@ -376,8 +377,9 @@ public:
+     basic_opstream& operator=(basic_opstream && lhs)
+     {
+         std::basic_ostream<CharT, Traits>::operator=(std::move(lhs));
+-        _buf = std::move(lhs);
++        _buf = std::move(lhs._buf);
+         std::basic_ostream<CharT, Traits>::rdbuf(&_buf);
++        return *this;
+     };
+ 
+     ///Move assignment of a pipe.
+@@ -459,8 +461,9 @@ public:
+     basic_pstream& operator=(basic_pstream && lhs)
+     {
+         std::basic_istream<CharT, Traits>::operator=(std::move(lhs));
+-        _buf = std::move(lhs);
++        _buf = std::move(lhs._buf);
+         std::basic_iostream<CharT, Traits>::rdbuf(&_buf);
++        return *this;
+     };
+     ///Move assignment of a pipe.
+     basic_pstream& operator=(pipe_type && p)

--- a/libraries/cmake/source/modules/Findboost.cmake
+++ b/libraries/cmake/source/modules/Findboost.cmake
@@ -89,4 +89,7 @@ importSourceSubmodule(
     "src/libs/iostreams"
     "src/libs/scope_exit"
     "src/libs/typeof"
+
+  PATCH
+    "src/libs/process"
 )


### PR DESCRIPTION
The move assignment operator of boost::basic_ipstream is bugged.
It has been fixed on upstream in commit
https://github.com/boostorg/process/commit/ca994c1972d87939d60f5899e51bf3a43bc59cd8
which is not on any stable build, so we will patch boost with that commit.
