### PR TITLE
Make ext socket writable for osquery group

### DIFF
--- a/tools/deployment/linux_postinstall.sh
+++ b/tools/deployment/linux_postinstall.sh
@@ -4,15 +4,27 @@
 # Could be called by DPKG or RPM.
 # Handle the cases we want to hook or silently claim success.
 case "$1" in
-  configure|2)
+configure | 2)
     : # Fall through to systemctl handle.
     ;;
-  *)
+*)
     exit 0
     ;;
 esac
 
+# Create 'osquery' group for extensions socket.
+if ! getent group osquery >/dev/null; then
+    addgroup --system osquery --quiet
+fi
+
+# Set group owner for directory to 'osquery'.
+chgrp osquery /var/osquery
+
+# Make sure 'osquery' group is inherited by extensions socket so
+# it's writable for group members.
+chmod 2775 /var/osquery
+
 # If we have a systemd, daemon-reload away now
-if [ -x /bin/systemctl ] && pidof systemd ; then
-  /bin/systemctl daemon-reload 2>/dev/null 2>&1
+if [ -x /bin/systemctl ] && pidof systemd; then
+    /bin/systemctl daemon-reload 2>/dev/null 2>&1
 fi

--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -85,6 +85,7 @@ start() {
   if [ -e $FLAGS_PATH ]; then ARGS="$ARGS --flagfile=$FLAGS_PATH"; fi
   if [ -e $REAL_CONFIG_PATH ]; then ARGS="$ARGS --config_path=$REAL_CONFIG_PATH"; fi
 
+  umask 0002
   $EXEC $ARGS \
         --pidfile=$PIDFILE \
         --daemonize=true

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -5,6 +5,7 @@ After=network.service syslog.service
 [Service]
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
+UMask 0002
 ExecStartPre=/bin/sh -c "if [ ! -f $CONFIG_FILE ]; then echo {} > $CONFIG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -5,7 +5,7 @@ After=network.service syslog.service
 [Service]
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
-UMask 0002
+UMask=0002
 ExecStartPre=/bin/sh -c "if [ ! -f $CONFIG_FILE ]; then echo {} > $CONFIG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"


### PR DESCRIPTION
This relates to feature request #6172 to add a group for extension socket permissions.

It modifies the post script for Debian and RedHat packages to:

- Create 'osquery' group
- Set 'osquery' as the owner for '/var/osquery'
- Set SGID and group writable (2775) on '/var/osquery'

It also modifies the init.d and systemd scripts to use umask 0002 to make group writable.