### PR TITLE
Define UNICODE and _UNICODE preprocessors for windows

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -267,6 +267,8 @@ function(setupBuildFlags)
       OSQUERY_BUILD_PLATFORM=windows
       OSQUERY_BUILD_DISTRO=10
       BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE=1
+      UNICODE
+      _UNICODE
     )
 
     set(windows_common_defines

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -120,11 +120,7 @@ class TestConfigPlugin : public ConfigPlugin {
 
     std::string content;
     auto s = readFile(getTestConfigDirectory() / "test_noninline_packs.conf",
-                      content,
-                      0,
-                      false,
-                      false,
-                      true);
+                      content);
     config["data"] = content;
     return s;
   }
@@ -372,12 +368,7 @@ TEST_F(ConfigTests, test_content_update) {
 
   // Read config content manually.
   std::string content;
-  readFile(getTestConfigDirectory() / "test_parse_items.conf",
-           content,
-           0,
-           false,
-           false,
-           true);
+  readFile(getTestConfigDirectory() / "test_parse_items.conf", content);
 
   // Create the output of a `genConfig`.
   std::map<std::string, std::string> config_data;

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -120,7 +120,11 @@ class TestConfigPlugin : public ConfigPlugin {
 
     std::string content;
     auto s = readFile(getTestConfigDirectory() / "test_noninline_packs.conf",
-                      content);
+                      content,
+                      0,
+                      false,
+                      false,
+                      true);
     config["data"] = content;
     return s;
   }
