### PR TITLE
Add additional logging in the watcher for windows

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -708,8 +708,9 @@ void Initializer::requestShutdown(int retcode) {
   });
 }
 
-void Initializer::requestShutdown(int retcode, const std::string& system_log) {
-  systemLog(system_log);
+void Initializer::requestShutdown(int retcode, const std::string& message) {
+  LOG(ERROR) << message;
+  systemLog(message);
   requestShutdown(retcode);
 }
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -532,9 +532,8 @@ void Initializer::start() const {
       }
 
       if (i == kDatabaseMaxRetryCount) {
-        std::string message =
-            RLOG(1629) + binary_ +
-            " initialize failed: Could not initialize database";
+        auto message = std::string(RLOG(1629)) + binary_ +
+                       " initialize failed: Could not initialize database";
         auto retcode = (isWorker()) ? EXIT_CATASTROPHIC : EXIT_FAILURE;
         requestShutdown(retcode, message);
         return;

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -506,9 +506,9 @@ void Initializer::initActivePlugin(const std::string& type,
   }));
 
   if (!status.ok()) {
-    LOG(ERROR) << "Cannot activate " << name << " " << type
-               << " plugin: " << status.getMessage();
-    requestShutdown(EXIT_CATASTROPHIC);
+    std::string message = "Cannot activate " + name + " " + type +
+                          " plugin: " + status.getMessage();
+    requestShutdown(EXIT_CATASTROPHIC, message);
   }
 }
 
@@ -532,10 +532,11 @@ void Initializer::start() const {
       }
 
       if (i == kDatabaseMaxRetryCount) {
-        LOG(ERROR) << RLOG(1629) << binary_
-                   << " initialize failed: Could not initialize database";
+        std::string message =
+            RLOG(1629) + binary_ +
+            " initialize failed: Could not initialize database";
         auto retcode = (isWorker()) ? EXIT_CATASTROPHIC : EXIT_FAILURE;
-        requestShutdown(retcode);
+        requestShutdown(retcode, message);
         return;
       }
 
