### PR TITLE
Update some sqlite types

### DIFF
--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -42,7 +42,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);
     switch (column_type) {
-    case SQLITE_TEXT: {
+    case SQLITE_BLOB: case SQLITE_TEXT: {
       auto text_value = sqlite3_column_text(stmt, i);
       if (text_value != nullptr) {
         r[column_name] = std::string(reinterpret_cast<const char*>(text_value));
@@ -55,7 +55,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
       break;
     }
     case SQLITE_INTEGER: {
-      auto int_value = sqlite3_column_int(stmt, i);
+      auto int_value = sqlite3_column_int64(stmt, i);
       r[column_name] = INTEGER(int_value);
       break;
     }

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -42,7 +42,8 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);
     switch (column_type) {
-    case SQLITE_BLOB: case SQLITE_TEXT: {
+    case SQLITE_BLOB:
+    case SQLITE_TEXT: {
       auto text_value = sqlite3_column_text(stmt, i);
       if (text_value != nullptr) {
         r[column_name] = std::string(reinterpret_cast<const char*>(text_value));

--- a/osquery/tables/system/darwin/quicklook_cache.cpp
+++ b/osquery/tables/system/darwin/quicklook_cache.cpp
@@ -44,7 +44,7 @@ void genQuicklookRow(sqlite3_stmt* stmt, Row& r) {
       }
     } else if (column_type == SQLITE_INTEGER) {
       // Handle INTEGER columns explicitly to handle the date-value offset.
-      auto value = sqlite3_column_int(stmt, i);
+      auto value = sqlite3_column_int64(stmt, i);
       if (column_name == "last_hit_date") {
         value += kReferenceDateOffset;
       }

--- a/osquery/tables/system/freebsd/pkg_packages.cpp
+++ b/osquery/tables/system/freebsd/pkg_packages.cpp
@@ -33,7 +33,7 @@ void genPkgRow(sqlite3_stmt* stmt, Row& r) {
         r[column_name] = std::string((const char*)value);
       }
     } else if (column_type == SQLITE_INTEGER) {
-      auto value = sqlite3_column_int(stmt, i);
+      auto value = sqlite3_column_int64(stmt, i);
       r[column_name] = INTEGER(value);
     }
   }


### PR DESCRIPTION
sqlite [defines](https://www.sqlite.org/c3ref/column_blob.html) `SQLITE_INTEGER` as 64bit, not 32bit. Most of our usage seems correct, but a couple did not. This updates them

Also include `SQLITE_BLOB` in ATC tables.

Fixes: #6391

Not sure how to add tests for this.

```
dover:build seph$ ./osquery/osqueryi  --config_path  /tmp/osq.conf "select * from url_timestamp limit 4;"
W0414 23:25:26.263969 284452288 auto_constructed_tables.cpp:178] ATC Table: url_timestamp is misconfigured. The configuration include `path`, which is a reserved column
+-------------------------------------------------------------------------+-------------------+---------------------+
| path                                                                    | time              | time_converted      |
+-------------------------------------------------------------------------+-------------------+---------------------+
| /Users/seph/Library/Application Support/Google/Chrome/Profile 1/History | 13231386168665043 | 2020-04-15 01:02:48 |
| /Users/seph/Library/Application Support/Google/Chrome/Profile 1/History | 13231386168665043 | 2020-04-15 01:02:48 |
| /Users/seph/Library/Application Support/Google/Chrome/Profile 1/History | 13227724671117522 | 2020-03-03 15:57:51 |
| /Users/seph/Library/Application Support/Google/Chrome/Profile 1/History | 13227724671117522 | 2020-03-03 15:57:51 |
+-------------------------------------------------------------------------+-------------------+---------------------+
```