### PR TITLE
Fixing the description of failed_login_count from account_policy_data

### DIFF
--- a/specs/darwin/account_policy_data.table
+++ b/specs/darwin/account_policy_data.table
@@ -3,7 +3,7 @@ description("Additional OS X user account data from the AccountPolicy section of
 schema([
     Column("uid", BIGINT, "User ID"),
     Column("creation_time", DOUBLE, "When the account was first created"),
-    Column("failed_login_count", BIGINT, "The number of times the user failed to login with the correct password. Resets after a correct password is entered"),
+    Column("failed_login_count", BIGINT, "The number of failed login attempts using an incorrect password. Count resets after a correct password is entered."),
     Column("failed_login_timestamp", DOUBLE, "The time of the last failed login attempt. Resets after a correct password is entered"),
     Column("password_last_set_time", DOUBLE, "The time the password was last changed"),
     ForeignKey(column="uid", table="users"),


### PR DESCRIPTION
https://github.com/osquery/osquery/issues/6345

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target,  
      if not move the committed files to the stage area,
      build the `format` target to format, then re-commit.
      More information is available on the wiki.
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
