### PR TITLE
Implement container access from tables on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
           -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain
           -DOSQUERY_BUILD_TESTS=ON
+          -DOSQUERY_BUILD_ROOT_TESTS=ON
           $(EXTRA_CMAKE_ARGS)
           $(Build.SourcesDirectory)
 
@@ -88,8 +89,13 @@ jobs:
         cmakeArgs: --build . --target cppcheck
 
     - script: |
-        ctest --build-nocmake -V
-      displayName: "Run tests"
+        ctest --build-nocmake -LE "root-required" -V
+      displayName: "Run tests with a normal user"
+      workingDirectory: $(BUILD_DIR)
+
+    - script: |
+        sudo ctest --build-nocmake -L "root-required" -V
+      displayName: "Run tests which requires root"
       workingDirectory: $(BUILD_DIR)
 
     - script: |

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -68,6 +68,7 @@ option(ADD_HEADERS_AS_SOURCES "Whether to add headers as sources of a target or 
 option(OSQUERY_NO_DEBUG_SYMBOLS "Whether to build without debug symbols or not, even if a build type that normally have them has been selected")
 
 option(OSQUERY_BUILD_TESTS "Whether to enable and build tests or not")
+option(OSQUERY_BUILD_ROOT_TESTS "Whether to enable and build tests that require root access")
 
 option(OSQUERY_ENABLE_FUZZER_SANITIZERS "Whether to build fuzzing harnesses")
 option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -30,6 +30,7 @@ function(osqueryMain)
   add_subdirectory("ev2")
   add_subdirectory("experimental")
   add_subdirectory("system")
+  add_subdirectory("worker")
 
   generateOsqueryHeaders()
   generateOsqueryd()

--- a/osquery/core/sql/query_data.cpp
+++ b/osquery/core/sql/query_data.cpp
@@ -42,14 +42,21 @@ Status serializeQueryData(const QueryDataTyped& q,
   return Status::success();
 }
 
-Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
-  auto doc = JSON::newArray();
-
+Status serializeQueryDataJSON(const QueryData& q, JSON& doc) {
+  doc = JSON::newArray();
   ColumnNames cols;
   auto status = serializeQueryData(q, cols, doc, doc.doc());
+  return status;
+}
+
+Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
+  JSON doc;
+  auto status = serializeQueryDataJSON(q, doc);
+
   if (!status.ok()) {
     return status;
   }
+
   return doc.toString(json);
 }
 
@@ -113,13 +120,21 @@ Status deserializeQueryData(const rj::Value& v, QueryDataSet& qd) {
   return Status::success();
 }
 
-Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
-  auto doc = JSON::newArray();
-  if (!doc.fromString(json) || !doc.doc().IsArray()) {
+Status deserializeQueryDataJSON(const JSON& doc, QueryData& qd) {
+  if (!doc.doc().IsArray()) {
     return Status(1, "Cannot deserializing JSON");
   }
 
   return deserializeQueryData(doc.doc(), qd);
+}
+
+Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
+  auto doc = JSON::newArray();
+  if (!doc.fromString(json)) {
+    return Status(1, "Cannot deserializing JSON");
+  }
+
+  return deserializeQueryDataJSON(doc, qd);
 }
 
 Status deserializeQueryDataJSON(const std::string& json, QueryDataSet& qd) {

--- a/osquery/core/sql/query_data.h
+++ b/osquery/core/sql/query_data.h
@@ -70,6 +70,16 @@ Status serializeQueryData(const QueryDataTyped& q,
                           bool asNumeric);
 
 /**
+ * @brief Serialize a QueryData object into a JSON document.
+ *
+ * @param q the QueryData to serialize.
+ * @param doc [output] the output JSON document.
+ *
+ * @return Status indicating the success or failure of the operation.
+ */
+Status serializeQueryDataJSON(const QueryData& q, JSON& doc);
+
+/**
  * @brief Serialize a QueryData object into a JSON string.
  *
  * @param q the QueryData to serialize.
@@ -100,6 +110,8 @@ Status deserializeQueryData(const rapidjson::Value& arr, QueryDataTyped& qd);
 
 /// Inverse of serializeQueryData, convert JSON to QueryDataSet.
 Status deserializeQueryData(const rapidjson::Value& arr, QueryDataSet& qd);
+
+Status deserializeQueryDataJSON(const JSON& doc, QueryData& qd);
 
 /// Inverse of serializeQueryDataJSON, convert a JSON string to QueryData.
 Status deserializeQueryDataJSON(const std::string& json, QueryData& qd);

--- a/osquery/include/osquery/tables.h
+++ b/osquery/include/osquery/tables.h
@@ -653,9 +653,6 @@ struct QueryContext {
   friend class TablePlugin;
 };
 
-using QueryContext = struct QueryContext;
-using Constraint = struct Constraint;
-
 /**
  * @brief The TablePlugin defines the name, types, and column information.
  *
@@ -930,4 +927,8 @@ inline const std::string& columnTypeName(ColumnType type) {
 
 /// Get the column type from the string representation.
 ColumnType columnTypeName(const std::string& type);
+
+Status deserializeQueryContextJSON(const JSON& json_helper,
+                                   QueryContext& context);
+void serializeQueryContextJSON(const QueryContext& context, JSON& json_helper);
 } // namespace osquery

--- a/osquery/process/process.h
+++ b/osquery/process/process.h
@@ -77,6 +77,7 @@ class PlatformProcess : private boost::noncopyable {
   virtual ~PlatformProcess();
 
   PlatformProcess& operator=(const PlatformProcess& process) = delete;
+  PlatformProcess& operator=(PlatformProcess&& process) noexcept;
   bool operator==(const PlatformProcess& process) const;
   bool operator!=(const PlatformProcess& process) const;
 

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -51,8 +51,8 @@ PlatformProcess::PlatformProcess(pid_t pid) {
 }
 
 PlatformProcess::PlatformProcess(PlatformProcess&& src) noexcept {
-  id_ = kInvalidPid;
-  std::swap(id_, src.id_);
+  id_ = src.id_;
+  src.id_ = kInvalidPid;
 }
 
 PlatformProcess::~PlatformProcess() {
@@ -60,6 +60,13 @@ PlatformProcess::~PlatformProcess() {
     ::CloseHandle(id_);
     id_ = kInvalidPid;
   }
+}
+
+PlatformProcess& PlatformProcess::operator=(
+    PlatformProcess&& process) noexcept {
+  id_ = process.id_;
+  process.id_ = kInvalidPid;
+  return *this;
 }
 
 bool PlatformProcess::operator==(const PlatformProcess& process) const {

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -234,6 +234,7 @@ function(generateOsqueryTablesSystemSystemtable)
     osquery_utils_system_systemutils
     osquery_utils_system_time
     osquery_utils_system_uptime
+    osquery_worker_ipc_platformtablecontaineripc
     thirdparty_boost
     osquery_rows_processes_header
   )

--- a/osquery/tables/utility/CMakeLists.txt
+++ b/osquery/tables/utility/CMakeLists.txt
@@ -23,6 +23,8 @@ function(generateTablesUtilityUtilitytable)
     osquery_process
     osquery_utils_macros
     osquery_utils_system_systemutils
+    osquery_worker_ipc_platformtablecontaineripc
+    osquery_worker_logging_glog_logger
     thirdparty_boost
   )
 endfunction()

--- a/osquery/worker/CMakeLists.txt
+++ b/osquery/worker/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerMain)
+    add_subdirectory("ipc")
+    add_subdirectory("logging")
+endfunction()
+
+osqueryWorkerMain()

--- a/osquery/worker/ipc/CMakeLists.txt
+++ b/osquery/worker/ipc/CMakeLists.txt
@@ -1,0 +1,114 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcMain)
+  if(OSQUERY_BUILD_TESTS)
+    add_subdirectory("tests")
+  endif()
+
+  generateOsqueryWorkerIpcTableIpcJsonConverter()
+  generateOsqueryWorkerIpcPlatformTableContainerIpc()
+  generateOsqueryWorkerIpcTableChannel()
+  generateOsqueryWorkerIpcTableIpc()
+
+  if(DEFINED PLATFORM_POSIX)
+    add_subdirectory("posix")
+  endif()
+
+  if(DEFINED PLATFORM_LINUX)
+    add_subdirectory("linux")
+  endif()
+endfunction()
+
+function(generateOsqueryWorkerIpcTableIpcJsonConverter)
+  set(source_files
+    table_ipc_json_converter.cpp
+  )
+
+  set(public_header_files
+    table_ipc_json_converter.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_tableipcjsonconverter EXCLUDE_FROM_ALL ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_tableipcjsonconverter PUBLIC
+    osquery_cxx_settings
+    osquery_core_sql
+    osquery_headers
+    osquery_utils_status
+    osquery_utils_json
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_tableipcjsonconverter "osquery/worker/ipc" FULL_PATH ${public_header_files})
+
+  add_test(NAME osquery_worker_ipc_tests_jsonconversions-test COMMAND osquery_worker_ipc_tests_jsonconversions-test)
+endfunction()
+
+function(generateOsqueryWorkerIpcPlatformTableContainerIpc)
+
+  add_osquery_library(osquery_worker_ipc_platformtablecontaineripc INTERFACE)
+
+  if(DEFINED PLATFORM_LINUX)
+    target_link_libraries(osquery_worker_ipc_platformtablecontaineripc INTERFACE
+      osquery_worker_ipc_linux_platformtablecontaineripc
+    )
+  else()
+    set(public_header_files
+      include/platform_table_container_ipc.h
+    )
+
+    target_link_libraries(osquery_worker_ipc_platformtablecontaineripc INTERFACE
+      osquery_cxx_settings
+      osquery_core_sql
+      osquery_headers
+      osquery_worker_logging_glog_logger
+    )
+  endif()
+
+  generateIncludeNamespace(osquery_worker_ipc_platformtablecontaineripc "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+endfunction()
+
+function(generateOsqueryWorkerIpcTableChannel)
+  set(public_header_files
+    include/table_channel_base.h
+    include/table_channel_factory_base.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_tablechannel INTERFACE)
+
+  target_link_libraries(osquery_worker_ipc_tablechannel INTERFACE
+    osquery_cxx_settings
+    osquery_utils
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_tablechannel "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+endfunction()
+
+function(generateOsqueryWorkerIpcTableIpc)
+
+  set(public_header_files
+    include/table_ipc_base.h
+    include/table_ipc_message_handler.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_tableipc INTERFACE)
+
+  generateIncludeNamespace(osquery_worker_ipc_tableipc "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+
+  target_link_libraries(osquery_worker_ipc_tableipc INTERFACE
+    osquery_cxx_settings
+    osquery_core
+    osquery_core_sql
+    osquery_headers
+    osquery_utils_status
+    osquery_worker_ipc_tablechannel
+    osquery_worker_ipc_tableipcjsonconverter
+    osquery_worker_logging_logger
+  )
+
+endfunction()
+
+osqueryWorkerIpcMain()

--- a/osquery/worker/ipc/include/platform_table_container_ipc.h
+++ b/osquery/worker/ipc/include/platform_table_container_ipc.h
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/tables.h>
+#include <osquery/worker/logging/logger.h>
+
+namespace osquery {
+
+using TableGeneratePtr = QueryData (*)(QueryContext& query_context,
+                                       Logger& logger_);
+
+inline bool hasNamespaceConstraint(const QueryContext&) {
+  return false;
+}
+
+inline QueryData generateInNamespace(const QueryContext&,
+                                     const std::string&,
+                                     TableGeneratePtr) {
+  throw std::logic_error("generateInNamespace not implemented!");
+
+  return QueryData();
+}
+} // namespace osquery

--- a/osquery/worker/ipc/include/table_channel_base.h
+++ b/osquery/worker/ipc/include/table_channel_base.h
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <osquery/utils/only_movable.h>
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+template <typename Derived>
+class TableChannelBase : only_movable {
+ public:
+  TableChannelBase() = delete;
+  TableChannelBase(const std::string& table_name) : table_name_(table_name) {}
+
+  virtual ~TableChannelBase() {}
+
+  Status sendStringMessage(const std::string& message) {
+    return static_cast<Derived&>(*this).sendStringMessageImpl(message);
+  }
+  Status recvStringMessage(std::string& message) {
+    return static_cast<Derived&>(*this).recvStringMessageImpl(message);
+  }
+
+  std::string table_name_;
+};
+} // namespace osquery

--- a/osquery/worker/ipc/include/table_channel_factory_base.h
+++ b/osquery/worker/ipc/include/table_channel_factory_base.h
@@ -1,0 +1,70 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+
+#include "table_channel_base.h"
+
+namespace osquery {
+template <typename T>
+struct GetChannelType;
+
+template <typename TableChannelFactory>
+class TableChannelFactoryBase {
+ private:
+  using TableChannel = typename GetChannelType<TableChannelFactory>::Channel;
+  static_assert(
+      std::is_base_of<TableChannelBase<TableChannel>, TableChannel>::value,
+      "The TableChannel type do not implement the interface from "
+      "TableChannelBase<TableChannel>");
+
+ public:
+  template <typename... ConstructorArgs>
+  TableChannel& createChannel(const std::string table_name,
+                              ConstructorArgs&&... args) {
+    std::unique_ptr<TableChannel> channel =
+        static_cast<TableChannelFactory&>(*this).createChannelImpl(
+            table_name, std::forward<ConstructorArgs>(args)...);
+    auto channel_ptr = channel.get();
+    table_to_channel.emplace(table_name, std::move(channel));
+
+    return *channel_ptr;
+  }
+
+  TableChannel* getTableChannel(const std::string& table_name) {
+    auto it = table_to_channel.find(table_name);
+    if (it != table_to_channel.end())
+      return it->second.get();
+
+    return nullptr;
+  }
+
+  void dropTableChannel(const std::string& table_name) {
+    int erased = table_to_channel.erase(table_name);
+
+    if (erased == 0) {
+      throw std::logic_error("Trying to drop non existing channel to table " +
+                             table_name);
+    }
+  }
+
+  void clear() {
+    table_to_channel.clear();
+  }
+
+ private:
+  std::unordered_map<std::string, std::unique_ptr<TableChannel>>
+      table_to_channel;
+  TableChannelFactoryBase() {}
+  friend TableChannelFactory;
+};
+} // namespace osquery

--- a/osquery/worker/ipc/include/table_ipc_base.h
+++ b/osquery/worker/ipc/include/table_ipc_base.h
@@ -1,0 +1,142 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/worker/ipc/table_ipc_json_converter.h>
+
+#include <osquery/worker/logging/glog_logger_types.h>
+
+namespace osquery {
+template <typename Derived>
+class TableIPCBase {
+ public:
+  Status sendQueryData(const QueryData& query_data) {
+    JSON json_helper;
+    auto status =
+        TableIPCJSONConverter::queryDataToJSON(query_data, json_helper);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    json_helper.add("Type", "QueryData");
+
+    std::string json_string;
+    status = json_helper.toString(json_string);
+
+    if (!status.ok())
+      return status;
+
+    return static_cast<Derived&>(*this).sendJSONString(json_string);
+  }
+
+  Status sendLogMessage(int severity,
+                        GLOGLogType log_type,
+                        const std::string& message) {
+    JSON json_helper;
+    auto status = TableIPCJSONConverter::logMessageToJSON(
+        severity, static_cast<int>(log_type), message, json_helper);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    json_helper.add("Type", "Log");
+
+    std::string json_string;
+    status = json_helper.toString(json_string);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    return static_cast<Derived&>(*this).sendJSONString(json_string);
+  }
+
+  Status sendJob(const QueryContext& context) {
+    JSON json_helper;
+    serializeQueryContextJSON(context, json_helper);
+    json_helper.add("Type", "Job");
+
+    std::string json_string;
+    auto status = json_helper.toString(json_string);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    return static_cast<Derived&>(*this).sendJSONString(json_string);
+  }
+
+  Status recvJSONMessage(JSON& json_message, JSONMessageType& message_type) {
+    std::string json_string;
+    auto status = static_cast<Derived&>(*this).recvJSONString(json_string);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    status = json_message.fromString(json_string);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    if (!json_message.doc().HasMember("Type")) {
+      return Status::failure("No Type member");
+    }
+
+    return TableIPCJSONConverter::JSONTypeToMessageType(json_message,
+                                                        message_type);
+  }
+
+  Status processOneMessage(QueryData* query_results,
+                           JSONMessageType& message_type) {
+    JSON json_message;
+    Status status = recvJSONMessage(json_message, message_type);
+
+    if (!status.ok()) {
+      return status;
+    }
+
+    switch (message_type) {
+    case JSONMessageType::Log: {
+      status = static_cast<Derived&>(*this).processLogMessage(json_message);
+      break;
+    }
+    case JSONMessageType::QueryData: {
+      if (!query_results) {
+        status = Status::failure(1, "Received unexpected QueryData message");
+        break;
+      }
+
+      status = static_cast<Derived&>(*this).processQueryDataMessage(
+          json_message, *query_results);
+      break;
+    }
+    case JSONMessageType::Job: {
+      status = static_cast<Derived&>(*this).processJobMessage(json_message);
+      break;
+    }
+    default: {
+      status = Status::failure("Invalid message type received, type " +
+                               std::to_string(static_cast<int>(message_type)));
+      break;
+    }
+    }
+
+    return status;
+  }
+};
+} // namespace osquery

--- a/osquery/worker/ipc/include/table_ipc_message_handler.h
+++ b/osquery/worker/ipc/include/table_ipc_message_handler.h
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <osquery/tables.h>
+#include <osquery/utils/status/status.h>
+
+#include <osquery/worker/logging/glog_logger_types.h>
+
+namespace osquery {
+class TableIPCMessageHandler {
+ public:
+  virtual ~TableIPCMessageHandler() {}
+  virtual Status handleLog(GLOGLogType log_type,
+                           int priority,
+                           const std::string& message) = 0;
+  virtual Status handleJob(QueryContext& context) = 0;
+};
+
+} // namespace osquery

--- a/osquery/worker/ipc/linux/CMakeLists.txt
+++ b/osquery/worker/ipc/linux/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcLinuxMain)
+
+  if(OSQUERY_BUILD_TESTS)
+    add_subdirectory("tests")
+  endif()
+
+  generateOSqueryWorkerIpcLinuxTableIpc()
+  generateOsqueryWorkerIpcLinuxTableContainerIpc()
+  generateOsqueryWorkerIpcLinuxPlatformTableContainerIpc()
+endfunction()
+
+function(generateOsqueryWorkerIpcLinuxTableContainerIpc)
+  set(source_files
+    linux_table_container_ipc.cpp
+  )
+
+  set(public_header_files
+    linux_table_container_ipc.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_linux_tablecontaineripc EXCLUDE_FROM_ALL ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_linux_tablecontaineripc PUBLIC
+    osquery_cxx_settings
+    osquery_worker_logging_glog_logger
+    osquery_worker_ipc_linux_tableipc
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_linux_tablecontaineripc "osquery/worker/ipc/linux" FILE_ONLY ${public_header_files})
+
+  if(OSQUERY_BUILD_ROOT_TESTS)
+    add_test(NAME osquery_worker_ipc_linux_tests_tablecontainer-test COMMAND osquery_worker_ipc_linux_tests_tablecontainer-test)
+    set_tests_properties(osquery_worker_ipc_linux_tests_tablecontainer-test PROPERTIES LABELS "root-required")
+  endif()
+endfunction()
+
+function(generateOSqueryWorkerIpcLinuxTableIpc)
+  set(source_files
+    linux_table_ipc.cpp
+  )
+
+  set(public_header_files
+    linux_table_ipc.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_linux_tableipc EXCLUDE_FROM_ALL ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_linux_tableipc PUBLIC
+    osquery_cxx_settings
+    osquery_worker_ipc_tableipc
+    osquery_worker_ipc_posix_pipechannel
+    osquery_worker_ipc_tableipcjsonconverter
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_linux_tableipc "osquery/worker/ipc/linux" FILE_ONLY ${public_header_files})
+
+endfunction()
+
+function(generateOsqueryWorkerIpcLinuxPlatformTableContainerIpc)
+  add_osquery_library(osquery_worker_ipc_linux_platformtablecontaineripc INTERFACE)
+
+  set(public_header_files
+    platform_table_container_ipc.h
+  )
+
+  target_link_libraries(osquery_worker_ipc_linux_platformtablecontaineripc INTERFACE
+    osquery_cxx_settings
+    osquery_worker_ipc_linux_tablecontaineripc
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_linux_platformtablecontaineripc "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+endfunction()
+
+
+osqueryWorkerIpcLinuxMain()

--- a/osquery/worker/ipc/linux/linux_table_container_ipc.cpp
+++ b/osquery/worker/ipc/linux/linux_table_container_ipc.cpp
@@ -1,0 +1,457 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "linux_table_container_ipc.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <syscall.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/worker/ipc/posix/pipe_channel_factory.h>
+#include <osquery/worker/ipc/table_ipc_json_converter.h>
+
+#include "osquery/worker/logging/glog/glog_logger.h"
+
+namespace osquery {
+
+DECLARE_bool(verbose);
+
+CLI_FLAG(bool,
+         keep_container_worker_open,
+         false,
+         "Keep the container worker running to be reused instead of closing it "
+         "after each query");
+
+namespace {
+
+const std::string kProc = "/proc";
+const std::string kMountNamespace = "/ns/mnt";
+
+/*
+ * A namespace id as read from the pseudo link /proc/<pid>/ns/mnt
+ * has the format mnt:[<id>] where <id> is an unsigned int representing
+ * the namespace id; the max value of an unsigned int has 10 digits
+ * and the rest of the string are 6 characters, so the content
+ * of the link is max 16 characters.
+ */
+const int kMaxNamespaceIdLinkChars = 16;
+
+PlatformProcess current_running_process;
+
+Status extractMountNamespaceId(const std::string& mount_namespace_path,
+                               std::string& mount_namespace_id) {
+  std::string mnt_namespace_id_source(kMaxNamespaceIdLinkChars, 0);
+  auto chars_read = readlink(mount_namespace_path.data(),
+                             &mnt_namespace_id_source[0],
+                             mnt_namespace_id_source.size());
+
+  if (chars_read < 0) {
+    return Status::failure("Could not read the mount namespace id from " +
+                           mount_namespace_path +
+                           ", error: " + std::to_string(errno));
+  }
+
+  mnt_namespace_id_source.resize(static_cast<size_t>(chars_read));
+
+  if (mnt_namespace_id_source.empty()) {
+    return Status::failure(
+        "Failed to parse the mount namespace id, string is empty");
+  }
+
+  auto start = mnt_namespace_id_source.find('[');
+
+  if (start == std::string::npos) {
+    return Status::failure(
+        "Failed to find the start of the mount namespace id in \"" +
+        mnt_namespace_id_source + "\"");
+  }
+
+  auto end = mnt_namespace_id_source.find(']', start);
+
+  if (end == std::string::npos) {
+    return Status::failure(
+        "Failed to find the end of the mount namespace id in \"" +
+        mnt_namespace_id_source + "\"");
+  }
+
+  size_t namespace_id_size = end - start - 1;
+
+  if (namespace_id_size == 0) {
+    return Status::failure(
+        "Failed to parse the mount namespace id, no id found");
+  }
+
+  mount_namespace_id =
+      mnt_namespace_id_source.substr(start + 1, namespace_id_size);
+
+  return Status::success();
+}
+
+ProcessState checkProcessStateAndLog(const PlatformProcess& process,
+                                     const std::string& table_name) {
+  int child_exit_status = 0;
+
+  ProcessState process_state = process.checkStatus(child_exit_status);
+
+  if (process_state == ProcessState::PROCESS_ERROR) {
+    LOG(ERROR)
+        << "Failed to get the process state of container worker of table "
+        << table_name << " with pid " << process.pid();
+  } else if (process_state == ProcessState::PROCESS_EXITED &&
+             child_exit_status != 0) {
+    std::string message =
+        "Container worker of table " + table_name +
+        " exited with exit status: " + std::to_string(child_exit_status);
+    if (child_exit_status == 2 && FLAGS_verbose) {
+      syslog(LOG_NOTICE, "%s", message.c_str());
+    } else {
+      LOG(ERROR) << message;
+    }
+  }
+
+  return process_state;
+}
+} // namespace
+
+extern template std::set<int> ConstraintList::getAll<int>(
+    ConstraintOperator) const;
+
+LinuxTableContainerIPC::LinuxTableContainerIPC(PipeChannelFactory& factory)
+    : ipc_(factory, *this) {}
+
+LinuxTableContainerIPC::~LinuxTableContainerIPC() {
+  close(original_mnt_fd_);
+}
+
+Status LinuxTableContainerIPC::connectToContainer(
+    const std::string& table_name,
+    bool keep_process_open,
+    TableGeneratePtr function_ptr) {
+  keep_process_open_ = keep_process_open;
+
+  auto current_pid = getpid();
+  std::string original_mnt_path =
+      kProc + "/" + std::to_string(current_pid) + kMountNamespace;
+
+  if (original_mnt_fd_ > 0) {
+    close(original_mnt_fd_);
+  }
+
+  original_mnt_fd_ = open(original_mnt_path.c_str(), O_RDONLY);
+
+  if (original_mnt_fd_ < 0) {
+    return Status::failure(
+        "Failed to open the original mount namespace of the worker");
+  }
+
+  bool is_open = ipc_.setActiveChannelIfOpen(table_name);
+
+  if (!is_open) {
+    // This will stop any worker connected to another table,
+    // so that we only have one open each time
+    if (keep_process_open_) {
+      stopContainerWorker();
+    }
+
+    PipeChannelTicket channel_ticket = ipc_.createChannelTicket();
+
+    auto process_group = getpgrp();
+    table_generate_ptr_ = function_ptr;
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto result = setpgid(0, process_group);
+
+      if (result < 0) {
+        std::_Exit(1);
+      }
+
+      try {
+        ipc_.connectToParent(table_name, std::move(channel_ticket));
+      } catch (const std::exception& e) {
+        syslog(LOG_NOTICE, "Failed to connect to parent: %s", e.what());
+        std::_Exit(1);
+      }
+
+      executeQueryJobs();
+    } else if (pid == -1) {
+      return Status::failure("Failed to start container worker to table " +
+                             table_name);
+    } else {
+      current_running_process = PlatformProcess(pid);
+      ipc_.connectToChild(table_name, std::move(channel_ticket), pid);
+    }
+  }
+
+  return Status::success();
+}
+void LinuxTableContainerIPC::stopContainerWorker() {
+  PlatformProcess child_process(std::move(current_running_process));
+
+  if (child_process.pid() == kInvalidPid) {
+    return;
+  }
+
+  std::string table_name = ipc_.isChannelOpen()
+                               ? ipc_.getTableName()
+                               : ipc_.getTableNameFromPid(child_process.pid());
+
+  ipc_.setActiveChannelIfOpen(table_name);
+  ipc_.closeActiveChannel();
+
+  ProcessState process_state =
+      checkProcessStateAndLog(child_process, table_name);
+
+  if (process_state == ProcessState::PROCESS_STILL_ALIVE) {
+    // Wait for the process to close on a separate thread.
+    // If it doesn't close in a timely fashion it will be forcefully terminated.
+    auto wait_and_kill = [](PlatformProcess process, std::string table_name) {
+      auto time_passed = std::chrono::milliseconds(0);
+      auto interval = std::chrono::milliseconds(500);
+      auto max_delay = std::chrono::milliseconds(2000);
+
+      ProcessState process_state = ProcessState::PROCESS_STILL_ALIVE;
+      while (time_passed < max_delay) {
+        sleepFor(static_cast<size_t>(interval.count()));
+        time_passed += interval;
+
+        process_state = checkProcessStateAndLog(process, table_name);
+
+        if (process_state == ProcessState::PROCESS_ERROR ||
+            process_state == ProcessState::PROCESS_EXITED) {
+          break;
+        }
+      }
+
+      if (process_state == ProcessState::PROCESS_STILL_ALIVE) {
+        LOG(ERROR) << "Container worker to table " << table_name << " and pid "
+                   << process.pid()
+                   << " did not stop in a timely fashion, so it will be "
+                      "forcefully terminated";
+        process.kill();
+        process.cleanup();
+      }
+    };
+
+    auto wait_and_kill_thread =
+        std::thread(wait_and_kill, std::move(child_process), table_name);
+    wait_and_kill_thread.detach();
+  }
+}
+
+Status LinuxTableContainerIPC::handleLog(GLOGLogType log_type,
+                                         int priority,
+                                         const std::string& message) {
+  auto logger = GLOGLogger::instance();
+  switch (log_type) {
+  case GLOGLogType::LOG: {
+    logger.log(priority, message);
+    break;
+  }
+  case GLOGLogType::VLOG: {
+    logger.vlog(priority, message);
+    break;
+  }
+  default: {
+    return Status::failure("Unknown log message type " +
+                           std::to_string(static_cast<int>(log_type)));
+  }
+  }
+
+  return Status::success();
+}
+
+Status LinuxTableContainerIPC::handleJob(QueryContext& context) {
+  QueryData query_data;
+  auto pids_with_namespace =
+      context.constraints.at("pid_with_namespace").getAll<int>(EQUALS);
+
+  if (pids_with_namespace.empty()) {
+    return Status::failure(
+        "Column constraint pid_with_namespace has been passed but there's no "
+        "value in it");
+  }
+
+  for (const auto pid : pids_with_namespace) {
+    std::string path = kProc + "/" + std::to_string(pid) + kMountNamespace;
+    auto fd = open(path.c_str(), O_RDONLY);
+
+    if (fd < 0) {
+      logger_.vlog(1,
+                   "Could not open mount namespace of pid " +
+                       std::to_string(pid) +
+                       ", error: " + std::to_string(errno));
+      continue;
+    }
+
+    std::string mount_namespace_id;
+    auto status = extractMountNamespaceId(path, mount_namespace_id);
+
+    if (!status.ok()) {
+      logger_.vlog(1, status.getMessage());
+      close(fd);
+      continue;
+    }
+
+    // We call the syscall directly because setns() has been added as a function
+    // from glibc 2.14 and on only.
+    int result = static_cast<int>(syscall(SYS_setns, fd, 0));
+
+    close(fd);
+
+    if (result < 0) {
+      logger_.vlog(1,
+                   "Could not switch namespace of pid " + std::to_string(pid) +
+                       ", error: " + std::to_string(errno));
+      continue;
+    }
+
+    QueryData namespace_query_data = table_generate_ptr_(context, logger_);
+    for (auto& row : namespace_query_data) {
+      row["pid_with_namespace"] = INTEGER(pid);
+      row["mount_namespace_id"] = mount_namespace_id;
+    }
+
+    query_data.insert(query_data.end(),
+                      std::make_move_iterator(namespace_query_data.begin()),
+                      std::make_move_iterator(namespace_query_data.end()));
+  }
+
+  /*
+    While we still want to return results to the parent,
+    but not being able to restore the original namespace means that
+    if the child is kept around, it won't be able to be reused.
+    So after delivering the results, we return with an error so
+    that the process will be always closed.
+  */
+  auto write_status = ipc_.sendQueryData(query_data);
+
+  if (keep_process_open_) {
+    int result = static_cast<int>(syscall(SYS_setns, original_mnt_fd_, 0));
+
+    if (result < 0) {
+      auto status = Status::failure(
+          "Failed to restore the original mount namespace, due to error: " +
+          std::to_string(errno));
+      logger_.vlog(1, status.getMessage());
+      return status;
+    }
+  }
+
+  return write_status;
+}
+
+void LinuxTableContainerIPC::executeQueryJobs() {
+  int exit_status_code = 0;
+  if (keep_process_open_) {
+    while (true) {
+      JSONMessageType message_type;
+      auto status = ipc_.processOneMessage(nullptr, message_type);
+
+      if (!status.ok()) {
+        exit_status_code = status.getCode();
+
+        if (exit_status_code != 2 || FLAGS_verbose) {
+          syslog(LOG_NOTICE, "%s", status.getMessage().c_str());
+        }
+        break;
+      }
+    }
+  } else {
+    JSONMessageType message_type;
+    auto status = ipc_.processOneMessage(nullptr, message_type);
+
+    if (!status.ok()) {
+      exit_status_code = status.getCode();
+
+      if (exit_status_code != 2 || FLAGS_verbose) {
+        syslog(LOG_NOTICE, "%s", status.getMessage().c_str());
+      }
+    }
+  }
+
+  std::_Exit(exit_status_code);
+}
+
+Status LinuxTableContainerIPC::retrieveQueryDataFromContainer(
+    const QueryContext& context, QueryData& result) {
+  CleanupWorkerOnError cleanupOnError(*this);
+  auto status = ipc_.sendJob(context);
+
+  if (!status.ok()) {
+    return status;
+  }
+
+  bool child_has_result = false;
+  while (!child_has_result) {
+    JSONMessageType message_type;
+    auto status = ipc_.processOneMessage(&result, message_type);
+
+    if (!status.ok())
+      return status;
+
+    if (message_type == JSONMessageType::QueryData) {
+      child_has_result = true;
+    }
+  }
+
+  cleanupOnError.dismiss();
+  return status;
+}
+
+QueryData generateInNamespace(const QueryContext& context,
+                              const std::string& table_name,
+                              TableGeneratePtr generate_ptr) {
+  bool keep_container_worker_open = FLAGS_keep_container_worker_open;
+  QueryData results;
+
+  static PipeChannelFactory factory;
+
+  try {
+    LinuxTableContainerIPC ipc(factory);
+    auto status = ipc.connectToContainer(
+        table_name, keep_container_worker_open, generate_ptr);
+
+    if (!status.ok()) {
+      LOG(ERROR) << "Table " << table_name
+                 << " failed to connect to the container: "
+                 << status.getMessage();
+      return results;
+    }
+
+    status = ipc.retrieveQueryDataFromContainer(context, results);
+
+    if (!status.ok()) {
+      LOG(ERROR) << "Table " << table_name
+                 << " failed to retrieve QueryData from the container: "
+                 << status.getMessage();
+    }
+
+    if (!keep_container_worker_open)
+      ipc.stopContainerWorker();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Table " << table_name
+               << " failed to run query in the container: " << e.what();
+  }
+
+  return results;
+}
+
+}; // namespace osquery

