### PR TITLE
Fix chromeExtensions.test_sanity failure

### DIFF
--- a/tests/integration/tables/chrome_extension_content_scripts.cpp
+++ b/tests/integration/tables/chrome_extension_content_scripts.cpp
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+// Sanity check integration test for chrome_extension_content_scripts
+// Spec file: specs/chrome_extension_content_scripts.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class chromeExtensions : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(chromeExtensions, test_sanity) {
+  auto const data =
+      execute_query("select * from chrome_extension_content_scripts");
+  ASSERT_GE(data.size(), 0ul);
+  ValidationMap row_map = {{"uid", IntType},
+                           {"identifier", NonEmptyString},
+                           {"version", NonEmptyString},
+                           {"script", NormalType},
+                           {"match", NormalType}};
+  validate_rows(data, row_map);
+}
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/chrome_extensions.cpp
+++ b/tests/integration/tables/chrome_extensions.cpp
@@ -15,10 +15,10 @@ namespace osquery {
 namespace table_tests {
 
 class chromeExtensions : public testing::Test {
-  protected:
-    void SetUp() override {
-      setUpEnvironment();
-    }
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
 };
 
 TEST_F(chromeExtensions, test_sanity) {
@@ -36,9 +36,7 @@ TEST_F(chromeExtensions, test_sanity) {
                            {"persistent", IntType},
                            {"path", NonEmptyString},
                            {"permissions", NormalType},
-                           {"profile", NormalType},
-                           {"script", NormalType},
-                           {"match", NormalType}};
+                           {"profile", NormalType}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
Removed the columns "script" and "match" from the test
since they do not belong to the chrome_extensions table,
they belong to chrome_extension_content_scripts.

Added the missing integration test for the table
chrome_extension_content_scripts.

Fixes https://github.com/osquery/osquery/issues/6306
