### PR TITLE
Fix heap buffer overflow in callDoubleFunc and powerFunc

### DIFF
--- a/osquery/sql/sqlite_math.cpp
+++ b/osquery/sql/sqlite_math.cpp
@@ -67,7 +67,7 @@ static void callDoubleFunc(sqlite3_context* context,
     if (errno == 0) {
       sqlite3_result_double(context, val);
     } else {
-      sqlite3_result_error(context, platformStrerr(errno).c_str(), errno);
+      sqlite3_result_error(context, platformStrerr(errno).c_str(), -1);
     }
     break;
   }
@@ -139,7 +139,7 @@ static void powerFunc(sqlite3_context* context,
     if (errno == 0) {
       sqlite3_result_double(context, val);
     } else {
-      sqlite3_result_error(context, platformStrerr(errno).c_str(), errno);
+      sqlite3_result_error(context, platformStrerr(errno).c_str(), -1);
     }
   }
 }


### PR DESCRIPTION
sqlite3_result_error() third parameter is the length
of the string of the second parameter, not the error code.

We set that to -1, which means that the length of the string
will be taken using strlen().

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18694
