### PR TITLE
Fix format folder exclusion and format check self test

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -262,7 +262,7 @@ function(generateSpecialTargets)
   add_custom_target(prepare_for_ide)
 
   set(excluded_folders
-    "libraries/cmake/source"
+    "libraries"
   )
 
   set(command_prefix)

--- a/tools/formatting/format-test.sh
+++ b/tools/formatting/format-test.sh
@@ -20,7 +20,7 @@ build_dir=${args[1]}
 set -e
 
 # List all files to format, skipping all the ones inside the libraries folder, sort them and save the list on a file
-find . -type d -path ./libraries -prune -o -type f -regex ".*\.cpp$\|.*\.h$\|.*\.hpp$" -print | sort > $build_dir/files_to_format.txt
+find . -type d -path ./libraries -prune -o -type f -regex ".*\.cpp$\|.*\.h$\|.*\.hpp$\|.*\.mm$" -print | sort > $build_dir/files_to_format.txt
 
 # Read back the list of files, modify them appending two newlines, so that the format_check.py is triggered
 while read line; do echo -e "\n\n" >> $line; done <<< `cat $build_dir/files_to_format.txt`


### PR DESCRIPTION
- Exclude the whole "libraries" folder so that
  we don't attempt formatting code from the other layers.

- Add .mm files to the format-check self test, otherwise
  if one of those gets actually modified by a user
  the test will fail.

Co-Authored-By: Alessandro Gario <alessandro.gario@gmail.com>
