### PR TITLE
Add 'maintainer', 'section', 'priority' columns to deb_packages

### DIFF
--- a/osquery/tables/system/linux/deb_packages.cpp
+++ b/osquery/tables/system/linux/deb_packages.cpp
@@ -74,7 +74,7 @@ void dpkg_setup(struct pkg_array* packages) {
   dpkg_set_progname("osquery");
   push_error_context();
 
-  dpkg_db_set_dir("/var/lib/dpkg/");
+  dpkg_db_set_dir(kDPKGPath.c_str());
   modstatdb_init();
   modstatdb_open(msdbrw_readonly);
 
@@ -101,7 +101,10 @@ const std::map<std::string, std::string> kFieldMappings = {
     {"Architecture", "arch"},
     {"Source", "source"},
     {"Revision", "revision"},
-    {"Status", "status"}};
+    {"Status", "status"},
+    {"Maintainer", "maintainer"},
+    {"Section", "section"},
+    {"Priority", "priority"}};
 
 /**
  * @brief Field names and function references to extract information.
@@ -121,6 +124,9 @@ const struct fieldinfo fieldinfos[] = {
     {FIELD("Version"), f_version, w_version, PKGIFPOFF(version)},
     {FIELD("Revision"), f_revision, w_revision, 0},
     {FIELD("Status"), f_status, w_status, 0},
+    {FIELD("Maintainer"), f_charfield, w_charfield, PKGIFPOFF(maintainer)},
+    {FIELD("Priority"), f_priority, w_priority, 0},
+    {FIELD("Section"), f_section, w_section, 0},
     {}};
 
 void extractDebPackageInfo(const struct pkginfo* pkg, QueryData& results) {

--- a/specs/linux/deb_packages.table
+++ b/specs/linux/deb_packages.table
@@ -7,7 +7,10 @@ schema([
     Column("size", BIGINT, "Package size in bytes"),
     Column("arch", TEXT, "Package architecture"),
     Column("revision", TEXT, "Package revision"),
-    Column("status", TEXT, "Package status")
+    Column("status", TEXT, "Package status"),
+    Column("maintainer", TEXT, "Package maintainer"),
+    Column("section", TEXT, "Package section"),
+    Column("priority", TEXT, "Package priority")
 ])
 attributes(cacheable=True)
 implementation("system/deb_packages@genDebPackages")

--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -32,7 +32,10 @@ TEST_F(DebPackages, test_sanity) {
                              {"size", IntType},
                              {"arch", NonEmptyString},
                              {"revision", NormalType},
-                             {"status", NonEmptyString}};
+                             {"status", NonEmptyString},
+                             {"maintainer", NonEmptyString},
+                             {"section", NonEmptyString},
+                             {"priority", NonEmptyString}};
     validate_rows(rows, row_map);
 
     auto all_packages = std::unordered_set<std::string>{};


### PR DESCRIPTION
To expand the information available about packages installed on a distro and also to be able to better filter them to find vulnerabilities, this commit adds 3 new columns: maintainer, section, priority.

They are standard/official fields available in the dpkg database.