### PR TITLE
Fix build without tests enabled

### DIFF
--- a/plugins/config/CMakeLists.txt
+++ b/plugins/config/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 function(pluginsConfigMain)
   add_subdirectory("parsers")
-  add_subdirectory("tests")
+  if(OSQUERY_BUILD_TESTS)
+    add_subdirectory("tests")
+  endif()
 
   generatePluginsConfigFilesystemconfig()
   generatePluginsConfigTlsconfig()


### PR DESCRIPTION
A regression from https://github.com/osquery/osquery/pull/6170 I didn't notice.