### PR TITLE
Do not install openssl docs

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -44,7 +44,7 @@ function(opensslMain)
     )
 
     set(install_command
-      make install
+      make install_sw install_ssldirs
     )
 
     set(openssl_libs
@@ -84,7 +84,7 @@ function(opensslMain)
     )
 
     set(install_command
-      make install
+      make install_sw install_ssldirs
     )
 
     set(openssl_libs


### PR DESCRIPTION
This is meant to reduce the noise in the installation output of openssl,
since docs would easily fill the scrollback of most terminals.
Since we don't care about the docs, only install binaries.