### PR TITLE
Add 'vendor', 'package_group' columns to rpm_packages

### DIFF
--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -158,6 +158,8 @@ QueryData genRpmPackages(QueryContext& context) {
     r["epoch"] = INTEGER(getRpmAttribute(header, RPMTAG_EPOCH, td));
     r["install_time"] =
         INTEGER(getRpmAttribute(header, RPMTAG_INSTALLTIME, td));
+    r["vendor"] = getRpmAttribute(header, RPMTAG_VENDOR, td);
+    r["package_group"] = getRpmAttribute(header, RPMTAG_GROUP, td);
 
     rpmtdFree(td);
     results.push_back(r);
@@ -243,5 +245,5 @@ void genRpmPackageFiles(RowYield& yield, QueryContext& context) {
   rpmtsFree(ts);
   rpmFreeRpmrc();
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/specs/linux/rpm_packages.table
+++ b/specs/linux/rpm_packages.table
@@ -10,6 +10,8 @@ schema([
     Column("arch", TEXT, "Architecture(s) supported", index=True),
     Column("epoch", INTEGER, "Package epoch value", index=True),
     Column("install_time", INTEGER, "When the package was installed"),
+    Column("vendor", TEXT, "Package vendor"),
+    Column("package_group", TEXT, "Package group")
 ])
 attributes(cacheable=True)
 implementation("@genRpmPackages")

--- a/tests/integration/tables/rpm_packages.cpp
+++ b/tests/integration/tables/rpm_packages.cpp
@@ -11,6 +11,8 @@
 
 #include <osquery/tests/integration/tables/helper.h>
 
+#include <osquery/logger.h>
+
 namespace osquery {
 namespace table_tests {
 
@@ -22,27 +24,25 @@ class rpmPackages : public testing::Test {
 };
 
 TEST_F(rpmPackages, test_sanity) {
-  // 1. Query data
-  auto const data = execute_query("select * from rpm_packages");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"name", NormalType}
-  //      {"version", NormalType}
-  //      {"release", NormalType}
-  //      {"source", NormalType}
-  //      {"size", IntType}
-  //      {"sha1", NormalType}
-  //      {"arch", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
-}
+  auto const rows = execute_query("select * from rpm_packages");
+  if (rows.size() > 0) {
+    ValidationMap row_map = {{"name", NonEmptyString},
+                             {"version", NormalType},
+                             {"release", NormalType},
+                             {"source", NormalType},
+                             {"size", IntType},
+                             {"sha1", NonEmptyString},
+                             {"arch", NonEmptyString},
+                             {"epoch", IntType},
+                             {"install_time", IntType},
+                             {"vendor", NonEmptyString},
+                             {"package_group", NonEmptyString}};
 
+    validate_rows(rows, row_map);
+  } else {
+    LOG(WARNING) << "Empty results of query from 'rpm_packages', assume there "
+                    "is no rpm in the system";
+  }
+}
 } // namespace table_tests
 } // namespace osquery


### PR DESCRIPTION
As for the deb_packages table we expand the rpm_packages table, to add more information about the packages installed on the distribution and to better filter them. The two columns added are: vendor, group.

These are standard/official fields in the rpm database.

I've also enabled its respective integration test.
