### PR TITLE
libs: Update the bzip2 remote URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libraries/cmake/source/bzip2/src"]
 	path = libraries/cmake/source/bzip2/src
-	url = https://sourceware.org/git/bzip2.git
+	url = https://github.com/osquery/third-party-bzip2
 [submodule "libraries/cmake/source/libarchive/src"]
 	path = libraries/cmake/source/libarchive/src
 	url = https://github.com/libarchive/libarchive


### PR DESCRIPTION
The upstream repository (located on sourceware.com) has started causing connection issues when cloning with the HTTPS protocol.

This PR updates the remote of the submodule so that it uses our mirror inside the osquery organization (https://github.com/osquery/third-party-bzip2).