--- a/osquery/worker/ipc/linux/linux_table_container_ipc.h
+++ b/osquery/worker/ipc/linux/linux_table_container_ipc.h
@@ -1,0 +1,89 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "osquery/worker/ipc/linux/linux_table_ipc.h"
+
+#include <string>
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/utils/status/status.h>
+
+#include "osquery/worker/ipc/posix/pipe_channel.h"
+#include "osquery/worker/ipc/posix/pipe_channel_factory.h"
+#include "osquery/worker/ipc/table_ipc_message_handler.h"
+#include "osquery/worker/logging/glog_logger_types.h"
+#include "osquery/worker/logging/logger.h"
+
+namespace osquery {
+using TableGeneratePtr = QueryData (*)(QueryContext& query_context,
+                                       Logger& logger_);
+
+/**
+ * @brief The LinuxTableContainerIPC class drives the logic to connect to, query
+ * and retrieve results from a container, together with managing the container
+ * worker lifetime.
+ */
+class LinuxTableContainerIPC : TableIPCMessageHandler {
+ public:
+  LinuxTableContainerIPC() = delete;
+  LinuxTableContainerIPC(PipeChannelFactory& factory);
+  ~LinuxTableContainerIPC();
+
+  Status connectToContainer(const std::string& table_name,
+                            bool keep_process_open,
+                            TableGeneratePtr table_generate_ptr_);
+  Status retrieveQueryDataFromContainer(const QueryContext& context,
+                                        QueryData& result);
+  [[noreturn]] void executeQueryJobs();
+  void stopContainerWorker();
+
+  Status handleLog(GLOGLogType log_type,
+                   int priority,
+                   const std::string& message) override;
+  Status handleJob(QueryContext& context) override;
+
+ private:
+  LinuxTableIPC ipc_;
+  LinuxTableIPCLogger logger_{ipc_};
+  TableGeneratePtr table_generate_ptr_;
+  bool keep_process_open_{false};
+  int original_mnt_fd_{-1};
+
+  class CleanupWorkerOnError {
+   public:
+    CleanupWorkerOnError() = delete;
+    CleanupWorkerOnError(LinuxTableContainerIPC& container_ipc)
+        : container_ipc_(&container_ipc) {}
+    ~CleanupWorkerOnError() {
+      if (cleanup_)
+        container_ipc_->stopContainerWorker();
+    }
+
+    void dismiss() {
+      cleanup_ = false;
+    }
+
+   private:
+    LinuxTableContainerIPC* container_ipc_;
+    bool cleanup_{true};
+  };
+
+  FRIEND_TEST(WorkerTableContainerTests, test_ipc_container_connect);
+};
+
+inline bool hasNamespaceConstraint(const QueryContext& context) {
+  return context.hasConstraint("pid_with_namespace");
+}
+
+QueryData generateInNamespace(const QueryContext& context,
+                              const std::string& table_name,
+                              TableGeneratePtr generate_ptr);
+} // namespace osquery

