### PR TITLE
Fix Userassist.test_sanity test sometimes failing

### DIFF
--- a/tests/integration/tables/userassist.cpp
+++ b/tests/integration/tables/userassist.cpp
@@ -26,10 +26,12 @@ TEST(Rot13Test, DecodeData) {
 
 TEST_F(UserassistTest, test_sanity) {
   QueryData const rows = execute_query("select * from userassist");
-  QueryData const specific_query_rows = execute_query(
-      "select * from userassist where path is 'Microsoft.Windows.Explorer'");
+  QueryData const specific_query_rows =
+      execute_query("select * from userassist where path is 'UEME_CTLSESSION'");
+
   ASSERT_GT(rows.size(), 0ul);
-  ASSERT_EQ(specific_query_rows.size(), 1ul);
+  ASSERT_GT(specific_query_rows.size(), 0ul);
+
   ValidationMap row_map = {
       {"path", NonEmptyString},
       {"last_execution_time", NormalType},


### PR DESCRIPTION
The specific key the test checks for its existence,
which is Microsoft.Windows.Explorer,
might not be always present.
Use UEME_CTLSESSION key which should be always present since
it generically represents the start of a session.

Fixes https://github.com/osquery/osquery/issues/6360