### PR TITLE
Add support for processing KILL syscall

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -63,6 +63,7 @@ FLAG(int32, audit_backlog_limit, 4096, "The audit backlog limit");
 DECLARE_bool(audit_allow_fim_events);
 DECLARE_bool(audit_allow_process_events);
 DECLARE_bool(audit_allow_fork_process_events);
+DECLARE_bool(audit_allow_kill_process_events);
 DECLARE_bool(audit_allow_sockets);
 DECLARE_bool(audit_allow_user_events);
 DECLARE_bool(audit_allow_selinux_events);
@@ -350,6 +351,14 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
                  "clone) table";
 
       for (int syscall : kForkProcessEventsSyscalls) {
+        monitored_syscall_list_.insert(syscall);
+      }
+    }
+
+    if (FLAGS_audit_allow_kill_process_events) {
+      VLOG(1) << "Enabling audit rules for the process_events (kill, tkill, "
+                 "tgkill) table";
+      for (int syscall : kKillProcessEventsSyscalls) {
         monitored_syscall_list_.insert(syscall);
       }
     }

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -24,6 +24,7 @@ DECLARE_bool(audit_allow_process_events);
 DECLARE_bool(audit_allow_sockets);
 DECLARE_bool(audit_allow_user_events);
 DECLARE_bool(audit_allow_selinux_events);
+DECLARE_bool(audit_allow_kill_process_events);
 
 REGISTER(AuditEventPublisher, "event_publisher", "auditeventpublisher");
 
@@ -35,7 +36,8 @@ bool IsPublisherEnabled() noexcept {
 
   return (FLAGS_audit_allow_fim_events || FLAGS_audit_allow_process_events ||
           FLAGS_audit_allow_sockets || FLAGS_audit_allow_user_events ||
-          FLAGS_audit_allow_selinux_events);
+          FLAGS_audit_allow_selinux_events ||
+          FLAGS_audit_allow_kill_process_events);
 }
 } // namespace
 

