### PR TITLE
Fix pci.ids path on RedHat like system

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -32,7 +32,8 @@ const std::string kPCIClassID = "PCI_CLASS";
 const std::string kPCIKeyDriver = "DRIVER";
 const std::string kPCISubsysID = "PCI_SUBSYS_ID";
 
-const std::string kPciidsPath = "/usr/share/misc/pci.ids";
+const std::vector<std::string> kPciidsPathList{
+  "/usr/share/misc/pci.ids", "/usr/share/hwdata/pci.ids"};
 const std::string kPciidsDeviceClassStartIndicator = "ffff";
 const std::string kPciidsValidHexChars = "0123456789abcdef";
 const char kPciidsCommentChar = '#';
@@ -392,10 +393,20 @@ QueryData genPCIDevices(QueryContext& context) {
     return results;
   }
 
-  std::ifstream raw(kPciidsPath);
-  if (raw.fail()) {
+  std::ifstream raw;
+  std::string all_path;
+  for (const std::string& kPciidsPath : kPciidsPathList) {
+    raw.open(kPciidsPath);
+    if (raw) {
+      break;
+    }
+    if (! all_path.empty()) all_path.append(" ");
+    all_path.append(kPciidsPath);
+  }
+  if (raw.fail())
+  {
     LOG(ERROR) << "Unexpected error attempting to read pci.ids at path: "
-               << kPciidsPath;
+               << all_path;
     return results;
   }
 

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -32,8 +32,8 @@ const std::string kPCIClassID = "PCI_CLASS";
 const std::string kPCIKeyDriver = "DRIVER";
 const std::string kPCISubsysID = "PCI_SUBSYS_ID";
 
-const std::vector<std::string> kPciidsPathList{
-  "/usr/share/misc/pci.ids", "/usr/share/hwdata/pci.ids"};
+const std::vector<std::string> kPciidsPathList{"/usr/share/misc/pci.ids",
+                                               "/usr/share/hwdata/pci.ids"};
 const std::string kPciidsDeviceClassStartIndicator = "ffff";
 const std::string kPciidsValidHexChars = "0123456789abcdef";
 const char kPciidsCommentChar = '#';
@@ -400,11 +400,11 @@ QueryData genPCIDevices(QueryContext& context) {
     if (raw) {
       break;
     }
-    if (! all_path.empty()) all_path.append(" ");
+    if (!all_path.empty())
+      all_path.append(" ");
     all_path.append(kPciidsPath);
   }
-  if (raw.fail())
-  {
+  if (raw.fail()) {
     LOG(ERROR) << "Unexpected error attempting to read pci.ids at path: "
                << all_path;
     return results;


### PR DESCRIPTION
This patch iterates over the following paths
to find out which one is present on the system

* /usr/share/misc/pci.ids (Debian like)
* /usr/share/hwdata/pci.ids (Redhat like)

Fixes #5569

