### PR TITLE
Return error detaching table, only use primary database

### DIFF
--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -53,7 +53,9 @@ class SQLPlugin : public Plugin {
   }
 
   /// Tables may be detached by name.
-  virtual void detach(const std::string& /*name*/) {}
+  virtual Status detach(const std::string& /*name*/) {
+    return Status::success();
+  }
 
  public:
   Status call(const PluginRequest& request, PluginResponse& response) override;

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -158,8 +158,7 @@ Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
     // Attach a virtual table name using an optional included definition.
     return this->attach(request.at("table"));
   } else if (request.at("action") == "detach") {
-    this->detach(request.at("table"));
-    return Status::success();
+    return this->detach(request.at("table"));
   } else if (request.at("action") == "tables") {
     std::vector<std::string> tables;
     auto status = this->getQueryTables(request.at("query"), tables);


### PR DESCRIPTION
### Description

Osquery can fail to detach existing tables when an extension has gone away. This then causes issues re-registering the extension tables when the extension was added back. We can see here that the call to detach will always return success: https://github.com/osquery/osquery/blob/master/osquery/sql/sql.cpp#L162 instead this should return a status stating why it failed. 

The reason the detach fails is because it doesn't necessarily use the primary database when calling it. The fix has already been applied to attach function: https://github.com/osquery/osquery/blob/master/osquery/sql/sqlite_util.cpp#L247
