### PR TITLE
Add validate_container_rows helper for integration tests

### DIFF
--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -51,11 +51,7 @@ TEST_F(DebPackages, test_sanity) {
     ASSERT_EQ(all_packages.count("dpkg"), 1u);
 
     if (isPlatform(PlatformType::TYPE_LINUX)) {
-      rows = execute_query(
-          "select *, pid_with_namespace, mount_namespace_id from deb_packages");
-      row_map["pid_with_namespace"] = IntType;
-      row_map["mount_namespace_id"] = NormalType;
-      validate_rows(rows, row_map);
+      validate_container_rows("deb_packages", row_map);
     }
 
   } else {

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -304,6 +304,15 @@ bool validate_value_using_flags(const std::string& value, int flags) {
   return true;
 }
 
+void validate_container_rows(const std::string& table_name,
+                             ValidationMap& validation_map) {
+  auto rows = execute_query(
+      "select *, pid_with_namespace, mount_namespace_id from " + table_name);
+  validation_map["pid_with_namespace"] = IntType;
+  validation_map["mount_namespace_id"] = NormalType;
+  validate_rows(rows, validation_map);
+}
+
 void setUpEnvironment() {
   Initializer::platformSetup();
   registryAndPluginInit();

--- a/tests/integration/tables/helper.h
+++ b/tests/integration/tables/helper.h
@@ -89,6 +89,8 @@ void validate_row(const Row& row, const ValidationMap& validation_map);
 void validate_rows(const std::vector<Row>& rows,
                    const ValidationMap& validation_map);
 bool validate_value_using_flags(const std::string& value, int flags);
+void validate_container_rows(const std::string& table_name,
+                             ValidationMap& validation_map);
 bool is_valid_hex(const std::string& value);
 
 void setUpEnvironment();

--- a/tests/integration/tables/npm_packages.cpp
+++ b/tests/integration/tables/npm_packages.cpp
@@ -38,11 +38,7 @@ TEST_F(NpmPackagesTest, test_sanity) {
   validate_rows(data, row_map);
 
   if (isPlatform(PlatformType::TYPE_LINUX)) {
-    data = execute_query(
-        "select *, pid_with_namespace, mount_namespace_id from npm_packages");
-    row_map["pid_with_namespace"] = IntType;
-    row_map["mount_namespace_id"] = NormalType;
-    validate_rows(data, row_map);
+    validate_container_rows("npm_packages", row_map);
   }
 }
 

--- a/tests/integration/tables/os_version.cpp
+++ b/tests/integration/tables/os_version.cpp
@@ -47,13 +47,7 @@ TEST_F(OsVersion, test_sanity) {
 
   // Query again with hidden columns too
   if (isPlatform(PlatformType::TYPE_LINUX)) {
-    data = execute_query(
-        "select *, pid_with_namespace, mount_namespace_id from os_version");
-
-    row_map["pid_with_namespace"] = IntType;
-    row_map["mount_namespace_id"] = NormalType;
-
-    validate_rows(data, row_map);
+    validate_container_rows("os_version", row_map);
   }
 }
 

--- a/tests/integration/tables/rpm_packages.cpp
+++ b/tests/integration/tables/rpm_packages.cpp
@@ -43,11 +43,7 @@ TEST_F(rpmPackages, test_sanity) {
     validate_rows(rows, row_map);
 
     if (isPlatform(PlatformType::TYPE_LINUX)) {
-      rows = execute_query(
-          "select *, pid_with_namespace, mount_namespace_id from rpm_packages");
-      row_map["pid_with_namespace"] = IntType;
-      row_map["mount_namespace_id"] = NormalType;
-      validate_rows(rows, row_map);
+      validate_container_rows("rpm_packages", row_map);
     }
   } else {
     LOG(WARNING) << "Empty results of query from 'rpm_packages', assume there "


### PR DESCRIPTION
This simple helper takes a table name and
an already prepared rows map to add the container
columns, which are normally hidden, and call validate_rows on it.

We use this function in deb_packages, rpm_packages, npm_packages,
os_version integration tests.

Follow up to #6413 and #6414