### PR TITLE
Add path to ATC generated specs

### DIFF
--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -98,7 +98,7 @@ Status genTableRowsForSqliteTable(const fs::path& sqlite_db,
   rc = sqlite3_prepare_v2(db, sqlite_query.c_str(), -1, &stmt, nullptr);
   if (rc != SQLITE_OK) {
     sqlite3_close(db);
-    VLOG(1) << "Could not prepare database at path: " << sqlite_db;
+    VLOG(1) << "ATC table: Could not prepare database at path: " << sqlite_db;
     return Status(rc, "Could not prepare database");
   }
 

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -62,7 +62,8 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     }
   }
   if (r.count("path") > 0) {
-    LOG(WARNING) << "Row contains a path key, refusing to overwrite";
+    LOG(WARNING) << "ATC Table: Row contains a defined path key, omitting the "
+                    "implicit one";
   } else {
     r["path"] = sqlite_db.string();
   }

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -152,7 +152,11 @@ Status ATCConfigParserPlugin::update(const std::string& source,
     TableColumns columns;
     std::string columns_value;
     columns_value.reserve(256);
-    bool has_path_column = false;
+
+    // Always add the implicit path column
+    columns.push_back(
+        make_tuple(std::string("path"), TEXT_TYPE, ColumnOptions::DEFAULT));
+    columns_value += "path,";
 
     if (!params.HasMember("columns") || !params["columns"].IsArray()) {
       LOG(WARNING) << "ATC Table: " << table_name
@@ -166,17 +170,14 @@ Status ATCConfigParserPlugin::update(const std::string& source,
         continue;
       }
 
+      if (std::string(column.GetString()) == std::string("path")) {
+        LOG(WARNING) << "ATC Table: Includes `path`, which is implicit";
+        continue;
+      }
+
       columns.push_back(make_tuple(
           std::string(column.GetString()), TEXT_TYPE, ColumnOptions::DEFAULT));
       columns_value += std::string(column.GetString()) + ",";
-      if (std::string(column.GetString()) == std::string("path")) {
-        has_path_column = true;
-      }
-    }
-    if (!has_path_column) {
-      columns.push_back(
-          make_tuple(std::string("path"), TEXT_TYPE, ColumnOptions::DEFAULT));
-      columns_value += "path,";
     }
 
     registered.erase(table_name);

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -36,7 +36,7 @@ TableRows ATCPlugin::generate(QueryContext& context) {
     if (!s.ok()) {
       VLOG(1) << "ATC Table: Unable to detect journal mode, applying default "
                  "locking policy"
-              << " for path " << path_;
+              << " for path " << path;
     } else {
       preserve_locking = s.getMessage() == "wal";
     }

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -27,22 +27,25 @@ TableRows ATCPlugin::generate(QueryContext& context) {
   std::vector<std::string> paths;
   auto s = resolveFilePattern(path_, paths);
   if (!s.ok()) {
-    LOG(WARNING) << "Could not glob: " << path_;
+    LOG(WARNING) << "ATC Table: Could not glob: " << path_ << " skipping";
+    return result;
   }
   for (const auto& path : paths) {
     s = getSqliteJournalMode(path);
     bool preserve_locking = false;
     if (!s.ok()) {
-      VLOG(1)
-          << "Unable to detect journal mode, applying default locking policy";
+      VLOG(1) << "ATC Table: Unable to detect journal mode, applying default "
+                 "locking policy"
+              << " for path " << path_;
     } else {
       preserve_locking = s.getMessage() == "wal";
     }
     s = genTableRowsForSqliteTable(
         path, sqlite_query_, result, preserve_locking);
     if (!s.ok()) {
-      LOG(WARNING) << "Error Code: " << s.getCode()
-                   << " Could not generate data: " << s.getMessage();
+      LOG(WARNING) << "ATC Table: Error Code: " << s.getCode()
+                   << " Could not generate data: " << s.getMessage()
+                   << " for path " << path_;
     }
   }
   return result;
@@ -63,7 +66,7 @@ Status ATCConfigParserPlugin::removeATCTables(
         PluginResponse resp;
         Registry::call(
             "sql", "sql", {{"action", "detatch"}, {"table", table}}, resp);
-        LOG(INFO) << "Removed ATC table: " << table;
+        VLOG(1) << "ATC table: " << table << " Removed";
       } else {
         failed_tables.insert(table);
       }
@@ -96,7 +99,8 @@ Status ATCConfigParserPlugin::setUp() {
   for (const auto& key : keys) {
     auto s = deleteDatabaseValue(kPersistentSettings, key);
     if (!s.ok()) {
-      LOG(INFO) << "Could not clear ATC key " << key << "from database";
+      LOG(INFO) << "ATC table: Could not clear ATC key " << key
+                << "from database";
     }
   }
   return Status();
@@ -138,13 +142,13 @@ Status ATCConfigParserPlugin::update(const std::string& source,
                              : ""};
 
     if (query.empty() || path.empty()) {
-      LOG(WARNING) << "ATC Table: " << table_name
-                   << " is misconfigured (no query or path)";
+      LOG(WARNING) << "ATC Table: Skipping " << table_name
+                   << " because it is misconfigured (missing query or path)";
       continue;
     }
 
     if (!checkPlatform(platform)) {
-      VLOG(1) << "Skipping ATC table: " << table_name
+      VLOG(1) << "ATC table: Skipping " << table_name
               << " because platform doesn't match";
       continue;
     }
@@ -166,12 +170,14 @@ Status ATCConfigParserPlugin::update(const std::string& source,
     for (const auto& column : params["columns"].GetArray()) {
       if (!column.IsString()) {
         LOG(WARNING) << "ATC Table: " << table_name
-                     << " is misconfigured. (non-string columns)";
+                     << " is misconfigured. (non-string column)";
         continue;
       }
 
       if (std::string(column.GetString()) == std::string("path")) {
-        LOG(WARNING) << "ATC Table: Includes `path`, which is implicit";
+        LOG(WARNING) << "ATC Table: " << table_name
+                     << " is misconfigured. The configuration include `path`,"
+                     << " which is a reserved column";
         continue;
       }
 
@@ -194,21 +200,23 @@ Status ATCConfigParserPlugin::update(const std::string& source,
     // Remove the old table to replace with the new one
     s = removeATCTables({table_name});
     if (!s.ok()) {
-      LOG(WARNING) << "ATC table overrides core table; Refusing registration";
+      LOG(WARNING) << "ATC Table: " << table_name
+                   << " overrides core table; Refusing registration";
       continue;
     }
 
     s = setDatabaseValue(
         kPersistentSettings, kDatabaseKeyPrefix + table_name, table_settings);
     if (!s.ok()) {
-      LOG(WARNING) << "Could not write to database";
+      LOG(WARNING) << "ATC Table: " << table_name
+                   << " could not write to database";
       continue;
     }
 
     s = tables->add(
         table_name, std::make_shared<ATCPlugin>(path, columns, query), true);
     if (!s.ok()) {
-      LOG(WARNING) << s.getMessage();
+      LOG(WARNING) << "ATC Table: " << table_name << ": " << s.getMessage();
       deleteDatabaseValue(kPersistentSettings, kDatabaseKeyPrefix + table_name);
       continue;
     }
@@ -216,7 +224,7 @@ Status ATCConfigParserPlugin::update(const std::string& source,
     PluginResponse resp;
     Registry::call(
         "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
-    LOG(INFO) << "Registered ATC table: " << table_name;
+    LOG(INFO) << "ATC table: " << table_name << " Registered";
   }
 
   if (registered.size() > 0) {


### PR DESCRIPTION
Add the `path` column to the ATC generate specs. This matches the existing data, which already includes it here: https://github.com/osquery/osquery/blob/master/osquery/sql/virtual_sqlite_table.cpp#L64-L68

I'm assuming this wasn't intentionally omitted, since it is already in the underlying data.

tested manually on macOS