--- a/osquery/worker/ipc/linux/linux_table_ipc.cpp
+++ b/osquery/worker/ipc/linux/linux_table_ipc.cpp
@@ -1,0 +1,113 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "linux_table_ipc.h"
+
+namespace osquery {
+Status LinuxTableIPC::sendJSONString(const std::string& json_string) {
+  if (active_channel_ == nullptr) {
+    return Status::failure("No active channel to write to");
+  }
+
+  return active_channel_->sendStringMessage(json_string);
+}
+
+Status LinuxTableIPC::recvJSONString(std::string& json_string) {
+  if (active_channel_ == nullptr) {
+    return Status::failure("No active channel to read from");
+  }
+
+  return active_channel_->recvStringMessage(json_string);
+}
+
+Status LinuxTableIPC::processLogMessage(const JSON& json_message) {
+  std::string message;
+  int priority;
+  int log_type_int;
+
+  auto status = TableIPCJSONConverter::JSONToLogMessage(
+      json_message, priority, log_type_int, message);
+
+  if (!status.ok())
+    return status;
+
+  if (log_type_int != static_cast<int>(GLOGLogType::LOG) &&
+      log_type_int != static_cast<int>(GLOGLogType::VLOG)) {
+    return Status::failure("Received unknown log message type " +
+                           std::to_string(log_type_int));
+  }
+
+  GLOGLogType log_type = static_cast<GLOGLogType>(log_type_int);
+
+  return message_handler_->handleLog(log_type, priority, message);
+}
+
+Status LinuxTableIPC::processJobMessage(const JSON& json_message) {
+  QueryContext context;
+
+  auto status = deserializeQueryContextJSON(json_message, context);
+  if (!status.ok()) {
+    const std::string error_message =
+        "Failed to deserialize the query context: " + status.getMessage();
+    return Status::failure(error_message);
+  }
+
+  return message_handler_->handleJob(context);
+}
+
+Status LinuxTableIPC::processQueryDataMessage(const JSON& json_message,
+                                              QueryData& query_results) {
+  auto status =
+      TableIPCJSONConverter::JSONToQueryData(json_message, query_results);
+
+  if (!status.ok()) {
+    return status;
+  }
+
+  return Status::success();
+}
+
+bool LinuxTableIPC::setActiveChannelIfOpen(const std::string table_name) {
+  auto* channel = factory_->getTableChannel(table_name);
+
+  if (!channel) {
+    return false;
+  }
+
+  active_channel_ = channel;
+  return true;
+}
+
+void LinuxTableIPC::connectToChild(const std::string table_name,
+                                   PipeChannelTicket channel_ticket,
+                                   pid_t child_pid) {
+  active_channel_ = &factory_->createParentChannel(
+      table_name, std::move(channel_ticket), child_pid);
+}
+
+void LinuxTableIPC::connectToParent(const std::string table_name,
+                                    PipeChannelTicket channel_ticket) {
+  active_channel_ =
+      &factory_->createChildChannel(table_name, std::move(channel_ticket));
+}
+
+void LinuxTableIPC::closeActiveChannel() {
+  if (active_channel_ == nullptr) {
+    return;
+  }
+
+  factory_->dropTableChannel(active_channel_->table_name_);
+
+  active_channel_ = nullptr;
+}
+
+std::string LinuxTableIPC::getTableNameFromPid(pid_t pid) {
+  return factory_->getTableNameFromPid(pid);
+}
+
+} // namespace osquery

--- a/osquery/worker/ipc/linux/linux_table_ipc.h
+++ b/osquery/worker/ipc/linux/linux_table_ipc.h
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/worker/ipc/posix/pipe_channel.h>
+#include <osquery/worker/ipc/posix/pipe_channel_factory.h>
+
+#include "osquery/worker/ipc/table_ipc_base.h"
+#include "osquery/worker/ipc/table_ipc_message_handler.h"
+#include "osquery/worker/logging/glog_logger_types.h"
+#include "osquery/worker/logging/logger.h"
+
+namespace osquery {
+
+/**
+ * @brief The LinuxTableIPC class manages the communication and connection
+ * between processes handling table logic, using JSON as message protocol and
+ * blocking pipes as communication channel.
+ *
+ */
+class LinuxTableIPC : public TableIPCBase<LinuxTableIPC> {
+ public:
+  LinuxTableIPC(PipeChannelFactory& factory,
+                TableIPCMessageHandler& message_handler)
+      : factory_(&factory), message_handler_(&message_handler) {}
+
+  Status sendJSONString(const std::string& json_string);
+  Status recvJSONString(std::string& json_string);
+
+  Status processLogMessage(const JSON& json_message);
+  Status processJobMessage(const JSON& json_message);
+  Status processQueryDataMessage(const JSON& json_message,
+                                 QueryData& query_results);
+
+  PipeChannelTicket createChannelTicket() {
+    return factory_->createChannelTicket();
+  }
+  bool setActiveChannelIfOpen(const std::string table_name);
+  void connectToChild(const std::string table_name,
+                      PipeChannelTicket channel_ticket,
+                      pid_t child_pid);
+  void connectToParent(const std::string table_name,
+                       PipeChannelTicket channel_ticket);
+  void closeActiveChannel();
+
+  std::string getTableNameFromPid(pid_t pid);
+
+  bool isChannelOpen() {
+    return active_channel_ != nullptr;
+  };
+
+  pid_t getRemotePid() {
+    return active_channel_ ? active_channel_->getRemotePid() : -1;
+  }
+  std::string getTableName() {
+    return active_channel_ ? active_channel_->table_name_ : "Not Connected";
+  }
+
+ private:
+  PipeChannel* active_channel_{nullptr};
+  PipeChannelFactory* factory_;
+  TableIPCMessageHandler* message_handler_;
+};
+
+class LinuxTableIPCLogger final : public Logger {
+ public:
+  LinuxTableIPCLogger() = delete;
+  LinuxTableIPCLogger(LinuxTableIPC& ipc) : ipc(&ipc) {}
+
+  void log(int severity, const std::string& message) override {
+    ipc->sendLogMessage(severity, GLOGLogType::LOG, message);
+  }
+
+  void vlog(int priority, const std::string& message) override {
+    ipc->sendLogMessage(priority, GLOGLogType::VLOG, message);
+  }
+
+  LinuxTableIPC* ipc;
+};
+} // namespace osquery

--- a/osquery/worker/ipc/linux/platform_table_container_ipc.h
+++ b/osquery/worker/ipc/linux/platform_table_container_ipc.h
@@ -1,0 +1,11 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/worker/ipc/linux/linux_table_container_ipc.h>

--- a/osquery/worker/ipc/linux/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/linux/tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcLinuxTestsMain)
+  if(OSQUERY_BUILD_ROOT_TESTS)
+    generateOsqueryWorkerIpcLinuxTestsTableContainerTest()
+  endif()
+endfunction()
+
+function(generateOsqueryWorkerIpcLinuxTestsTableContainerTest)
+  set(source_files
+    worker_table_container_tests.cpp
+  )
+
+  add_osquery_executable(osquery_worker_ipc_linux_tests_tablecontainer-test ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_linux_tests_tablecontainer-test PRIVATE
+    osquery_cxx_settings
+    osquery_cxx_settings
+    osquery_core
+    osquery_core_sql
+    osquery_database
+    osquery_dispatcher
+    osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_registry
+    osquery_remote_enroll_tlsenroll
+    osquery_tables_events_eventstable
+    osquery_utils_status
+    specs_tables
+    osquery_worker_ipc_linux_tablecontaineripc
+    thirdparty_googletest
+  )
+endfunction()
+
+osqueryWorkerIpcLinuxTestsMain()

