### PR TITLE
macos: automating audit rules install

### DIFF
--- a/osquery/events/audit_flags.cpp
+++ b/osquery/events/audit_flags.cpp
@@ -25,4 +25,19 @@ FLAG(bool,
      false,
      "Allow the audit publisher to install socket-related rules");
 
+FLAG(bool,
+     audit_allow_process_events,
+     true,
+     "Allow the audit publisher to install process-related rules");
+
+FLAG(bool,
+     audit_allow_user_events,
+     true,
+     "Allow the audit publisher to install user-related rules");
+
+FLAG(bool,
+     audit_allow_fim_events,
+     false,
+     "Allow the audit publisher to install filesystem-related rules");
+
 } // namespace osquery

--- a/osquery/events/audit_flags.cpp
+++ b/osquery/events/audit_flags.cpp
@@ -20,6 +20,12 @@ FLAG(bool,
      true,
      "Disable receiving events from the audit subsystem");
 
+/// Control the audit subsystem by allowing subscriptions to apply rules.
+FLAG(bool,
+     audit_allow_config,
+     false,
+     "Allow the audit publisher to change auditing configuration");
+
 FLAG(bool,
      audit_allow_sockets,
      false,

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -29,7 +29,7 @@ DECLARE_bool(audit_allow_fim_events);
 REGISTER(OpenBSMEventPublisher, "event_publisher", "openbsm");
 
 static Status configureAuditPipe(FILE* au_pipe) {
-  auto au_fd = fileno(au_pipe)
+  auto au_fd = fileno(au_pipe);
   audit_pipe_ = nullptr;
 
   int pr_sel_mode = AUDITPIPE_PRESELECT_MODE_LOCAL;

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -46,7 +46,6 @@ Status OpenBSMEventPublisher::configureAuditPipe() {
     LOG(INFO) << "The auditpipe:ioctl AUDITPIPE_SET_QLIMIT failed";
   }
 
-  struct au_class_ent* ace;
   au_mask_t pr_flags = {0, 0};
   std::vector<std::string> ev_classes;
 
@@ -77,6 +76,7 @@ Status OpenBSMEventPublisher::configureAuditPipe() {
     ev_classes.push_back("fm");
   }
 
+  struct au_class_ent* ace = nullptr;
   while ((ace = getauclassent()) != nullptr) {
     for (auto& cl : ev_classes) {
       if (cl == ace->ac_name) {

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -65,7 +65,7 @@ Status OpenBSMEventPublisher::configureAuditPipe(FILE* au_pipe) {
     ev_classes.push_back("ad");
   }
 
-  if (true == FLAGS_audit_allow_fim_events)
+  if (true == FLAGS_audit_allow_fim_events) {
     // capture file events
     ev_classes.push_back("fc");
     ev_classes.push_back("fd");

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -28,11 +28,12 @@ DECLARE_bool(audit_allow_fim_events);
 
 REGISTER(OpenBSMEventPublisher, "event_publisher", "openbsm");
 
-static Status configureAuditPipe(FILE* au_pipe) {
+Status OpenBSMEventPublisher::configureAuditPipe(FILE* au_pipe) {
   auto au_fd = fileno(au_pipe);
+  int pr_sel_mode = AUDITPIPE_PRESELECT_MODE_LOCAL;
+
   audit_pipe_ = nullptr;
 
-  int pr_sel_mode = AUDITPIPE_PRESELECT_MODE_LOCAL;
   if (ioctl(au_fd, AUDITPIPE_SET_PRESELECT_MODE, &pr_sel_mode) == -1) {
     LOG(WARNING) << "The auditpipe:ioctl AUDITPIPE_SET_PRESELECT_MODE failed";
     fclose(au_pipe);

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <bsm/libbsm.h>
+#include <security/audit/audit_ioctl.h>
+#include <sys/ioctl.h>
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -16,9 +18,90 @@
 
 namespace osquery {
 
+const int kQLimit = 512;
+
 DECLARE_bool(disable_audit);
+DECLARE_bool(audit_allow_process_events);
+DECLARE_bool(audit_allow_sockets);
+DECLARE_bool(audit_allow_user_events);
+DECLARE_bool(audit_allow_fim_events);
 
 REGISTER(OpenBSMEventPublisher, "event_publisher", "openbsm");
+
+static Status configureAuditPipe(FILE* au_pipe) {
+  auto au_fd = fileno(au_pipe)
+  audit_pipe_ = nullptr;
+
+  int pr_sel_mode = AUDITPIPE_PRESELECT_MODE_LOCAL;
+  if (ioctl(au_fd, AUDITPIPE_SET_PRESELECT_MODE, &pr_sel_mode) == -1) {
+    LOG(WARNING) << "The auditpipe:ioctl AUDITPIPE_SET_PRESELECT_MODE failed";
+    fclose(au_pipe);
+    return Status(1, "Failed to set AUDITPIPE_SET_PRESELECT_MODE");
+  }
+
+  if (ioctl(au_fd, AUDITPIPE_SET_QLIMIT, &kQLimit) == -1) {
+    LOG(INFO) << "The auditpipe:ioctl AUDITPIPE_SET_QLIMIT failed";
+  }
+
+  struct au_class_ent* ace;
+  au_mask_t pr_flags = {0, 0};
+  std::vector<std::string> ev_classes;
+
+  if (true == FLAGS_audit_allow_process_events) {
+    // capture process events
+    ev_classes.push_back("pc");
+  }
+
+  if (true == FLAGS_audit_allow_sockets) {
+    // capture network events
+    ev_classes.push_back("nt");
+  }
+
+  if (true == FLAGS_audit_allow_user_events) {
+    // capture user (login, autherization etc...) events
+    ev_classes.push_back("lo");
+    ev_classes.push_back("aa");
+    ev_classes.push_back("ad");
+  }
+
+  if (true == FLAGS_audit_allow_fim_events)
+    // capture file events
+    ev_classes.push_back("fc");
+    ev_classes.push_back("fd");
+    ev_classes.push_back("fw");
+    ev_classes.push_back("fr");
+    ev_classes.push_back("fa");
+    ev_classes.push_back("fm");
+  }
+
+  while ((ace = getauclassent()) != nullptr) {
+    for (auto& cl : ev_classes) {
+      if (cl == ace->ac_name) {
+        ADD_TO_MASK(&pr_flags, ace->ac_class, AU_PRS_BOTH);
+        break;
+      }
+    }
+  }
+  endauclass();
+
+  au_mask_t na_pr_flags = pr_flags;
+
+  if (ioctl(au_fd, AUDITPIPE_SET_PRESELECT_FLAGS, &pr_flags) == -1) {
+    LOG(WARNING) << "The auditpipe:ioctl AUDITPIPE_SET_PRESELECT_FLAGS failed";
+    fclose(au_pipe);
+    return Status(1, "Failed to set AUDITPIPE_SET_PRESELECT_FLAGS");
+  }
+
+  if (ioctl(au_fd, AUDITPIPE_SET_PRESELECT_NAFLAGS, &na_pr_flags) == -1) {
+    LOG(WARNING)
+        << "The auditpipe:ioctl AUDITPIPE_SET_PRESELECT_NAFLAGS failed";
+    fclose(au_pipe);
+    return Status(1, "Failed to set AUDITPIPE_SET_PRESELECT_NAFLAGS");
+  }
+
+  audit_pipe_ = au_pipe;
+  return Status(0);
+}
 
 Status OpenBSMEventPublisher::setUp() {
   if (FLAGS_disable_audit) {
@@ -29,7 +112,8 @@ Status OpenBSMEventPublisher::setUp() {
     LOG(WARNING) << "The auditpipe couldn't be opened.";
     return Status(1, "Could not open OpenBSM pipe");
   }
-  return Status(0);
+
+  return configureAuditPipe(audit_pipe_);
 }
 
 void OpenBSMEventPublisher::configure() {}

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -59,5 +59,7 @@ class OpenBSMEventPublisher
   /// Apply normal subscription to event matching logic.
   bool shouldFire(const OpenBSMSubscriptionContextRef& mc,
                   const OpenBSMEventContextRef& ec) const override;
+
+  Status configureAuditPipe(FILE* au_pipe);
 };
 } // namespace osquery

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -60,6 +60,6 @@ class OpenBSMEventPublisher
   bool shouldFire(const OpenBSMSubscriptionContextRef& mc,
                   const OpenBSMEventContextRef& ec) const override;
 
-  Status configureAuditPipe(FILE* au_pipe);
+  Status configureAuditPipe();
 };
 } // namespace osquery

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -34,12 +34,6 @@ FLAG(bool, audit_persist, true, "Attempt to retain control of audit");
 /// Audit debugger helper
 HIDDEN_FLAG(bool, audit_debug, false, "Debug Linux audit messages");
 
-/// Control the audit subsystem by allowing subscriptions to apply rules.
-FLAG(bool,
-     audit_allow_config,
-     false,
-     "Allow the audit publisher to change auditing configuration");
-
 /// Always uninstall all the audit rules that osquery uses when exiting
 FLAG(bool,
      audit_force_unconfigure,
@@ -60,6 +54,7 @@ FLAG(int32, audit_backlog_wait_time, 0, "The audit backlog wait time");
 FLAG(int32, audit_backlog_limit, 4096, "The audit backlog limit");
 
 // External flags; they are used to determine which rules need to be installed
+DECLARE_bool(audit_allow_config);
 DECLARE_bool(audit_allow_fim_events);
 DECLARE_bool(audit_allow_process_events);
 DECLARE_bool(audit_allow_fork_process_events);

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -25,10 +25,7 @@ const std::unordered_map<int, std::string> kSyscallNameMap = {
     {__NR_clone, "clone"}};
 }
 
-FLAG(bool,
-     audit_allow_process_events,
-     true,
-     "Allow the audit publisher to install process event monitoring rules");
+DECLARE_bool(audit_allow_process_events);
 
 FLAG(bool,
      audit_allow_fork_process_events,

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -29,10 +29,7 @@ namespace boostfs = boost::filesystem;
 namespace osquery {
 
 // Recommended configuration is just --audit_allow_fim_events=true
-FLAG(bool,
-     audit_allow_fim_events,
-     false,
-     "Allow the audit publisher to install file event monitoring rules");
+DECLARE_bool(audit_allow_fim_events);
 
 HIDDEN_FLAG(bool,
             audit_show_partial_fim_events,

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -14,10 +14,7 @@
 
 namespace osquery {
 
-FLAG(bool,
-     audit_allow_user_events,
-     true,
-     "Allow the audit publisher to install user events-related rules");
+DECLARE_bool(audit_allow_user_events);
 
 class UserEventSubscriber final : public EventSubscriber<AuditEventPublisher> {
  public:


### PR DESCRIPTION
No need to edit macos /etc/security/* files and reboot the machine  anymore.
if --disable_audit is false, rules are controlled by -
--audit_allow_sockets  default(false)
--audit_allow_process_events  default(true)
--audit_allow_user_events  default(true)
--audit_allow_fim_events  default(false)

With this implementation osquery can inform kernel in what events its interested.  That way it will not interfere with default audit trail mechanism of the system. Unlike linux kernel, OSX takes the responsibility of de-multiplexing the audit messages and apply the installed rules before delivering the messages to the userland.

