### PR TITLE
Fix readFile API doing blocking I/O with a non-blocking handle

### DIFF
--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -573,4 +573,15 @@ TEST_F(FilesystemTests, create_dir_recursive_ignore_existence) {
   fs::remove_all(tmp_root_path);
 }
 
+TEST_F(FilesystemTests, test_read_empty_file) {
+  auto test_file = test_working_dir_ / "fstests-empty";
+
+  ASSERT_TRUE(writeTextFile(test_file, "").ok());
+  ASSERT_TRUE(fs::is_empty(test_file));
+
+  std::string content;
+  ASSERT_TRUE(readFile(test_file, content));
+  ASSERT_TRUE(content.empty());
+}
+
 } // namespace osquery


### PR DESCRIPTION
When a block size is passed to the readFile function
or a file has no size, the read is forced to be blocking,
even if the handle is opened as non-blocking.
The opposite can happen too, a blocking handle is opened
but since a block size of 0 is passed, and the file size is not 0,
the file is read with non-blocking I/O.

This change bases the decision of doing blocking
or non-blocking I/O mainly on the "blocking" parameter
of the readFile function and the file being a special file or not.
If a handle is opened in non-blocking mode but the file is special,
the handle is reopened as blocking.

Also give a different name to the overload that provides
a way to do a read file check via readFile.

This should address the most concerning issues found in https://github.com/osquery/osquery/issues/5661
