### PR TITLE
Use LOAD_LIBRARY_SEARCH_SYSTEM32 for LoadLibrary

### DIFF
--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -200,7 +200,8 @@ bool isLauncherProcessDead(PlatformProcess& launcher) {
 }
 
 ModuleHandle platformModuleOpen(const std::string& path) {
-  return ::LoadLibraryW(stringToWstring(path).c_str());
+  return ::LoadLibraryExW(
+      stringToWstring(path).c_str(), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 }
 
 void* platformModuleGetSymbol(ModuleHandle module, const std::string& symbol) {

--- a/osquery/tables/system/windows/windows_security_center.cpp
+++ b/osquery/tables/system/windows/windows_security_center.cpp
@@ -33,7 +33,8 @@ std::string resolveProductHealthOrError(int productName) {
   typedef HRESULT(WINAPI * pWscGetSecurityProviderHealth)(
       _In_ DWORD Providers, _Out_ PWSC_SECURITY_PROVIDER_HEALTH);
   pWscGetSecurityProviderHealth WscGetSecurityProviderHealth;
-  static HMODULE hDLL = LoadLibrary("wscapi.dll");
+  static HMODULE hDLL =
+      LoadLibraryEx("wscapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (hDLL == nullptr) {
     VLOG(1) << "Could not dynamically load 'wscapi.dll'";
     return "Error";

--- a/osquery/tables/system/windows/windows_security_products.cpp
+++ b/osquery/tables/system/windows/windows_security_products.cpp
@@ -49,7 +49,8 @@ Status GetSecurityProducts(WSC_SECURITY_PROVIDER provider,
   // since linking the library was causing a crash on some Windows
   // machines (like the CI server).
   CLSID* productListClassPtr = nullptr;
-  static HINSTANCE wscLib = LoadLibrary(TEXT("wscapi.dll"));
+  static HINSTANCE wscLib =
+      LoadLibraryEx(TEXT("wscapi.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (wscLib != nullptr) {
     productListClassPtr = (CLSID *)GetProcAddress(wscLib, "CLSID_WSCProductList");
   }


### PR DESCRIPTION
This hardens our runtime DLL loading a bit more. I am assuming we only ever want to load system DLLs and wont be packaging libraries with osquery. See #6426.