### PR TITLE
Add new macOS virtual table screenlock

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -215,6 +215,7 @@ osquery_cxx_library(
                 "darwin/quicklook_cache.cpp",
                 "darwin/running_apps.mm",
                 "darwin/sandboxes.cpp",
+                "darwin/screenlock.mm",
                 "darwin/shared_folders.mm",
                 "darwin/sharing_preferences.cpp",
                 "darwin/signature.mm",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -128,6 +128,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/quicklook_cache.cpp
       darwin/running_apps.mm
       darwin/sandboxes.cpp
+      darwin/screenlock.mm
       darwin/shared_folders.mm
       darwin/sharing_preferences.cpp
       darwin/signature.mm

--- a/osquery/tables/system/darwin/screenlock.mm
+++ b/osquery/tables/system/darwin/screenlock.mm
@@ -15,16 +15,10 @@
 namespace osquery {
 namespace tables {
 
-
 void logUnsupportedError(const std::string& reason) {
   LOG(ERROR)
       << "The screenlock table is not supported on this version of macOS: "
       << reason;
-}
-  LOG(ERROR) << "This table is not supported on this version of macOS";
-  VLOG(1) << vlogMessage;
-
-  return;
 }
 
 QueryData genScreenlock(QueryContext& context) {

--- a/osquery/tables/system/darwin/screenlock.mm
+++ b/osquery/tables/system/darwin/screenlock.mm
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#include <limits.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <stdbool.h>
+
+namespace osquery {
+namespace tables {
+
+void logUnsupportedError() {
+  LOG(ERROR) << "This table is not supported on this version of macOS";
+  return;
+}
+
+QueryData genScreenlock(QueryContext& context) {
+  QueryData results;
+  Row r;
+
+  auto bundle_url = CFURLCreateWithFileSystemPath(
+      kCFAllocatorDefault,
+      CFSTR("/System/Library/PrivateFrameworks/MobileKeyBag.framework"),
+      kCFURLPOSIXPathStyle,
+      true);
+
+  if (bundle_url == nullptr) {
+    logUnsupportedError();
+    VLOG(1) << "Error parsing MobileKeyBag bundle URL";
+
+    return results;
+  }
+
+  auto bundle = CFBundleCreate(kCFAllocatorDefault, bundle_url);
+  CFRelease(bundle_url);
+
+  if (bundle == nullptr) {
+    logUnsupportedError();
+    VLOG(1) << "Error opening MobileKeyBag bundle";
+
+    return results;
+  }
+
+  auto MKBDeviceGetGracePeriod =
+      (NSDictionary * (*)(NSDictionary*)) CFBundleGetFunctionPointerForName(
+          bundle, CFSTR("MKBDeviceGetGracePeriod"));
+  if (MKBDeviceGetGracePeriod == nullptr) {
+    logUnsupportedError();
+    VLOG(1) << "MKBDeviceGetGracePeriod returned null";
+    CFRelease(bundle);
+
+    return results;
+  }
+
+  NSDictionary* durationDict;
+
+  // MKBDeviceGetGracePeriod requires an empty dictionary as the sole argument
+  durationDict = MKBDeviceGetGracePeriod(@{});
+  int duration = [durationDict[@"GracePeriod"] integerValue];
+  // A value of INT_MAX indicates that the lock is disabled
+  int enabled = (duration == INT_MAX) ? 0 : 1;
+  // Return -1 for grace_period when the lock is not set
+  int grace_period = enabled == 0 ? -1 : duration;
+
+  r["enabled"] = INTEGER(enabled);
+  r["grace_period"] = INTEGER(grace_period);
+
+  results.push_back(r);
+  CFRelease(bundle);
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/screenlock.mm
+++ b/osquery/tables/system/darwin/screenlock.mm
@@ -58,11 +58,22 @@ QueryData genScreenlock(QueryContext& context) {
     return results;
   }
 
-  NSDictionary* durationDict;
-
   // MKBDeviceGetGracePeriod requires an empty dictionary as the sole argument
-  durationDict = MKBDeviceGetGracePeriod(@{});
-  int duration = [durationDict[@"GracePeriod"] integerValue];
+  NSDictionary* durationDict = MKBDeviceGetGracePeriod(@{});
+  if (![durationDict isKindOfClass:[NSDictionary class]]) {
+    VLOG(1) << "MKBDeviceGetGracePeriod did not return an NSDictionary";
+    CFRelease(bundle);
+    return results;
+  }
+
+  NSNumber* durationNumber = durationDict[@"GracePeriod"];
+  if (![durationNumber isKindOfClass:[NSNumber class]]) {
+    VLOG(1) << "GracePeriod did not contain an NSNumber";
+    CFRelease(bundle);
+    return results;
+  }
+
+  int duration = durationNumber.integerValue;
   // A value of INT_MAX indicates that the lock is disabled
   int enabled = (duration == INT_MAX) ? 0 : 1;
   // Return -1 for grace_period when the lock is not set

--- a/osquery/tables/system/darwin/screenlock.mm
+++ b/osquery/tables/system/darwin/screenlock.mm
@@ -15,7 +15,12 @@
 namespace osquery {
 namespace tables {
 
-void logUnsupportedError(std::string vlogMessage) {
+
+void logUnsupportedError(const std::string& reason) {
+  LOG(ERROR)
+      << "The screenlock table is not supported on this version of macOS: "
+      << reason;
+}
   LOG(ERROR) << "This table is not supported on this version of macOS";
   VLOG(1) << vlogMessage;
 

--- a/osquery/tables/system/darwin/screenlock.mm
+++ b/osquery/tables/system/darwin/screenlock.mm
@@ -15,8 +15,10 @@
 namespace osquery {
 namespace tables {
 
-void logUnsupportedError() {
+void logUnsupportedError(std::string vlogMessage) {
   LOG(ERROR) << "This table is not supported on this version of macOS";
+  VLOG(1) << vlogMessage;
+
   return;
 }
 
@@ -31,8 +33,7 @@ QueryData genScreenlock(QueryContext& context) {
       true);
 
   if (bundle_url == nullptr) {
-    logUnsupportedError();
-    VLOG(1) << "Error parsing MobileKeyBag bundle URL";
+    logUnsupportedError("Error parsing MobileKeyBag bundle URL");
 
     return results;
   }
@@ -41,8 +42,7 @@ QueryData genScreenlock(QueryContext& context) {
   CFRelease(bundle_url);
 
   if (bundle == nullptr) {
-    logUnsupportedError();
-    VLOG(1) << "Error opening MobileKeyBag bundle";
+    logUnsupportedError("Error opening MobileKeyBag bundle");
 
     return results;
   }
@@ -51,8 +51,7 @@ QueryData genScreenlock(QueryContext& context) {
       (NSDictionary * (*)(NSDictionary*)) CFBundleGetFunctionPointerForName(
           bundle, CFSTR("MKBDeviceGetGracePeriod"));
   if (MKBDeviceGetGracePeriod == nullptr) {
-    logUnsupportedError();
-    VLOG(1) << "MKBDeviceGetGracePeriod returned null";
+    logUnsupportedError("MKBDeviceGetGracePeriod returned null");
     CFRelease(bundle);
 
     return results;

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -213,6 +213,10 @@ osquery_gentable_cxx_library(
             "macos",
         ),
         (
+            "darwin/screenlock.table",
+            "macos",
+        ),
+        (
             "darwin/shared_folders.table",
             "macos",
         ),
@@ -735,7 +739,7 @@ osquery_gentable_cxx_library(
         (
             "windows/hvci_status.table",
             "windows",
-        ),        
+        ),
         (
             "windows/pipes.table",
             "windows",

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -119,6 +119,7 @@ function(generateNativeTables)
     "darwin/running_apps.table:macos"
     "darwin/safari_extensions.table:macos"
     "darwin/sandboxes.table:macos"
+    "darwin/screenlock.table:macos"
     "darwin/shared_folders.table:macos"
     "darwin/sharing_preferences.table:macos"
     "darwin/signature.table:macos"

--- a/specs/darwin/screenlock.table
+++ b/specs/darwin/screenlock.table
@@ -1,0 +1,7 @@
+table_name("screenlock")
+description("macOS screenlock status.")
+schema([
+    Column("enabled", INTEGER, "1 If a password is required after sleep or the screensaver begins; else 0"),
+    Column("grace_period", INTEGER, "The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake"),
+])
+implementation("screenlock@genScreenlock")

--- a/specs/darwin/screenlock.table
+++ b/specs/darwin/screenlock.table
@@ -1,5 +1,5 @@
 table_name("screenlock")
-description("macOS screenlock status.")
+description("macOS screenlock status for the current logged in user context.")
 schema([
     Column("enabled", INTEGER, "1 If a password is required after sleep or the screensaver begins; else 0"),
     Column("grace_period", INTEGER, "The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake"),


### PR DESCRIPTION
This PR adds a new virtual table to the darwin platform called `screenlock`. This is a single row table that when queried with `SELECT * FROM screenlock` returns the following output...

```
+---------+--------------+
| enabled | grace_period |
+---------+--------------+
| 1       | 60           |
+---------+--------------+
```
### Why is this important?
An unattended Mac without the screenlock enabled is susceptible to an Evil Maid attack. This is one of the most requested checks by Kolide customers.

### Why is this a big deal?
Previously, it was thought to be impossible to capture this data programmatically after Apple made significant changes the screenlock API in macOS 10.13 where instead of encoding the values in an easily accessible plist, they were instead stored in an encrypted keychain that requires the user's password to unlock.

More info can be found on this issue in a Kolide blog post called [Screensaver Security on macOS 10.13 is broken](https://blog.kolide.com/screensaver-security-on-macos-10-13-is-broken-a385726e2ae2)

@FritzX6 and I were able to find a CLI tool called `sysadminctl` which is capable of setting the lock grace period duration. After disassembling the binary in Hopper, we were able to determine the location of a private framework that contained the API we needed to call to obtain this information without requiring the user's password. 

Some might call this the Holy Grail of Mac virtual tables...they might be right!

### Notes on compatibility
This table relies on a private framework called MobileKeyBag to read the state of the screen lock (and its duration). Based on our testing. this framework is not available on macs prior to 10.13 (which is when reading the values from a plist changed) and as a result, this table will not produce a row on any devices missing that framework.

I took care to load this framework at runtime vs linking it at compile time so that the Osquery binary should run just fine. An appropriate error message is omitted when this table is run on those devices.

```
osquery> select * from screenlock;

E0214 14:36:34.267244 1956663296 screenlock.mm:19] This table is not supported on this version of macOS

I0214 14:36:34.267267 1956663296 screenlock.mm:45] Error opening MobileKeyBag bundle
```