### PR TITLE
Update schedule counter behavior

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -276,7 +276,7 @@ To aid with this, osquery maintains an **epoch** marker along with each schedule
 
 ### Schedule counter
 
-When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial **added** records. **counter** can be used to identify if the added records are all records from initial query of if they are new records. For initial query results that includes all records counter will be **"0"**. For subsequent query executions counter will be incremented by **1**. When **epoch** changes, counter will be reset back to "0".
+When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial **added** records. **counter** can be used to identify if the added records are all records from initial query of if they are new records. For initial query results that includes all records counter will be **"0"**. For subsequent query results counter will be incremented by **1**. When **epoch** changes, counter will be reset back to "0".
 
 ### Numerics
 

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -162,9 +162,11 @@ Status Query::addNewResults(QueryDataTyped current_qd,
     if (!status.ok()) {
       return status;
     }
+  }
 
+  if (update_db || fresh_results || new_query) {
     counter = getQueryCounter(fresh_results || new_query);
-    status =
+    auto status =
         setDatabaseValue(kQueries, name_ + "counter", std::to_string(counter));
     if (!status.ok()) {
       return status;

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -144,17 +144,10 @@ Status Query::addNewResults(QueryDataTyped current_qd,
     target_gd = &dr.added;
   }
 
-  counter = getQueryCounter(fresh_results || new_query);
-  auto status =
-      setDatabaseValue(kQueries, name_ + "counter", std::to_string(counter));
-  if (!status.ok()) {
-    return status;
-  }
-
   if (update_db) {
     // Replace the "previous" query data with the current.
     std::string json;
-    status = serializeQueryDataJSON(*target_gd, json, true);
+    auto status = serializeQueryDataJSON(*target_gd, json, true);
     if (!status.ok()) {
       return status;
     }
@@ -166,6 +159,13 @@ Status Query::addNewResults(QueryDataTyped current_qd,
 
     status = setDatabaseValue(
         kQueries, name_ + "epoch", std::to_string(current_epoch));
+    if (!status.ok()) {
+      return status;
+    }
+
+    counter = getQueryCounter(fresh_results || new_query);
+    status =
+        setDatabaseValue(kQueries, name_ + "counter", std::to_string(counter));
     if (!status.ok()) {
       return status;
     }


### PR DESCRIPTION
## **What is being changed?**
The schedule counter increments every query execution. This is true even when a query has no new results to log. The Current behavior, which increments the query counter every execution, makes it difficult to determine whether or not a differential result was missed. 

Change the counter behavior so only when a differential results is calculated the counter increments. With this change the counter represents the order in which differential results should be replayed to recreate the point in time state.

Looking for initial thoughts on this change. The documentation and original PR #3651 suggest the counter is only ever useful to detect the initial results. Changing the counter behavior this way doesn't break this use case. 