### PR TITLE
Make file and hash container columns hidden

### DIFF
--- a/specs/hash.table
+++ b/specs/hash.table
@@ -11,8 +11,8 @@ extended_schema(POSIX, [
     Column("ssdeep", TEXT, "ssdeep hash of provided filesystem data"),
 ])
 extended_schema(LINUX, [
-    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True),
-    Column("mount_namespace_id", TEXT, "Mount namespace id"),
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
+    Column("mount_namespace_id", TEXT, "Mount namespace id", hidden=True),
 ])
 implementation("hash@genHash")
 examples([

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -29,8 +29,8 @@ extended_schema(DARWIN, [
     Column("bsd_flags", TEXT, "The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND")
 ])
 extended_schema(LINUX, [
-    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True),
-    Column("mount_namespace_id", TEXT, "Mount namespace id"),
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
+    Column("mount_namespace_id", TEXT, "Mount namespace id", hidden=True),
 ])
 attributes(utility=True)
 implementation("utility/file@genFile")

--- a/tests/integration/tables/hash.cpp
+++ b/tests/integration/tables/hash.cpp
@@ -39,8 +39,8 @@ class Hash : public testing::Test {
 };
 
 TEST_F(Hash, test_sanity) {
-  const std::string query = std::string{"select * from hash where path = '"} +
-                            path.string() + std::string{"'"};
+  const std::string query =
+      "select * from hash where path = '" + path.string() + "'";
 
   QueryData data = execute_query(query);
 
@@ -68,12 +68,11 @@ TEST_F(Hash, test_sanity) {
     ASSERT_EQ(data[0]["ssdeep"], "3:f4oo8MRwRJFGW1gC64:f4kPvtHF");
   }
 
-  if (isPlatform(PlatformType::TYPE_LINUX)) {
-    row_map["pid_with_namespace"] = IntType;
-    row_map["mount_namespace_id"] = NormalType;
-  }
-
   validate_rows(data, row_map);
+
+  if (isPlatform(PlatformType::TYPE_LINUX)) {
+    validate_container_rows("hash", row_map, "path = '" + path.string() + "'");
+  }
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -305,9 +305,20 @@ bool validate_value_using_flags(const std::string& value, int flags) {
 }
 
 void validate_container_rows(const std::string& table_name,
-                             ValidationMap& validation_map) {
-  auto rows = execute_query(
-      "select *, pid_with_namespace, mount_namespace_id from " + table_name);
+                             ValidationMap& validation_map,
+                             const std::string& sql_constraints) {
+  std::string extra_sql;
+  if (!sql_constraints.empty()) {
+    extra_sql = " where " + sql_constraints;
+  }
+
+  std::cout << "select *, pid_with_namespace, mount_namespace_id from " +
+                   table_name + extra_sql
+            << std::endl;
+
+  auto rows =
+      execute_query("select *, pid_with_namespace, mount_namespace_id from " +
+                    table_name + extra_sql);
   validation_map["pid_with_namespace"] = IntType;
   validation_map["mount_namespace_id"] = NormalType;
   validate_rows(rows, validation_map);

--- a/tests/integration/tables/helper.h
+++ b/tests/integration/tables/helper.h
@@ -89,8 +89,10 @@ void validate_row(const Row& row, const ValidationMap& validation_map);
 void validate_rows(const std::vector<Row>& rows,
                    const ValidationMap& validation_map);
 bool validate_value_using_flags(const std::string& value, int flags);
-void validate_container_rows(const std::string& table_name,
-                             ValidationMap& validation_map);
+void validate_container_rows(
+    const std::string& table_name,
+    ValidationMap& validation_map,
+    const std::string& sql_constraints = std::string());
 bool is_valid_hex(const std::string& value);
 
 void setUpEnvironment();


### PR DESCRIPTION
This is for consistency with the decisions taken
for PR osquery/osquery#6413 and osquery/osquery#6414.

We also update the integration test helper to accept custom constraints,
in the case the table has required columns.

Depends on #6485