@@ -544,9 +545,8 @@ void Initializer::start() const {
 
     // Ensure the database results version is up to date before proceeding
     if (!upgradeDatabase()) {
-      LOG(ERROR) << "Failed to upgrade database";
       auto retcode = (isWorker()) ? EXIT_CATASTROPHIC : EXIT_FAILURE;
-      requestShutdown(retcode);
+      requestShutdown(retcode, "Failed to upgrade database");
       return;
     }
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -544,8 +544,9 @@ void WatcherRunner::createWorker() {
                             EQUALS,
                             INTEGER(PlatformProcess::getCurrentPid()));
   if (qd.size() != 1 || qd[0].count("path") == 0 || qd[0]["path"].size() == 0) {
-    LOG(ERROR) << "osquery watcher cannot determine process path for worker";
-    Initializer::requestShutdown(EXIT_FAILURE);
+    Initializer::requestShutdown(
+        EXIT_FAILURE,
+        "osquery watcher cannot determine process path for worker");
     return;
   }
 
@@ -565,9 +566,9 @@ void WatcherRunner::createWorker() {
   if (!safePermissions(
           exec_path.parent_path().string(), exec_path.string(), true)) {
     // osqueryd binary has become unsafe.
-    LOG(ERROR) << RLOG(1382)
-               << "osqueryd has unsafe permissions: " << exec_path.string();
-    Initializer::requestShutdown(EXIT_FAILURE);
+    std::string message =
+        RLOG(1382) + "osqueryd has unsafe permissions: " + exec_path.string();
+    Initializer::requestShutdown(EXIT_FAILURE, message);
     return;
   }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -566,8 +566,8 @@ void WatcherRunner::createWorker() {
   if (!safePermissions(
           exec_path.parent_path().string(), exec_path.string(), true)) {
     // osqueryd binary has become unsafe.
-    std::string message =
-        RLOG(1382) + "osqueryd has unsafe permissions: " + exec_path.string();
+    auto message = std::string(RLOG(1382)) +
+                   "osqueryd has unsafe permissions: " + exec_path.string();
     Initializer::requestShutdown(EXIT_FAILURE, message);
     return;
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -215,8 +215,8 @@ void WatcherRunner::start() {
 
       auto status = watcher.getWorkerStatus();
       if (status == EXIT_CATASTROPHIC) {
-        LOG(ERROR) << "Worker returned exit status";
-        Initializer::requestShutdown(EXIT_CATASTROPHIC);
+        Initializer::requestShutdown(EXIT_CATASTROPHIC,
+                                     "Worker returned exit status");
         break;
       }
 
@@ -238,10 +238,9 @@ void WatcherRunner::start() {
     if (use_worker_) {
       auto status = isWatcherHealthy(*self, watcher_state);
       if (!status.ok()) {
-        std::string message("Watcher has become unhealthy: " +
-                            status.getMessage());
-        LOG(ERROR) << message;
-        Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
+        Initializer::requestShutdown(
+            EXIT_CATASTROPHIC,
+            "Watcher has become unhealthy: " + status.getMessage());
         break;
       }
     }
@@ -360,7 +359,6 @@ void WatcherRunner::stopChild(const PlatformProcess& child) const {
     if (!child.cleanup()) {
       auto message = std::string("Watcher cannot stop worker process (") +
                      std::to_string(child_pid) + ").";
-      LOG(ERROR) << message;
       Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
     }
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -215,6 +215,7 @@ void WatcherRunner::start() {
 
       auto status = watcher.getWorkerStatus();
       if (status == EXIT_CATASTROPHIC) {
+        LOG(ERROR) << "Worker returned exit status";
         Initializer::requestShutdown(EXIT_CATASTROPHIC);
         break;
       }
@@ -237,9 +238,10 @@ void WatcherRunner::start() {
     if (use_worker_) {
       auto status = isWatcherHealthy(*self, watcher_state);
       if (!status.ok()) {
-        Initializer::requestShutdown(
-            EXIT_CATASTROPHIC,
-            "Watcher has become unhealthy: " + status.getMessage());
+        std::string message("Watcher has become unhealthy: " +
+                            status.getMessage());
+        LOG(ERROR) << message;
+        Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
         break;
       }
     }
@@ -358,6 +360,7 @@ void WatcherRunner::stopChild(const PlatformProcess& child) const {
     if (!child.cleanup()) {
       auto message = std::string("Watcher cannot stop worker process (") +
                      std::to_string(child_pid) + ").";
+      LOG(ERROR) << message;
       Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
     }
   }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -136,12 +136,10 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
     status = dbQuery.addNewResults(
         std::move(sql.rowsTyped()), item.epoch, item.counter, diff_results);
     if (!status.ok()) {
-      std::string line = "Error adding new results to database for query " +
-                         name + ": " + status.what();
-      LOG(ERROR) << line;
-
+      std::string message = "Error adding new results to database for query " +
+                            name + ": " + status.what();
       // If the database is not available then the daemon cannot continue.
-      Initializer::requestShutdown(EXIT_CATASTROPHIC, line);
+      Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
     }
   } else {
     diff_results.added = std::move(sql.rowsTyped());
@@ -161,10 +159,9 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
   status = logQueryLogItem(item);
   if (!status.ok()) {
     // If log directory is not available, then the daemon shouldn't continue.
-    std::string error = "Error logging the results of query: " + name + ": " +
-                        status.toString();
-    LOG(ERROR) << error;
-    Initializer::requestShutdown(EXIT_CATASTROPHIC, error);
+    std::string message = "Error logging the results of query: " + name + ": " +
+                          status.toString();
+    Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
   }
   return status;
 }


### PR DESCRIPTION
### Description

requestShutdown(int retcode, const std::string& system_log) only logs to the syslog which is not available on Windows. 
### Fix
When the watcher exits log the error in the standard log saying why it's exiting. 