### PR TITLE
Fix codegen template for extension group

### DIFF
--- a/tools/codegen/templates/osquery_extension_group_main.cpp.in
+++ b/tools/codegen/templates/osquery_extension_group_main.cpp.in
@@ -25,6 +25,6 @@ int main(int argc, char* argv[]) {
   }
 
   // Finally wait for a signal / interrupt to shutdown.
-  runner.waitThenShutdown();
+  runner.waitForShutdown();
   return 0;
 }


### PR DESCRIPTION
Fix codegen template for extension group. The template has a reference
of `waitThenShutdown` which does not exist in the definitions. Instead
of that, a function, `waitForShutdown` is defined in the
`osquery/system.h` which should have been used. This causes compilation
to fail in case of building an extension. This commit fixes that
function call in the template.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [x] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target,  
      if not move the committed files to the stage area,
      build the `format` target to format, then re-commit.
      More information is available on the wiki.
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- Support for both CMake and BUCK (we are happy to help).
- The code mostly looks and feels similar to the existing codebase.

-->
