### PR TITLE
Update hash cache inode number

### DIFF
--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -178,6 +178,7 @@ bool FileHashCache::load(const std::string& path,
     auto hashes = hashMultiFromFile(
         HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256, path);
     entry->second.cache_access_time = time(nullptr);
+    entry->second.file_inode = st.st_ino;
     entry->second.file_mtime = st.st_mtime;
     entry->second.file_size = st.st_size;
     entry->second.hashes = std::move(hashes);


### PR DESCRIPTION
When a file on disk has been replaced and the cache is updated with the new hash value, it was not updating the inode number in the cache used for future lookups. This resulted in the cache being perpetually stale and recomputing the hash for every future lookup of the file.

One line fix to update the inode number in the cache entry along with updating the size and mtime.