### PR TITLE
Fix assert used to check the retcode in test_5_daemon_sigint

### DIFF
--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -145,7 +145,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         os.kill(daemon.pid, signal.SIGINT)
         self.assertTrue(daemon.isDead(daemon.pid, 10))
         if os.name != "nt":
-            self.assertTrue(daemon.retcode in [0])
+            self.assertEqual(daemon.retcode, 0)
 
     @test_base.flaky
     def test_6_logger_mode(self):


### PR DESCRIPTION
Partially addresses https://github.com/osquery/osquery/issues/6300