### PR TITLE
process_dns_events: Implement BPF-based getaddrinfo tracer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,3 +124,6 @@
 [submodule "libraries/cmake/source/augeas/gnulib/src"]
 	path = libraries/cmake/source/augeas/gnulib/src
 	url = https://github.com/osquery/third-party-gnulib
+[submodule "libraries/cmake/source/ebpfpub/src"]
+	path = libraries/cmake/source/ebpfpub/src
+	url = https://github.com/trailofbits/ebpfpub

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ function(importLibraries)
     "Linux,Darwin,Windows:zstd"
     "Linux,Darwin,Windows:openssl"
     "Linux,Darwin,Windows:aws-sdk-cpp"
+    "Linux:ebpfpub"
   )
 
   foreach(python_module ${python_module_list})

--- a/libraries/cmake/source/ebpfpub/CMakeLists.txt
+++ b/libraries/cmake/source/ebpfpub/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(ebpfpubLibraryMain)
+  if(NOT DEFINED PLATFORM_LINUX)
+    message(FATAL_ERROR "ebpfpub can only be imported when compiling for Linux")
+  endif()
+
+  if(NOT STREQUAL "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    message(FATAL_ERROR "Clang is required when building ebpfpub")
+  endif()
+
+  if(NOT "${OSQUERY_TOOLCHAIN_SYSROOT}" STREQUAL "")
+    set(EBPF_COMMON_TOOLCHAIN_PATH "${OSQUERY_TOOLCHAIN_SYSROOT}" CACHE PATH "osquery toolchain sysroot path" FORCE)
+  else()
+    unset(EBPF_COMMON_TOOLCHAIN_PATH CACHE)
+  endif()
+
+  add_subdirectory("src")
+
+  target_link_libraries(ebpfpub PUBLIC thirdparty_cxx_settings)
+  add_library(thirdparty_ebpfpub ALIAS ebpfpub)
+endfunction()
+
+ebpfpubLibraryMain()

--- a/libraries/cmake/source/modules/Findebpfpub.cmake
+++ b/libraries/cmake/source/modules/Findebpfpub.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.14.6)
+include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
+
+importSourceSubmodule(
+  NAME "ebpfpub"
+  SUBMODULES "src"
+)

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -21,6 +21,7 @@ function(generateOsqueryEvents)
       linux/auditdnetlink.cpp
       linux/auditeventpublisher.cpp
       linux/inotify.cpp
+      linux/processdnseventspublisher.cpp
       linux/syslog.cpp
       linux/udev.cpp
     )
@@ -61,6 +62,7 @@ function(generateOsqueryEvents)
     osquery_utils_expected
     osquery_utils_system_time
     thirdparty_boost
+    thirdparty_ebpfpub
   )
 
   if(DEFINED PLATFORM_LINUX)
@@ -84,6 +86,7 @@ function(generateOsqueryEvents)
       linux/inotify.h
       linux/process_events.h
       linux/process_file_events.h
+      linux/processdnseventspublisher.h
       linux/selinux_events.h
       linux/socket_events.h
       linux/syslog.h

