### PR TITLE
Only explode registry key if it can be tokenized

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -227,9 +227,11 @@ inline void explodeRegistryPath(const std::string& path,
                                 std::string& rHive,
                                 std::string& rKey) {
   auto toks = osquery::split(path, kRegSep);
-  rHive = toks.front();
-  toks.erase(toks.begin());
-  rKey = osquery::join(toks, kRegSep);
+  if (!toks.empty()) {
+    rHive = toks.front();
+    toks.erase(toks.begin());
+    rKey = osquery::join(toks, kRegSep);
+  }
 }
 
 /// Microsoft helper function for getting the contents of a registry key


### PR DESCRIPTION
### Description

Running "SELECT * FROM registry WHERE (path like ' ')" causes osquery to crash. This is due to the explodeRegistryKey function assuming that whatever string is passed into it is prepended with the registry hive.

### Testing
Before:
```
C:\test>osqueryd.exe --allow_unsafe --S
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> SELECT * FROM registry WHERE (path like ' ');

C:\test>
```
After:
```
C:\test>osqueryd.exe --allow_unsafe --S
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> SELECT * FROM registry WHERE (path like ' ');
osquery>
```