### PR TITLE
Add 'arch' column to os_version

### DIFF
--- a/osquery/tables/system/darwin/os_version.cpp
+++ b/osquery/tables/system/darwin/os_version.cpp
@@ -6,8 +6,12 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
+#include <cerrno>
+#include <sys/utsname.h>
+
 #include <string>
 
+#include <osquery/logger.h>
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/split.h>
@@ -22,6 +26,14 @@ QueryData genOSVersion(QueryContext& context) {
   Row r;
   r["platform"] = "darwin";
   r["platform_like"] = "darwin";
+
+  struct utsname uname_buf {};
+
+  if (uname(&uname_buf) == 0) {
+    r["arch"] = TEXT(uname_buf.machine);
+  } else {
+    LOG(INFO) << "Failed to determine the OS architecture, error " << errno;
+  }
 
   // The version path plist is parsed by the OS X tool: sw_vers.
   auto sw_vers = SQL::selectAllFrom("plist", "path", EQUALS, kVersionPath);

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -6,6 +6,9 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
+#include <cerrno>
+#include <sys/utsname.h>
+
 #include <map>
 #include <regex>
 #include <string>
@@ -16,6 +19,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include <osquery/filesystem/filesystem.h>
+#include <osquery/logger.h>
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/split.h>
@@ -97,6 +101,14 @@ QueryData genOSVersion(QueryContext& context) {
     if (boost::filesystem::file_size(kOSRelease, ec) > 0) {
       genOSRelease(r);
     }
+  }
+
+  struct utsname uname_buf {};
+
+  if (uname(&uname_buf) == 0) {
+    r["arch"] = TEXT(uname_buf.machine);
+  } else {
+    LOG(INFO) << "Failed to determine the OS architecture, error " << errno;
   }
 
   std::string content;

--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -21,7 +21,8 @@ QueryData genOSVersion(QueryContext& context) {
   std::string version_string;
 
   const std::string kWmiQuery =
-      "SELECT CAPTION,VERSION,INSTALLDATE FROM Win32_OperatingSystem";
+      "SELECT CAPTION,VERSION,INSTALLDATE,OSARCHITECTURE FROM "
+      "Win32_OperatingSystem";
 
   const WmiRequest wmiRequest(kWmiQuery);
   const std::vector<WmiResultItem>& wmiResults = wmiRequest.results();
@@ -49,6 +50,8 @@ QueryData genOSVersion(QueryContext& context) {
   default:
     break;
   }
+
+  wmiResults[0].GetString("OSArchitecture", r["arch"]);
 
   r["platform"] = "windows";
   r["platform_like"] = "windows";

--- a/specs/os_version.table
+++ b/specs/os_version.table
@@ -10,6 +10,7 @@ schema([
     Column("platform", TEXT, "OS Platform or ID"),
     Column("platform_like", TEXT, "Closely related platforms"),
     Column("codename", TEXT, "OS version codename"),
+    Column("arch", TEXT, "OS Architecture"),
 ])
 extended_schema(WINDOWS, [
     Column("install_date", TEXT, "The install date of the OS."),

--- a/tests/integration/tables/os_version.cpp
+++ b/tests/integration/tables/os_version.cpp
@@ -36,6 +36,7 @@ TEST_F(OsVersion, test_sanity) {
       {"platform", NonEmptyString},
       {"platform_like", NonEmptyString},
       {"codename", NormalType},
+      {"arch", NonEmptyString},
 #ifdef OSQUERY_WINDOWS
       {"install_date", NonEmptyString},
 #endif


### PR DESCRIPTION
To be able to quickly determine the architecture of the system osquery is running on, we add an `arch` column to all platform.
The architecture is shown in the system native format.
Linux and macOS basically use the same information available with `uname -m`, while on Windows we use the same WMI class used to get other information about the OS, but we also query `OSArchitecture`.