--- a/osquery/events/linux/processdnseventspublisher.cpp
+++ b/osquery/events/linux/processdnseventspublisher.cpp
@@ -1,0 +1,376 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <array>
+
+#include <osquery/events/linux/processdnseventspublisher.h>
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry_factory.h>
+#include <osquery/utils/conversions/tryto.h>
+
+#include <ebpfpub/ifunctiontracer.h>
+
+#include <sys/resource.h>
+
+namespace tob::ebpfpub {
+namespace {
+static const std::string kSerializerName{"getaddrinfo"};
+
+StringErrorOr<std::string> bufferStorageEntryToString(
+    std::uint64_t index, IBufferStorage& buffer_storage) {
+  auto L_getStringLength =
+      [](const std::vector<std::uint8_t>& buffer) -> std::size_t {
+    auto buffer_ptr = buffer.data();
+
+    std::size_t length = 0;
+    while (length < buffer.size() && buffer_ptr[length] != '\x00') {
+      ++length;
+    }
+
+    return length;
+  };
+
+  std::vector<std::uint8_t> buffer;
+
+  auto buffer_storage_err = buffer_storage.getBuffer(buffer, index);
+  if (!buffer_storage_err.succeeded()) {
+    return StringError::create("Failed to acquire the buffer");
+  }
+
+  auto length = L_getStringLength(buffer);
+  if (length == 0U) {
+    return std::string();
+  }
+
+  std::string output;
+  output.resize(length);
+
+  std::memcpy(&output[0], buffer.data(), length);
+  return output;
+}
+} // namespace
+
+class GetaddrinfoSerializer final : public IFunctionSerializer {
+ public:
+  static StringErrorOr<IFunctionSerializer::Ref> create() {
+    try {
+      return Ref(new GetaddrinfoSerializer());
+
+    } catch (const std::bad_alloc&) {
+      return StringError::create("Memory allocation failure");
+
+    } catch (const StringError& error) {
+      return error;
+    }
+  }
+
+  virtual ~GetaddrinfoSerializer() override {}
+
+  const std::string& name() const {
+    return kSerializerName;
+  }
+
+  SuccessOrStringError generate(const ebpf::Structure& enter_structure,
+                                IBPFProgramWriter& bpf_prog_writer) {
+    // Take the event entry
+    auto value_exp = bpf_prog_writer.value("event_entry");
+    if (!value_exp.succeeded()) {
+      return StringError::create("The event_entry value is not set");
+    }
+
+    auto event_entry = value_exp.takeValue();
+
+    // Take the function ptr
+    auto exit_function_exp = bpf_prog_writer.getExitFunction();
+    if (!exit_function_exp.succeeded()) {
+      return exit_function_exp.error();
+    }
+
+    auto exit_function = exit_function_exp.takeValue();
+
+    // Take the event data structure
+    auto& builder = bpf_prog_writer.builder();
+    auto& context = bpf_prog_writer.context();
+
+    auto event_data = builder.CreateGEP(
+        event_entry, {builder.getInt32(0), builder.getInt32(1)});
+
+    // Take the event header structure
+    auto event_header = builder.CreateGEP(
+        event_entry, {builder.getInt32(0), builder.getInt32(0)});
+
+    // Capture the 'prompt' parameter
+    auto named_basic_block = llvm::BasicBlock::Create(
+        context, "capture_string_prompt", exit_function);
+
+    builder.CreateBr(named_basic_block);
+    builder.SetInsertPoint(named_basic_block);
+
+    auto memory_pointer = builder.CreateGEP(
+        event_data, {builder.getInt32(0), builder.getInt32(0)});
+
+    auto success_exp = bpf_prog_writer.captureString(memory_pointer);
+    if (success_exp.failed()) {
+      return success_exp.error();
+    }
+
+    // Capture the returned pointer
+    named_basic_block = llvm::BasicBlock::Create(
+        context, "capture_string_return_value", exit_function);
+
+    builder.CreateBr(named_basic_block);
+    builder.SetInsertPoint(named_basic_block);
+
+    memory_pointer = builder.CreateGEP(
+        event_header, {builder.getInt32(0), builder.getInt32(5)});
+
+    success_exp = bpf_prog_writer.captureString(memory_pointer);
+    if (success_exp.failed()) {
+      return success_exp.error();
+    }
+
+    return {};
+  }
+
+  SuccessOrStringError parseEvents(IFunctionSerializer::Event& event,
+                                   IBufferReader& buffer_reader,
+                                   IBufferStorage& buffer_storage) {
+    // Get the 'node' parameter
+    IFunctionSerializer::Event::Variant event_value = {};
+
+    IFunctionSerializer::Event::Integer string_ptr;
+    string_ptr.type = IFunctionSerializer::Event::Integer::Type::Int64;
+    string_ptr.is_signed = false;
+    string_ptr.value = buffer_reader.u64();
+
+    bool save_raw_str_pointer{true};
+    if ((string_ptr.value >> 56) == 0xFF) {
+      auto string_exp =
+          bufferStorageEntryToString(string_ptr.value, buffer_storage);
+
+      if (string_exp.succeeded()) {
+        event_value = string_exp.takeValue();
+        save_raw_str_pointer = false;
+      }
+    }
+
+    if (save_raw_str_pointer) {
+      event_value = string_ptr;
+    }
+
+    event.field_map.insert({"node", std::move(event_value)});
+
+    // Get the 'service' parameter
+    event_value = {};
+
+    string_ptr = {};
+    string_ptr.type = IFunctionSerializer::Event::Integer::Type::Int64;
+    string_ptr.is_signed = false;
+    string_ptr.value = buffer_reader.u64();
+
+    save_raw_str_pointer = true;
+    if ((string_ptr.value >> 56) == 0xFF) {
+      auto string_exp =
+          bufferStorageEntryToString(string_ptr.value, buffer_storage);
+
+      if (string_exp.succeeded()) {
+        event_value = string_exp.takeValue();
+        save_raw_str_pointer = false;
+      }
+    }
+
+    if (save_raw_str_pointer) {
+      event_value = string_ptr;
+    }
+
+    event.field_map.insert({"service", std::move(event_value)});
+
+    return {};
+  }
+
+ private:
+  GetaddrinfoSerializer() = default;
+};
+} // namespace tob::ebpfpub
+
+namespace osquery {
+namespace {
+// clang-format off
+const tob::ebpf::Structure kDNSArgumentList = {
+  { "const char *", "node", 0U, 8U, false },
+  { "const char *", "service", 8U, 8U, false },
+  { "const struct addrinfo *", "hints", 16U, 8U, false },
+  { "struct addrinfo **", "res", 24U, 8U, false }
+};
+// clang-format on
+} // namespace
+
+FLAG(bool,
+     enable_process_dns_events,
+     false,
+     "Enables the process_dns_events publisher");
+
+REGISTER(ProcessDNSEventsPublisher,
+         "event_publisher",
+         "processdnseventspublisher");
+
+Status ProcessDNSEventsPublisher::setUp() {
+  if (!FLAGS_enable_process_dns_events) {
+    return Status::failure("Publisher disabled via configuration");
+  }
+
+  struct rlimit rl = {};
+  rl.rlim_max = RLIM_INFINITY;
+  rl.rlim_cur = rl.rlim_max;
+
+  auto err = setrlimit(RLIMIT_MEMLOCK, &rl);
+  if (err != 0) {
+    return Status::failure("Failed to setup the memory lock limits");
+  }
+
+  auto buffer_storage_exp = tob::ebpfpub::IBufferStorage::create(4096U, 100U);
+  if (!buffer_storage_exp.succeeded()) {
+    return Status::failure("Failed to create the buffer storage");
+  }
+
+  buffer_storage = buffer_storage_exp.takeValue();
+
+  auto perf_event_array_exp = tob::ebpf::PerfEventArray::create(11U);
+
+  if (!perf_event_array_exp.succeeded()) {
+    return Status::failure("Failed to create the perf event array");
+  }
+
+  perf_event_array = perf_event_array_exp.takeValue();
+
+  auto perf_event_reader_exp = tob::ebpfpub::IPerfEventReader::create(
+      *perf_event_array.get(), *buffer_storage.get());
+
+  if (!perf_event_reader_exp.succeeded()) {
+    return Status::failure("Failed to create the perf event reader");
+  }
+
+  perf_event_reader = perf_event_reader_exp.takeValue();
+
+  auto serializer_exp = tob::ebpfpub::GetaddrinfoSerializer::create();
+  if (!serializer_exp.succeeded()) {
+    const auto& error = serializer_exp.error();
+    return Status::failure(error.message());
+  }
+
+  auto serializer = serializer_exp.takeValue();
+
+  auto function_tracer_exp = tob::ebpfpub::IFunctionTracer::createFromUprobe(
+      "getaddrinfo",
+      "/lib/x86_64-linux-gnu/libc.so.6",
+      kDNSArgumentList,
+      *buffer_storage.get(),
+      *perf_event_array.get(),
+      256U,
+      std::move(serializer));
+
+  if (!function_tracer_exp.succeeded()) {
+    const auto& error = function_tracer_exp.error();
+    return Status::failure(error.message());
+  }
+
+  auto function_tracer = function_tracer_exp.takeValue();
+  perf_event_reader->insert(std::move(function_tracer));
+
+  return Status::success();
+}
+
+void ProcessDNSEventsPublisher::configure() {
+  if (!FLAGS_enable_process_dns_events) {
+    return;
+  }
+}
+
+void ProcessDNSEventsPublisher::tearDown() {
+  if (!FLAGS_enable_process_dns_events) {
+    return;
+  }
+}
+
+Status ProcessDNSEventsPublisher::run() {
+  if (!FLAGS_enable_process_dns_events) {
+    return Status::failure("Publisher disabled via configuration");
+  }
+
+  std::atomic_bool terminate{false};
+  auto event_context = createEventContext();
+
+  // clang-format off
+  auto success_exp = perf_event_reader->exec(
+    terminate,
+
+    [&event_context](const tob::ebpfpub::IFunctionSerializer::EventList &event_list) -> void {
+      for (const auto &event : event_list) {
+        ProcessDNSEvent new_event = {};
+        new_event.timestamp = event.header.timestamp;
+
+        new_event.user_id = event.header.user_id;
+        new_event.group_id = event.header.group_id;
+
+        new_event.process_id = event.header.process_id;
+        new_event.thread_id = event.header.thread_id;
+
+        new_event.exit_code = event.header.exit_code;
+
+        auto node_field_opt_it = event.field_map.find("node");
+        if (node_field_opt_it != event.field_map.end()) {
+          const auto node_field_opt = node_field_opt_it->second;
+
+          if (node_field_opt.has_value()) {
+            const auto &node_field_var = node_field_opt.value();
+
+            if (std::holds_alternative<std::string>(node_field_var)) {
+              const auto &node_value = std::get<std::string>(node_field_var);
+              new_event.node = node_value;
+            }
+          }
+        }
+
+        auto service_field_opt_it = event.field_map.find("service");
+        if (service_field_opt_it != event.field_map.end()) {
+          const auto service_field_opt = service_field_opt_it->second;
+
+          if (service_field_opt.has_value()) {
+            const auto &service_field_var = service_field_opt.value();
+
+            if (std::holds_alternative<std::string>(service_field_var)) {
+              const auto &service_value = std::get<std::string>(service_field_var);
+              new_event.service = service_value;
+            }
+          }
+        }
+
+
+        event_context->event_list.push_back(std::move(new_event));
+      }
+    }
+  );
+  // clang-format on
+
+  if (success_exp.failed()) {
+    const auto& error = success_exp.error();
+    return Status::failure(error.message());
+  }
+
+  if (!event_context->event_list.empty()) {
+    fire(event_context);
+  }
+
+  return Status::success();
+}
+
+ProcessDNSEventsPublisher::~ProcessDNSEventsPublisher() {
+  tearDown();
+}
+} // namespace osquery

