### PR TITLE
Add git-lfs as dep for macOS build in documentation

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -58,7 +58,7 @@ Please ensure [Homebrew](https://brew.sh/) has been installed, first. Then do th
 ```bash
 # Install prerequisites
 xcode-select --install
-brew install git cmake python clang-format
+brew install git git-lfs cmake python clang-format
 
 # Optional: install python tests prerequisites
 pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery


### PR DESCRIPTION
Add git-lfs as dependency in documentation because without it the `cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ..` fails

Here the output, (I kept the all output if needed:
```bash
❯ mkdir build; cd buildcd
❯ cd osquery
❯ mkdir build; cd build
❯ cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ..
...
-- Importing: source/icu
Submodule 'libraries/cmake/source/icu/src' (https://github.com/unicode-org/icu) registered for path 'src'
Cloning into '/Users/gaetan.piquenot/Workspace/tools/osquery/libraries/cmake/source/icu/src'...
From https://github.com/unicode-org/icu
 * branch            e2d85306162d3a0691b070b4f0a73e4012433444 -> FETCH_HEAD
git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
Unable to checkout 'e2d85306162d3a0691b070b4f0a73e4012433444' in submodule path 'src'
CMake Error at libraries/cmake/source/modules/utils.cmake:55 (message):
  Failed to update the following git submodule:
  "/Users/gaetan.piquenot/tools/osquery/libraries/cmake/source/icu/src"
Call Stack (most recent call first):
  libraries/cmake/source/modules/utils.cmake:149 (initializeGitSubmodule)
  libraries/cmake/source/modules/Findicu.cmake:10 (importSourceSubmodule)
  libraries/cmake/source_migration/modules/Findicu.cmake:7 (include)
  CMakeLists.txt:152 (find_package)
  CMakeLists.txt:68 (importLibraries)
  CMakeLists.txt:192 (main)


-- Configuring incomplete, errors occurred!
See also "/Users/gaetan.piquenot/tools/osquery/build/CMakeFiles/CMakeOutput.log".
See also "/Users/gaetan.piquenot/tools/osquery/build/CMakeFiles/CMakeError.log".
```

<!-- Thank you for contributing to osquery! -->

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
