### PR TITLE
macos: Add polling to OpenBSM publisher

### DIFF
--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -190,7 +190,7 @@ OpenBSM is enabled on all macOS installations, but doesn't audit process executi
 # $P4: //depot/projects/trustedbsd/openbsm/etc/audit_control#8 $
 #
 dir:/var/audit
-flags:ex,pc,ap,aa,lo,ad,nt
+flags:ex,pc,ap,aa,lo,nt
 minfree:5
 naflags:no
 policy:cnt,argv,arge

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -187,7 +187,7 @@ Status OpenBSMEventPublisher::run() {
   struct timeval timeout;
   timeout.tv_sec = 0;
   timeout.tv_usec = 0;
-  while (!interrupted()) {
+  while (!isEnding()) {
     int rc = select(FD_SETSIZE, &fdset, nullptr, nullptr, &timeout);
     if (rc == 0) {
       break;

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -36,6 +36,7 @@ class OpenBSMConsumerRunner;
 class OpenBSMEventPublisher
     : public EventPublisher<OpenBSMSubscriptionContext, OpenBSMEventContext> {
   DECLARE_PUBLISHER("openbsm");
+
  public:
   Status setUp() override;
 
@@ -43,6 +44,7 @@ class OpenBSMEventPublisher
 
   void tearDown() override;
 
+  /// Poll the audit descriptor until the publisher is interrupted.
   Status run() override;
 
   OpenBSMEventPublisher(const std::string& name = "OpenBSMEventPublisher")
@@ -55,11 +57,16 @@ class OpenBSMEventPublisher
   }
 
  private:
-  FILE* audit_pipe_ = nullptr;
+  /// Dequeue from the audit descriptor when data is available.
+  void acquireMessages();
+
+  Status configureAuditPipe();
+
   /// Apply normal subscription to event matching logic.
   bool shouldFire(const OpenBSMSubscriptionContextRef& mc,
                   const OpenBSMEventContextRef& ec) const override;
 
-  Status configureAuditPipe();
+ private:
+  FILE* audit_pipe_{nullptr};
 };
 } // namespace osquery

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <osquery/events.h>
+#include <osquery/utils/mutex.h>
 
 #include <set>
 
@@ -70,8 +71,10 @@ class OpenBSMEventPublisher
 
  private:
   FILE* audit_pipe_{nullptr};
+  Mutex audit_pipe_mutex_;
 
   /// Total set of event IDs from subscriptions.
   std::set<size_t> event_ids_;
+  Mutex event_ids_mutex_;
 };
 } // namespace osquery

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -10,6 +10,8 @@
 
 #include <osquery/events.h>
 
+#include <set>
+
 namespace osquery {
 
 struct OpenBSMSubscriptionContext : public SubscriptionContext {
@@ -68,5 +70,8 @@ class OpenBSMEventPublisher
 
  private:
   FILE* audit_pipe_{nullptr};
+
+  /// Total set of event IDs from subscriptions.
+  std::set<size_t> event_ids_;
 };
 } // namespace osquery

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -780,9 +780,11 @@ Status EventFactory::run(const std::string& type_id) {
   } else if (publisher->hasStarted()) {
     return Status(1, "Cannot restart an event publisher");
   }
+
   setThreadName(publisher->name());
   VLOG(1) << "Starting event publisher run loop: " + type_id;
   publisher->hasStarted(true);
+  publisher->state(EventState::EVENT_RUNNING);
 
   auto status = Status(0, "OK");
   while (!publisher->isEnding()) {
@@ -797,6 +799,7 @@ Status EventFactory::run(const std::string& type_id) {
     // prevents the thread from thrashing through exiting checks.
     publisher->pause(std::chrono::milliseconds(200));
   }
+
   if (!status.ok()) {
     // The runloop status is not reflective of the event type's.
     VLOG(1) << "Event publisher " << publisher->type()
@@ -1049,8 +1052,8 @@ Status EventFactory::deregisterEventSubscriber(const std::string& sub) {
   }
 
   auto& subscriber = ef.event_subs_.at(sub);
-  subscriber->state(EventState::EVENT_NONE);
   subscriber->tearDown();
+  subscriber->state(EventState::EVENT_NONE);
   ef.event_subs_.erase(sub);
   return Status(0);
 }

--- a/osquery/include/osquery/events.h
+++ b/osquery/include/osquery/events.h
@@ -248,6 +248,9 @@ class EventPublisherPlugin : public Plugin,
    * osquery is about to end, the EventPublisher should close handle descriptors
    * unblock resources, and prepare to exit. This will be called from the main
    * thread after the run loop thread has exited.
+   *
+   * Expect this may be called multiple times, when the event loop stops and
+   * optionally by the publisher destructor.
    */
   void tearDown() override {}
 
@@ -375,6 +378,12 @@ class EventPublisherPlugin : public Plugin,
 
   /// A helper count of event publisher runloop iterations.
   std::atomic<size_t> restart_count_{0};
+
+ private:
+  /// Do not check for interrupted, instead use isEnding.
+  bool interrupted() override {
+    return false;
+  }
 
  private:
   /// Enable event factory "callins" through static publisher callbacks.


### PR DESCRIPTION
I don't think this is the root cause of #6431, but while reviewing the OpenBSM publisher I noticed it can hang osquery if there are no events in the audit queue.

This change applies the same polling interval and error handling as Linux.