### PR TITLE
add status column to deb_packages table

### DIFF
--- a/specs/linux/deb_packages.table
+++ b/specs/linux/deb_packages.table
@@ -6,7 +6,8 @@ schema([
     Column("source", TEXT, "Package source"),
     Column("size", BIGINT, "Package size in bytes"),
     Column("arch", TEXT, "Package architecture"),
-    Column("revision", TEXT, "Package revision")
+    Column("revision", TEXT, "Package revision"),
+    Column("status", TEXT, "Package status")
 ])
 attributes(cacheable=True)
 implementation("system/deb_packages@genDebPackages")

--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -26,14 +26,13 @@ class DebPackages : public testing::Test {
 TEST_F(DebPackages, test_sanity) {
   QueryData rows = execute_query("select * from deb_packages");
   if (rows.size() > 0) {
-    ValidationMap row_map = {
-        {"name", NonEmptyString},
-        {"version", NonEmptyString},
-        {"source", NormalType},
-        {"size", IntType},
-        {"arch", NonEmptyString},
-        {"revision", NormalType},
-    };
+    ValidationMap row_map = {{"name", NonEmptyString},
+                             {"version", NonEmptyString},
+                             {"source", NormalType},
+                             {"size", IntType},
+                             {"arch", NonEmptyString},
+                             {"revision", NormalType},
+                             {"source", NonEmptyString}};
     validate_rows(rows, row_map);
 
     auto all_packages = std::unordered_set<std::string>{};

--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -32,7 +32,7 @@ TEST_F(DebPackages, test_sanity) {
                              {"size", IntType},
                              {"arch", NonEmptyString},
                              {"revision", NormalType},
-                             {"source", NonEmptyString}};
+                             {"status", NonEmptyString}};
     validate_rows(rows, row_map);
 
     auto all_packages = std::unordered_set<std::string>{};


### PR DESCRIPTION
Fixes #4740

The deb_packages table includes packages that are uninstalled but have config files left over.

This PR adds a `status` column to the table so a user can filter on packages with a specific status.

The most common statuses are

`install ok installed`
`deinstall ok config-files`

