### PR TITLE
Limit regex_match and regex_split regex size

### DIFF
--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -19,12 +19,19 @@
 #include <string>
 #include <vector>
 
+#include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/utils/conversions/split.h>
 
 #include <sqlite3.h>
 
 namespace osquery {
+
+FLAG(uint32,
+     regex_max_size,
+     4096,
+     "Defines the maximum size in bytes of a regex that can be used with the "
+     "regex_match and regex_split functions");
 
 using SplitResult = std::vector<std::string>;
 using StringSplitFunction = std::function<SplitResult(
@@ -69,6 +76,11 @@ static SplitResult regexSplit(const std::string& input,
   // Split using the token as a regex to support multi-character tokens.
   // Exceptions are caught by the caller, as that's where the sql context is
   std::vector<std::string> result;
+
+  if (token.size() > FLAGS_regex_max_size) {
+    throw std::regex_error(std::regex_constants::error_complexity);
+  }
+
   std::regex pattern = std::regex(token);
   std::sregex_token_iterator iter_begin(
       input.begin(), input.end(), pattern, -1);
@@ -148,15 +160,32 @@ static void regexStringMatchFunc(sqlite3_context* context,
     return;
   }
 
+  const char* regex =
+      reinterpret_cast<const char*>(sqlite3_value_text(argv[1]));
+
+  if (regex == nullptr) {
+    sqlite3_result_null(context);
+    return;
+  }
+
   // parse and verify input parameters
-  std::string input((char*)sqlite3_value_text(argv[0]));
+  const std::string input(
+      reinterpret_cast<const char*>(sqlite3_value_text(argv[0])));
   std::smatch results;
   auto index = static_cast<size_t>(sqlite3_value_int(argv[2]));
   bool isMatchFound = false;
 
+  if (strnlen(regex, FLAGS_regex_max_size) == FLAGS_regex_max_size &&
+      regex[FLAGS_regex_max_size] != '\0') {
+    std::string error = "Invalid regex: too big, max size is " +
+                        std::to_string(FLAGS_regex_max_size) + " bytes";
+    LOG(INFO) << error;
+    sqlite3_result_error(context, error.c_str(), -1);
+    return;
+  }
+
   try {
-    isMatchFound = std::regex_search(
-        input, results, std::regex((char*)sqlite3_value_text(argv[1])));
+    isMatchFound = std::regex_search(input, results, std::regex(regex));
   } catch (const std::regex_error& e) {
     LOG(INFO) << "Invalid regex: " << e.what();
     sqlite3_result_error(context, "Invalid regex", -1);

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -27,11 +27,12 @@
 
 namespace osquery {
 
-FLAG(uint32,
-     regex_max_size,
-     4096,
-     "Defines the maximum size in bytes of a regex that can be used with the "
-     "regex_match and regex_split functions");
+HIDDEN_FLAG(
+    uint32,
+    regex_max_size,
+    256,
+    "Defines the maximum size in bytes of a regex that can be used with the "
+    "regex_match and regex_split functions");
 
 using SplitResult = std::vector<std::string>;
 using StringSplitFunction = std::function<SplitResult(

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -248,7 +248,20 @@ TEST_F(SQLTests, test_regex_match_invalid3) {
   // it much as an empty string. Encode that expection here in tests.
   query("select regex_match('foo/bar', '|', 0) as test", d);
   ASSERT_EQ(d.size(), 1U);
-  EXPECT_EQ(d[0]["test"], "");
+
+  std::string query_result;
+  ASSERT_NO_THROW(query_result = d[0].at("test"));
+  ASSERT_TRUE(query_result.empty());
+}
+
+TEST_F(SQLTests, test_regex_match_too_big) {
+  QueryData d;
+  std::string regex(100000, '|');
+  auto status = query("select regex_match('foo/bar', '" + regex + "', 0)", d);
+  ASSERT_TRUE(!status.ok());
+  std::string error_too_big = "Invalid regex: too big";
+  ASSERT_EQ(status.getMessage().compare(0, error_too_big.size(), error_too_big),
+            0);
 }
 
 /*
@@ -369,17 +382,24 @@ TEST_F(SQLTests, test_regex_split_invalid2) {
   ASSERT_EQ(d.size(), 0U);
 }
 
-/*
- * FIXME: This invalid regex hangs boost
- * See:
- *   https://github.com/boostorg/regex/issues/76
- *   https://github.com/facebook/osquery/issues/5443
-TEST_F(SQLTests, test_regex_split_invalid3) {
+TEST_F(SQLTests, test_regex_split_with_or) {
   QueryData d;
-  query("select regex_split('foo/bar', '|', 0)", d);
-  ASSERT_EQ(d.size(), 0U);
+  // `|` is an invalid regexp but std::basic_regex doesn't complain, and treats
+  // it much as an empty string. Encode that expection here in tests.
+  query("select regex_split('foo/bar', '|', 0) as test", d);
+  ASSERT_EQ(d.size(), 1U);
+
+  std::string query_result;
+  ASSERT_NO_THROW(query_result = d[0].at("test"));
+  ASSERT_TRUE(query_result.empty());
 }
-*/
+
+TEST_F(SQLTests, test_regex_split_too_big) {
+  QueryData d;
+  std::string regex(100000, '|');
+  auto status = query("select regex_split('foo/bar', '" + regex + "', 0)", d);
+  ASSERT_TRUE(!status.ok());
+}
 
 /*
  * ssdeep_compare


### PR DESCRIPTION
Add a new FLAG, regex_max_size, with a default of 4096 bytes,
which limits the size of the regex that can be used
with regex_match and regex_split SQL functions.

This is done since it's possible to create a regex
which makes the std::regex destruction go into a stack overflow,
due to too many alternate states (|).

Add a couple of tests to verify that the limit is correctly respected.

Restore the test for regex_split that was originally hanging when using
boost.
