### PR TITLE
Update winbaseobj.table

### DIFF
--- a/specs/windows/winbaseobj.table
+++ b/specs/windows/winbaseobj.table
@@ -1,5 +1,5 @@
 table_name("winbaseobj")
-description("Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows ojbect types include Mutexes, Events, Jobs and Semaphors")
+description("Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows ojbect types include Mutexes, Events, Jobs and Semaphors.")
 schema([
     Column("session_id", INTEGER, "Terminal Services Session Id"),
     Column("object_name", TEXT, "Object Name"),

--- a/specs/windows/winbaseobj.table
+++ b/specs/windows/winbaseobj.table
@@ -1,5 +1,5 @@
 table_name("winbaseobj")
-description("Lists named Windows objects in the default object directories, across all terminal services sessions.")
+description("Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows ojbect types include Mutexes, Events, Jobs and Semaphors")
 schema([
     Column("session_id", INTEGER, "Terminal Services Session Id"),
     Column("object_name", TEXT, "Object Name"),


### PR DESCRIPTION
Add common windows object types to winbaseobj table description.  The reasoning behind the change is that what people are looking for is typically an object type such as a mutex.  It is not common knowledge that mutexes, for example, are a type of Windows object.  So when searching to see if osquery supports enumerating mutexs, it is not easy to determine that the answer is yes.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target,  
      if not move the committed files to the stage area,
      build the `format` target to format, then re-commit.
      More information is available on the wiki.
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