@@ -368,7 +372,12 @@ TEST_F(ConfigTests, test_content_update) {
 
   // Read config content manually.
   std::string content;
-  readFile(getTestConfigDirectory() / "test_parse_items.conf", content);
+  readFile(getTestConfigDirectory() / "test_parse_items.conf",
+           content,
+           0,
+           false,
+           false,
+           true);
 
   // Create the output of a `genConfig`.
   std::map<std::string, std::string> config_data;

--- a/osquery/config/tests/test_utils.cpp
+++ b/osquery/config/tests/test_utils.cpp
@@ -56,7 +56,7 @@ fs::path const& getTestHelperScriptsDirectory() {
 std::map<std::string, std::string> getTestConfigMap(const std::string& file) {
   std::string content;
   auto const filepath = getTestConfigDirectory() / file;
-  auto status = readFile(filepath, content);
+  auto status = readFile(filepath, content, 0, false, false, true);
   EXPECT_TRUE(status.ok())
       << "Could not read file: " << boost::io::quoted(filepath.string())
       << ", because: " << status.what();
@@ -68,7 +68,7 @@ std::map<std::string, std::string> getTestConfigMap(const std::string& file) {
 JSON getExamplePacksConfig() {
   std::string content;
   auto const filepath = getTestConfigDirectory() / "test_inline_pack.conf";
-  auto status = readFile(filepath, content);
+  auto status = readFile(filepath, content, 0, false, false, true);
   EXPECT_TRUE(status.ok())
       << "Could not read file: " << boost::io::quoted(filepath.string())
       << ", because: " << status.what();

--- a/osquery/config/tests/test_utils.cpp
+++ b/osquery/config/tests/test_utils.cpp
@@ -56,7 +56,7 @@ fs::path const& getTestHelperScriptsDirectory() {
 std::map<std::string, std::string> getTestConfigMap(const std::string& file) {
   std::string content;
   auto const filepath = getTestConfigDirectory() / file;
-  auto status = readFile(filepath, content, 0, false, false, true);
+  auto status = readFile(filepath, content);
   EXPECT_TRUE(status.ok())
       << "Could not read file: " << boost::io::quoted(filepath.string())
       << ", because: " << status.what();
@@ -68,7 +68,7 @@ std::map<std::string, std::string> getTestConfigMap(const std::string& file) {
 JSON getExamplePacksConfig() {
   std::string content;
   auto const filepath = getTestConfigDirectory() / "test_inline_pack.conf";
-  auto status = readFile(filepath, content, 0, false, false, true);
+  auto status = readFile(filepath, content);
   EXPECT_TRUE(status.ok())
       << "Could not read file: " << boost::io::quoted(filepath.string())
       << ", because: " << status.what();

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -279,18 +279,26 @@ Status WmiResultItem::GetUnsignedLongLong(const std::string& name,
 Status WmiResultItem::GetString(const std::string& name,
                                 std::string& ret) const {
   std::wstring property_name = stringToWstring(name);
+  std::wstring result;
+  auto status = GetString(property_name, result);
+  ret = wstringToString(result);
+  return status;
+}
+
+Status WmiResultItem::GetString(const std::wstring& name,
+                                std::wstring& ret) const {
   VARIANT value;
-  HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
+  HRESULT hr = result_->Get(name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
-    ret = "";
+    ret = L"";
     return Status::failure("Error retrieving data from WMI query.");
   }
   if (value.vt != VT_BSTR) {
-    ret = "";
+    ret = L"";
     VariantClear(&value);
     return Status::failure("Invalid data type returned.");
   }
-  ret = bstrToString(value.bstrVal);
+  ret = value.bstrVal;
   VariantClear(&value);
   return Status::success();
 }

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -187,6 +187,14 @@ class WmiResultItem {
   Status GetString(const std::string& name, std::string& ret) const;
 
   /**
+   * @brief Windows WMI Helper function to retrieve a String result from a WMI
+   * query
+   *
+   * @returns Status indicating the success of the query
+   */
+  Status GetString(const std::wstring& name, std::wstring& ret) const;
+
+  /**
    * @brief Windows WMI Helper function to retrieve a vector of String result
    * from
    * a WMI query

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1841,7 +1841,7 @@ fs::path getSystemRoot() {
   std::vector<WCHAR> winDirectory(MAX_PATH + 1);
   ZeroMemory(winDirectory.data(), MAX_PATH + 1);
   GetWindowsDirectoryW(winDirectory.data(), MAX_PATH);
-  return fs::path(wstringToString(winDirectory.data()));
+  return fs::path(winDirectory.data());
 }
 
 Status platformLstat(const std::string& path, struct stat& d_stat) {

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -235,16 +235,17 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
 
   std::wstring environmentString = childEnvironment.str();
 
-  auto status = ::CreateProcess(NULL,
-                                mutable_argv.data(),
-                                nullptr,
-                                nullptr,
-                                TRUE,
-                                CREATE_UNICODE_ENVIRONMENT|IDLE_PRIORITY_CLASS,
-                                &environmentString[0],
-                                nullptr,
-                                &si,
-                                &pi);
+  auto status =
+      ::CreateProcess(NULL,
+                      mutable_argv.data(),
+                      nullptr,
+                      nullptr,
+                      TRUE,
+                      CREATE_UNICODE_ENVIRONMENT | IDLE_PRIORITY_CLASS,
+                      &environmentString[0],
+                      nullptr,
+                      &si,
+                      &pi);
   ::CloseHandle(hLauncherProcess);
 
   if (!status) {
@@ -305,16 +306,17 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     return launchTestPythonScript(wstringToString(
         std::wstring(mutable_argv.begin(), mutable_argv.end())));
   } else {
-    auto status = ::CreateProcess(NULL,
-                                  mutable_argv.data(),
-                                  nullptr,
-                                  nullptr,
-                                  TRUE,
-                                  CREATE_UNICODE_ENVIRONMENT|IDLE_PRIORITY_CLASS,
-                                  nullptr,
-                                  nullptr,
-                                  &si,
-                                  &pi);
+    auto status =
+        ::CreateProcess(NULL,
+                        mutable_argv.data(),
+                        nullptr,
+                        nullptr,
+                        TRUE,
+                        CREATE_UNICODE_ENVIRONMENT | IDLE_PRIORITY_CLASS,
+                        nullptr,
+                        nullptr,
+                        &si,
+                        &pi);
     unsetEnvVar("OSQUERY_EXTENSION");
 
     if (!status) {

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -158,13 +158,13 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getLauncherProcess() {
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
     const std::string& exec_path, int argc, char** argv) {
-  ::STARTUPINFOA si = {0};
+  ::STARTUPINFO si = {0};
   ::PROCESS_INFORMATION pi = {nullptr};
 
   si.cb = sizeof(si);
 
-  std::stringstream argv_stream;
-  std::stringstream handle_stream;
+  std::wstringstream argv_stream;
+  std::wstringstream handle_stream;
 
   // The HANDLE exposed to the child process is currently limited to only having
   // SYNCHRONIZE and PROCESS_QUERY_LIMITED_INFORMATION capabilities. The
@@ -197,25 +197,25 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   // instead, we off-load the contents of argv into a vector which will have its
   // backing memory as modifiable.
   for (size_t i = 0; i < argc; i++) {
-    std::string component(argv[i]);
+    std::wstring component(stringToWstring(argv[i]));
     if (component.find(' ') != std::string::npos) {
-      boost::replace_all(component, "\"", "\\\"");
-      argv_stream << "\"" << component << "\" ";
+      boost::replace_all(component, L"\"", L"\\\"");
+      argv_stream << L"\"" << component << L"\" ";
     } else {
-      argv_stream << component << " ";
+      argv_stream << component << L" ";
     }
   }
 
   auto cmdline = argv_stream.str();
-  std::vector<char> mutable_argv(cmdline.begin(), cmdline.end());
-  mutable_argv.push_back('\0');
+  std::vector<WCHAR> mutable_argv(cmdline.begin(), cmdline.end());
+  mutable_argv.push_back(L'\0');
 
-  LPCH retrievedEnvironment = GetEnvironmentStringsA();
-  LPTSTR currentEnvironment = (LPTSTR)retrievedEnvironment;
-  std::stringstream childEnvironment;
+  LPWCH retrievedEnvironment = GetEnvironmentStrings();
+  LPCWSTR currentEnvironment = retrievedEnvironment;
+  std::wstringstream childEnvironment;
   while (*currentEnvironment) {
     childEnvironment << currentEnvironment;
-    childEnvironment << '\0';
+    childEnvironment << L'\0';
     currentEnvironment += lstrlen(currentEnvironment) + 1;
   }
 
@@ -230,21 +230,21 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   // OSQUERY_LAUNCHER. OSQUERY_LAUNCHER stores the string form of a HANDLE to
   // the current process. This is mostly used for detecting the death of the
   // launcher process in WatcherWatcherRunner::start
-  childEnvironment << "OSQUERY_WORKER=1" << '\0';
-  childEnvironment << "OSQUERY_LAUNCHER=" << handle << '\0' << '\0';
+  childEnvironment << L"OSQUERY_WORKER=1" << L'\0';
+  childEnvironment << L"OSQUERY_LAUNCHER=" << handle << L'\0' << L'\0';
 
-  std::string environmentString = childEnvironment.str();
+  std::wstring environmentString = childEnvironment.str();
 
-  auto status = ::CreateProcessA(exec_path.c_str(),
-                                 mutable_argv.data(),
-                                 nullptr,
-                                 nullptr,
-                                 TRUE,
-                                 IDLE_PRIORITY_CLASS,
-                                 &environmentString[0],
-                                 nullptr,
-                                 &si,
-                                 &pi);
+  auto status = ::CreateProcess(NULL,
+                                mutable_argv.data(),
+                                nullptr,
+                                nullptr,
+                                TRUE,
+                                CREATE_UNICODE_ENVIRONMENT|IDLE_PRIORITY_CLASS,
+                                &environmentString[0],
+                                nullptr,
+                                &si,
+                                &pi);
   ::CloseHandle(hLauncherProcess);
 
   if (!status) {
@@ -264,29 +264,32 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     const std::string& extensions_timeout,
     const std::string& extensions_interval,
     bool verbose) {
-  ::STARTUPINFOA si = {0};
+  ::STARTUPINFO si = {0};
   ::PROCESS_INFORMATION pi = {nullptr};
 
   si.cb = sizeof(si);
 
+  std::wstring const wexec_path = stringToWstring(exec_path);
+
   // To prevent errant double quotes from altering the intended arguments for
   // argv, we strip them out completely.
-  std::stringstream argv_stream;
-  argv_stream << "\"" << boost::replace_all_copy(exec_path, "\"", "") << "\" ";
+  std::wstringstream argv_stream;
+  argv_stream << L"\"" << boost::replace_all_copy(wexec_path, L"\"", L"")
+              << L"\" ";
   if (verbose) {
-    argv_stream << "--verbose ";
+    argv_stream << L"--verbose ";
   }
-  argv_stream << "--socket \"" << extensions_socket << "\" ";
-  argv_stream << "--timeout " << extensions_timeout << " ";
-  argv_stream << "--interval " << extensions_interval << " ";
+  argv_stream << L"--socket \"" << stringToWstring(extensions_socket) << L"\" ";
+  argv_stream << L"--timeout " << stringToWstring(extensions_timeout) << L" ";
+  argv_stream << L"--interval " << stringToWstring(extensions_interval) << L" ";
 
   // We don't directly use argv.c_str() as the value for lpCommandLine in
   // CreateProcess since that argument requires a modifiable buffer. So,
   // instead, we off-load the contents of argv into a vector which will have its
   // backing memory as modifiable.
   auto argv = argv_stream.str();
-  std::vector<char> mutable_argv(argv.begin(), argv.end());
-  mutable_argv.push_back('\0');
+  std::vector<WCHAR> mutable_argv(argv.begin(), argv.end());
+  mutable_argv.push_back(L'\0');
 
   // In POSIX, this environment variable is set to the child's process ID. But
   // that is not easily accomplishable on Windows and provides no value since
@@ -295,23 +298,23 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     return std::shared_ptr<PlatformProcess>();
   }
 
-  auto ext_path = fs::path(exec_path);
+  auto ext_path = fs::path(wexec_path);
 
   // We are autoloading a Python extension, so pass off to our helper
-  if (ext_path.extension().string() == ".ext") {
-    return launchTestPythonScript(
-        std::string(mutable_argv.begin(), mutable_argv.end()));
+  if (ext_path.extension().wstring() == L".ext") {
+    return launchTestPythonScript(wstringToString(
+        std::wstring(mutable_argv.begin(), mutable_argv.end())));
   } else {
-    auto status = ::CreateProcessA(exec_path.c_str(),
-                                   mutable_argv.data(),
-                                   nullptr,
-                                   nullptr,
-                                   TRUE,
-                                   IDLE_PRIORITY_CLASS,
-                                   nullptr,
-                                   nullptr,
-                                   &si,
-                                   &pi);
+    auto status = ::CreateProcess(NULL,
+                                  mutable_argv.data(),
+                                  nullptr,
+                                  nullptr,
+                                  TRUE,
+                                  CREATE_UNICODE_ENVIRONMENT|IDLE_PRIORITY_CLASS,
+                                  nullptr,
+                                  nullptr,
+                                  &si,
+                                  &pi);
     unsetEnvVar("OSQUERY_EXTENSION");
 
     if (!status) {
@@ -331,9 +334,9 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchTestPythonScript(
   STARTUPINFOW si = {0};
   PROCESS_INFORMATION pi = {nullptr};
 
-  auto argv = "python " + args;
+  auto argv = L"python " + stringToWstring(args);
   std::vector<WCHAR> mutable_argv(argv.begin(), argv.end());
-  mutable_argv.push_back('\0');
+  mutable_argv.push_back(L'\0');
   si.cb = sizeof(si);
 
   const auto pythonEnv = getEnvVar("OSQUERY_PYTHON_INTERPRETER_PATH");

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -236,7 +236,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   std::wstring environmentString = childEnvironment.str();
 
   auto status =
-      ::CreateProcess(NULL,
+      ::CreateProcess(nullptr,
                       mutable_argv.data(),
                       nullptr,
                       nullptr,
@@ -307,7 +307,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
         std::wstring(mutable_argv.begin(), mutable_argv.end())));
   } else {
     auto status =
-        ::CreateProcess(NULL,
+        ::CreateProcess(nullptr,
                         mutable_argv.data(),
                         nullptr,
                         nullptr,

--- a/osquery/tables/cloud/aws/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/aws/ec2_instance_tags.cpp
@@ -55,8 +55,8 @@ QueryData genEc2InstanceTags(QueryContext& context) {
   for (const auto& it : response.GetTags()) {
     Row r;
     r["instance_id"] = instance_id;
-    r["key"] = TEXT(it.GetKey());
-    r["value"] = TEXT(it.GetValue());
+    r["key"] = SQL_TEXT(it.GetKey());
+    r["value"] = SQL_TEXT(it.GetValue());
     results.push_back(r);
   }
 

--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -108,15 +108,15 @@ Status PowershellEventSubscriber::generateRow(
   }
 
   row["time"] = INTEGER(first_script_message.osquery_time);
-  row["datetime"] = TEXT(first_script_message.event_time);
-  row["script_block_id"] = TEXT(first_script_message.script_block_id);
+  row["datetime"] = SQL_TEXT(first_script_message.event_time);
+  row["script_block_id"] = SQL_TEXT(first_script_message.script_block_id);
 
   row["script_block_count"] =
       INTEGER(first_script_message.expected_message_count);
 
-  row["script_text"] = TEXT(std::move(full_script));
-  row["script_name"] = TEXT(first_script_message.script_name);
-  row["script_path"] = TEXT(first_script_message.script_path);
+  row["script_text"] = SQL_TEXT(std::move(full_script));
+  row["script_name"] = SQL_TEXT(first_script_message.script_name);
+  row["script_path"] = SQL_TEXT(first_script_message.script_path);
   row["cosine_similarity"] = DOUBLE(cosine_similarity);
 
   return Status::success();

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -247,14 +247,14 @@ void WindowsEventSubscriber::generateRow(Row& row, const Event& windows_event) {
   row = {};
 
   row["time"] = INTEGER(windows_event.osquery_time);
-  row["datetime"] = TEXT(windows_event.datetime);
-  row["source"] = TEXT(windows_event.source);
-  row["provider_name"] = TEXT(windows_event.provider_name);
-  row["provider_guid"] = TEXT(windows_event.provider_guid);
+  row["datetime"] = SQL_TEXT(windows_event.datetime);
+  row["source"] = SQL_TEXT(windows_event.source);
+  row["provider_name"] = SQL_TEXT(windows_event.provider_name);
+  row["provider_guid"] = SQL_TEXT(windows_event.provider_guid);
   row["eventid"] = INTEGER(windows_event.event_id);
   row["task"] = INTEGER(windows_event.task_id);
   row["level"] = INTEGER(windows_event.level);
-  row["keywords"] = TEXT(windows_event.keywords);
-  row["data"] = TEXT(windows_event.data);
+  row["keywords"] = SQL_TEXT(windows_event.keywords);
+  row["data"] = SQL_TEXT(windows_event.data);
 }
 } // namespace osquery

--- a/osquery/tables/networking/etc_services.cpp
+++ b/osquery/tables/networking/etc_services.cpp
@@ -14,10 +14,10 @@
 #include <boost/filesystem/path.hpp>
 
 #include <osquery/core.h>
+#include <osquery/filesystem/fileops.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/filesystem/fileops.h>
 #include <osquery/utils/conversions/split.h>
 
 namespace fs = boost::filesystem;
@@ -63,20 +63,21 @@ QueryData parseEtcServicesContent(const std::string& content) {
     }
 
     Row r;
-    r["name"] = TEXT(service_info[0]);
+    r["name"] = SQL_TEXT(service_info[0]);
     r["port"] = INTEGER(service_port_protocol[0]);
-    r["protocol"] = TEXT(service_port_protocol[1]);
+    r["protocol"] = SQL_TEXT(service_port_protocol[1]);
 
     // Removes the name and the port/protcol elements.
     service_info.erase(service_info.begin(), service_info.begin() + 2);
-    r["aliases"] = TEXT(boost::algorithm::join(service_info, " "));
+    r["aliases"] = SQL_TEXT(boost::algorithm::join(service_info, " "));
 
     // If there is a comment for the service.
     if (service_info_comment.size() > 1) {
       // Removes everything except the comment (parts of the comment).
       service_info_comment.erase(service_info_comment.begin(),
                                  service_info_comment.begin() + 1);
-      r["comment"] = TEXT(boost::algorithm::join(service_info_comment, " # "));
+      r["comment"] =
+          SQL_TEXT(boost::algorithm::join(service_info_comment, " # "));
     }
     results.push_back(r);
   }
@@ -93,5 +94,5 @@ QueryData genEtcServices(QueryContext& context) {
     return {};
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -180,7 +180,7 @@ void DeviceHelper::generateFile(const std::string& partition,
     r["inode"] = BIGINT(meta->getAddr());
     r["uid"] = BIGINT(meta->getUid());
     r["gid"] = BIGINT(meta->getGid());
-    r["mode"] = TEXT(meta->getMode());
+    r["mode"] = SQL_TEXT(meta->getMode());
     r["size"] = BIGINT(meta->getSize());
     r["atime"] = BIGINT(meta->getATime());
     r["mtime"] = BIGINT(meta->getMTime());

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -21,7 +21,9 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
+#ifdef OSQUERY_WINDOWS
 #include <osquery/utils/conversions/windows/strings.h>
+#endif
 #include <osquery/utils/info/platform_type.h>
 
 namespace osquery {

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -21,6 +21,7 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
+#include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/utils/info/platform_type.h>
 
 namespace osquery {
@@ -230,20 +231,20 @@ TEST_F(SystemsTablesTests, test_table_constraints) {
   {
     // Check LIKE and = operands.
 #ifdef OSQUERY_WINDOWS
-    TCHAR windows_path[64];
+    WCHAR windows_path[64];
     auto windows_path_length =
-        GetSystemWindowsDirectory(windows_path, sizeof(windows_path));
+        GetSystemWindowsDirectoryW(windows_path, ARRAYSIZE(windows_path));
     ASSERT_FALSE(windows_path_length == 0);
 
     std::stringstream qry_stream;
     qry_stream << boost::format("select path from file where path LIKE '%s") %
-                      windows_path
+                      wstringToString(windows_path)
                << R"(\%';)";
     std::string like_query = qry_stream.str();
     qry_stream = std::stringstream();
 
     qry_stream << boost::format("select path from file where path = '%s") %
-                      windows_path
+                      wstringToString(windows_path)
                << R"(';)";
     std::string equal_query = qry_stream.str();
 

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -102,7 +102,7 @@ std::string getKeyUsage(const PCERT_INFO& certInfo) {
 
 void getCertCtxProp(const PCCERT_CONTEXT& certContext,
                     unsigned long propId,
-                    std::vector<char>& dataBuff) {
+                    std::vector<BYTE>& dataBuff) {
   unsigned long dataBuffLen = 0;
   auto ret = CertGetCertificateContextProperty(
       certContext, propId, nullptr, &dataBuffLen);
@@ -405,53 +405,59 @@ void addCertRow(PCCERT_CONTEXT certContext,
                 const std::string& username,
                 const std::string& storeLocation,
                 QueryData& results) {
-  std::vector<char> certBuff;
-  getCertCtxProp(certContext, CERT_HASH_PROP_ID, certBuff);
+  std::vector<BYTE> fingerprintBuff;
+  getCertCtxProp(certContext, CERT_HASH_PROP_ID, fingerprintBuff);
   std::string fingerprint;
-  toHexStr(certBuff.begin(), certBuff.end(), fingerprint);
+  toHexStr(fingerprintBuff.begin(), fingerprintBuff.end(), fingerprint);
 
   Row r;
   r["sid"] = sid;
   r["username"] = username;
   r["store_id"] = storeId;
   r["sha1"] = fingerprint;
+  std::vector<WCHAR> certBuff;
   certBuff.resize(256, 0);
   std::fill(certBuff.begin(), certBuff.end(), 0);
-  CertGetNameString(certContext,
-                    CERT_NAME_SIMPLE_DISPLAY_TYPE,
-                    0,
-                    nullptr,
-                    certBuff.data(),
-                    static_cast<unsigned long>(certBuff.size()));
-  r["common_name"] = certBuff.data();
+  CertGetNameString(
+      certContext,
+      CERT_NAME_SIMPLE_DISPLAY_TYPE | CERT_NAME_STR_ENABLE_PUNYCODE_FLAG,
+      0,
+      nullptr,
+      certBuff.data(),
+      static_cast<unsigned long>(certBuff.size()));
+  r["common_name"] = wstringToString(certBuff.data());
 
-  auto subjSize = CertNameToStr(certContext->dwCertEncodingType,
-                                &(certContext->pCertInfo->Subject),
-                                CERT_SIMPLE_NAME_STR,
-                                nullptr,
-                                0);
+  auto subjSize =
+      CertNameToStr(certContext->dwCertEncodingType,
+                    &(certContext->pCertInfo->Subject),
+                    CERT_SIMPLE_NAME_STR | CERT_NAME_STR_ENABLE_PUNYCODE_FLAG,
+                    nullptr,
+                    0);
   certBuff.resize(subjSize, 0);
   std::fill(certBuff.begin(), certBuff.end(), 0);
-  subjSize = CertNameToStr(certContext->dwCertEncodingType,
-                           &(certContext->pCertInfo->Subject),
-                           CERT_SIMPLE_NAME_STR,
-                           certBuff.data(),
-                           subjSize);
-  r["subject"] = subjSize == 0 ? "" : certBuff.data();
+  subjSize =
+      CertNameToStr(certContext->dwCertEncodingType,
+                    &(certContext->pCertInfo->Subject),
+                    CERT_SIMPLE_NAME_STR | CERT_NAME_STR_ENABLE_PUNYCODE_FLAG,
+                    certBuff.data(),
+                    subjSize);
+  r["subject"] = subjSize == 0 ? "" : wstringToString(certBuff.data());
 
-  auto issuerSize = CertNameToStr(certContext->dwCertEncodingType,
-                                  &(certContext->pCertInfo->Issuer),
-                                  CERT_SIMPLE_NAME_STR,
-                                  nullptr,
-                                  0);
+  auto issuerSize =
+      CertNameToStr(certContext->dwCertEncodingType,
+                    &(certContext->pCertInfo->Issuer),
+                    CERT_SIMPLE_NAME_STR | CERT_NAME_STR_ENABLE_PUNYCODE_FLAG,
+                    nullptr,
+                    0);
   certBuff.resize(issuerSize, 0);
   std::fill(certBuff.begin(), certBuff.end(), 0);
-  issuerSize = CertNameToStr(certContext->dwCertEncodingType,
-                             &(certContext->pCertInfo->Issuer),
-                             CERT_SIMPLE_NAME_STR,
-                             certBuff.data(),
-                             issuerSize);
-  r["issuer"] = issuerSize == 0 ? "" : certBuff.data();
+  issuerSize =
+      CertNameToStr(certContext->dwCertEncodingType,
+                    &(certContext->pCertInfo->Issuer),
+                    CERT_SIMPLE_NAME_STR | CERT_NAME_STR_ENABLE_PUNYCODE_FLAG,
+                    certBuff.data(),
+                    issuerSize);
+  r["issuer"] = issuerSize == 0 ? "" : wstringToString(certBuff.data());
 
   // TODO(#5654) 1: Find the right API calls to get whether a cert is for a CA
   r["ca"] = INTEGER(-1);
@@ -478,10 +484,10 @@ void addCertRow(PCCERT_CONTEXT certContext,
   r["key_strength"] = INTEGER(
       (certContext->pCertInfo->SubjectPublicKeyInfo.PublicKey.cbData) * 8);
 
-  certBuff.clear();
-  getCertCtxProp(certContext, CERT_KEY_IDENTIFIER_PROP_ID, certBuff);
+  std::vector<BYTE> keypropBuff;
+  getCertCtxProp(certContext, CERT_KEY_IDENTIFIER_PROP_ID, keypropBuff);
   std::string subjectKeyId;
-  toHexStr(certBuff.begin(), certBuff.end(), subjectKeyId);
+  toHexStr(keypropBuff.begin(), keypropBuff.end(), subjectKeyId);
   r["subject_key_id"] = subjectKeyId;
 
   r["path"] =

--- a/osquery/tables/system/windows/dns_cache.cpp
+++ b/osquery/tables/system/windows/dns_cache.cpp
@@ -134,7 +134,7 @@ QueryData genDnsCache(QueryContext& context) {
 
   PDNSCACHEENTRY pEntry = (PDNSCACHEENTRY)malloc(sizeof(DNSCACHEENTRY));
   HINSTANCE hLib =
-      LoadLibraryEx(TEXT("DNSAPI.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+      LoadLibraryExW(L"DNSAPI.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   DNS_GET_CACHE_DATA_TABLE DnsGetCacheDataTable =
       (DNS_GET_CACHE_DATA_TABLE)GetProcAddress(hLib, "DnsGetCacheDataTable");
 

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -56,7 +56,7 @@ static inline void win32LogWARNING(const std::string& msg,
 static inline std::string kNormalizeImage(std::string& path) {
   boost::algorithm::to_lower(path);
 
-  std::string sys_root(MAX_PATH, '\0');
+  std::wstring sys_root(MAX_PATH, L'\0');
   auto ret = GetSystemDirectory(&sys_root.front(),
                                 static_cast<unsigned int>(sys_root.size()));
   if (ret == 0) {
@@ -71,7 +71,7 @@ static inline std::string kNormalizeImage(std::string& path) {
   if (path.find("system32") != std::string::npos) {
     boost::regex_replace(path, boost::regex("^.*?system32"), "");
   }
-  return sys_root.append(path);
+  return wstringToString(sys_root.append(stringToWstring(path)));
 }
 
 device_infoset_t setupDevInfoSet(const DWORD flags) {
@@ -223,7 +223,7 @@ QueryData genDrivers(QueryContext& context) {
     return results;
   }
 
-  std::map<std::string, Row> api_devices;
+  std::map<std::wstring, Row> api_devices;
   std::vector<SP_DEVINFO_DATA> devices;
   auto ret = getDeviceList(dev_info_set, devices);
   if (!ret.ok()) {
@@ -239,7 +239,7 @@ QueryData genDrivers(QueryContext& context) {
 
   // Then, leverage the Windows APIs to get whatever remains
   for (auto& device : devices) {
-    char devId[MAX_DEVICE_ID_LEN] = {0};
+    WCHAR devId[MAX_DEVICE_ID_LEN] = {0};
     if (CM_Get_Device_ID(device.DevInst, devId, MAX_DEVICE_ID_LEN, 0) !=
         CR_SUCCESS) {
       win32LogWARNING("Failed to get device ID");
@@ -283,9 +283,9 @@ QueryData genDrivers(QueryContext& context) {
    */
   for (const auto& row : wmi_results) {
     Row r;
-    std::string devid;
-    row.GetString("DeviceID", devid);
-    r["device_id"] = devid;
+    std::wstring devid;
+    row.GetString(L"DeviceID", devid);
+    r["device_id"] = wstringToString(devid);
     row.GetString("DeviceName", r["device_name"]);
     row.GetString("Description", r["description"]);
     row.GetString("DeviceClass", r["class"]);
@@ -303,13 +303,13 @@ QueryData genDrivers(QueryContext& context) {
       r["signed"] = "-1";
     }
 
-    std::string inf_name;
-    ret = row.GetString("InfName", inf_name);
+    std::wstring inf_name;
+    ret = row.GetString(L"InfName", inf_name);
     if (!ret.ok()) {
       VLOG(1) << "Failed to retrieve Inf name for " << r["device_name"]
               << " with " << ret.getMessage();
     } else {
-      std::vector<char> inf(MAX_PATH, 0x0);
+      std::vector<WCHAR> inf(MAX_PATH, 0x0);
       unsigned long inf_len = 0;
       auto sdi_ret =
           SetupGetInfDriverStoreLocation(inf_name.c_str(),
@@ -331,9 +331,9 @@ QueryData genDrivers(QueryContext& context) {
       if (sdi_ret != TRUE) {
         VLOG(1) << "Failed to derive full driver INF path for "
                 << r["device_name"] << " with " << GetLastError();
-        r["inf"] = inf_name;
+        r["inf"] = wstringToString(inf_name);
       } else {
-        r["inf"] = inf.data();
+        r["inf"] = wstringToString(inf.data());
       }
     }
 

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -14,6 +14,7 @@
 
 // clang-format off
 #include <osquery/utils/system/system.h>
+#include <osquery/utils/conversions/windows/strings.h>
 #include <SetupAPI.h>
 // clang-format on
 
@@ -331,16 +332,16 @@ osquery::Status getDeviceInterfacePath(
         std::to_string(err));
   }
 
-  std::string path;
+  std::wstring path;
   path.assign(device_details->DevicePath, buffer.size() - sizeof(DWORD));
 
-  if (std::strlen(path.c_str()) == 0U) {
+  if (std::wcslen(path.c_str()) == 0U) {
     return osquery::Status::failure(
         "Invalid path returned for the given device interface; the string is "
         "empty");
   }
 
-  dev_interface_path = std::move(path);
+  dev_interface_path = wstringToString(path);
   return osquery::Status::success();
 }
 
@@ -405,7 +406,7 @@ osquery::Status openDeviceInterface(DeviceHandle& device_handle,
                                     const std::string& dev_interface_path) {
   device_handle.reset();
 
-  auto device = CreateFile(dev_interface_path.c_str(),
+  auto device = CreateFile(stringToWstring(dev_interface_path).c_str(),
                            GENERIC_READ | GENERIC_WRITE,
                            FILE_SHARE_READ | FILE_SHARE_WRITE,
                            nullptr,

--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -65,9 +65,9 @@ QueryData queryLogonSessions(QueryContext& context) {
           kLogonTypeToStr.find(SECURITY_LOGON_TYPE(session_data->LogonType))
               ->second;
       r["session_id"] = INTEGER(session_data->Session);
-      LPTSTR sid = nullptr;
-      if (ConvertSidToStringSid(session_data->Sid, &sid)) {
-        r["logon_sid"] = sid;
+      LPWSTR sid = nullptr;
+      if (ConvertSidToStringSidW(session_data->Sid, &sid)) {
+        r["logon_sid"] = wstringToString(sid);
       }
       if (sid) {
         LocalFree(sid);

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -203,10 +203,10 @@ Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
   if (!ConvertStringSidToSidA(toks[1].c_str(), &sid)) {
     return Status(GetLastError(), "Could not convert string to sid");
   } else {
-    wchar_t accntName[UNLEN] = {0};
-    wchar_t domName[DNLEN] = {0};
-    unsigned long accntNameLen = UNLEN;
-    unsigned long domNameLen = DNLEN;
+    WCHAR accntName[UNLEN+1] = {0};
+    WCHAR domName[DNLEN+1] = {0};
+    DWORD accntNameLen = UNLEN+1;
+    DWORD domNameLen = DNLEN+1;
     SID_NAME_USE eUse;
     if (!LookupAccountSidW(nullptr,
                            sid,

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -203,10 +203,10 @@ Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
   if (!ConvertStringSidToSidA(toks[1].c_str(), &sid)) {
     return Status(GetLastError(), "Could not convert string to sid");
   } else {
-    WCHAR accntName[UNLEN+1] = {0};
-    WCHAR domName[DNLEN+1] = {0};
-    DWORD accntNameLen = UNLEN+1;
-    DWORD domNameLen = DNLEN+1;
+    WCHAR accntName[UNLEN + 1] = {0};
+    WCHAR domName[DNLEN + 1] = {0};
+    DWORD accntNameLen = UNLEN + 1;
+    DWORD domNameLen = DNLEN + 1;
     SID_NAME_USE eUse;
     if (!LookupAccountSidW(nullptr,
                            sid,

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -113,7 +113,7 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
     HRESULT lastTaskRun = E_FAIL;
     pRegisteredTask->get_LastTaskResult(&lastTaskRun);
     _com_error err(lastTaskRun);
-    r["last_run_message"] = err.ErrorMessage();
+    r["last_run_message"] = wstringToString(err.ErrorMessage());
     r["last_run_code"] = INTEGER(lastTaskRun);
 
     // We conver the COM Date type to a unix epoch timestamp

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -6,6 +6,7 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
+#include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/utils/system/env.h>
 #include <osquery/utils/system/system.h>
 
@@ -102,7 +103,7 @@ static inline Status getService(const SC_HANDLE& scmHandle,
         throw std::runtime_error(ss.str());
       }
       if (lpsd->lpDescription != nullptr) {
-        r["description"] = SQL_TEXT(lpsd->lpDescription);
+        r["description"] = SQL_TEXT(wstringToString(lpsd->lpDescription));
       }
     } else if (ERROR_MUI_FILE_NOT_FOUND != err) {
       // Bug in Windows 10 with CDPUserSvc_63718, just ignore description
@@ -112,16 +113,16 @@ static inline Status getService(const SC_HANDLE& scmHandle,
     LOG(WARNING) << svc.lpServiceName << ": " << e.what();
   }
 
-  r["name"] = SQL_TEXT(svc.lpServiceName);
-  r["display_name"] = SQL_TEXT(svc.lpDisplayName);
-  r["status"] = SQL_TEXT(kSvcStatus[svc.ServiceStatusProcess.dwCurrentState]);
+  r["name"] = SQL_TEXT(wstringToString(svc.lpServiceName));
+  r["display_name"] = SQL_TEXT(wstringToString(svc.lpDisplayName));
+  r["status"] = kSvcStatus[svc.ServiceStatusProcess.dwCurrentState];
   r["pid"] = INTEGER(svc.ServiceStatusProcess.dwProcessId);
   r["win32_exit_code"] = INTEGER(svc.ServiceStatusProcess.dwWin32ExitCode);
   r["service_exit_code"] =
       INTEGER(svc.ServiceStatusProcess.dwServiceSpecificExitCode);
   r["start_type"] = SQL_TEXT(kSvcStartType[lpsc->dwStartType]);
-  r["path"] = SQL_TEXT(lpsc->lpBinaryPathName);
-  r["user_account"] = SQL_TEXT(lpsc->lpServiceStartName);
+  r["path"] = SQL_TEXT(wstringToString(lpsc->lpBinaryPathName));
+  r["user_account"] = SQL_TEXT(wstringToString(lpsc->lpServiceStartName));
 
   if (kServiceType.count(lpsc->dwServiceType) > 0) {
     r["service_type"] = SQL_TEXT(kServiceType.at(lpsc->dwServiceType));

--- a/osquery/tables/system/windows/shimcache.cpp
+++ b/osquery/tables/system/windows/shimcache.cpp
@@ -145,7 +145,7 @@ void parseEntry(const Row& aKey, size_t& index, QueryData& results) {
   auto createRow = [&results, &index](const ShimcacheData& shimcache) {
     Row r;
     r["entry"] = INTEGER(index);
-    r["path"] = TEXT(shimcache.path);
+    r["path"] = SQL_TEXT(shimcache.path);
     r["modified_time"] = INTEGER(shimcache.last_modified);
     if (shimcache.execution_flag.is_initialized()) {
       if (shimcache.execution_flag.get()) {

--- a/osquery/tables/system/windows/windows_security_center.cpp
+++ b/osquery/tables/system/windows/windows_security_center.cpp
@@ -34,7 +34,7 @@ std::string resolveProductHealthOrError(int productName) {
       _In_ DWORD Providers, _Out_ PWSC_SECURITY_PROVIDER_HEALTH);
   pWscGetSecurityProviderHealth WscGetSecurityProviderHealth;
   static HMODULE hDLL =
-      LoadLibraryEx("wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+      LoadLibraryEx(L"wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (hDLL == nullptr) {
     VLOG(1) << "Could not dynamically load 'wscapi.dll'";
     return "Error";

--- a/osquery/tables/system/windows/windows_security_center.cpp
+++ b/osquery/tables/system/windows/windows_security_center.cpp
@@ -34,7 +34,7 @@ std::string resolveProductHealthOrError(int productName) {
       _In_ DWORD Providers, _Out_ PWSC_SECURITY_PROVIDER_HEALTH);
   pWscGetSecurityProviderHealth WscGetSecurityProviderHealth;
   static HMODULE hDLL =
-      LoadLibraryEx(L"wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+      LoadLibraryExW(L"wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (hDLL == nullptr) {
     VLOG(1) << "Could not dynamically load 'wscapi.dll'";
     return "Error";

--- a/osquery/tables/system/windows/windows_security_products.cpp
+++ b/osquery/tables/system/windows/windows_security_products.cpp
@@ -50,7 +50,7 @@ Status GetSecurityProducts(WSC_SECURITY_PROVIDER provider,
   // machines (like the CI server).
   CLSID* productListClassPtr = nullptr;
   static HINSTANCE wscLib =
-      LoadLibraryEx(TEXT("wscapi.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+      LoadLibraryExW(L"wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (wscLib != nullptr) {
     productListClassPtr = (CLSID *)GetProcAddress(wscLib, "CLSID_WSCProductList");
   }

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -15,6 +15,8 @@
 #include <osquery/logger.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
+#include <osquery/worker/ipc/platform_table_container_ipc.h>
+#include <osquery/worker/logging/glog/glog_logger.h>
 
 namespace fs = boost::filesystem;
 

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -15,8 +15,6 @@
 #include <osquery/logger.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
-#include <osquery/worker/ipc/platform_table_container_ipc.h>
-#include <osquery/worker/logging/glog/glog_logger.h>
 
 namespace fs = boost::filesystem;
 
@@ -126,7 +124,7 @@ void genFileInfo(const fs::path& path,
   r["inode"] = BIGINT(file_stat.inode);
   r["uid"] = BIGINT(file_stat.uid);
   r["gid"] = BIGINT(file_stat.gid);
-  r["mode"] = TEXT(file_stat.mode);
+  r["mode"] = SQL_TEXT(file_stat.mode);
   r["device"] = BIGINT(file_stat.device);
   r["size"] = BIGINT(file_stat.size);
   r["block_size"] = INTEGER(file_stat.block_size);
@@ -135,11 +133,11 @@ void genFileInfo(const fs::path& path,
   r["mtime"] = BIGINT(file_stat.mtime);
   r["ctime"] = BIGINT(file_stat.ctime);
   r["btime"] = BIGINT(file_stat.btime);
-  r["type"] = TEXT(file_stat.type);
-  r["attributes"] = TEXT(file_stat.attributes);
-  r["file_id"] = TEXT(file_stat.file_id);
-  r["volume_serial"] = TEXT(file_stat.volume_serial);
-  r["product_version"] = TEXT(file_stat.product_version);
+  r["type"] = SQL_TEXT(file_stat.type);
+  r["attributes"] = SQL_TEXT(file_stat.attributes);
+  r["file_id"] = SQL_TEXT(file_stat.file_id);
+  r["volume_serial"] = SQL_TEXT(file_stat.volume_serial);
+  r["product_version"] = SQL_TEXT(file_stat.product_version);
 
 #endif
 
@@ -219,5 +217,5 @@ QueryData genFile(QueryContext& context) {
     return genFileImpl(context, logger);
   }
 }
-}
+} // namespace tables
 } // namespace osquery


### PR DESCRIPTION
Define UNICODE and _UNICODE preprocessors. This will result in Windows API function macros defaulting to the wide implementation instead of the ANSI (local) implementations. This PR ought to be the final PR in the line of PRs that aim to resolve internationalization/localization issues observed in osquery on Windows.

This should resolve #2569 from 2016. :-)

Please encourage future PR submitters to not call the *A functions but the *W functions instead.