### PR TITLE
events/windows: Prevent overly eager old name record handling

### DIFF
--- a/osquery/events/tests/windows/usn_journal_reader_tests.cpp
+++ b/osquery/events/tests/windows/usn_journal_reader_tests.cpp
@@ -15,7 +15,7 @@ namespace osquery {
 class UsnJournalReaderTests : public testing::Test {};
 
 TEST_F(UsnJournalReaderTests, test_get_native_file_id) {
-  USNFileReferenceNumber usn_file_ref = 0x00BBFF66;
+  USNFileReferenceNumber usn_file_ref{0x00BBFF66};
   FILE_ID_DESCRIPTOR file_id;
   GetNativeFileIdFromUSNReference(file_id, usn_file_ref);
   ASSERT_TRUE(file_id.Type == ObjectIdType || file_id.Type == FileIdType);

--- a/osquery/events/windows/ntfs_event_publisher.cpp
+++ b/osquery/events/windows/ntfs_event_publisher.cpp
@@ -558,7 +558,7 @@ Status NTFSEventPublisher::run() {
       }
     }
 
-    if (old_name_record.node_ref_number != 0U) {
+    if (old_name_record.drive_letter != 0U) {
       status = getPathFromParentFRN(event.old_path,
                                     parent_frn_cache,
                                     old_name_record.drive_letter,

--- a/osquery/events/windows/usn_journal_reader.h
+++ b/osquery/events/windows/usn_journal_reader.h
@@ -35,7 +35,7 @@ namespace osquery {
 struct USNFileReferenceNumber {
   std::vector<std::uint8_t> data;
 
-  explicit USNFileReferenceNumber() : data() {}
+  USNFileReferenceNumber() : data() {}
   explicit USNFileReferenceNumber(std::uint64_t val) {
     data.resize(sizeof(val));
     std::memcpy(data.data(), &val, sizeof(val));

--- a/osquery/events/windows/usn_journal_reader.h
+++ b/osquery/events/windows/usn_journal_reader.h
@@ -35,8 +35,8 @@ namespace osquery {
 struct USNFileReferenceNumber {
   std::vector<std::uint8_t> data;
 
-  USNFileReferenceNumber() : data() {}
-  USNFileReferenceNumber(std::uint64_t val) {
+  explicit USNFileReferenceNumber() : data() {}
+  explicit USNFileReferenceNumber(std::uint64_t val) {
     data.resize(sizeof(val));
     std::memcpy(data.data(), &val, sizeof(val));
   }

--- a/osquery/tables/events/windows/ntfs_journal_events.cpp
+++ b/osquery/tables/events/windows/ntfs_journal_events.cpp
@@ -329,7 +329,7 @@ void processConfiguration(const NTFSEventSubscriptionContextRef context,
     // there's another TOCTOU here: another process could delete the file before
     // we get its information. We don't want to lock the file, though, since it
     // could be something imporant used by another process.
-    USNFileReferenceNumber frn = 0;
+    USNFileReferenceNumber frn{};
 
 #if _WIN32_WINNT > _WIN32_WINNT_WIN7
     FILE_ID_INFO file_id_info;


### PR DESCRIPTION
This fixes the verbosity observed in https://github.com/osquery/osquery/pull/5371#pullrequestreview-298697871:

A quick summary: `FileReferenceNumber` doesn't have an `operator==` for integers, but C++ gets clever and implicitly provides one because of the `FileReferenceNumber(DWORDLONG)` constructor. This ends up providing the wrong implicit comparison behavior, resulting in the branch below always being taken (and consequently erroring, since no old name record is actually present). This fix changes the comparison to `drive_letter`, which will always be compared correctly and will only be `0U` in the case we want to test.