### PR TITLE
Reduce ccache cache size

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,9 @@ jobs:
       BUILD_DIR: $(Build.BinariesDirectory)/usr/src/debug/osquery/build
 
     steps:
+    - script: |
+        df -h
+
     - checkout: self
       # See BUILD_DIR.
       path: s/usr/src/debug/osquery
@@ -117,6 +120,8 @@ jobs:
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
       name: JobResult
 
+    - script: |
+        df -h
 
   - job: LinuxBuck
     displayName: "LinuxBuck Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
 
 jobs:
 
+  # TEST
 # LINUX
 
   - job: LinuxCMake


### PR DESCRIPTION
Lately some of the Debug builds on Linux failed due to not enough space to prepare the 4GB tar of cache to upload to Azure.
We'll limit the cache size to 2GB to avoid this issue, although it might slow down the build due to cache misses.

WIP: Just double checking the available sizes, since in my Azure Pipelines instance I don't see this issue.