### PR TITLE
CMake: Update OpenSSL to version 1.1.1f

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.6)
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "1.1.1d")
+set(OPENSSL_VERSION "1.1.1f")
 
 include(ExternalProject)
 


### PR DESCRIPTION
The link for version 1.1.1d no longer works as the tarball has been moved under the `old` subfolder: https://www.openssl.org/source/old/1.1.1

Update the version to the latest available (1.1.1f) in order to fix the download.