### PR TITLE
Fix potential overread bug in package_bom

### DIFF
--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -139,6 +139,12 @@ const BOMVar* BOM::getVariable(size_t* offset) const {
   }
 
   *offset += sizeof(BOMVar) + var->length;
+  if (size_ < vars_offset_ + *offset) {
+    // Next offset overflows the variable list.
+    *offset = 0;
+    return nullptr;
+  }
+
   return var;
 }
 


### PR DESCRIPTION
After fixing #6457 I wanted to write a fuzzer for this data structure. It was time well spent as it found another bug in the BOM parsing. This prevents a crash in the case of parsing a malformed package BOM.