### PR TITLE
Fixed imports for python3 in test_http_server.py

### DIFF
--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -14,12 +14,12 @@ import random
 import ssl
 import string
 import sys
-import thread
+import _thread
 import threading
 
 # Create a simple TLS/HTTP server.
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-from urlparse import parse_qs
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs
 
 # Script run directory, used for default values
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -167,7 +167,7 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         debug("RealSimpleHandler::post %s" % self.path)
         self._set_headers()
-        content_len = int(self.headers.getheader('content-length', 0))
+        content_len = int(self.headers.get('content-length', 0))
 
         body = self.rfile.read(content_len)
         request = json.loads(body)
@@ -335,7 +335,7 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
 
     def _reply(self, response):
         debug("Replying: %s" % (str(response)))
-        self.wfile.write(json.dumps(response))
+        self.wfile.write(json.dumps(response).encode())
 
 
 def handler():
@@ -446,3 +446,4 @@ if __name__ == '__main__':
         for k, v in vars(parser.parse_args()).items() if v is not None
     }
     run_http_server(args['port'], **args)
+


### PR DESCRIPTION
The script didn't run for me because of wrong imports or nonexistent methods. The above changes fixed this for me.

<!-- Thank you for contributing to osquery! -->


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- The code is formatted correctly, considering using `make format_check`.
- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- Support for both CMake and BUCK (we are happy to help).
- The code mostly looks and feels similar to the existing codebase.

-->
