### PR TITLE
Fix format_check.py failing on Windows with Python 3.7

### DIFF
--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -15,7 +15,7 @@ import sys
 def check(base_commit, exclude_folders):
     try:
         cmd = [
-          "python3",
+          sys.executable,
           os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-clang-format.py"),
           "--style=file",
           "--diff",
@@ -56,7 +56,7 @@ def get_base_commit(base_branch):
     try:
         return subprocess.check_output(
                 ["git", "merge-base", "HEAD", base_branch]
-                ).strip()
+                ).decode().strip()
     except OSError as e:
         print("{}\n\n{}".format("Failed to execut git", str(e)))
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
- The output from the git subprocess has to be decoded from bytes
  to str before passing it as an argument of a new subprocess.

- Use the python interpreter of the current script to run git-clang-format.py.

Closes https://github.com/osquery/osquery/issues/6089