### PR TITLE
Pass the minimum macOS SDK version to openssl only if explicitly set

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -60,6 +60,16 @@ function(opensslMain)
     )
 
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(platform_c_flags
+      -fPIC
+    )
+
+    if(NOT "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
+      list(APPEND platform_c_flags
+        -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}
+      )
+    endif()
+
     set(configure_command
       "${CMAKE_COMMAND}" -E env "CC=${CMAKE_C_COMPILER}" "AR=${CMAKE_AR}"
       perl ./Configure darwin64-x86_64-cc
@@ -70,8 +80,7 @@ function(opensslMain)
         "--openssldir=${install_prefix}/etc/openssl"
 
         enable-ec_nistp_64_gcc_128
-        -fPIC
-        -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}
+        ${platform_c_flags}
     )
 
     # Don't be afraid to manually patch the build scripts; for some settings, there is no


### PR DESCRIPTION
If CMAKE_OSX_DEPLOYMENT_TARGET is not explicitly set, CMake will leave it empty and leave the sdk version choice to the compiler used.
Therefore we have to avoid to pass the minimum sdk flag to openssl if the deployment target is not explicitly set.

This is a follow up to https://github.com/osquery/osquery/pull/6469