### PR TITLE
Fix the handling of empty args strings, on Windows

### DIFF
--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -86,13 +86,23 @@ typedef struct {
 } UNICODE_STRING, *PUNICODE_STRING;
 
 typedef struct _RTL_USER_PROCESS_PARAMETERS {
-  BYTE Reserved1[16];
-  PVOID Reserved2[10];
+  ULONG MaximumLength;
+  ULONG Length;
+  ULONG Flags;
+  ULONG DebugFlags;
+  PVOID ConsoleHandle;
+  ULONG ConsoleFlags;
+  HANDLE StdInputHandle;
+  HANDLE StdOutputHandle;
+  HANDLE StdErrorHandle;
+  UNICODE_STRING CurrentDirectoryPath;
+  HANDLE CurrentDirectoryHandle;
+  UNICODE_STRING DllPath;
   UNICODE_STRING ImagePathName;
   UNICODE_STRING CommandLine;
 } RTL_USER_PROCESS_PARAMETERS, *PRTL_USER_PROCESS_PARAMETERS;
 
-typedef struct _PEB {
+  typedef struct _PEB {
   BYTE Reserved1[2];
   BYTE BeingDebugged;
   BYTE Reserved2[1];
@@ -301,6 +311,52 @@ Status getProcessCommandLine(HANDLE& proc,
   return Status::success();
 }
 
+// Regardless of the Windows version, the CWD of a process is only possible to
+// retrieve by reading it from the process's PEB structure.
+Status getProcessCurrentDirectory(HANDLE proc,
+                                   std::string& out,
+                                   const unsigned long pid) {
+  PROCESS_BASIC_INFORMATION pbi;
+  unsigned long len{0};
+  NTSTATUS status = NtQueryInformationProcess(
+      proc, ProcessBasicInformation, &pbi, sizeof(pbi), &len);
+
+  SetLastError(RtlNtStatusToDosError(status));
+  if (NT_ERROR(status) || !pbi.PebBaseAddress) {
+    return Status::failure("NtQueryInformationProcess failed for " +
+                           std::to_string(pid) + " with " +
+                           std::to_string(status));
+  }
+
+  size_t bytes_read = 0;
+  PEB peb;
+  if (!ReadProcessMemory(
+          proc, pbi.PebBaseAddress, &peb, sizeof(peb), &bytes_read)) {
+    return Status::failure("Reading PEB failed for " + std::to_string(pid) +
+                           " with " + std::to_string(status));
+  }
+
+  RTL_USER_PROCESS_PARAMETERS upp;
+  if (!ReadProcessMemory(
+          proc, peb.ProcessParameters, &upp, sizeof(upp), &bytes_read)) {
+    return Status::failure("Reading USER_PROCESS_PARAMETERS failed for " +
+                           std::to_string(pid));
+  }
+
+  std::vector<wchar_t> current_directory(kMaxPathSize, 0x0);
+  SecureZeroMemory(current_directory.data(), kMaxPathSize);
+  if (!ReadProcessMemory(proc,
+                         upp.CurrentDirectoryPath.Buffer,
+                         current_directory.data(),
+                         upp.CurrentDirectoryPath.Length,
+                         &bytes_read)) {
+    return Status::failure("Failed to read current working directory for " +
+                           std::to_string(pid));
+  }
+  out = wstringToString(current_directory.data());
+  return Status::success();
+}
+
 void getProcessPathInfo(HANDLE& proc,
                         const unsigned long pid,
                         DynamicTableRowHolder& r) {
@@ -320,18 +376,12 @@ void getProcessPathInfo(HANDLE& proc,
         boost_path.empty() ? -1 : osquery::pathExists(path.data()).ok());
   }
 
-  path.clear();
-  path.resize(kMaxPathSize, 0x0);
-  if (pid == GetCurrentProcessId()) {
-    ret = GetModuleFileNameW(nullptr, path.data(), kMaxPathSize);
-  } else {
-    ret = GetModuleFileNameExW(proc, nullptr, path.data(), kMaxPathSize);
-  }
-
-  if (ret == FALSE) {
+  std::string currDir{""};
+  auto s = getProcessCurrentDirectory(proc, currDir, pid);
+  if (!s.ok()) {
     LOG(INFO) << "Failed to get cwd for " << pid << " with " << GetLastError();
   } else {
-    r["cwd"] = SQL_TEXT(wstringToString(path.data()));
+    r["cwd"] = currDir;
   }
   r["root"] = r["cwd"];
 }

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -381,7 +381,7 @@ void getProcessPathInfo(HANDLE& proc,
   if (!s.ok()) {
     LOG(INFO) << "Failed to get cwd for " << pid << " with " << GetLastError();
   } else {
-    r["cwd"] = currDir;
+    r["cwd"] = SQL_TEXT(currDir);
   }
   r["root"] = r["cwd"];
 }

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -102,7 +102,7 @@ typedef struct _RTL_USER_PROCESS_PARAMETERS {
   UNICODE_STRING CommandLine;
 } RTL_USER_PROCESS_PARAMETERS, *PRTL_USER_PROCESS_PARAMETERS;
 
-  typedef struct _PEB {
+typedef struct _PEB {
   BYTE Reserved1[2];
   BYTE BeingDebugged;
   BYTE Reserved2[1];
@@ -314,8 +314,8 @@ Status getProcessCommandLine(HANDLE& proc,
 // Regardless of the Windows version, the CWD of a process is only possible to
 // retrieve by reading it from the process's PEB structure.
 Status getProcessCurrentDirectory(HANDLE proc,
-                                   std::string& out,
-                                   const unsigned long pid) {
+                                  std::string& out,
+                                  const unsigned long pid) {
   PROCESS_BASIC_INFORMATION pbi;
   unsigned long len{0};
   NTSTATUS status = NtQueryInformationProcess(

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -126,7 +126,7 @@ boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
     return boost::none;
   }
 
-  // Note: passing an empty string to CommandLineToArgW() will cause it
+  // Note: passing an empty string to CommandLineToArgvW() will cause it
   // to fill in the command line of the current process (of osquery!)
   auto argv = ::CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
   if (argv == nullptr) {

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -121,6 +121,13 @@ boost::optional<std::string> expandEnvString(const std::string& input) {
 boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
   int argc = 0;
 
+  // If the string is empty, there is nothing to split.
+  if (args == "") {
+    return boost::none;
+  }
+
+  // Note: passing an empty string to CommandLineToArgW() will cause it
+  // to fill in the command line of the current process (of osquery!)
   auto argv = ::CommandLineToArgvW(stringToWstring(args).c_str(), &argc);
   if (argv == nullptr) {
     return boost::none;

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -122,7 +122,7 @@ boost::optional<std::vector<std::string>> splitArgs(const std::string& args) {
   int argc = 0;
 
   // If the string is empty, there is nothing to split.
-  if (args == "") {
+  if (args.empty()) {
     return boost::none;
   }
 


### PR DESCRIPTION
Closes https://github.com/osquery/osquery/issues/6403

As seen in Windows' `startup_items`, if there's a startup item entry in the registry key which does not have an associated value, then an empty string is passed to a osquery helper function that tries to parse it into an `args` array. But it uses a Windows API that, if passed an empty string, fills in the command line args of the current osquery process, instead. This PR catches the empty string before that happens.