### PR TITLE
Adding docker_container_fs_changes table

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,8 @@ jobs:
       vmImage: 'Ubuntu-16.04'
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v6
-      options: --privileged --init
+      image: trailofbits/osquery:ubuntu-18.04-toolchain-v7
+      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     timeoutInMinutes: 120
 

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -183,6 +183,7 @@ function(generateNativeTables)
     "posix/docker_container_networks.table:linux,macos,freebsd"
     "posix/docker_container_ports.table:linux,macos,freebsd"
     "posix/docker_container_processes.table:linux,macos,freebsd"
+    "posix/docker_container_fs_changes.table:linux,macos,freebsd"
     "posix/docker_container_stats.table:linux,macos,freebsd"
     "posix/docker_containers.table:linux,macos,freebsd"
     "posix/docker_image_labels.table:linux,macos,freebsd"

--- a/specs/posix/docker_container_fs_changes.table
+++ b/specs/posix/docker_container_fs_changes.table
@@ -1,0 +1,12 @@
+table_name("docker_container_fs_changes")
+description("Changes to files or directories on container's filesystem.")
+schema([
+    Column("id", TEXT, "Container ID", index=True, required=True),
+    Column("path", TEXT, "FIle or directory path relative to rootfs"),
+    Column("change_type", TEXT, "Type of change: C:Modified, A:Added, D:Deleted")
+])
+implementation("applications/docker@genContainerFsChanges")
+examples([
+  "select * from docker_container_fs_changes where id = '1234567890abcdef'",
+  "select * from docker_container_fs_changes where id = '11b2399e1426d906e62a0c357650e363426d6c56dbe2f35cbaa9b452250e3355'"
+])

--- a/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
+++ b/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
@@ -27,7 +27,7 @@ RUN apt update -q -y && apt upgrade -q -y && apt install -q -y --no-install-reco
   python3-wheel \
 && dpkg -i linux-base_1.0_all.deb linux-firmware_1.0_all.deb linux-generic_1.0_all.deb \
 && apt clean && rm -rf /var/lib/apt/lists/* \
-&& sudo pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3
+&& sudo pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3 docker
 RUN cd ~ && wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz \
 && sudo tar xvf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1 && rm cmake-3.14.6-Linux-x86_64.tar.gz \
 && wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz \

--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -67,6 +67,9 @@ function(generatePythonTests)
 
   # Tests
   addPythonTest(NAME tools_tests_testosqueryd SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_osqueryd.py")
+  if(PLATFORM_LINUX)
+    addPythonTest(NAME tools_tests_testfschangestable SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_docker_container_fs_changes_table.py")
+  endif()
 endfunction()
 
 osqueryToolsTestsMain()

--- a/tools/tests/test_docker_container_fs_changes_table.py
+++ b/tools/tests/test_docker_container_fs_changes_table.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+import unittest
+import docker
+import requests
+
+import test_base
+
+exceptions = (docker.errors.ContainerError, docker.errors.ImageNotFound, docker.errors.APIError, requests.exceptions.ConnectionError)
+
+class FsChangesTableTest(unittest.TestCase):
+    def setUp(self):
+        self.binary = test_base.getLatestOsqueryBinary('osqueryi')
+        self.osqueryi = test_base.OsqueryWrapper(command=self.binary)
+        self.client = None
+        self.container = None
+        try:
+            self.client = docker.from_env()
+            self.container = self.client.containers.run("ubuntu:18.04", command="tail -f /dev/null", detach=True);
+            self.container.exec_run("touch xxx")
+        except exceptions as e:
+            print(f"Failed in creating test container: {e}") 
+
+    def tearDown(self):
+        if self.container:
+            self.container.stop()
+        if self.client:
+            self.client.close()
+    
+    def testFsChangesTable(self):
+        if not self.client or not self.container:
+            print("WARNING: Issue in creating test docker container; Skipping docker_container_fs_changes table testing")
+            return
+
+        query = "select * from docker_container_fs_changes where id = '" + self.container.id + "';"
+        result = self.osqueryi.run_query(query)
+        self.assertTrue(len(result) > 0)
+        self.assertTrue(any(row["id"] == self.container.id and row["path"] == "/xxx" and row["change_type"] == 'A' for row in result))
+
+if __name__ == '__main__':
+    test_base.Tester().run()
+


### PR DESCRIPTION
This table lists changes to a container's filesystem since it's creation.

Example query:

```
osquery> select * from docker_container_fs_changes where id = '6d4a0ff6d954';
+--------------+----------+-------------+
| id           | path     | change_type |
+--------------+----------+-------------+
| 6d4a0ff6d954 | /bin     | C           |
| 6d4a0ff6d954 | /bin/xxx | A           |
| 6d4a0ff6d954 | /bin/tar | D           |
| 6d4a0ff6d954 | /xxx     | A           |
+--------------+----------+-------------+
```
change_type legend: C:Modified, A:Added, D:Deleted