### PR TITLE
Ensure the extension uuid is never 0

### DIFF
--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -104,7 +104,7 @@ Status ExtensionManagerInterface::registerExtension(
         chrono_clock::now().time_since_epoch().count()));
   }
   // Every call to registerExtension is assigned a new RouteUUID.
-  uuid = static_cast<uint16_t>(rand());
+  uuid = static_cast<uint16_t>(rand() + 1);
   LOG(INFO) << "Registering extension (" << info.name << ", " << uuid
             << ", version=" << info.version << ", sdk=" << info.sdk_version
             << ")";


### PR DESCRIPTION
### Description

If the extension uuid is 0 osquery will set the extension's socket to the same value as the main socket:
https://github.com/osquery/osquery/blob/master/osquery/include/osquery/extensions.h#L42

It will then fail to load.

### Fix
Change the extension uuid so it can never be 0.