--- a/osquery/worker/ipc/linux/tests/worker_table_container_tests.cpp
+++ b/osquery/worker/ipc/linux/tests/worker_table_container_tests.cpp
@@ -1,0 +1,73 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/registry_interface.h>
+#include <osquery/tables.h>
+#include <osquery/worker/ipc/linux/linux_table_container_ipc.h>
+#include <osquery/worker/logging/logger.h>
+
+namespace osquery {
+
+DECLARE_bool(verbose);
+DECLARE_bool(disable_database);
+
+extern template std::set<int> ConstraintList::getAll<int>(
+    ConstraintOperator) const;
+
+class WorkerTableContainerTests : public testing::Test {
+  void SetUp() override {
+    FLAGS_verbose = true;
+    FLAGS_minloglevel = google::GLOG_INFO;
+    FLAGS_alsologtostderr = true;
+    FLAGS_v = 1;
+    Initializer::platformSetup();
+    registryAndPluginInit();
+  }
+};
+
+QueryData genTest1(QueryContext&, Logger&) {
+  Row r;
+  r["test"] = "Hello";
+  return {r};
+}
+
+TEST_F(WorkerTableContainerTests, test_ipc_container_connect) {
+  PipeChannelFactory factory;
+
+  LinuxTableContainerIPC container_ipc(factory);
+
+  auto status = container_ipc.connectToContainer("test", false, genTest1);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  auto my_pid = getpid();
+
+  QueryContext context;
+  context.constraints["pid_with_namespace"].add(
+      Constraint(ConstraintOperator::EQUALS, std::to_string(my_pid)));
+  UsedColumns columns_used;
+  columns_used.emplace("pid_with_namespace");
+  context.colsUsed = std::move(columns_used);
+
+  auto constraints =
+      context.constraints["pid_with_namespace"].getAll<int>(EQUALS);
+
+  ASSERT_EQ(constraints.size(), 1);
+
+  QueryData results;
+  status = container_ipc.retrieveQueryDataFromContainer(context, results);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_EQ(results[0].count("test"), 1);
+  EXPECT_EQ(results[0]["test"], "Hello");
+
+  container_ipc.stopContainerWorker();
+}
+} // namespace osquery

--- a/osquery/worker/ipc/posix/CMakeLists.txt
+++ b/osquery/worker/ipc/posix/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcPosixMain)
+
+  if(OSQUERY_BUILD_TESTS)
+    add_subdirectory("tests")
+  endif()
+
+  generateOsqueryWorkerIpcPosixPipeChannel()
+endfunction()
+
+function(generateOsqueryWorkerIpcPosixPipeChannel)
+  set(source_files
+    pipe_channel.cpp
+    pipe_channel_factory.cpp
+  )
+
+  set(public_header_files
+    pipe_channel.h
+    pipe_channel_factory.h
+  )
+
+  add_osquery_library(osquery_worker_ipc_posix_pipechannel EXCLUDE_FROM_ALL ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_posix_pipechannel PUBLIC
+    osquery_cxx_settings
+    osquery_utils
+    osquery_utils_status
+    osquery_process
+    osquery_worker_ipc_tablechannel
+  )
+
+  generateIncludeNamespace(osquery_worker_ipc_posix_pipechannel "osquery/worker/ipc/posix" FILE_ONLY ${public_header_files})
+
+  add_test(NAME osquery_worker_ipc_posix_tests_pipechannel-test COMMAND osquery_worker_ipc_posix_tests_pipechannel-test --gtest_filter=-WorkerIPCChannelsTest.test_pipe_ticket_leak)
+
+  if(OSQUERY_BUILD_ROOT_TESTS)
+    add_test(NAME osquery_worker_ipc_posix_tests_pipechannel_root-test COMMAND osquery_worker_ipc_posix_tests_pipechannel-test --gtest_filter=WorkerIPCChannelsTest.test_pipe_ticket_leak)
+    set_tests_properties(osquery_worker_ipc_posix_tests_pipechannel_root-test PROPERTIES LABELS "root-required")
+  endif()
+
+endfunction()
+
+osqueryWorkerIpcPosixMain()

--- a/osquery/worker/ipc/posix/pipe_channel.cpp
+++ b/osquery/worker/ipc/posix/pipe_channel.cpp
@@ -1,0 +1,151 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "pipe_channel.h"
+
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <limits>
+
+namespace osquery {
+PipeChannel::PipeChannel(const std::string& table_name,
+                         int read_pipe_fd,
+                         int write_pipe_fd,
+                         pid_t remote_pid)
+    : TableChannelBase<PipeChannel>(table_name),
+      read_pipe_fd(read_pipe_fd),
+      write_pipe_fd(write_pipe_fd),
+      remote_pid(remote_pid) {}
+
+Status PipeChannel::sendStringMessageImpl(const std::string& message) {
+  if (message.size() == 0) {
+    return Status::failure("Cannot send a zero length message");
+  }
+
+  if (message.size() > std::numeric_limits<ssize_t>::max()) {
+    return Status::failure("Cannot send, message too big, " +
+                           std::to_string(message.size()) + " bytes");
+  }
+
+  const ssize_t message_size = static_cast<ssize_t>(message.size());
+
+  auto old_mask = blockSIGPIPE();
+
+  ssize_t result = write(write_pipe_fd,
+                         reinterpret_cast<const char*>(&message_size),
+                         sizeof(message_size));
+
+  if (result < 0) {
+    restoreSIGPIPE(old_mask);
+    return Status::failure(
+        errno,
+        "Failed to write the size of the message through the pipe of table " +
+            table_name_ + ", errno " + std::to_string(errno));
+  }
+
+  if (result != sizeof(message_size)) {
+    restoreSIGPIPE(old_mask);
+    return Status::failure(
+        "Failed to write the entire size of the message through the pipe of "
+        "table " +
+        table_name_ + ", sent only " + std::to_string(result) + "/" +
+        std::to_string(message_size) + " bytes");
+  }
+
+  result = write(write_pipe_fd, &message[0], static_cast<size_t>(message_size));
+
+  restoreSIGPIPE(old_mask);
+
+  if (result < 0) {
+    return Status::failure(
+        errno,
+        "Failed to write the message through the pipe of table " + table_name_ +
+            ", errno " + std::to_string(errno));
+  }
+
+  if (result != message_size) {
+    return Status::failure("Failed to send the entire message of table " +
+                           table_name_ + ", sent only " +
+                           std::to_string(result) + "/" +
+                           std::to_string(message_size));
+  }
+
+  return Status::success();
+}
+
+Status PipeChannel::recvStringMessageImpl(std::string& message) {
+  ssize_t message_size;
+  ssize_t result = read(read_pipe_fd,
+                        reinterpret_cast<char*>(&message_size),
+                        sizeof(message_size));
+
+  if (result < 0) {
+    return Status::failure(
+        errno,
+        "Failed to read the size of the message from the pipe of table " +
+            table_name_ + ", errno " + std::to_string(errno));
+  }
+
+  if (result == 0) {
+    return Status::failure(
+        2, "Pipe to the table " + table_name_ + " closed while reading");
+  }
+
+  if (result != sizeof(message_size)) {
+    return Status::failure(
+        "Failed to read the entire size of the message from the pipe of "
+        "table " +
+        table_name_ + ", read only " + std::to_string(result) + "/" +
+        std::to_string(sizeof(message_size)) + " bytes");
+  }
+
+  if (message_size <= 0) {
+    return Status::failure("Message size too small, it's " +
+                           std::to_string(message_size) + " bytes");
+  }
+
+  message.resize(static_cast<size_t>(message_size));
+  result = read(read_pipe_fd,
+                reinterpret_cast<char*>(&message[0]),
+                static_cast<size_t>(message_size));
+
+  if (result < 0) {
+    return Status::failure(
+        errno,
+        "Failed to read the size of the message from the pipe of table " +
+            table_name_ + ", errno " + std::to_string(errno));
+  }
+
+  if (result != message_size) {
+    return Status::failure(
+        "Failed to read the entire message from the pipe of table " +
+        table_name_ + ", read only " + std::to_string(result) + "/" +
+        std::to_string(message_size) + " bytes");
+  }
+
+  return Status::success();
+}
+
+sigset_t PipeChannel::blockSIGPIPE() {
+  sigset_t new_mask;
+  sigset_t old_mask;
+
+  sigemptyset(&new_mask);
+  sigaddset(&new_mask, SIGPIPE);
+
+  pthread_sigmask(SIG_BLOCK, &new_mask, &old_mask);
+
+  return old_mask;
+}
+
+void PipeChannel::restoreSIGPIPE(const sigset_t& old_mask) {
+  pthread_sigmask(SIG_UNBLOCK, &old_mask, nullptr);
+}
+} // namespace osquery

--- a/osquery/worker/ipc/posix/pipe_channel.h
+++ b/osquery/worker/ipc/posix/pipe_channel.h
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/process/process.h>
+#include <osquery/utils/status/status.h>
+
+#include "osquery/worker/ipc/table_channel_base.h"
+
+namespace osquery {
+class PipeChannelFactory;
+
+class PipeChannel : public TableChannelBase<PipeChannel> {
+ public:
+  PipeChannel() = delete;
+  PipeChannel(const std::string& table_name,
+              int read_pipe_fd,
+              int write_pipe_fd,
+              pid_t remote_pid);
+  ~PipeChannel() {
+    close(read_pipe_fd);
+    close(write_pipe_fd);
+  }
+
+  pid_t getRemotePid() {
+    return remote_pid;
+  }
+
+ private:
+  friend TableChannelBase<PipeChannel>;
+
+  Status sendStringMessageImpl(const std::string& message);
+  Status recvStringMessageImpl(std::string& message);
+
+  sigset_t blockSIGPIPE();
+  void restoreSIGPIPE(const sigset_t& old_mask);
+
+  const int read_pipe_fd;
+  const int write_pipe_fd;
+  const pid_t remote_pid;
+};
+} // namespace osquery

--- a/osquery/worker/ipc/posix/pipe_channel_factory.cpp
+++ b/osquery/worker/ipc/posix/pipe_channel_factory.cpp
@@ -1,0 +1,80 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "pipe_channel_factory.h"
+
+#include <unistd.h>
+
+#include <array>
+#include <stdexcept>
+#include <string>
+
+namespace osquery {
+
+PipeChannelTicket::PipeChannelTicket(std::array<int, 2> read_pipe_fds,
+                                     std::array<int, 2> write_pipe_fds)
+    : read_pipe_fds_(read_pipe_fds), write_pipe_fds_(write_pipe_fds) {}
+
+PipeChannelTicket PipeChannelFactory::createChannelTicket() {
+  PipeChannelTicket ticket;
+  auto result = pipe(ticket.read_pipe_fds_.data());
+
+  if (result == -1) {
+    throw std::runtime_error(
+        "Failed to create parent_write_child_read_pipe, error: " +
+        std::to_string(errno));
+  }
+
+  result = pipe(ticket.write_pipe_fds_.data());
+
+  if (result == -1) {
+    throw std::runtime_error(
+        "Failed to create parent_read_child_write_pipe, error: " +
+        std::to_string(errno));
+  }
+
+  return ticket;
+}
+
+PipeChannel& PipeChannelFactory::createChildChannel(
+    const std::string& table_name, PipeChannelTicket channel_ticket) {
+  return createChannel(table_name,
+                       channel_ticket.getAndUseWriteFd(0),
+                       channel_ticket.getAndUseReadFd(1));
+}
+
+PipeChannel& PipeChannelFactory::createParentChannel(
+    const std::string& table_name,
+    PipeChannelTicket channel_ticket,
+    pid_t child_pid) {
+  return createChannel(table_name,
+                       channel_ticket.getAndUseReadFd(0),
+                       channel_ticket.getAndUseWriteFd(1),
+                       child_pid);
+}
+
+std::string PipeChannelFactory::getTableNameFromPid(pid_t pid) {
+  for (const auto& pair : table_to_channel) {
+    if (pair.second->getRemotePid() == pid) {
+      return pair.second->table_name_;
+    }
+  }
+
+  return "Not Connected";
+}
+
+std::unique_ptr<PipeChannel> PipeChannelFactory::createChannelImpl(
+    const std::string& table_name,
+    int read_pipe_fd,
+    int write_pipe_fd,
+    pid_t child_pid) {
+  return std::make_unique<PipeChannel>(
+      table_name, read_pipe_fd, write_pipe_fd, child_pid);
+}
+
+} // namespace osquery

