### PR TITLE
Fix flaky LoggerTests.test_logger_log_status

### DIFF
--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -191,7 +191,7 @@ TEST_F(LoggerTests, test_logger_log_status) {
   EXPECT_EQ(O_WARNING, LoggerTests::last_status.severity);
   EXPECT_GT(LoggerTests::last_status.line, 0U);
   EXPECT_EQ(warning, LoggerTests::last_status.message);
-  EXPECT_GE(now, LoggerTests::last_status.time);
+  EXPECT_GE(LoggerTests::last_status.time, now);
   EXPECT_EQ(getHostIdentifier(), LoggerTests::last_status.identifier);
 }
 


### PR DESCRIPTION
Logging happens after getting the current time,
so the time check should be inverted.

Example of a failure:
```
10: [ RUN      ] LoggerTests.test_logger_log_status
10: W0113 11:10:15.003626 58741 logger.cpp:186] Logger test is generating a warning status (2)
10: /__w/1/s/usr/src/debug/osquery/osquery/logger/tests/logger.cpp:194: Failure
10: Expected: (now) >= (LoggerTests::last_status.time), actual: 1578913814 vs 1578913815
10: [  FAILED  ] LoggerTests.test_logger_log_status (0 ms)
```