### PR TITLE
Fix Issue#6173: Update WmiRequest constructor to wstring from BSTR

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -376,11 +376,8 @@ WmiRequest::WmiRequest(const std::string& query, std::wstring nspace) {
     return;
   }
 
-  hr = services_->ExecQuery(language_str,
-                            wql_str,
-                            WBEM_FLAG_FORWARD_ONLY,
-                            nullptr,
-                            &wbem_enum);
+  hr = services_->ExecQuery(
+      language_str, wql_str, WBEM_FLAG_FORWARD_ONLY, nullptr, &wbem_enum);
 
   SysFreeString(wql_str);
   SysFreeString(language_str);

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -350,7 +350,7 @@ WmiRequest::WmiRequest(const std::string& query, std::wstring nspace) {
 
   IWbemServices* services = nullptr;
   BSTR nspace_str = SysAllocString(nspace.c_str());
-  if (NULL == nspace_str) {
+  if (nullptr == nspace_str) {
     return;
   }
 
@@ -366,12 +366,13 @@ WmiRequest::WmiRequest(const std::string& query, std::wstring nspace) {
   IEnumWbemClassObject* wbem_enum = nullptr;
 
   BSTR language_str = SysAllocString(L"WQL");
-  if (NULL == language_str) {
+  if (nullptr == language_str) {
     return;
   }
 
   BSTR wql_str = SysAllocString(wql.c_str());
-  if (NULL == wql_str) {
+  if (nullptr == wql_str) {
+    SysFreeString(language_str);
     return;
   }
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -209,7 +209,7 @@ class WmiResultItem {
 class WmiRequest {
  public:
   explicit WmiRequest(const std::string& query,
-                      BSTR nspace = (BSTR)L"ROOT\\CIMV2");
+                      std::wstring nspace = L"ROOT\\CIMV2");
   WmiRequest(WmiRequest&& src) = default;
 
   const std::vector<WmiResultItem>& results() const {


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

This PR fixes https://github.com/osquery/osquery/issues/6173. Now, BSTRs are allocated from wstrings, and freed after use. Previously, wide-character strings were being C-casted as BSTR and then provided to WMI objects: Providing wide-character strings as BSTRs to functions and methods requiring BSTRs is undefined.

At the moment, there are other source files calling WmiRequest both with valid BSTRs and wstrings. Both cases will work without any side-effect.  I will make these cases consistent in a separate PR.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- The code is formatted correctly, considering using `make format_check`.
- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- Support for both CMake and BUCK (we are happy to help).
- The code mostly looks and feels similar to the existing codebase.

-->
