### PR TITLE
fix: UTF-8<->UTF-16 conversion for windows; issue #6160

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1769,10 +1769,10 @@ int launchIntoShell(int argc, char** argv) {
   } else {
     // Run commands received from standard input
     if (stdin_is_interactive) {
-        #ifdef WIN32
+#ifdef WIN32
       SetConsoleCP(CP_UTF8);
       SetConsoleOutputCP(CP_UTF8);
-        #endif // WIN32
+#endif // WIN32
       printf("Using a ");
       print_bold("virtual database");
       printf(". Need help, type '.help'\n");

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1769,6 +1769,10 @@ int launchIntoShell(int argc, char** argv) {
   } else {
     // Run commands received from standard input
     if (stdin_is_interactive) {
+        #ifdef WIN32
+      SetConsoleCP(CP_UTF8);
+      SetConsoleOutputCP(CP_UTF8);
+        #endif // WIN32
       printf("Using a ");
       print_bold("virtual database");
       printf(". Need help, type '.help'\n");

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -58,10 +58,10 @@ QueryData genLoggedInUsers(QueryContext& context) {
     LPWSTR sessionInfo = nullptr;
     DWORD bytesRet = 0;
     res = WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE,
-                                     pSessionInfo[i].SessionId,
-                                     WTSSessionInfo,
-                                     &sessionInfo,
-                                     &bytesRet);
+                                      pSessionInfo[i].SessionId,
+                                      WTSSessionInfo,
+                                      &sessionInfo,
+                                      &bytesRet);
     if (res == 0 || sessionInfo == nullptr) {
       VLOG(1) << "Error querying WTS session information (" << GetLastError()
               << ")";
@@ -118,8 +118,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
       wtsClient = nullptr;
     }
 
-    const auto sidBuf =
-        getSidFromUsername(wtsSession->UserName);
+    const auto sidBuf = getSidFromUsername(wtsSession->UserName);
 
     if (sessionInfo != nullptr) {
       WTSFreeMemory(sessionInfo);

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -55,9 +55,9 @@ QueryData genLoggedInUsers(QueryContext& context) {
   for (size_t i = 0; i < count; i++) {
     Row r;
 
-    char* sessionInfo = nullptr;
-    unsigned long bytesRet = 0;
-    res = WTSQuerySessionInformation(WTS_CURRENT_SERVER_HANDLE,
+    LPWSTR sessionInfo = nullptr;
+    DWORD bytesRet = 0;
+    res = WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE,
                                      pSessionInfo[i].SessionId,
                                      WTSSessionInfo,
                                      &sessionInfo,
@@ -67,8 +67,8 @@ QueryData genLoggedInUsers(QueryContext& context) {
               << ")";
       continue;
     }
-    const auto wtsSession = reinterpret_cast<WTSINFOA*>(sessionInfo);
-    r["user"] = SQL_TEXT(wtsSession->UserName);
+    const auto wtsSession = reinterpret_cast<WTSINFOW*>(sessionInfo);
+    r["user"] = SQL_TEXT(wstringToString(wtsSession->UserName));
     r["type"] = SQL_TEXT(kSessionStates.at(pSessionInfo[i].State));
     r["tty"] = pSessionInfo[i].pSessionName == nullptr
                    ? ""
@@ -119,7 +119,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
     }
 
     const auto sidBuf =
-        getSidFromUsername(stringToWstring(wtsSession->UserName));
+        getSidFromUsername(wtsSession->UserName);
 
     if (sessionInfo != nullptr) {
       WTSFreeMemory(sessionInfo);

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -21,7 +21,7 @@ struct utf_converter {
     std::wstring result;
     if (str.length() > 0) {
       result.resize(str.length() * 2);
-      int count = MultiByteToWideChar(
+      auto count = MultiByteToWideChar(
           CP_UTF8, 0, str.c_str(), -1, &result[0], str.length() * 2);
       result.resize(count - 1);
     }
@@ -33,8 +33,8 @@ struct utf_converter {
     std::string result;
     if (str.length() > 0) {
       result.resize(str.length() * 4);
-      int count = WideCharToMultiByte(
-          CP_ACP, 0, str.c_str(), -1, &result[0], str.length() * 4, NULL, NULL);
+      auto count = WideCharToMultiByte(
+          CP_UTF8, 0, str.c_str(), -1, &result[0], str.length() * 4, NULL, NULL);
       result.resize(count - 1);
     }
 

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -33,8 +33,13 @@ struct utf_converter {
     std::string result;
     if (str.length() > 0) {
       result.resize(str.length() * 4);
-      auto count = WideCharToMultiByte(
-          CP_UTF8, 0, str.c_str(), -1, &result[0], str.length() * 4, NULL, NULL);
+      auto count = WideCharToMultiByte(CP_UTF8,
+                                       0,
+                                       str.c_str(),
+                                       -1, &result[0],
+                                       str.length() * 4,
+                                       NULL,
+                                       NULL);
       result.resize(count - 1);
     }
 

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -23,7 +23,7 @@ struct utf_converter {
       result.resize(str.length() * 2);
       int count = MultiByteToWideChar(
           CP_UTF8, 0, str.c_str(), -1, &result[0], str.length() * 2);
-      result.resize(count-1);
+      result.resize(count - 1);
     }
 
     return result;
@@ -35,7 +35,7 @@ struct utf_converter {
       result.resize(str.length() * 4);
       int count = WideCharToMultiByte(
           CP_ACP, 0, str.c_str(), -1, &result[0], str.length() * 4, NULL, NULL);
-      result.resize(count-1);
+      result.resize(count - 1);
     }
 
     return result;

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -15,9 +15,34 @@
 namespace osquery {
 
 // Helper object used by Wide/Narrow converter functions
-static std::wstring_convert<
-    std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::little_endian>>
-    converter;
+
+struct utf_converter {
+  std::wstring from_bytes(const std::string& str) {
+    std::wstring result;
+    if (str.length() > 0) {
+      result.resize(str.length() * 2);
+      int count = MultiByteToWideChar(
+          CP_UTF8, 0, str.c_str(), -1, &result[0], str.length() * 2);
+      result.resize(count-1);
+    }
+
+    return result;
+  }
+
+  std::string to_bytes(const std::wstring& str) {
+    std::string result;
+    if (str.length() > 0) {
+      result.resize(str.length() * 4);
+      int count = WideCharToMultiByte(
+          CP_ACP, 0, str.c_str(), -1, &result[0], str.length() * 4, NULL, NULL);
+      result.resize(count-1);
+    }
+
+    return result;
+  }
+};
+
+static utf_converter converter;
 
 std::wstring stringToWstring(const std::string& src) {
   std::wstring utf16le_str;

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -36,7 +36,8 @@ struct utf_converter {
       auto count = WideCharToMultiByte(CP_UTF8,
                                        0,
                                        str.c_str(),
-                                       -1, &result[0],
+                                       -1,
+                                       &result[0],
                                        str.length() * 4,
                                        NULL,
                                        NULL);

--- a/osquery/utils/conversions/windows/tests/strings.cpp
+++ b/osquery/utils/conversions/windows/tests/strings.cpp
@@ -29,4 +29,19 @@ TEST_F(ConversionsTests, test_wstring_to_string) {
   std::string expected{"The quick brown fox jumps over the lazy dog"};
   EXPECT_EQ(narrowString, expected);
 }
+
+TEST_F(ConversionsTests, test_string_to_wstring_extended) {
+  std::string narrowString{"fr\xc3\xb8tz-jorn"};
+  auto wideString = stringToWstring(narrowString.c_str());
+  std::wstring expected{L"fr\x00f8tz-jorn"};
+  EXPECT_EQ(wideString, expected);
+}
+
+TEST_F(ConversionsTests, test_wstring_to_string_extended) {
+  std::wstring wideString{L"fr\x00f8tz-jorn"};
+  auto narrowString = wstringToString(wideString.c_str());
+  std::string expected{"fr\xc3\xb8tz-jorn"};
+  EXPECT_EQ(narrowString, expected);
+}
+
 } // namespace osquery


### PR DESCRIPTION
- Updates code to properly widen and narrow strings on Windows for tables.
- Fixes issue observed in issue https://github.com/osquery/osquery/issues/6160.
~- Does not solve the specific display issue where `fr°tz-jorn` is printed to the console instead of `frøtz-jorn`: This is another independent issue.~
- Now solves issue where `fr°tz-jorn` is printed to the console instead of `frøtz-jorn`.