### PR TITLE
Update osquery-toolchain to the 1.1.0 version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       vmImage: 'Ubuntu-16.04'
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v7
+      image: trailofbits/osquery:ubuntu-18.04-toolchain-v8
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     timeoutInMinutes: 120

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -29,8 +29,8 @@ sudo apt install --no-install-recommends python3-pip python3-setuptools python3-
 pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3
 
 # Download and install the osquery toolchain
-wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz
-sudo tar xvf osquery-toolchain-1.0.0.tar.xz -C /usr/local
+wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz
+sudo tar xvf osquery-toolchain-1.1.0-x86_64.tar.xz -C /usr/local
 
 # Download and install a newer CMake
 wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz

--- a/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
+++ b/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
@@ -30,7 +30,7 @@ RUN apt update -q -y && apt upgrade -q -y && apt install -q -y --no-install-reco
 && sudo pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3 docker
 RUN cd ~ && wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz \
 && sudo tar xvf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1 && rm cmake-3.14.6-Linux-x86_64.tar.gz \
-&& wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz \
-&& sudo tar xvf osquery-toolchain-1.0.0.tar.xz -C /usr/local && rm osquery-toolchain-1.0.0.tar.xz
+&& wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz \
+&& sudo tar xvf osquery-toolchain-1.1.0-x86_64.tar.xz -C /usr/local && rm osquery-toolchain-1.1.0-x86_64.tar.xz
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
This new toolchain contains a newer LLVM version (9.0.1),
a fix for the scan-build scripts and it keeps the LLVM static libraries,
necessary to implement the new BPF framework and tables.