### PR TITLE
docs: Exclude all submodules for RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# We run out of memory on the RTD builder.
+submodules:
+  exclude: all


### PR DESCRIPTION
Take a look at the latest build failure: https://readthedocs.org/projects/osquery/builds/11004002/