--- a/osquery/worker/ipc/posix/pipe_channel_factory.h
+++ b/osquery/worker/ipc/posix/pipe_channel_factory.h
@@ -1,0 +1,124 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "osquery/worker/ipc/table_channel_base.h"
+
+#include "osquery/worker/ipc/posix/pipe_channel.h"
+#include "osquery/worker/ipc/table_channel_factory_base.h"
+
+namespace osquery {
+
+class PipeChannelFactory;
+template <>
+struct GetChannelType<PipeChannelFactory> {
+  using Channel = PipeChannel;
+};
+
+class PipeChannelTicket {
+ public:
+  ~PipeChannelTicket() {
+    if (read_pipe_fds_[0] >= 0) {
+      close(read_pipe_fds_[0]);
+    }
+
+    if (read_pipe_fds_[1] >= 0) {
+      close(read_pipe_fds_[1]);
+    }
+
+    if (write_pipe_fds_[0] >= 0) {
+      close(write_pipe_fds_[0]);
+    }
+
+    if (write_pipe_fds_[1] >= 0) {
+      close(write_pipe_fds_[1]);
+    }
+  }
+
+  int getAndUseReadFd(int index) {
+    if (used_) {
+      return -1;
+    }
+
+    return std::exchange(read_pipe_fds_[index], -1);
+  }
+
+  int getAndUseWriteFd(int index) {
+    if (used_) {
+      return -1;
+    }
+
+    return std::exchange(write_pipe_fds_[index], -1);
+  }
+
+  PipeChannelTicket(const PipeChannelTicket&) = delete;
+  PipeChannelTicket& operator=(const PipeChannelTicket&) = delete;
+
+  PipeChannelTicket(PipeChannelTicket&& other)
+      : read_pipe_fds_(std::move(other.read_pipe_fds_)),
+        write_pipe_fds_(std::move(other.write_pipe_fds_)),
+        used_(other.used_) {
+    if (used_) {
+      throw std::logic_error("Constructed a used PipeChannelTicket");
+    }
+
+    other.invalidate();
+  }
+
+  PipeChannelTicket& operator=(PipeChannelTicket&& other) {
+    if (other.used_) {
+      throw std::logic_error(
+          "Cannot move construct with a used PipeChannelTicket");
+    }
+
+    used_ = other.used_;
+    read_pipe_fds_ = std::move(other.read_pipe_fds_);
+    write_pipe_fds_ = std::move(other.write_pipe_fds_);
+    other.invalidate();
+    return *this;
+  }
+
+ private:
+  PipeChannelTicket() = default;
+  PipeChannelTicket(std::array<int, 2> read_pipe_fds_,
+                    std::array<int, 2> write_pipe_fds_);
+
+  void invalidate() {
+    used_ = true;
+    read_pipe_fds_.fill(-1);
+    write_pipe_fds_.fill(-1);
+  }
+
+  std::array<int, 2> read_pipe_fds_{-1, -1};
+  std::array<int, 2> write_pipe_fds_{-1, -1};
+
+  bool used_{false};
+
+  friend PipeChannelFactory;
+};
+
+class PipeChannelFactory : public TableChannelFactoryBase<PipeChannelFactory> {
+ public:
+  PipeChannelTicket createChannelTicket();
+  PipeChannel& createChildChannel(const std::string& table_name,
+                                  PipeChannelTicket channel_ticket);
+  PipeChannel& createParentChannel(const std::string& table_name,
+                                   PipeChannelTicket channel_ticket,
+                                   pid_t child_pid);
+
+  std::string getTableNameFromPid(pid_t pid);
+
+ private:
+  std::unique_ptr<PipeChannel> createChannelImpl(const std::string& table_name,
+                                                 int read_pipe_fd,
+                                                 int write_pipe_fd,
+                                                 pid_t child_pid = 0);
+  friend TableChannelFactoryBase<PipeChannelFactory>;
+};
+} // namespace osquery

--- a/osquery/worker/ipc/posix/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/posix/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcPosixTestsMain)
+  generateOsqueryWorkerIpcPosixTestsIpcPipeChannelTest()
+endfunction()
+
+
+function(generateOsqueryWorkerIpcPosixTestsIpcPipeChannelTest)
+  set(source_files
+    worker_ipc_channels_test.cpp
+  )
+
+  add_osquery_executable(osquery_worker_ipc_posix_tests_pipechannel-test ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_posix_tests_pipechannel-test PRIVATE
+    osquery_cxx_settings
+    osquery_events
+    osquery_tables_events_eventstable
+    osquery_dispatcher
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_filesystem
+    osquery_registry
+    osquery_remote_enroll_tlsenroll
+    osquery_sql
+    osquery_sdk_pluginsdk
+    osquery_events
+    osquery_worker_ipc_posix_pipechannel
+    thirdparty_googletest
+  )
+endfunction()
+
+osqueryWorkerIpcPosixTestsMain()

--- a/osquery/worker/ipc/posix/tests/worker_ipc_channels_test.cpp
+++ b/osquery/worker/ipc/posix/tests/worker_ipc_channels_test.cpp
@@ -1,0 +1,169 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+#include <string>
+#include <unistd.h>
+
+#include <sys/resource.h>
+#include <sys/time.h>
+
+#include <gtest/gtest.h>
+
+#ifdef OSQUERY_LINUX
+#include <osquery/filesystem/linux/proc.h>
+#endif
+#include <osquery/worker/ipc/posix/pipe_channel.h>
+#include <osquery/worker/ipc/posix/pipe_channel_factory.h>
+
+#ifdef DARWIN
+#include <boost/filesystem.hpp>
+#endif
+
+namespace osquery {
+class WorkerIPCChannelsTest : public testing::Test {
+ public:
+  int getFdsOpen() {
+#ifdef OSQUERY_LINUX
+    std::map<std::string, std::string> open_descriptors;
+    auto status = procDescriptors(std::to_string(getpid()), open_descriptors);
+
+    if (!status.ok()) {
+      return -1;
+    }
+
+    // The function always returns also the fd used find the open fds
+    return open_descriptors.size() - 1;
+#elif DARWIN
+    std::string descriptors_path = "/dev/fd";
+    boost::filesystem::directory_iterator it(descriptors_path), end;
+    return std::distance(it, end) - 1;
+#endif
+  }
+
+  // How many more fds we want to let the program open
+  void setRelativeFDLimit(int fd_num) {
+    auto current_fds_amount = getFdsOpen();
+
+    struct rlimit file_limits {
+      static_cast<rlim_t>(current_fds_amount + fd_num + 1),
+          static_cast<rlim_t>(current_fds_amount + fd_num + 1)
+    };
+    auto result = setrlimit(RLIMIT_NOFILE, &file_limits);
+
+    ASSERT_TRUE(result == 0)
+        << "Failed to set the limit of file descriptors: " << strerror(errno);
+  }
+};
+
+TEST_F(WorkerIPCChannelsTest, test_pipe_read_after_exit) {
+  PipeChannelFactory factory;
+  auto pipe_ticket = factory.createChannelTicket();
+
+  int pid = fork();
+
+  ASSERT_NE(pid, -1);
+
+  if (pid == 0) {
+    // Child
+    auto& child_channel =
+        factory.createChildChannel("test", std::move(pipe_ticket));
+
+    child_channel.sendStringMessage("Hello World!");
+    std::exit(testing::Test::HasFailure());
+  } else {
+    // Parent
+    auto& parent_channel =
+        factory.createParentChannel("test", std::move(pipe_ticket), pid);
+
+    int wexit;
+    waitpid(pid, &wexit, 0);
+    ASSERT_EQ(WEXITSTATUS(wexit), 0);
+
+    // We are able to read a message even after the child exited
+    std::string message;
+    auto status = parent_channel.recvStringMessage(message);
+
+    ASSERT_TRUE(status.ok());
+
+    EXPECT_EQ(message, "Hello World!");
+  }
+}
+
+TEST_F(WorkerIPCChannelsTest, test_pipe_sigpipe) {
+  PipeChannelFactory factory;
+  auto pipe_ticket = factory.createChannelTicket();
+
+  int pid = fork();
+
+  ASSERT_NE(pid, -1);
+
+  if (pid == 0) {
+    // Child
+    std::exit(testing::Test::HasFailure());
+  } else {
+    // Parent
+    auto& parent_channel =
+        factory.createParentChannel("test", std::move(pipe_ticket), pid);
+
+    int wexit;
+    waitpid(pid, &wexit, 0);
+    ASSERT_EQ(WEXITSTATUS(wexit), 0);
+
+    auto status = parent_channel.sendStringMessage("Hello World!");
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_EQ(status.getCode(), EPIPE);
+  }
+}
+
+TEST_F(WorkerIPCChannelsTest, test_pipe_close_while_reading) {
+  PipeChannelFactory factory;
+  auto pipe_ticket = factory.createChannelTicket();
+
+  int pid = fork();
+
+  ASSERT_NE(pid, -1);
+
+  if (pid == 0) {
+    // Child
+    std::exit(testing::Test::HasFailure());
+  } else {
+    // Parent
+    auto& parent_channel =
+        factory.createParentChannel("test", std::move(pipe_ticket), pid);
+
+    int wexit;
+    waitpid(pid, &wexit, 0);
+    ASSERT_EQ(WEXITSTATUS(wexit), 0);
+
+    std::string message;
+    auto status = parent_channel.recvStringMessage(message);
+
+    ASSERT_FALSE(status.ok());
+  }
+}
+
+TEST_F(WorkerIPCChannelsTest, test_pipe_ticket_leak) {
+  // Give enough fds for one pipe
+  setRelativeFDLimit(2);
+
+  int fds_open = getFdsOpen();
+  PipeChannelFactory factory;
+  ASSERT_THROW(factory.createChannelTicket(), std::runtime_error);
+
+  // Check we aren't leaking any fd
+  ASSERT_EQ(getFdsOpen(), fds_open);
+
+  setRelativeFDLimit(4);
+
+  fds_open = getFdsOpen();
+  auto ticket = factory.createChannelTicket();
+
+  // Check that there are actually two new fds for the pipes
+  ASSERT_EQ(getFdsOpen(), fds_open + 4);
+}
+} // namespace osquery

