### PR TITLE
Fix initialization of profiles variable

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -55,7 +55,7 @@ std::vector<ChromeUserExtensions> chromeExtensionPathsByUser(
 
   for (const auto& row : users) {
     if (row.count("uid") == 0 || row.count("directory") == 0) {
-      break;
+      continue;
     }
 
     // For each user, enumerate all of their chrome profiles.


### PR DESCRIPTION
Move `profiles` initialization into `chromePaths`

This code uses a deep set of nested for loops to iterate over all possible extension directories. `profiles` was initialized _outside_ the `chromePaths` loop, which caused it to erroneously repeat. I'm unsure whether or not adding some kind of unique (or set) functionality here makes any sense.

I also converted an `if` to an early return.

Manually tested on macOS

Fixes: https://github.com/osquery/osquery/issues/6276