### PR TITLE
docs: Update osquery security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,6 @@ We keep track of security announcements in our tagged version release
 notes on GitHub. We aggregate these into [SECURITY.md](SECURITY.md)
 too.
 
-Facebook has a [bug bounty](https://www.facebook.com/whitehat/)
-program that includes osquery. If you find a security vulnerability in
-osquery, please submit it via the process outlined on that page and
-**do not file a public issue**. For more information on finding
-vulnerabilities in osquery, see our blog post [Bug Hunting
-osquery](https://www.facebook.com/notes/facebook-bug-bounty/bug-hunting-osquery/954850014529225).
-
 ## Learn more
 
 The osquery documentation is available

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,10 @@ This document aggregates security issues (weaknesses and vulnerabilities) affect
 #PRNumber Title - (Optional CVE) - Fixed in Version - Optional Reporter
 ```
 
-There are several types of issues that do not include a CVE or reporter. If you find a security issue and believe a CVE should be assigned, please contact the project maintainers in the [osquery Slack](https://osquery-slack.herokuapp.com), we are happy to submit the request and provide attribution to you. The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
+There are several types of issues that do not include a CVE or reporter.
+If you find a security issue and believe a CVE should be assigned, please contact a [member of the TSC](https://github.com/osquery/osquery/blob/master/CONTRIBUTING.md#technical-steering-committee) in the [osquery Slack](https://osquery-slack.herokuapp.com), we are happy to submit the request and provide attribution to you.
+Specifically, we will use the GitHub Security Advisory features for CVE requests.
+The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
 
 If you are editing this document please feel encouraged to change this format to provide more details. This is intended to be a helpful resource so please keep content valuable and concise.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ This document aggregates security issues (weaknesses and vulnerabilities) affect
 There are several types of issues that do not include a CVE or reporter.
 If you find a security issue and believe a CVE should be assigned, please contact a [member of the TSC](https://github.com/osquery/osquery/blob/master/CONTRIBUTING.md#technical-steering-committee) in the [osquery Slack](https://osquery-slack.herokuapp.com), we are happy to submit the request and provide attribution to you.
 Specifically, we will use the GitHub Security Advisory features for CVE requests.
-The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
+The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/osquery/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
 
 If you are editing this document please feel encouraged to change this format to provide more details. This is intended to be a helpful resource so please keep content valuable and concise.
 


### PR DESCRIPTION
Please see my note in Slack in the #foundation channel. The changes here are to be more concrete about how we handle advisories and reports; and to remove osquery from FB Whitehat scope.