### PR TITLE
Azure Pipelines: reclaim disk space after building

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,6 +117,10 @@ jobs:
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
       name: JobResult
 
+    - script: |
+        rm -rf $(BUILD_DIR)
+      displayName: "Reclaim disk space"
+
 
   - job: LinuxBuck
     displayName: "LinuxBuck Release"
@@ -265,6 +269,10 @@ jobs:
     - script: |
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
       name: JobResult
+
+    - script: |
+        rm -rf $(Build.BinariesDirectory)/build
+      displayName: "Reclaim disk space"
 
 
   - job: macOSBuck
@@ -441,6 +449,10 @@ jobs:
 
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
       name: JobResult
+
+    - powershell: |
+        rm -r -Force $(Build.BinariesDirectory)/build
+      displayName: "Reclaim disk space"
 
 
   - job: WindowsBuck


### PR DESCRIPTION
With the increasing size of the build and the respective ccache
and sccache caches, the disk space sometimes is not enough
and the build fails.
This deletes the build folder as the last step since it shouldn't
be necessary anymore.