### PR TITLE
Add --setns flag to run osqueryi in container namespace

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -477,6 +477,12 @@ Augeas lenses are bundled with osquery distributions. On Linux they are installe
 
 Docker information for containers, networks, volumes, images etc is available in different tables. osquery uses docker's UNIX domain socket to invoke docker API calls. Provide the path to docker's domain socket file. User running osqueryd / osqueryi should have permission to read the socket file.
 
+### Container namespace flag (Linux only)
+
+`--setns`
+
+When osquery is run in shell-mode, it will check for the setns flag at startup.  If set, it will try to call setns system call to switch to the specified container namespace.  For example, if the container is running with pid 33900, using `--setns=/proc/33900/ns/mnt` will run the queries inside that container's namespace.  Run `sudo lsns` to view container namespaces.  This only works when the following conditions are met : osquery is run with sufficient privileges (e.g. run as root), and the osquery process does not yet have multiple threads running.  Therefore, extension support must be turned off using `--disable_extensions=true`.  Other settings that may be required, and are likely default when running in shell-mode are : `-S --disable_watchdog=true --disable_events=true --logger_stderr`.
+
 ### Shell-only flags
 
 Most of the shell flags are self-explanatory and are adapted from the SQLite shell. Refer to the shell's ".help" command for details and explanations.

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -10,6 +10,10 @@
 #include <io.h>
 #endif
 
+#ifdef LINUX
+#include <syscall.h>
+#endif
+
 #include <iostream>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -50,7 +54,12 @@ CLI_FLAG(bool, install, false, "Install osqueryd as a service");
 
 CLI_FLAG(bool, uninstall, false, "Uninstall osqueryd as a service");
 
+#ifdef LINUX
+SHELL_FLAG(string, setns, "", "Linux container namespace path to use for osqueryi");
+#endif
+
 DECLARE_bool(disable_caching);
+DECLARE_bool(logger_stderr);
 
 const std::string kWatcherWorkerName{"osqueryd: worker"};
 
@@ -111,7 +120,37 @@ void startDaemon(Initializer& runner) {
   runner.waitForShutdown();
 }
 
+void check_container_namespace_flag() {
+#ifdef LINUX
+  if (FLAGS_setns.empty()) {
+    return;
+  }
+
+  if (FLAGS_logger_stderr == false || FLAGS_disable_extensions == false) {
+    LOG(WARNING) << "--logger_stderr AND --disable_extensions"
+      " needed for setns to work, as the process needs to be single-threaded";
+  }
+
+  int fd = open(FLAGS_setns.c_str(), O_RDONLY);
+  if (fd <= 0) {
+    LOG(ERROR) << "Unable to open namespace path: " << FLAGS_setns << " . Running as root?";
+    return;
+  }
+
+  // We call the syscall directly because setns() has been added as a function
+  // from glibc 2.14 and on only.
+
+  int result = static_cast<int>(syscall(SYS_setns, fd, 0));
+  if (result == -1) {
+    LOG(ERROR) << "Unable to switch to namespace";
+  }
+  close(fd);
+#endif
+}
+
 int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
+  check_container_namespace_flag();
+
   // Check for shell-specific switches and positional arguments.
   if (argc > 1 || !osquery::platformIsatty(stdin) ||
       !osquery::FLAGS_A.empty() || !osquery::FLAGS_pack.empty() ||

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -55,7 +55,10 @@ CLI_FLAG(bool, install, false, "Install osqueryd as a service");
 CLI_FLAG(bool, uninstall, false, "Uninstall osqueryd as a service");
 
 #ifdef LINUX
-SHELL_FLAG(string, setns, "", "Linux container namespace path to use for osqueryi");
+SHELL_FLAG(string,
+           setns,
+           "",
+           "Linux container namespace path to use for osqueryi");
 #endif
 
 DECLARE_bool(disable_caching);
@@ -128,12 +131,14 @@ void check_container_namespace_flag() {
 
   if (FLAGS_logger_stderr == false || FLAGS_disable_extensions == false) {
     LOG(WARNING) << "--logger_stderr AND --disable_extensions"
-      " needed for setns to work, as the process needs to be single-threaded";
+                    " needed for setns to work, as the process needs to be "
+                    "single-threaded";
   }
 
   int fd = open(FLAGS_setns.c_str(), O_RDONLY);
   if (fd <= 0) {
-    LOG(ERROR) << "Unable to open namespace path: " << FLAGS_setns << " . Running as root?";
+    LOG(ERROR) << "Unable to open namespace path: " << FLAGS_setns
+               << " . Running as root?";
     return;
   }
 


### PR DESCRIPTION
This change allows osqueryi to be run with `--setns=/proc/3333/ns/mnt` to run queries within a container namespace. Very useful for command-line scripts and testing tables for container support.
It's only compiled-in for linux targets.
