### PR TITLE
Azure Pipelines: Fix Python2 discovery in Buck builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -464,12 +464,7 @@ jobs:
       workingDirectory: $(Build.BinariesDirectory)
 
     - powershell: |
-        $python2_path = (Get-Item C:\Python27amd64).FullName
-
-        if (-not $python2_path) {
-          $python2_path = ((Get-Item C:\hostedtoolcache\windows\Python\2*\x64) | Sort-Object -Descending)[0].FullName
-        }
-
+        $python2_path = ((Get-Item C:\hostedtoolcache\windows\Python\2*\x64) | Sort-Object -Descending)[0].FullName
         $python3_path = ((Get-Item C:\hostedtoolcache\windows\Python\3*\x64) | Sort-Object -Descending)[0].FullName
 
         echo "##vso[task.setvariable variable=python2]$python2_path"


### PR DESCRIPTION
In the past the Windows agent changed the path where Python2
was installed; a special logic was added which should've tested
if the path existed, though it wasn't correct in the case
the powershell script is configured to be aborted at the first error.

Since the old path should not be present anymore,
we simply remove the logic and use the path we expect to exist.