### PR TITLE
WIP: Add top-level decorations to status logs

### DIFF
--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -205,7 +205,7 @@ inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
   doc.add("epoch", static_cast<size_t>(item.epoch), obj);
   doc.add("counter", static_cast<size_t>(item.counter), obj);
 
-  // Apply field indicatiting if numerics are serialized as numbers
+  // Apply field indicating if numerics are serialized as numbers
   doc.add("numerics", FLAGS_logger_numerics, obj);
 
   // Append the decorations.


### PR DESCRIPTION
This PR will add top-level decoration to status logs.

Currently the `--decorations_top_level` flag only impacts the query logs. This PR will make it possible to get top-level decorations added to status logs as well.

Current:

```
# example status log:
{
  ... all the standard fields ...,
  "message": "my status log message",
  "decorations": {
    "my_decoration": "decorated"
  }
}
```

Future:

```
# example status log:
{
  ... all the standard fields ...,
  "message": "my status log message",
  "my_decoration": "decorated"
}
```

This will be helpful in certain log pipelines that require certain fields, as they can be set with decorators.
