### PR TITLE
Fix libelfin build on ossfuzz and LLVM/Clang 10

### DIFF
--- a/libraries/cmake/source/libelfin/patches/src/incorrect_const_set_binding.patch
+++ b/libraries/cmake/source/libelfin/patches/src/incorrect_const_set_binding.patch
@@ -1,0 +1,13 @@
+diff --git a/elf/data.hh b/elf/data.hh
+index ed5c7a1..4a60944 100644
+--- a/elf/data.hh
++++ b/elf/data.hh
+@@ -553,7 +553,7 @@ struct Sym<Elf64, Order>
+                 return (stb)(info >> 4);
+         }
+ 
+-        void set_binding(stb v) const
++        void set_binding(stb v)
+         {
+                 info = (info & 0xF) | ((unsigned char)v << 4);
+         }

--- a/libraries/cmake/source/modules/Findlibelfin.cmake
+++ b/libraries/cmake/source/modules/Findlibelfin.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )


### PR DESCRIPTION
The set_binding function is incorrectly marked as const,
since it actually modifies one of the struct members.
This was somehow not caught by older compilers,
but is failing on LLVM/Clang 10, so we create a patch to fix this.