### PR TITLE
replacing boost::regex with std::regex for SQL StringExtensions

### DIFF
--- a/docs/wiki/introduction/sql.md
+++ b/docs/wiki/introduction/sql.md
@@ -284,7 +284,7 @@ String parsing functions are always helpful, some help within subqueries so they
     </p>
     </details>
 
-- `regex_split(COLUMN, PATTERN, INDEX)`: similar to split, but instead of `TOKENS`, apply the POSIX regex `PATTERN` (as interpreted by boost::regex).
+- `regex_split(COLUMN, PATTERN, INDEX)`: similar to split, but instead of `TOKENS`, apply the POSIX regex `PATTERN` (as interpreted by std::regex).
 
     <details>
     <summary>Regex Split function example:</summary>

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -224,7 +224,6 @@ TEST_F(SQLTests, test_regex_match_fileextract) {
 
 TEST_F(SQLTests, test_regex_match_empty) {
   QueryData d;
-
   // Empty regex gets you a null result
   query("select regex_match('hello world', '', 0) as test", d);
   ASSERT_EQ(d.size(), 1U);
@@ -245,9 +244,8 @@ TEST_F(SQLTests, test_regex_match_invalid2) {
 
 TEST_F(SQLTests, test_regex_match_invalid3) {
   QueryData d;
-  // `|` is an invalid regexp, but boost doesn't complain, and treats
-  // it much as an empty string. Encode that expection here in
-  // tests.
+  // `|` is an invalid regexp but std::basic_regex doesn't complain, and treats
+  // it much as an empty string. Encode that expection here in tests.
   query("select regex_match('foo/bar', '|', 0) as test", d);
   ASSERT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "");

--- a/tools/buckconfigs/windows-x86_64/base.bcfg
+++ b/tools/buckconfigs/windows-x86_64/base.bcfg
@@ -58,4 +58,5 @@
     userenv.lib \
     wevtapi.lib \
     shell32.lib \
-    gdi32.lib
+    gdi32.lib \
+    user32.lib


### PR DESCRIPTION
Fixes #5443. Related to #6061 