### PR TITLE
Fix typing issue with CFNumber conversion

### DIFF
--- a/osquery/utils/conversions/darwin/cfnumber.cpp
+++ b/osquery/utils/conversions/darwin/cfnumber.cpp
@@ -28,8 +28,13 @@ std::string stringFromCFNumber(const CFDataRef& cf_number, CFNumberType type) {
     if (CFNumberGetValue((CFNumberRef)cf_number, type, &value)) {
       return boost::lexical_cast<std::string>(value);
     }
-  } else if (type == kCFNumberDoubleType) {
+  } else if (type == kCFNumberFloat64Type || type == kCFNumberDoubleType) {
     double value;
+    if (CFNumberGetValue((CFNumberRef)cf_number, type, &value)) {
+      return boost::lexical_cast<std::string>(value);
+    }
+  } else if (type == kCFNumberFloat32Type) {
+    float value;
     if (CFNumberGetValue((CFNumberRef)cf_number, type, &value)) {
       return boost::lexical_cast<std::string>(value);
     }


### PR DESCRIPTION
## What is the purpose of this PR?

As I began testing the newly merged `mdls` table, I came across some results that did not match my expectations (and also did not match the standard CLI mdls output).

For example:
```
➜  mdls /Users/fritz-imac/Pictures/summer-2019-onward-card/_DSC8054.JPG

kMDItemFocalLength                 = 28
kMDItemFocalLength35mm             = 28
kMDItemFNumber                     = 2.8
```

vs.

```shell
osquery> SELECT key, value, mdls.valuetype FROM mdfind, mdls USING(path) WHERE query = "kMDItemFSName == '_DSC8054.JPG'" AND key IN ('kMDItemFNumber', 'kMDItemFocalLength', 'kMDItemFocalLength35mm');
+------------------------+------------+-----------+
| key                    | value      | valuetype |
+------------------------+------------+-----------+
| kMDItemFocalLength     | 1105199104 | CFNumber  |
| kMDItemFocalLength35mm | 28         | CFNumber  |
| kMDItemFNumber         | 1717986918 | CFNumber  |
+------------------------+------------+-----------+
```

## How was this fixed?

With @terracatta's assistance, we were able to track the bug down to the `CFNumber` utility and add the missing type conversions to it.

## How does this affect the previously broken output?

Post-fix osquery results:

```shell
osquery> SELECT key, value, mdls.valuetype FROM mdfind, mdls USING(path) WHERE query = "kMDItemFSName == '_DSC8054.JPG'" AND key IN ('kMDItemFNumber', 'kMDItemFocalLength', 'kMDItemFocalLength35mm');
+------------------------+--------------------+-----------+
| key                    | value              | valuetype |
+------------------------+--------------------+-----------+
| kMDItemFocalLength     | 28                 | CFNumber  |
| kMDItemFocalLength35mm | 28                 | CFNumber  |
| kMDItemFNumber         | 2.7999999999999998 | CFNumber  |
+------------------------+--------------------+-----------+
```

As we can see the numbers returned are now correct. 

It might be suggested that we apply `ROUND` logic to the values (eg. 2.79999999998 = 2.8) but I would avoid this route as some returned values will have that level of significance (eg. GPS Lat & Long values: `kMDItemLongitude = -71.12597783333334`)