--- a/osquery/worker/ipc/table_ipc_json_converter.cpp
+++ b/osquery/worker/ipc/table_ipc_json_converter.cpp
@@ -1,0 +1,121 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "table_ipc_json_converter.h"
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+Status TableIPCJSONConverter::JSONToQueryData(const JSON& json_helper,
+                                              QueryData& query_data) {
+  const auto& rapidjson_doc = json_helper.doc();
+
+  if (!rapidjson_doc.IsObject()) {
+    return Status::failure("Expected an object as the root JSON element");
+  }
+
+  if (!rapidjson_doc.HasMember("QueryData")) {
+    return Status::failure("Missing QueryData member");
+  }
+
+  if (!rapidjson_doc["QueryData"].IsArray()) {
+    return Status::failure("QueryData member is not an array");
+  }
+
+  JSON query_data_array = json_helper.newFromValue(rapidjson_doc["QueryData"]);
+
+  return deserializeQueryDataJSON(query_data_array, query_data);
+}
+
+Status TableIPCJSONConverter::queryDataToJSON(const QueryData& query_data,
+                                              JSON& json_helper) {
+  JSON query_data_doc;
+  auto status = serializeQueryDataJSON(query_data, query_data_doc);
+
+  if (!status.ok()) {
+    return status;
+  }
+
+  json_helper.add("QueryData", query_data_doc.doc());
+
+  return Status::success();
+}
+
+Status TableIPCJSONConverter::JSONToLogMessage(const JSON& json_helper,
+                                               int& priority,
+                                               int& log_type,
+                                               std::string& message) {
+  const auto& rapidjson_doc = json_helper.doc();
+
+  if (!rapidjson_doc.IsObject()) {
+    return Status::failure("Expected an object as the root JSON element");
+  }
+
+  if (!rapidjson_doc.HasMember("Priority")) {
+    return Status::failure("Missing Priority member");
+  }
+
+  if (!rapidjson_doc.HasMember("Message")) {
+    return Status::failure("Missing Message member");
+  }
+
+  if (!rapidjson_doc.HasMember("LogType")) {
+    return Status::failure("Missing LogType member");
+  }
+
+  if (!rapidjson_doc["Priority"].IsNumber()) {
+    return Status::failure("Security member is not a number");
+  }
+
+  if (!rapidjson_doc["Message"].IsString()) {
+    return Status::failure("Message member is not a string");
+  }
+
+  if (!rapidjson_doc["LogType"].IsNumber()) {
+    return Status::failure("LogType member is not a number");
+  }
+
+  log_type = rapidjson_doc["LogType"].GetInt();
+  message = rapidjson_doc["Message"].GetString();
+  priority = rapidjson_doc["Priority"].GetInt();
+
+  return Status::success();
+}
+
+Status TableIPCJSONConverter::logMessageToJSON(int priority,
+                                               int log_type,
+                                               const std::string& message,
+                                               JSON& json_helper) {
+  json_helper = JSON::newObject();
+  json_helper.add("Priority", priority);
+  json_helper.add("LogType", log_type);
+  json_helper.add("Message", message);
+
+  return Status::success();
+}
+
+Status TableIPCJSONConverter::JSONTypeToMessageType(
+    const JSON& json_helper, JSONMessageType& message_type) {
+  std::string type = json_helper.doc()["Type"].GetString();
+
+  if (type == "Log") {
+    message_type = JSONMessageType::Log;
+  } else if (type == "QueryData") {
+    message_type = JSONMessageType::QueryData;
+  } else if (type == "Job") {
+    message_type = JSONMessageType::Job;
+  } else {
+    message_type = JSONMessageType::None;
+    return Status::failure("Unsupported JSON message type: " + type);
+  }
+
+  return Status::success();
+}
+
+} // namespace osquery

--- a/osquery/worker/ipc/table_ipc_json_converter.h
+++ b/osquery/worker/ipc/table_ipc_json_converter.h
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/tables.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+enum class JSONMessageType { None, QueryData, Log, Job };
+
+class TableIPCJSONConverter {
+ public:
+  static Status JSONToQueryData(const JSON& json_helper, QueryData& query_data);
+  static Status queryDataToJSON(const QueryData& query_data, JSON& json_helper);
+  static Status JSONToLogMessage(const JSON& json_helper,
+                                 int& priority,
+                                 int& log_type,
+                                 std::string& message);
+  static Status logMessageToJSON(int priority,
+                                 int log_type,
+                                 const std::string& message,
+                                 JSON& json_helper);
+  static Status JSONTypeToMessageType(const JSON& json_helper,
+                                      JSONMessageType& message_type);
+};
+} // namespace osquery

--- a/osquery/worker/ipc/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/tests/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerIpcTestsMain)
+  generateOsqueryWorkerIpcTestsJsonConversionsTest()
+endfunction()
+
+function(generateOsqueryWorkerIpcTestsJsonConversionsTest)
+  set(source_files
+    worker_json_conversions_test.cpp
+  )
+
+  add_osquery_executable(osquery_worker_ipc_tests_jsonconversions-test ${source_files})
+
+  target_link_libraries(osquery_worker_ipc_tests_jsonconversions-test PRIVATE
+    osquery_cxx_settings
+    osquery_core
+    osquery_core_sql
+    osquery_database
+    osquery_dispatcher
+    osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_registry
+    osquery_remote_enroll_tlsenroll
+    osquery_tables_events_eventstable
+    osquery_utils_status
+    osquery_worker_ipc_tableipc
+    osquery_worker_ipc_tableipcjsonconverter
+    specs_tables
+    thirdparty_googletest
+  )
+endfunction()
+
+osqueryWorkerIpcTestsMain()

--- a/osquery/worker/ipc/tests/worker_json_conversions_test.cpp
+++ b/osquery/worker/ipc/tests/worker_json_conversions_test.cpp
@@ -1,0 +1,252 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/tables.h>
+#include <osquery/utils/status/status.h>
+#include <osquery/worker/ipc/table_ipc_base.h>
+
+namespace osquery {
+
+class TestTableIPC : public TableIPCBase<TestTableIPC> {
+ public:
+  Status sendJSONString(const std::string json_string) {
+    auto status = json_helper.fromString(json_string);
+
+    if (!status.ok()) {
+      return Status::failure(1, "Failed to parse json_string:\n" + json_string);
+    }
+
+    return Status::success();
+  }
+
+  Status recvJSONString(std::string& json_string) {
+    return json_helper.toString(json_string);
+  }
+
+  JSON json_helper;
+};
+
+class WorkerJSONConversionsTests : public testing::Test {
+ public:
+  void verifyMessageType(const rapidjson::Document& rapidjson_doc,
+                         const std::string& type) {
+    ASSERT_TRUE(rapidjson_doc.HasMember("Type"));
+    ASSERT_TRUE(rapidjson_doc["Type"].IsString());
+
+    EXPECT_EQ(std::string(rapidjson_doc["Type"].GetString()), type);
+  }
+};
+
+TEST_F(WorkerJSONConversionsTests, test_querydata_and_json_conversions) {
+  QueryData data;
+  Row r1;
+  r1["column1"] = "test";
+  r1["column2"] = "1";
+  data.push_back(r1);
+
+  Row r2;
+  r2["column1"] = "test2";
+  r2["column2"] = "2";
+  data.push_back(r2);
+
+  TestTableIPC ipc;
+  auto status = ipc.sendQueryData(data);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  auto& rapidjson_doc = ipc.json_helper.doc();
+
+  ASSERT_TRUE(rapidjson_doc.IsObject());
+
+  verifyMessageType(rapidjson_doc, "QueryData");
+
+  ASSERT_TRUE(rapidjson_doc.HasMember("QueryData"));
+  EXPECT_TRUE(rapidjson_doc["QueryData"].IsArray());
+
+  const auto& query_data_array = rapidjson_doc["QueryData"].GetArray();
+  ASSERT_EQ(query_data_array.Size(), 2);
+  ASSERT_TRUE(query_data_array[0].IsObject());
+  ASSERT_TRUE(query_data_array[0].HasMember("column1"));
+  EXPECT_TRUE(query_data_array[0]["column1"].IsString());
+  EXPECT_EQ(std::string(query_data_array[0]["column1"].GetString()), "test");
+
+  ASSERT_TRUE(query_data_array[0].HasMember("column2"));
+  EXPECT_TRUE(query_data_array[0]["column2"].IsString());
+  EXPECT_EQ(std::string(query_data_array[0]["column2"].GetString()), "1");
+
+  ASSERT_TRUE(query_data_array[1].IsObject());
+  ASSERT_TRUE(query_data_array[1].HasMember("column1"));
+  EXPECT_TRUE(query_data_array[1]["column1"].IsString());
+  EXPECT_EQ(std::string(query_data_array[1]["column1"].GetString()), "test2");
+
+  ASSERT_TRUE(query_data_array[1].HasMember("column2"));
+  EXPECT_TRUE(query_data_array[1]["column2"].IsString());
+  EXPECT_EQ(std::string(query_data_array[1]["column2"].GetString()), "2");
+
+  JSONMessageType message_type;
+  JSON json_helper;
+  status = ipc.recvJSONMessage(json_helper, message_type);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  ASSERT_TRUE(message_type == JSONMessageType::QueryData);
+
+  QueryData read_query_data;
+  status = TableIPCJSONConverter::JSONToQueryData(json_helper, read_query_data);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  ASSERT_EQ(read_query_data.size(), 2);
+  EXPECT_EQ(read_query_data[0]["column1"], "test");
+  EXPECT_EQ(read_query_data[0]["column2"], "1");
+  EXPECT_EQ(read_query_data[1]["column1"], "test2");
+  EXPECT_EQ(read_query_data[1]["column2"], "2");
+
+  // Try to read the JSON message erroneously as a Log message
+  std::string message;
+  int priority;
+  int log_type_int;
+  status = TableIPCJSONConverter::JSONToLogMessage(
+      json_helper, priority, log_type_int, message);
+
+  EXPECT_FALSE(status.ok()) << status.getMessage();
+}
+
+TEST_F(WorkerJSONConversionsTests, test_log_message_and_json_conversions) {
+  TestTableIPC ipc;
+  auto status =
+      ipc.sendLogMessage(1, GLOGLogType::LOG, "This is a test message");
+
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  auto& rapidjson_doc = ipc.json_helper.doc();
+
+  ASSERT_TRUE(rapidjson_doc.IsObject());
+
+  verifyMessageType(rapidjson_doc, "Log");
+
+  ASSERT_TRUE(rapidjson_doc.HasMember("Priority"));
+  EXPECT_TRUE(rapidjson_doc["Priority"].IsNumber());
+  EXPECT_EQ(rapidjson_doc["Priority"].GetInt(), 1);
+
+  ASSERT_TRUE(rapidjson_doc.HasMember("Message"));
+  EXPECT_TRUE(rapidjson_doc["Message"].IsString());
+  EXPECT_EQ(std::string(rapidjson_doc["Message"].GetString()),
+            "This is a test message");
+
+  JSONMessageType message_type;
+  JSON json_helper;
+  status = ipc.recvJSONMessage(json_helper, message_type);
+  ASSERT_TRUE(status.ok());
+  ASSERT_TRUE(message_type == JSONMessageType::Log);
+
+  int priority = 0;
+  int log_type_int = 0;
+  std::string message;
+  status = TableIPCJSONConverter::JSONToLogMessage(
+      json_helper, priority, log_type_int, message);
+
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  EXPECT_EQ(priority, 1);
+  EXPECT_EQ(message, "This is a test message");
+
+  QueryData query_data;
+  status = TableIPCJSONConverter::JSONToQueryData(json_helper, query_data);
+
+  EXPECT_FALSE(status.ok()) << status.getMessage();
+}
+
+TEST_F(WorkerJSONConversionsTests, test_job_and_json_conversions) {
+  TestTableIPC ipc;
+  QueryContext context;
+
+  context.constraints["job_test_1"].add(Constraint(ConstraintOperator::EQUALS));
+  context.constraints["job_test_1"].add(
+      Constraint(ConstraintOperator::GREATER_THAN));
+  context.constraints["job_test_2"].add(Constraint(ConstraintOperator::LIKE));
+  context.constraints["job_test_2"].add(Constraint(ConstraintOperator::MATCH));
+
+  UsedColumns used_columns;
+  used_columns.emplace("job_test_1");
+  used_columns.emplace("job_test_2");
+  used_columns.emplace("job_test_3");
+  context.colsUsed = std::move(used_columns);
+
+  auto status = ipc.sendJob(context);
+
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  auto& rapidjson_doc = ipc.json_helper.doc();
+
+  ASSERT_TRUE(rapidjson_doc.IsObject());
+
+  verifyMessageType(rapidjson_doc, "Job");
+
+  ASSERT_TRUE(rapidjson_doc.HasMember("constraints"));
+  ASSERT_TRUE(rapidjson_doc["constraints"].IsArray());
+
+  auto constraints = rapidjson_doc["constraints"].GetArray();
+
+  ASSERT_EQ(constraints.Size(), 2);
+
+  for (const auto& constraint : constraints) {
+    ASSERT_TRUE(constraint.IsObject());
+    ASSERT_TRUE(constraint.HasMember("name"));
+    ASSERT_TRUE(constraint["name"].IsString());
+    ASSERT_TRUE(constraint.HasMember("list"));
+    ASSERT_TRUE(constraint["list"].IsArray());
+    auto ops = constraint["list"].GetArray();
+
+    ASSERT_EQ(ops.Size(), 2);
+
+    for (const auto& op : ops) {
+      ASSERT_TRUE(op.IsObject());
+      ASSERT_TRUE(op.HasMember("op"));
+      ASSERT_TRUE(op["op"].IsNumber());
+    }
+  }
+
+  ASSERT_TRUE(rapidjson_doc.HasMember("colsUsed"));
+  ASSERT_TRUE(rapidjson_doc["colsUsed"].IsArray());
+  EXPECT_EQ(rapidjson_doc["colsUsed"].Size(), 3);
+
+  QueryContext read_query_context;
+
+  JSONMessageType message_type;
+  JSON json_helper;
+  status = ipc.recvJSONMessage(json_helper, message_type);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  ASSERT_TRUE(message_type == JSONMessageType::Job);
+
+  status = deserializeQueryContextJSON(json_helper, read_query_context);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  ASSERT_TRUE(read_query_context.colsUsed);
+
+  ASSERT_EQ(read_query_context.colsUsed->size(), 3);
+
+  ASSERT_EQ(read_query_context.colsUsed.get().count("job_test_1"), 1);
+  ASSERT_EQ(read_query_context.colsUsed.get().count("job_test_2"), 1);
+  ASSERT_EQ(read_query_context.colsUsed.get().count("job_test_3"), 1);
+
+  ASSERT_EQ(read_query_context.constraints.size(), 2);
+  ASSERT_EQ(read_query_context.constraints.count("job_test_1"), 1);
+  ASSERT_EQ(read_query_context.constraints.count("job_test_2"), 1);
+
+  ASSERT_TRUE(read_query_context.constraints["job_test_1"].exists(
+      ConstraintOperator::EQUALS));
+  ASSERT_TRUE(read_query_context.constraints["job_test_1"].exists(
+      ConstraintOperator::GREATER_THAN));
+  ASSERT_TRUE(read_query_context.constraints["job_test_2"].exists(
+      ConstraintOperator::LIKE));
+  ASSERT_TRUE(read_query_context.constraints["job_test_2"].exists(
+      ConstraintOperator::MATCH));
+}
+} // namespace osquery

