### PR TITLE
Don't check logged in users in session 0 or non-active sessions

### DIFF
--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -53,7 +53,6 @@ QueryData genLoggedInUsers(QueryContext& context) {
   }
 
   for (size_t i = 0; i < count; i++) {
-  
     if (pSessionInfo[i].State != WTSActive || pSessionInfo[i].SessionId == 0) {
       // https://docs.microsoft.com/en-gb/windows/win32/api/wtsapi32/ne-wtsapi32-wts_connectstate_class
       // The only state for a user logged in is WTSActive and session 0 is the

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -53,6 +53,14 @@ QueryData genLoggedInUsers(QueryContext& context) {
   }
 
   for (size_t i = 0; i < count; i++) {
+  
+    if (pSessionInfo[i].State != WTSActive || pSessionInfo[i].SessionId == 0) {
+      // https://docs.microsoft.com/en-gb/windows/win32/api/wtsapi32/ne-wtsapi32-wts_connectstate_class
+      // The only state for a user logged in is WTSActive and session 0 is the
+      // non-interactive system session
+      continue;
+    }
+
     Row r;
 
     LPWSTR sessionInfo = nullptr;
@@ -67,6 +75,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
               << ")";
       continue;
     }
+
     const auto wtsSession = reinterpret_cast<WTSINFOW*>(sessionInfo);
     r["user"] = SQL_TEXT(wstringToString(wtsSession->UserName));
     r["type"] = SQL_TEXT(kSessionStates.at(pSessionInfo[i].State));


### PR DESCRIPTION
### Description

On Windows the logged_in_users table accesses non-interactive sessions and returns them as logged on users. We can see from the Windows documentation: https://docs.microsoft.com/en-gb/windows/win32/api/wtsapi32/ne-wtsapi32-wts_connectstate_class that a user is only logged on if the state is WTSActive.

### Fix
If the session is non-interactive or is session 0 it can't be a logged on user and should be ignored.

### Testing
On Windows run:
```
select *from logged_in_users;
```
Without change:
```
C:\osquery_test\original>osquery.exe --verbose
I0408 11:40:21.701100 27116 init.cpp:340] osquery initialized [version=4.2.0]
I0408 11:40:21.701100 27116 extensions.cpp:349] Could not autoload extensions: Failed reading: \Program Files\osquery\extensions.load
I0408 11:40:21.701100 19312 interface.cpp:268] Extension manager service starting: \\.\pipe\shell.em
I0408 11:40:21.717139 27116 auto_constructed_tables.cpp:93] Removing stale ATC entries
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> select * from logged_in_users;
I0408 11:40:27.788151 27116 process_ops.cpp:99] No account name provided
I0408 11:40:27.788151 27116 logged_in_users.cpp:129] Error converting username to SID
I0408 11:40:27.788151 27116 process_ops.cpp:99] No account name provided
I0408 11:40:27.788151 27116 logged_in_users.cpp:129] Error converting username to SID
+--------------+---------------+-------------------------+----------------+------------+-----+----------------------------------------------+---------------------------------------------------------+
| type         | user          | tty                     | host           | time       | pid | sid                                          | registry_hive                                           |
+--------------+---------------+-------------------------+----------------+------------+-----+----------------------------------------------+---------------------------------------------------------+
| disconnected |               | Services                |                | 0          | -1  |                                              |                                                         |
| active       | Administrator | 31C5CE94259D4006A9E4#19 | 10.100.110.185 | 1586342396 | -1  | S-1-5-21-1860232918-163864199-3232310675-500 | HKEY_USERS\S-1-5-21-1860232918-163864199-3232310675-500 |
| connected    |               | Console                 |                | 1584972478 | -1  |                                              |                                                         |
+--------------+---------------+-------------------------+----------------+------------+-----+----------------------------------------------+---------------------------------------------------------+
```
You can see rows that are clearly not logged in users such as services.
 
With change:
```
C:\osquery_test\modified>osquery.exe --verbose
I0408 11:42:45.499208 23996 init.cpp:345] osquery initialized [version=4.2.0]
I0408 11:42:45.499208 23996 extensions.cpp:376] Could not autoload extensions: Failed reading: \Program Files\osquery\extensions.load
I0408 11:42:45.514966 23996 dispatcher.cpp:78] Adding new service: ExtensionWatcher (00000275453E6D60) to thread: 32688 (00000275453C6C90) in process 19060
I0408 11:42:45.514966 23996 dispatcher.cpp:78] Adding new service: ExtensionRunnerCore (00000275453EF910) to thread: 21324 (00000275453C6770) in process 19060
I0408 11:42:45.514966 21324 interface.cpp:268] Extension manager service starting: \\.\pipe\shell.em
I0408 11:42:45.514966 23996 auto_constructed_tables.cpp:93] Removing stale ATC entries
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> select * from logged_in_users;
+--------+---------------+-------------------------+------+------------+-----+----------------------------------------------+---------------------------------------------------------+
| type   | user          | tty                     | host | time       | pid | sid                                          | registry_hive                                           |
+--------+---------------+-------------------------+------+------------+-----+----------------------------------------------+---------------------------------------------------------+
| active | Administrator | 31C5CE94259D4006A9E4#19 |      | 1586342396 | -1  | S-1-5-21-1860232918-163864199-3232310675-500 | HKEY_USERS\S-1-5-21-1860232918-163864199-3232310675-500 |
+--------+---------------+-------------------------+------+------------+-----+----------------------------------------------+---------------------------------------------------------+
```
