### PR TITLE
Fix boost process and asio build on Windows

### DIFF
--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -191,6 +191,14 @@ function(importBoostInterfaceLibrary folder_name)
       BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX)
   endif()
 
+  if(DEFINED PLATFORM_WINDOWS)
+    if("${folder_name}" STREQUAL "asio")
+      target_compile_definitions(${target_name} INTERFACE
+        BOOST_ASIO_WINDOWS
+      )
+    endif()
+  endif()
+
   foreach(additional_dependency ${ARGN})
 
     if(additional_dependency MATCHES "^thirdparty_")


### PR DESCRIPTION
When using Boost.Process on Windows with Boost.Asio for async_pipe,
the build fails because Asio requires BOOST_ASIO_WINDOWS define
to enable access to async_pipe.

This only partially solves the issue since it's necessary that
Asio users will also include the "sdkddkver.h" header
before the "boost/asio.hpp" header to properly define
_WIN32_WINNT_WIN7, used by osquery.

