### PR TITLE
Add messages to distributed query results

### DIFF
--- a/osquery/include/osquery/distributed.h
+++ b/osquery/include/osquery/distributed.h
@@ -84,13 +84,15 @@ struct DistributedQueryResult {
   DistributedQueryResult(const DistributedQueryRequest& req,
                          const QueryData& res,
                          const ColumnNames& cols,
-                         const Status& s)
-      : request(req), results(res), columns(cols), status(s) {}
+                         const Status& s,
+                         const std::string& msg)
+      : request(req), results(res), columns(cols), status(s), message(msg) {}
 
   DistributedQueryRequest request;
   QueryData results;
   ColumnNames columns;
   Status status;
+  std::string message;
 };
 
 /**


### PR DESCRIPTION
Currently the distributed write API sends back status codes that indicate whether or not a particular query was successful. However, in the event that a query was not successful, we have no other information as to what the failure was. This PR solves the issue by adding a new top-level field to the distributed write results:

`messages`: A map of queryID -> error message for queries that fail. Successful queries will have an empty string for the message.

Also another top-level key was added for the original sql query statement corresponding to the distributed write request:

`statements`: A map of queryID -> sql statement.

Together, these fields help TLS distributed api implementors to inform clients about *why* an error happened - as opposed to just letting them know that *some* error happened.