### PR TITLE
Update build files to include windows_optional_features table

### DIFF
--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -137,6 +137,7 @@ osquery_cxx_test(
             [
                 "windows/certificates_tests.cpp",
                 "windows/registry_tests.cpp",
+                "windows/windows_optional_features_tests.cpp",
             ],
         ),
     ],

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ function(generateOsqueryTablesSystemWindowsTests)
   add_osquery_executable(osquery_tables_system_windows_tests-test
     windows/certificates_tests.cpp
     windows/registry_tests.cpp
+    windows/windows_optional_features_tests.cpp
   )
 
   target_link_libraries(osquery_tables_system_windows_tests-test PRIVATE

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -816,6 +816,10 @@ osquery_gentable_cxx_library(
             "windows/windows_security_products.table",
             "windows",
         ),
+        (
+            "windows/windows_optional_features.table",
+            "windows",
+        ),
     ],
     spec_files = [
         "azure_instance_metadata.table",

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -265,6 +265,7 @@ function(generateNativeTables)
     "windows/autoexec.table:windows"
     "windows/default_environment.table:windows"
     "windows/windows_security_products.table:windows"
+    "windows/windows_optional_features.table:windows"
     "windows/connectivity.table:windows"
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,freebsd"

--- a/specs/windows/windows_optional_features.table
+++ b/specs/windows/windows_optional_features.table
@@ -6,7 +6,7 @@ schema([
   Column("state", INTEGER, "Installation state value. 1 == Enabled, 2 == Disabled, 3 == Absent"),
   Column("statename", TEXT, "Installation state name. 'Enabled','Disabled','Absent'"),
 ])
-implementation("windows_optional_features@genWinOptionalFeatures")
+implementation("system/windows/windows_optional_features@genWinOptionalFeatures")
 examples([
   "select * from windows_optional_features",
   "select * from windows_optional_features where name = 'SMB1Protocol' AND state = 1",


### PR DESCRIPTION
The table was added without the proper updates to the build files, so it is not built into the binary.