### PR TITLE
Update unwanted-chrome-extensions.conf queries to include all users

### DIFF
--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -2,57 +2,57 @@
   "platform": "windows,darwin",
   "queries": {
     "BetternetVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "Chrometana": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "CopyFish": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)"
     },
     "Giphy": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
       "interval": 3600,
       "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)"
     },
     "HolaVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
       "interval": 3600,
       "description": "(http://adios-hola.org)"
     },
     "InfinityNewTab": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "SocialFixer": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "TouchVPN": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "WebDeveloper": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/)"
     },
     "WebPaint": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "MacOSInstallCore": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';",
       "interval": 3600,
       "description": "(https://www.virustotal.com/#/file/5cab0821f597100dc1170bfef704d8cebaf67743e9d509e83b0b208eb630d992/detection)"
     }

--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -16,11 +16,6 @@
       "interval": 3600,
       "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)"
     },
-    "Giphy": {
-      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
-      "interval": 3600,
-      "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)"
-    },
     "HolaVPN": {
       "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
       "interval": 3600,


### PR DESCRIPTION
Seems like a common pitfall/gotcha when running osquery as root is that queries are run against the root user. You'll see warning messages like 

```
W0221 13:48:37.001775 267830720 virtual_table.cpp:987] The chrome_extensions table returns data based on the current user by default, consider JOINing against the users table
W0221 13:48:37.001806 267830720 virtual_table.cpp:1002] Please see the table documentation: https://osquery.io/schema/#chrome_extensions
```

The fix is to join against `users` table (as noted in the warning messages). However, another thing to keep an eye out on is whether the query optimizer will affect query execution and cause osquery to continue using the root user context. An example of when this happens is:

```sql
SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm'
```

There's some articles online that suggests you use `CROSS JOIN` to fix this. 

- https://blog.kolide.com/running-osquery-as-sudo-root-vs-user-4fcfc698c45e
- https://defensivedepth.com/2019/02/21/osquery-join-with-users-table-not-returning-results/

So, I think we should fix the queries in `unwanted-chrome-extensions.conf` by using `CROSS JOIN` to avoid confusion down the line. I think it also makes sense to have these queries include all users by default instead of the root user by default.

In addition, this PR removes the `Giphy` query as the identifier it's referencing is the same as the one in `Chrometana` query.