### PR TITLE
Link librdkafka on windows

### DIFF
--- a/libraries/cmake/source/librdkafka/CMakeLists.txt
+++ b/libraries/cmake/source/librdkafka/CMakeLists.txt
@@ -117,6 +117,13 @@ function(generateLibrdkafka)
     )
   endif()
 
+  if(BUILD_SHARED_LIBS)
+  else()
+    target_compile_definitions(thirdparty_librdkafka_c PUBLIC
+      LIBRDKAFKA_STATICLIB
+    )
+  endif()
+
 
   target_link_libraries(thirdparty_librdkafka_c PUBLIC
     thirdparty_openssl
@@ -188,10 +195,6 @@ function(generateLibrdkafkaxx)
       "${CMAKE_CURRENT_SOURCE_DIR}/config/macos/dummy"
     )
   endif()
-
-  target_compile_definitions(thirdparty_librdkafka_cxx PUBLIC
-    LIBRDKAFKA_STATICLIB
-  )
 
   target_include_directories(thirdparty_librdkafka_cxx SYSTEM INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/include"

--- a/libraries/cmake/source/librdkafka/CMakeLists.txt
+++ b/libraries/cmake/source/librdkafka/CMakeLists.txt
@@ -117,13 +117,9 @@ function(generateLibrdkafka)
     )
   endif()
 
-  if(BUILD_SHARED_LIBS)
-  else()
-    target_compile_definitions(thirdparty_librdkafka_c PUBLIC
-      LIBRDKAFKA_STATICLIB
-    )
-  endif()
-
+  target_compile_definitions(thirdparty_librdkafka_c PUBLIC
+    LIBRDKAFKA_STATICLIB
+  )
 
   target_link_libraries(thirdparty_librdkafka_c PUBLIC
     thirdparty_openssl
@@ -176,6 +172,10 @@ function(generateLibrdkafkaxx)
     "${library_root}/rdkafkacpp.h"
     "${CMAKE_CURRENT_BINARY_DIR}/include/librdkafka/rdkafkacpp.h"
     COPYONLY
+  )
+
+  target_compile_definitions(thirdparty_librdkafka_cxx PUBLIC
+    LIBRDKAFKA_STATICLIB
   )
 
   target_link_libraries(thirdparty_librdkafka_cxx PRIVATE

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -145,30 +145,26 @@ endfunction()
 
 function(generatePluginsLoggerKafkaproducer)
 
-  if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
-    add_osquery_library(plugins_logger_kafkaproducer EXCLUDE_FROM_ALL
-      kafka_producer.cpp
-    )
+  add_osquery_library(plugins_logger_kafkaproducer EXCLUDE_FROM_ALL
+    kafka_producer.cpp
+  )
 
-    enableLinkWholeArchive(plugins_logger_kafkaproducer)
+  enableLinkWholeArchive(plugins_logger_kafkaproducer)
 
-    target_link_libraries(plugins_logger_kafkaproducer PUBLIC
-      osquery_cxx_settings
-      plugins_logger_commondeps
-      osquery_dispatcher
-      osquery_utils_config
-      thirdparty_librdkafka
-    )
+  target_link_libraries(plugins_logger_kafkaproducer PUBLIC
+    osquery_cxx_settings
+    plugins_logger_commondeps
+    osquery_dispatcher
+    osquery_utils_config
+    thirdparty_librdkafka
+  )
 
-    set(public_header_files
-      kafka_producer.h
-    )
+  set(public_header_files
+    kafka_producer.h
+  )
 
-    generateIncludeNamespace(plugins_logger_kafkaproducer "plugins/logger" "FILE_ONLY" ${public_header_files})
-    add_test(NAME plugins_logger_tests_kafkaproducerloggertests-test COMMAND plugins_logger_tests_kafkaproducerloggertests-test)
-  else()
-    add_osquery_library(plugins_logger_kafkaproducer INTERFACE)
-  endif()
+  generateIncludeNamespace(plugins_logger_kafkaproducer "plugins/logger" "FILE_ONLY" ${public_header_files})
+  add_test(NAME plugins_logger_tests_kafkaproducerloggertests-test COMMAND plugins_logger_tests_kafkaproducerloggertests-test)
 endfunction()
 
 function(generatePluginsLoggerStdout)

--- a/plugins/logger/tests/CMakeLists.txt
+++ b/plugins/logger/tests/CMakeLists.txt
@@ -7,11 +7,7 @@
 function(pluginsLoggerTestsMain)
   generatePluginsLoggerTestsFilesystemloggertestsTest()
   generatePluginsLoggerTestsBufferedloggertestsTest()
-
-  if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)
-    generatePluginsLoggerTestsKafkaproducerloggertestsTest()
-  endif()
-
+  generatePluginsLoggerTestsKafkaproducerloggertestsTest()
   generatePluginsLoggerTestsAwskinesisloggertestsTest()
   generatePluginsLoggerTestsTlsloggertestsTest()
 


### PR DESCRIPTION
I fixed the issues left open in (https://github.com/osquery/osquery/pull/6095)

- CMake now also links librdkafka on windows
- Fixed the usage of the LIBRDKAFKA_STATICLIB macro
