### PR TITLE
Copy the parent environment when launching worker

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -136,6 +136,7 @@ const std::string kBackupDefaultFlagfile{OSQUERY_HOME "osquery.flags.default"};
 
 const size_t kDatabaseMaxRetryCount{25};
 const size_t kDatabaseRetryDelay{200};
+bool Initializer::isWorker_{false};
 
 namespace {
 
@@ -209,6 +210,8 @@ Initializer::Initializer(int& argc,
       chrono_clock::now().time_since_epoch().count()));
   // The config holds the initialization time for easy access.
   Config::setStartTime(getUnixTime());
+
+  isWorker_ = hasWorkerVariable();
 
   // osquery can function as the daemon or shell depending on argv[0].
   if (tool == ToolType::SHELL_DAEMON) {
@@ -482,7 +485,7 @@ void Initializer::initWorkerWatcher(const std::string& name) const {
 }
 
 bool Initializer::isWorker() {
-  return hasWorkerVariable();
+  return isWorker_;
 }
 
 bool Initializer::isWatcher() {

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -206,6 +206,9 @@ class Initializer : private boost::noncopyable {
 
   /// The deduced program name determined by executing path.
   std::string binary_;
+
+  /// Is this a worker process
+  static bool isWorker_;
 };
 
 /**


### PR DESCRIPTION
### Description

On Windows launching the worker took advantage of the fact a child process inherits from it's environment from the parent. You can see here when launching a worker osquery will change its own environment to set the worker variable for the child environment: https://github.com/osquery/osquery/blob/master/osquery/process/windows/process.cpp#L188

After the processes are launched the environment variables OSQUERY_WORKER and OSQUERY_LAUNCHER are then unset. This means the briefly the watcher can set itself as a worker. 

This then combine with the osquery checking if it's a worker by reading directly from the environment: https://github.com/osquery/osquery/blob/master/osquery/core/init.cpp#L143 causes a race condition where the watcher will begin behaving as the worker.

### Fix
Copy the environment and add the OSQUERY_WORKER flag then launch the new worker process with it.