### PR TITLE
Change process table log errors to info

### DIFF
--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -114,7 +114,7 @@ std::unique_ptr<BYTE[]> getSidFromUsername(std::wstring accountName) {
                                 &eSidType);
 
   if (ret == 0 && GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-    LOG(INFO) << "Failed to lookup accoun name "
+    LOG(INFO) << "Failed to lookup account name "
               << wstringToString(accountName.c_str()) << " with "
               << GetLastError();
     return nullptr;
@@ -134,7 +134,7 @@ std::unique_ptr<BYTE[]> getSidFromUsername(std::wstring accountName) {
                            &domainNameSize,
                            &eSidType);
   if (ret == 0) {
-    LOG(INFO) << "Failed to lookup accoun name "
+    LOG(INFO) << "Failed to lookup account name "
               << wstringToString(accountName.c_str()) << " with "
               << GetLastError();
     return nullptr;

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -309,7 +309,7 @@ void getProcessPathInfo(HANDLE& proc,
   SecureZeroMemory(path.data(), kMaxPathSize);
   auto ret = QueryFullProcessImageNameW(proc, 0, path.data(), &out);
   if (ret != TRUE) {
-    LOG(ERROR) << "Failed to lookup path information for process " << pid;
+    LOG(INFO) << "Failed to lookup path information for process " << pid;
   } else {
     r["path"] = SQL_TEXT(wstringToString(path.data()));
   }
@@ -329,7 +329,7 @@ void getProcessPathInfo(HANDLE& proc,
   }
 
   if (ret == FALSE) {
-    LOG(ERROR) << "Failed to get cwd for " << pid << " with " << GetLastError();
+    LOG(INFO) << "Failed to get cwd for " << pid << " with " << GetLastError();
   } else {
     r["cwd"] = SQL_TEXT(wstringToString(path.data()));
   }


### PR DESCRIPTION
### Description

Change the logs in the processes table to be info to prevent constant errors caused by querying. Without SeDebugPriviledge https://support.microsoft.com/en-gb/help/131065/how-to-obtain-a-handle-to-any-process-with-sedebugprivilege you cannot access information about system processes. This means failing to get certain process information isn't really an error. To reduce the noise change the log level to information.

### Testing

Run 

```
select cwd from processes
```

Without change:

```
C:\osquery_test\original>osquery.exe
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> select description from processes;
Error: no such column: description
osquery> select cwd from processes;
E0407 13:17:41.395509 31256 processes.cpp:312] Failed to lookup path information for process 4
E0407 13:17:41.411082 31256 processes.cpp:332] Failed to get cwd for 4 with 31
E0407 13:17:41.411082 31256 processes.cpp:312] Failed to lookup path information for process 136
E0407 13:17:41.411082 31256 processes.cpp:332] Failed to get cwd for 136 with 31
E0407 13:17:41.411082 31256 processes.cpp:312] Failed to lookup path information for process 2408
E0407 13:17:41.411082 31256 processes.cpp:332] Failed to get cwd for 2408 with 31
+------------------------------------------------------------------------------------------------------------------------------------------------+
| cwd                                                                                                                                            |
...
```

With change:

```
C:\osquery_test\modified>osquery.exe
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> select cwd from processes;
+------------------------------------------------------------------------------------------------------------------------------------------------+
| cwd                                                                                                                                            |
...
```