### PR TITLE
Change ErrorBase::takeUnderlyingError to non const

### DIFF
--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -64,7 +64,7 @@ class Error final : public ErrorBase {
     return *underlyingError_;
   }
 
-  std::unique_ptr<ErrorBase> takeUnderlyingError() const {
+  std::unique_ptr<ErrorBase> takeUnderlyingError() {
     return std::move(underlyingError_);
   }
 


### PR DESCRIPTION
Fix a build error with newer LLVM/Clang (11), as found on
oss-fuzz.

The member function returns a member variable via std::move,
but the member function is marked as const.
Since that variable to be actually moved would require
the class instance to be non const, a copy is used instead;
the return type has its copy constructor deleted though,
so this is always incorrect and removing the const qualifier
is the solution.