--- a/osquery/events/linux/processdnseventspublisher.h
+++ b/osquery/events/linux/processdnseventspublisher.h
@@ -1,0 +1,61 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ebpfpub/iperfeventreader.h>
+#include <osquery/events.h>
+
+#include <vector>
+
+namespace osquery {
+struct ProcessDNSEventsSubscriptionContext final : public SubscriptionContext {
+ private:
+  friend class ProcessDNSEventsPublisher;
+};
+
+struct ProcessDNSEvent final {
+  std::uint64_t timestamp;
+
+  uid_t user_id{};
+  gid_t group_id{};
+
+  pid_t process_id{};
+  pid_t thread_id{};
+
+  int exit_code{};
+
+  std::string node;
+  std::string service;
+};
+
+using ProcessDNSEventList = std::vector<ProcessDNSEvent>;
+
+struct DNSEventContext final : public EventContext {
+  ProcessDNSEventList event_list;
+};
+
+using DNSEventContextRef = std::shared_ptr<DNSEventContext>;
+
+class ProcessDNSEventsPublisher final
+    : public EventPublisher<ProcessDNSEventsSubscriptionContext,
+                            DNSEventContext> {
+  DECLARE_PUBLISHER("processdnseventspublisher");
+
+  tob::ebpfpub::IBufferStorage::Ref buffer_storage;
+  tob::ebpf::PerfEventArray::Ref perf_event_array;
+  tob::ebpfpub::IPerfEventReader::Ref perf_event_reader;
+
+ public:
+  Status setUp() override;
+  void configure() override;
+  void tearDown() override;
+  Status run() override;
+  virtual ~ProcessDNSEventsPublisher() override;
+};
+} // namespace osquery

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -24,6 +24,7 @@ function(generateOsqueryTablesEventsEventstable)
       linux/hardware_events.cpp
       linux/process_events.cpp
       linux/process_file_events.cpp
