### PR TITLE
Add WiFi security type to the wifi_survey table

### DIFF
--- a/osquery/tables/networking/darwin/wifi_survey.mm
+++ b/osquery/tables/networking/darwin/wifi_survey.mm
@@ -42,6 +42,7 @@ QueryData genWifiScan(QueryContext& context) {
         if (country_code != nil) {
           r["country_code"] = [country_code UTF8String];
         }
+        r["security_type"] = getSecurityName([network security]);
         r["rssi"] = INTEGER([network rssiValue]);
         r["noise"] = INTEGER([network noiseMeasurement]);
         CWChannel* cwc = [network wlanChannel];

--- a/specs/darwin/wifi_scan.table
+++ b/specs/darwin/wifi_scan.table
@@ -6,6 +6,7 @@ schema([
     Column("bssid", TEXT, "The current basic service set identifier"),
     Column("network_name", TEXT, "Name of the network"),
     Column("country_code", TEXT, "The country code (ISO/IEC 3166-1:1997) for the network"),
+    Column("security_type", TEXT, "Type of security on this network"),
     Column("rssi", INTEGER, "The current received signal strength indication (dbm)"),
     Column("noise", INTEGER, "The current noise measurement (dBm)"),
     Column("channel", INTEGER, "Channel number"),


### PR DESCRIPTION
This change adds the `security_type` column from the `wifi_networks`/`wifi_status` tables to `wifi_survey` table to differentiate secure vs. unsecured nearby wifi networks.