### PR TITLE
Fix database_dump for rocksdb

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -453,8 +453,21 @@ void resetDatabase() {
 }
 
 void dumpDatabase() {
-  auto plugin = getDatabasePlugin();
-  plugin->dumpDatabase();
+  for (const auto& domain : kDomains) {
+    std::vector<std::string> keys;
+    if (!scanDatabaseKeys(domain, keys)) {
+      continue;
+    }
+    for (const auto& key : keys) {
+      std::string value;
+      if (!getDatabaseValue(domain, key, value)) {
+        continue;
+      }
+      fprintf(
+          stdout, "%s[%s]: %s\n", domain.c_str(), key.c_str(), value.c_str());
+    }
+  }
+  fflush(stdout);
 }
 
 Status ptreeToRapidJSON(const std::string& in, std::string& out) {

--- a/osquery/include/osquery/database.h
+++ b/osquery/include/osquery/database.h
@@ -124,8 +124,6 @@ class DatabasePlugin : public Plugin {
   virtual Status putBatch(const std::string& domain,
                           const DatabaseStringValueList& data) = 0;
 
-  virtual void dumpDatabase() const = 0;
-
   /// Data removal method.
   virtual Status remove(const std::string& domain, const std::string& k) = 0;
 

--- a/plugins/database/ephemeral.cpp
+++ b/plugins/database/ephemeral.cpp
@@ -86,17 +86,6 @@ Status EphemeralDatabasePlugin::putBatch(const std::string& domain,
   return Status::success();
 }
 
-void EphemeralDatabasePlugin::dumpDatabase() const {
-  for (const auto& domainValue : db_) {
-    const auto& domain = domainValue.first;
-    for (const auto& keyValue : domainValue.second) {
-      const auto& key = keyValue.first;
-      const auto& value = keyValue.second;
-      std::cout << domain << "[" << key << "]: " << value << std::endl;
-    }
-  }
-}
-
 Status EphemeralDatabasePlugin::remove(const std::string& domain,
                                        const std::string& k) {
   db_[domain].erase(k);

--- a/plugins/database/ephemeral.h
+++ b/plugins/database/ephemeral.h
@@ -53,8 +53,6 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
   Status putBatch(const std::string& domain,
                   const DatabaseStringValueList& data) override;
 
-  void dumpDatabase() const override;
-
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;
 

--- a/plugins/database/rocksdb.cpp
+++ b/plugins/database/rocksdb.cpp
@@ -316,7 +316,22 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
   return putBatch(domain, {std::make_pair(key, std::to_string(value))});
 }
 
-void RocksDBDatabasePlugin::dumpDatabase() const {}
+void RocksDBDatabasePlugin::dumpDatabase() const {
+  for (const auto& domain : kDomains) {
+    std::vector<std::string> keys;
+    if (!scanDatabaseKeys(domain, keys)) {
+      continue;
+    }
+    for (const auto& key : keys) {
+      std::string value;
+      if (!getDatabaseValue(domain, key, value)) {
+        continue;
+      }
+      fprintf(
+          stdout, "%s[%s]: %s\n", domain.c_str(), key.c_str(), value.c_str());
+    }
+  }
+}
 
 Status RocksDBDatabasePlugin::remove(const std::string& domain,
                                      const std::string& key) {

--- a/plugins/database/rocksdb.cpp
+++ b/plugins/database/rocksdb.cpp
@@ -316,23 +316,6 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
   return putBatch(domain, {std::make_pair(key, std::to_string(value))});
 }
 
-void RocksDBDatabasePlugin::dumpDatabase() const {
-  for (const auto& domain : kDomains) {
-    std::vector<std::string> keys;
-    if (!scanDatabaseKeys(domain, keys)) {
-      continue;
-    }
-    for (const auto& key : keys) {
-      std::string value;
-      if (!getDatabaseValue(domain, key, value)) {
-        continue;
-      }
-      fprintf(
-          stdout, "%s[%s]: %s\n", domain.c_str(), key.c_str(), value.c_str());
-    }
-  }
-}
-
 Status RocksDBDatabasePlugin::remove(const std::string& domain,
                                      const std::string& key) {
   if (read_only_) {

--- a/plugins/database/rocksdb.h
+++ b/plugins/database/rocksdb.h
@@ -56,8 +56,6 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
   Status putBatch(const std::string& domain,
                   const DatabaseStringValueList& data) override;
 
-  void dumpDatabase() const override;
-
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;
 

--- a/plugins/database/sqlite.cpp
+++ b/plugins/database/sqlite.cpp
@@ -260,8 +260,6 @@ Status SQLiteDatabasePlugin::remove(const std::string& domain,
   return Status(0);
 }
 
-void SQLiteDatabasePlugin::dumpDatabase() const {}
-
 Status SQLiteDatabasePlugin::removeRange(const std::string& domain,
                                          const std::string& low,
                                          const std::string& high) {

--- a/plugins/database/sqlite.h
+++ b/plugins/database/sqlite.h
@@ -40,8 +40,6 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
   Status putBatch(const std::string& domain,
                   const DatabaseStringValueList& data) override;
 
-  void dumpDatabase() const override;
-
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;
 


### PR DESCRIPTION
See #5296.

`--database_dump` flag does not output anything. I dug around and found that the functionality was added in https://github.com/osquery/osquery/commit/fef53fa0d0a30afc8cf08fa02e193723ee1e3097. But then, it seems that the functionality was accidentally removed in https://github.com/osquery/osquery/commit/521041ba86cd4f76a4272ec12ba5919d4af64b9a. (You can see that `dumpDatabase` method was moved to the specific db plugin and was implemented in `EphemeralDatabasePlugin` but NOT `RocksDBDatabasePlugin`.)

I copied the implementation over and built it locally and it seems to be working. But I'm a total newbie to osquery and c++ so my work may be incorrect (and perhaps an alternative approach is better). Or should I add tests? Let me know - just posting this PR for some discussion! ❤️ 