+      linux/process_dns_events.cpp
       linux/selinux_events.cpp
       linux/socket_events.cpp
       linux/syslog_events.cpp
@@ -83,6 +84,7 @@ function(generateOsqueryTablesEventsEventstable)
     set(platform_public_header_files
       linux/process_events.h
       linux/process_file_events.h
+      linux/process_dns_events.h
       linux/selinux_events.h
       linux/socket_events.h
     )

--- a/osquery/tables/events/linux/process_dns_events.cpp
+++ b/osquery/tables/events/linux/process_dns_events.cpp
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <asm/unistd_64.h>
+
+#include <osquery/events/linux/processdnseventspublisher.h>
+#include <osquery/logger.h>
+#include <osquery/registry_factory.h>
+#include <osquery/sql.h>
+#include <osquery/tables/events/linux/process_dns_events.h>
+#include <osquery/utils/system/uptime.h>
+
+namespace osquery {
+REGISTER(ProcessDNSEventsSubscriber, "event_subscriber", "process_dns_events");
+
+Status ProcessDNSEventsSubscriber::init() {
+  auto sc = createSubscriptionContext();
+  subscribe(&ProcessDNSEventsSubscriber::Callback, sc);
+
+  return Status::success();
+}
+
+Status ProcessDNSEventsSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
+  std::vector<Row> row_list;
+
+  for (const auto& event : ec->event_list) {
+    Row row = {};
+    row["timestamp"] = INTEGER(event.timestamp);
+    row["user_id"] = INTEGER(event.user_id);
+    row["group_id"] = INTEGER(event.group_id);
+    row["process_id"] = INTEGER(event.process_id);
+    row["thread_id"] = INTEGER(event.thread_id);
+    row["node"] = TEXT(event.node);
+    row["service"] = TEXT(event.service);
+    row["exit_code"] = INTEGER(event.exit_code);
+
+    row_list.push_back(std::move(row));
+  }
+
+  if (!row_list.empty()) {
+    addBatch(row_list);
+  }
+
+  return Status::success();
+}
+} // namespace osquery

