### PR TITLE
Azure Pipelines: Do not ignore a build failure on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -415,6 +415,7 @@ jobs:
     - script: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.1
         cmake --build . -j 3
+        if %errorlevel% neq 0 exit /b %errorlevel%
         sccache.exe --stop-server
       displayName: "Build osquery"
       workingDirectory: $(Build.BinariesDirectory)\build


### PR DESCRIPTION
When the batch script that implements the build step has been
changed to stop the sccache server as the last command,
all build failures started to be ignored because the last command,
always succeeding, was clearing out the exit status.
Batch scripts do not have a global "exit on error" option,
so manually checking the error level and exiting with such error is needed.
