### PR TITLE
Updating memory_info_ex function call to non-deprecated function

### DIFF
--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -134,7 +134,7 @@ def get_stats(p, interval=1):
         "counters": p.io_counters() if platform() != "darwin" else None,
         "fds": p.num_fds(),
         "cpu_times": p.cpu_times(),
-        "memory": p.memory_info_ex(),
+        "memory": p.memory_info(),
     }
 
 


### PR DESCRIPTION
psutil deprecated memory_info_ex in version 4.0.0 and suggests using memory_info() instead.See psutil documentation for more (https://psutil.readthedocs.io/en/latest/index.html#psutil.Process.memory_info_ex)