--- a/osquery/tables/events/linux/process_dns_events.h
+++ b/osquery/tables/events/linux/process_dns_events.h
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/events/linux/processdnseventspublisher.h>
+
+namespace osquery {
+
+class ProcessDNSEventsSubscriber final
+    : public EventSubscriber<ProcessDNSEventsPublisher> {
+ public:
+  Status init() override;
+  Status Callback(const ECRef& ec, const SCRef& sc);
+};
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -148,6 +148,7 @@ function(generateNativeTables)
     "linux/elf_segments.table:linux"
     "linux/md_devices.table:linux"
     "linux/process_namespaces.table:linux"
+    "linux/process_dns_events.table:linux"
     "linux/syslog_events.table:linux"
     "linux/rpm_packages.table:linux"
     "linux/portage_packages.table:linux"

--- a/specs/linux/process_dns_events.table
+++ b/specs/linux/process_dns_events.table
@@ -1,0 +1,16 @@
+table_name("process_dns_events")
+description("Track dns events.")
+schema([
+    Column("timestamp", BIGINT, "Event timestamp"),
+    Column("user_id", BIGINT, "User id"),
+    Column("group_id", BIGINT, "Group id"),
+    Column("process_id", BIGINT, "Process id"),
+    Column("thread_id", BIGINT, "Thread id"),
+    Column("node", TEXT, "Node"),
+    Column("service", TEXT, "Service"),
+    Column("exit_code", BIGINT, "Exit code"),
+    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("eid", TEXT, "Event ID", hidden=True),
+])
+attributes(event_subscriber=True)
+implementation("process_dns_events@process_dns_events::genTable")


### PR DESCRIPTION
## Demo
https://asciinema.org/a/302647

## Requirements
### CMake >= 3.16.4
Get it from the official download page: https://github.com/Kitware/CMake/releases/download/v3.17.0-rc1/cmake-3.17.0-rc1-Linux-x86_64.tar.gz

### osquery-toolchain with BPF libraries
Pending PR: https://github.com/osquery/osquery-toolchain/pull/14
Binary can be downloaded here: https://alessandrogar.io/downloads/osquery-toolchain-1.0.1.tar.xz