--- a/osquery/worker/logging/CMakeLists.txt
+++ b/osquery/worker/logging/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+function(osqueryWorkerLoggingMain)
+
+  generateOsqueryWorkerLoggingLogger()
+
+  add_subdirectory("glog")
+
+endfunction()
+
+function(generateOsqueryWorkerLoggingLogger)
+
+  add_osquery_library(osquery_worker_logging_logger INTERFACE)
+
+  set(public_header_files
+    include/logger.h
+    include/glog_logger_types.h
+  )
+
+  generateIncludeNamespace(osquery_worker_logging_logger "osquery/worker/logging" FILE_ONLY ${public_header_files})
+
+endfunction()
+
+osqueryWorkerLoggingMain()

--- a/osquery/worker/logging/glog/CMakeLists.txt
+++ b/osquery/worker/logging/glog/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(osqueryWorkerLoggingGlogMain)
+  generateOsqueryWorkerLoggingGloglogger()
+endfunction()
+
+function(generateOsqueryWorkerLoggingGloglogger)
+  set(source_files
+    glog_logger.cpp
+  )
+
+  set(public_header_files
+    glog_logger.h
+  )
+
+  add_osquery_library(osquery_worker_logging_glog_logger EXCLUDE_FROM_ALL ${source_files})
+
+  target_link_libraries(osquery_worker_logging_glog_logger PUBLIC
+    osquery_cxx_settings
+    osquery_worker_logging_logger
+    osquery_logger
+  )
+
+  generateIncludeNamespace(osquery_worker_logging_glog_logger "osquery/worker/logging/glog" FULL_PATH ${public_header_files})
+endfunction()
+
+osqueryWorkerLoggingGlogMain()

--- a/osquery/worker/logging/glog/glog_logger.cpp
+++ b/osquery/worker/logging/glog/glog_logger.cpp
@@ -1,0 +1,47 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "glog_logger.h"
+
+#include <string>
+
+#include <osquery/logger.h>
+
+namespace osquery {
+
+GLOGLogger& GLOGLogger::instance() {
+  static GLOGLogger logger;
+  return logger;
+}
+
+void GLOGLogger::log(int severity, const std::string& message) {
+  switch (severity) {
+  case google::GLOG_ERROR: {
+    LOG(ERROR) << message;
+    break;
+  }
+  case google::GLOG_INFO: {
+    LOG(INFO) << message;
+    break;
+  }
+  case google::GLOG_FATAL: {
+    LOG(FATAL) << message;
+    break;
+  }
+  default: {
+    LOG(ERROR) << "severity " << severity << " not supported!";
+    break;
+  }
+  }
+}
+
+void GLOGLogger::vlog(int priority, const std::string& message) {
+  VLOG(priority) << message;
+}
+
+} // namespace osquery

--- a/osquery/worker/logging/glog/glog_logger.h
+++ b/osquery/worker/logging/glog/glog_logger.h
@@ -1,0 +1,22 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <osquery/worker/logging/logger.h>
+
+namespace osquery {
+class GLOGLogger final : public Logger {
+ public:
+  static GLOGLogger& instance();
+  void log(int severity, const std::string& message) override;
+  void vlog(int severity, const std::string& message) override;
+};
+} // namespace osquery

--- a/osquery/worker/logging/include/glog_logger_types.h
+++ b/osquery/worker/logging/include/glog_logger_types.h
@@ -1,0 +1,13 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+enum class GLOGLogType { LOG, VLOG };
+}

--- a/osquery/worker/logging/include/logger.h
+++ b/osquery/worker/logging/include/logger.h
@@ -1,0 +1,20 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace osquery {
+class Logger {
+ public:
+  virtual ~Logger() = default;
+  virtual void log(int severity, const std::string& message) = 0;
+  virtual void vlog(int severity, const std::string& message) = 0;
+};
+} // namespace osquery

--- a/specs/hash.table
+++ b/specs/hash.table
@@ -10,6 +10,10 @@ schema([
 extended_schema(POSIX, [
     Column("ssdeep", TEXT, "ssdeep hash of provided filesystem data"),
 ])
+extended_schema(LINUX, [
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True),
+    Column("mount_namespace_id", TEXT, "Mount namespace id"),
+])
 implementation("hash@genHash")
 examples([
   "select * from hash where path = '/etc/passwd'",

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -28,6 +28,10 @@ extended_schema(WINDOWS, [
 extended_schema(DARWIN, [
     Column("bsd_flags", TEXT, "The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND")
 ])
+extended_schema(LINUX, [
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True),
+    Column("mount_namespace_id", TEXT, "Mount namespace id"),
+])
 attributes(utility=True)
 implementation("utility/file@genFile")
 examples([

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/utils/info/platform_type.h>
 
 #include <boost/filesystem.hpp>
 
@@ -75,6 +76,11 @@ TEST_F(FileTests, test_sanity) {
 #ifdef __APPLE__
   row_map["bsd_flags"] = NormalType;
 #endif
+
+  if (isPlatform(PlatformType::TYPE_LINUX)) {
+    row_map["pid_with_namespace"] = IntType;
+    row_map["mount_namespace_id"] = NormalType;
+  }
 
   validate_rows(data, row_map);
   ASSERT_EQ(data[0]["path"], filepath.string());

--- a/tests/integration/tables/hash.cpp
+++ b/tests/integration/tables/hash.cpp
@@ -68,6 +68,11 @@ TEST_F(Hash, test_sanity) {
     ASSERT_EQ(data[0]["ssdeep"], "3:f4oo8MRwRJFGW1gC64:f4kPvtHF");
   }
 
+  if (isPlatform(PlatformType::TYPE_LINUX)) {
+    row_map["pid_with_namespace"] = IntType;
+    row_map["mount_namespace_id"] = NormalType;
+  }
+
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
- Add the possibility of running table logic inside a container
  namespace, so that's possible to query it instead of the host.
  Needs minor modifications to each table logic and how they use logging.

  In practice it works by having a pid_with_namespace column, which should
  contain pids that are in the same mount namespace of the container one
  wants to query.
  The worker receives that column as a constraint, prepares two unnamed
  pipes for read/write communications with the future child, then forks
  into a new process.

  While the parent sends a query job to the just created child and then waits
  for results, the child receives the job, takes all the values given in the
  pid_with_namespace constraint, retrieves the fd of the mount namespace
  under "/proc/<constraint pid>/ns/mnt", then switches to it.
  Finally it runs the table logic, sending the results back to the parent
  through the pipe with a JSON message.

  Important to note that the logging in the table logic is not GLOG
  directly, because in the child this is in an unknown state; a custom
  logging system that resembles glog and that takes advantage of the
  existing communication channel is used to send the messages in JSON
  format to the parent, which will take care to forward to GLOG.

- Add FLAGS_keep_container_worker_open so that the process used for
  accessing a container is kept open, until the queries are for the same
  table; when the table changes, the process will be closed
  and a new one created.
  This is off by default, which means that a new process will be always
  created.

- Implemented a way to run tests that require root separated
  from the others.
  The OSQUERY_BUILD_ROOT_TESTS has been added to requests such tests to
  be built.
  To run only tests which require a normal user, one has to use
  `ctest -LE "root-required"`, while `sudo ctest -L "root-required"`
  to run those who need root.

- Add container access to the file table

- Add container access to the hash table

Implements https://github.com/osquery/osquery/issues/5975