--- a/osquery/events/linux/process_events.h
+++ b/osquery/events/linux/process_events.h
@@ -15,6 +15,9 @@
 namespace osquery {
 const std::set<int> kExecProcessEventsSyscalls = {__NR_execve, __NR_execveat};
 
+const std::set<int> kKillProcessEventsSyscalls = {
+    __NR_kill, __NR_tkill, __NR_tgkill};
+
 const std::set<int> kForkProcessEventsSyscalls = {
     __NR_fork, __NR_vfork, __NR_clone};
 } // namespace osquery

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -22,8 +22,11 @@ const std::unordered_map<int, std::string> kSyscallNameMap = {
     {__NR_execveat, "execveat"},
     {__NR_fork, "fork"},
     {__NR_vfork, "vfork"},
-    {__NR_clone, "clone"}};
-}
+    {__NR_clone, "clone"},
+    {__NR_kill, "kill"},
+    {__NR_tkill, "tkill"},
+    {__NR_tgkill, "tgkill"}};
+};
 
 FLAG(bool,
      audit_allow_process_events,
@@ -35,6 +38,12 @@ FLAG(bool,
      false,
      "Allow the audit publisher to install process event monitoring rules to "
      "capture fork/vfork/clone system calls");
+
+FLAG(bool,
+     audit_allow_kill_process_events,
+     false,
+     "Allow the audit publisher to install process event monitoring rules to "
+     "capture kill/tkill/tgkill system calls");
 
 REGISTER(AuditProcessEventSubscriber, "event_subscriber", "process_events");
 
@@ -127,12 +136,17 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     const auto& event_data = boost::get<SyscallAuditEventData>(event.data);
 
     bool is_exec_syscall{false};
+    bool is_kill_syscall{false};
     if (kExecProcessEventsSyscalls.count(event_data.syscall_number) > 0U) {
       is_exec_syscall = true;
 
     } else if (kForkProcessEventsSyscalls.count(event_data.syscall_number) >
                0U) {
       is_exec_syscall = false;
+
+    } else if (kKillProcessEventsSyscalls.count(event_data.syscall_number) >
+               0U) {
+      is_kill_syscall = true;
 
     } else {
       continue;
@@ -214,6 +228,11 @@ Status AuditProcessEventSubscriber::ProcessEvents(
         VLOG(1) << "Failed to parse the event: " << status.getMessage();
         continue;
       }
+
+    } else if (is_kill_syscall) {
+      CopyFieldFromMap(row, syscall_event_record->fields, "tty", "");
+      CopyFieldFromMap(row, syscall_event_record->fields, "ses", "-1");
+      CopyFieldFromMap(row, syscall_event_record->fields, "comm", "");
 
     } else {
       row["owner_uid"] = "0";

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -230,9 +230,15 @@ Status AuditProcessEventSubscriber::ProcessEvents(
       }
 
     } else if (is_kill_syscall) {
+      const AuditEventRecord* obj_pid_recod =
+          GetEventRecord(event, AUDIT_OBJ_PID);
+
       CopyFieldFromMap(row, syscall_event_record->fields, "tty", "");
       CopyFieldFromMap(row, syscall_event_record->fields, "ses", "-1");
       CopyFieldFromMap(row, syscall_event_record->fields, "comm", "");
+      CopyFieldFromMap(row, obj_pid_recod->fields, "ocomm", "-1");
+      CopyFieldFromMap(row, obj_pid_recod->fields, "oses", "-1");
+      CopyFieldFromMap(row, obj_pid_recod->fields, "oauid", "-1");
 
     } else {
       row["owner_uid"] = "0";

--- a/osquery/tables/events/tests/linux/process_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/process_events_tests.cpp
@@ -90,9 +90,10 @@ void GenerateEventRow(Row& row, const RawAuditEvent& audit_event) {
 class ProcessEventsTests : public testing::Test {};
 
 TEST_F(ProcessEventsTests, syscall_name_label) {
-  ASSERT_EQ(
-      kExecProcessEventsSyscalls.size() + kForkProcessEventsSyscalls.size(),
-      AuditProcessEventSubscriber::GetSyscallNameMap().size());
+  ASSERT_EQ(kExecProcessEventsSyscalls.size() +
+                kForkProcessEventsSyscalls.size() +
+                kKillProcessEventsSyscalls.size(),
+            AuditProcessEventSubscriber::GetSyscallNameMap().size());
 
   std::string name;
 
@@ -148,6 +149,56 @@ TEST_F(ProcessEventsTests, exec_event_processing) {
       {"mode", "0100755"},
       {"owner_uid", "0"},
       {"owner_gid", "0"}};
+
+  for (const auto& key : kExpectedFields) {
+    EXPECT_TRUE(event_row.find(key) != event_row.end());
+  }
+
+  for (const auto& p : kExpectedFieldMap) {
+    const auto& key = p.first;
+    const auto& expected_value = p.second;
+
+    auto it = event_row.find(key);
+    ASSERT_TRUE(it != event_row.end());
+
+    const auto& actual_value = it->second;
+    EXPECT_EQ(expected_value, actual_value);
+  }
+}
+
+TEST_F(ProcessEventsTests, kill_syscall_event_processing) {
+  // clang-format off
+  const RawAuditEvent kSampleKillEvent = {
+    { 1300, "audit(1588703361.452:26860): arch=c000003e syscall=62 success=yes exit=0 a0=6334 a1=f a2=0 a3=7f8b95cbbcc0 items=0 ppid=6198 pid=6199 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts3 ses=5 comm=\"bash\" exe=\"/bin/bash\" key=226B696C6C73686F7422" },
+    { 1318, "audit(1588703361.452:26860): opid=25396 oauid=1000 ouid=1000 oses=5 ocomm=\"python3\"" },
+    { 1307, "audit(1588703361.452:26860): proctitle=\"-bash\"" },
+    { 1320, "audit(1588703361.452:26860): " }
+  };
+  // clang-format on
+
+  Row event_row;
+  GenerateEventRow(event_row, kSampleKillEvent);
+
+  const std::vector<std::string> kExpectedFields = {
+      "uptime", "overflows", "env", "env_size", "env_count"};
+
+  const std::unordered_map<std::string, std::string> kExpectedFieldMap = {
+      {"syscall", "kill"},
+      {"parent", "6198"},
+      {"pid", "6199"},
+      {"auid", "1000"},
+      {"uid", "1000"},
+      {"gid", "1000"},
+      {"euid", "1000"},
+      {"suid", "1000"},
+      {"fsuid", "1000"},
+      {"egid", "1000"},
+      {"sgid", "1000"},
+      {"fsgid", "1000"},
+      {"tty", "pts3"},
+      {"ses", "5"},
+      {"comm", "\"bash\""},
+      {"path", "/bin/bash"}};
 
   for (const auto& key : kExpectedFields) {
     EXPECT_TRUE(event_row.find(key) != event_row.end());

--- a/osquery/tables/events/tests/linux/process_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/process_events_tests.cpp
@@ -198,7 +198,10 @@ TEST_F(ProcessEventsTests, kill_syscall_event_processing) {
       {"tty", "pts3"},
       {"ses", "5"},
       {"comm", "\"bash\""},
-      {"path", "/bin/bash"}};
+      {"path", "/bin/bash"},
+      {"ocomm", "\"python3\""},
+      {"oauid", "1000"},
+      {"oses", "5"}};
 
   for (const auto& key : kExpectedFields) {
     EXPECT_TRUE(event_row.find(key) != event_row.end());


### PR DESCRIPTION
Add support for processing KILL, TKILL and TGKILL syscalls. The first
message of the SYSCALL message type is handled in a similar way as
EXECVE as the structure is more or less the same.

Three additional fields are parsed from the message which are "ses"
(session of the process), "comm" (the command that was executed, eg: the
script name in case of a /bin/bash invoke) and "tty" (the controlling
terminal for the process). These fields will not be published though
since the table schema doesn't support it at the moment.

The above feature is activated using the
```
--audit_allow_kill_process_events=true
```

Sample columns:
```
"columns": {
  "atime": "1589007635",
  "auid": "4294967295",
  "btime": "0",
  "cmdline": "",
  "ctime": "1587237608",
  "cwd": "",
  "egid": "1000",
  "euid": "1000",
  "fsgid": "1000",
  "fsuid": "1000",
  "gid": "1000",
  "mode": "0755",
  "mtime": "1586904788",
  "owner_gid": "",
  "owner_uid": "",
  "parent": "4781",
  "path": "/home/p0n002h/code-server-3.1.1-linux-x86_64/node",
  "pid": "4795",
  "sgid": "1000",
  "suid": "1000",
  "syscall": "kill",
  "time": "1589052835",
  "uid": "1000",
  "uptime": "26902"
}
```