### PR TITLE
proper subscriber registration in sqlite util unit test

### DIFF
--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -10,6 +10,7 @@
 #include <osquery/database.h>
 #include <osquery/events.h>
 #include <osquery/flags.h>
+#include <osquery/registry_factory.h>
 #include <osquery/registry_interface.h>
 #include <osquery/sql.h>
 #include <osquery/sql/sqlite_util.h>
@@ -37,6 +38,7 @@ class SQLiteUtilTests : public testing::Test {
                       "test_table,time,process_events,osquery_info,file,users,"
                       "curl,fake_table");
     Flag::updateValue("disable_tables", "fake_table");
+    RegistryFactory::get().registry("config_parser")->setUp();
   }
 };
 


### PR DESCRIPTION
Fixes issue #6027.

Other tests with `Subscriber table missing: <table_name>` error are empty. So skipping fixing them.