### PR TITLE
Fix `cmdline` not populated in MacOS

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -334,7 +334,7 @@ std::string getProcCmdline(int pid) {
 
   // Walk the \0-tokenized list of arguments until reaching the returned 'max'
   // number of arguments or the number appended to the front.
-  char* ptr = procargs;
+  char* ptr = procargs + sizeof(nargs);
   char* cmdline = nullptr;
   for (int i = 0; i < nargs && ptr < procargs + len; i++) {
     // Find the end of the arg
@@ -342,8 +342,8 @@ std::string getProcCmdline(int pid) {
       ptr += 1;
     }
 
-    // Replace the null with a space except for the final null in the cmdline
-    if (*ptr == '\0' && i < nargs - 1) {
+    // Replace the null with a space except for the final null in the cmdline.
+    while (ptr < procargs + len && *ptr == '\0' && i < nargs) {
       *ptr = ' ';
       ptr += 1;
     }


### PR DESCRIPTION
Fix the missing/improper `cmdline` field in the processes table, as
mentioned in #6330. The contents of the call stack was initially read
from the stack pointer, `argc`. That has been moved to start now from

```
char* ptr = procargs + sizeof(nargs);
```

From experiments, it looks like there are leading null-byte chars after
argc[0] that causes the counter `i` to advance thus missing some args
from the `nargs` count. To avoid that, a null-byte sink-hole has been
written that will convert all null-bytes to space by using while instead
of if in the second conditional in the for loop.

```
while (*ptr == '\0' && ptr < procargs + len && i < nargs) {
  *ptr = ' ';
  ptr += 1;
}
```

The last byte is not converted to a space as, argc[1] is also
representing the executable name. So, the parsing loop will only run to
second last argument and then rely on the next null-byte for
termination.

### Output
Release Build
```
osquery> select pid, name, cmdline from processes where pid=23112;
+-------+--------+---------+
| pid   | name   | cmdline |
+-------+--------+---------+
| 23112 | Python |         |
+-------+--------+---------+
osquery> SELECT version from osquery_info;
+---------+
| version |
+---------+
| 4.2.0   |
+---------+
``` 
Build with this PR
```
osquery> select pid, name, cmdline from processes where pid=23112;
+-------+--------+-------------------------------------------------------------------------------------------------------------------------------------+
| pid   | name   | cmdline                                                                                                                             |
+-------+--------+-------------------------------------------------------------------------------------------------------------------------------------+
| 23112 | Python | /usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/Resources/Python.app/Contents/MacOS/Python -m http.server |
+-------+--------+-------------------------------------------------------------------------------------------------------------------------------------+
osquery> SELECT version from osquery_info;
+--------------------------+
| version                  |
+--------------------------+
| 4.2.0-45-g46a46da0-dirty |
+--------------------------+
```
ref:
* https://github.com/skaht/Csu-85/blob/master/start.s
* https://github.com/hishamhm/htop/blob/master/darwin/Platform.c
* Code for experiment: https://paste.ubuntu.com/p/QxTyvZ7cXn/