### PR TITLE
Services query fails if osquery cannot get service description

### DIFF
--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -80,30 +80,36 @@ static inline Status getService(const SC_HANDLE& scmHandle,
     return Status(GetLastError(), "Failed to query service config");
   }
 
-  (void)QueryServiceConfig2(
-      svcHandle.get(), SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &cbBufSize);
-  err = GetLastError();
-  if (ERROR_INSUFFICIENT_BUFFER == err) {
-    svc_descr_t lpsd(static_cast<LPSERVICE_DESCRIPTION>(malloc(cbBufSize)),
-                     freePtr);
-    if (lpsd == nullptr) {
-      return Status(1, "Failed to malloc service description buffer");
+  try {
+    (void)QueryServiceConfig2(
+        svcHandle.get(), SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &cbBufSize);
+    err = GetLastError();
+    if (ERROR_INSUFFICIENT_BUFFER == err) {
+      svc_descr_t lpsd(static_cast<LPSERVICE_DESCRIPTION>(malloc(cbBufSize)),
+                       freePtr);
+      if (lpsd == nullptr) {
+        throw std::runtime_error("failed to malloc service description buffer");
+      }
+      ret = QueryServiceConfig2(svcHandle.get(),
+                                SERVICE_CONFIG_DESCRIPTION,
+                                (LPBYTE)lpsd.get(),
+                                cbBufSize,
+                                &cbBufSize);
+      if (ret == 0) {
+        std::stringstream ss;
+        ss << "failed to query size of service description buffer, error: "
+           << GetLastError();
+        throw std::runtime_error(ss.str());
+      }
+      if (lpsd->lpDescription != nullptr) {
+        r["description"] = SQL_TEXT(lpsd->lpDescription);
+      }
+    } else if (ERROR_MUI_FILE_NOT_FOUND != err) {
+      // Bug in Windows 10 with CDPUserSvc_63718, just ignore description
+      throw std::runtime_error("failed to query service description");
     }
-    ret = QueryServiceConfig2(svcHandle.get(),
-                              SERVICE_CONFIG_DESCRIPTION,
-                              (LPBYTE)lpsd.get(),
-                              cbBufSize,
-                              &cbBufSize);
-    if (ret == 0) {
-      return Status(GetLastError(),
-                    "Failed to query size of service description buffer");
-    }
-    if (lpsd->lpDescription != nullptr) {
-      r["description"] = SQL_TEXT(lpsd->lpDescription);
-    }
-  } else if (ERROR_MUI_FILE_NOT_FOUND != err) {
-    // Bug in Windows 10 with CDPUserSvc_63718, just ignore description
-    return Status(err, "Failed to query service description");
+  } catch (const std::runtime_error& e) {
+    LOG(WARNING) << svc.lpServiceName << ": " << e.what();
   }
 
   r["name"] = SQL_TEXT(svc.lpServiceName);
@@ -190,7 +196,7 @@ static inline Status getServices(QueryData& results) {
   for (size_t i = 0; i < serviceCount; i++) {
     auto s = getService(scmHandle.get(), lpSvcBuf[i], results);
     if (!s.ok()) {
-      return s;
+      LOG(WARNING) << s.getMessage();
     }
   }
 
@@ -201,7 +207,6 @@ QueryData genServices(QueryContext& context) {
   QueryData results;
   auto status = getServices(results);
   if (!status.ok()) {
-    // Prefer no results to incomplete results
     LOG(WARNING) << status.getMessage();
     results = QueryData();
   }


### PR DESCRIPTION
### Description

Osquery will discard all services if there's an error querying a specific service. This means if there is one service that errors osquery will never produce results. 

An example of this is an issue I've seen in the windows service manager:
```
Service name: NetTcpPortSharing
Description: <Failed to Read Description. Error Code: 15101 >
```
With the broken service on the machine querying the services table produced no results and logged a warning:
```
select * from services;
W0302 15:50:00.633996  7340 services.cpp:199] Failed to query service description
```
Osquery should skip over that service if it failed to query and continue. I have made two changes to overcome the issue:

1. If there's a failure to query a service log a warning and continue
2. If osquery cannot query the service description continue to add the other service data

### Testing

1. Corrupt a service description:
Certain services will read their description from an offset in file, I've chosen NetTcpPortSharing

Change the description value:
HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetTcpPortSharing

I've changed it from @%systemroot%\Microsoft.NET\Framework64\v4.0.30319\ServiceModelInstallRC.dll,-8200 
to @%systemroot%\Microsoft.NET\Framework64\v4.0.30319\ServiceModelInstallRC.dll,-820000 and rebooted.

2. Get the service:
```
osquery> select name, description from services where name="NetTcpPortSharing";
W0303 09:36:20.171411  3744 services.cpp:199] Failed to query service description
```

With change:

```
osquery> select name, description from services where name="NetTcpPortSharing";
W0303 09:34:24.805490  1144 services.cpp:111] NetTcpPortSharing: Failed to query service description
+-------------------+-------------+
| name              | description |
+-------------------+-------------+
| NetTcpPortSharing |             |
+-------------------+-------------+

```