### PR TITLE
When flag -extension is present, only initialize that extension

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -406,6 +406,10 @@ Status loadExtensions(const std::string& loadfile) {
     // This is a shell-only development flag for quickly loading/using a single
     // extension. It bypasses the safety check.
     Watcher::get().addExtensionPath(FLAGS_extension);
+    VLOG(1) << "Successfully loaded extension specified in --extension. Skipped autoloads";
+    return Status(0,
+                  "Successfully loaded extension specified in --extension "
+                  "flag. Ignored autoloaded extensions");
   }
 
   std::string autoload_paths;


### PR DESCRIPTION
When -extension and --extensions_autoload are used together, and both contain extension with the same name, osquery goes into a crash extension -> watcher respawns extension loop. 

When --extension is passed in, ignore autoload and notify the user as such in logs?

Will need to dive deeper into core to figure out how to prevent this altogether. This did prevent crashloop on my osqueryi: 

To repro,

 sudo osqueryi --flagfile=/path/to/osquery.flags --extension=extension.ext--allow-unsafe -verbose 

a few times where extension.ext should also be there in --extensions_autoload. 



