### PR TITLE
Hotfix a use-after-free accessing rows data

### DIFF
--- a/osquery/sql/dynamic_table_row.cpp
+++ b/osquery/sql/dynamic_table_row.cpp
@@ -107,7 +107,7 @@ int DynamicTableRow::get_column(sqlite3_context* ctx,
     sqlite3_result_null(ctx);
   } else if (type == TEXT_TYPE || type == BLOB_TYPE) {
     sqlite3_result_text(
-        ctx, value.c_str(), static_cast<int>(value.size()), SQLITE_STATIC);
+        ctx, value.c_str(), static_cast<int>(value.size()), SQLITE_TRANSIENT);
   } else if (type == INTEGER_TYPE) {
     auto afinite = tryTo<long>(value, 0);
     if (afinite.isError()) {


### PR DESCRIPTION
When a query triggers multiple xFilter calls
and there's an operation that has to work on the sum of rows
resulting from all those calls, we trigger a use-after-free
when such operation tries to access the rows data.

This happens because each xFilter call we clear the rows
resulting from the previous xFilter call, and because
when returning the values of a text column we don't copy it,
but return a pointer to it.

A contrived example of a query with the issue is:
SELECT path=count(*) FROM file WHERE path = '/' OR path = '1'

This changes the last sqlite3_result_text parameter
from SQLITE_STATIC to SQLITE_TRANSIENT.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20833
