### PR TITLE
Add dns_cache table for Windows

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -172,6 +172,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/cpu_info.cpp
       windows/default_environment.cpp
       windows/disk_info.cpp
+      windows/dns_cache.cpp
       windows/drivers.cpp
       windows/groups.cpp
       windows/ie_extensions.cpp

--- a/osquery/tables/system/windows/dns_cache.cpp
+++ b/osquery/tables/system/windows/dns_cache.cpp
@@ -140,8 +140,7 @@ QueryData genDnsCache(QueryContext& context) {
 
   int stat = DnsGetCacheDataTable(pEntry);
   pEntry = pEntry->pNext;
-  while (pEntry != nullptr)
-  {
+  while (pEntry != nullptr) {
     Row r;
 
     r["name"] = wstringToString(pEntry->pszName);

--- a/osquery/tables/system/windows/dns_cache.cpp
+++ b/osquery/tables/system/windows/dns_cache.cpp
@@ -30,99 +30,99 @@ typedef int(WINAPI *DNS_GET_CACHE_DATA_TABLE)(PDNSCACHEENTRY);
 std::string dnsTypeToString(unsigned short wType) {
   switch (wType)
   {
-	case 1:
+  case 1:
     return "A";
-	case 2:
+  case 2:
     return "NS";
-	case 5:
+  case 5:
     return "CNAME";
-	case 6:
+  case 6:
     return "SOA";
-	case 12:
+  case 12:
     return "PTR";
-	case 13:
+  case 13:
     return "HINFO";
-	case 15:
+  case 15:
     return "MX";
-	case 16:
+  case 16:
     return "TXT";
-	case 17:
+  case 17:
     return "RP";
-	case 18:
+  case 18:
     return "AFSDB";
-	case 24:
+  case 24:
     return "SIG";
-	case 25:
+  case 25:
     return "KEY";
-	case 28:
+  case 28:
     return "AAAA";
-	case 29:
+  case 29:
     return "LOC";
-	case 33:
+  case 33:
     return "SRV";
-	case 35:
+  case 35:
     return "NAPTR";
-	case 36:
+  case 36:
     return "KX";
-	case 37:
+  case 37:
     return "CERT";
-	case 39:
+  case 39:
     return "DNAME";
-	case 41:
+  case 41:
     return "OPT";
-	case 42:
+  case 42:
     return "APL";
-	case 43:
+  case 43:
     return "DS";
-	case 44:
+  case 44:
     return "SSHFP";
-	case 45:
+  case 45:
     return "IPSECKEY";
-	case 46:
+  case 46:
     return "RRSIG";
-	case 47:
+  case 47:
     return "NSEC";
-	case 48:
+  case 48:
     return "DNSKEY";
-	case 49:
+  case 49:
     return "DHCID";
-	case 50:
+  case 50:
     return "NSEC3";
-	case 51:
+  case 51:
     return "NSEC3PARAM";
-	case 52:
+  case 52:
     return "TLSA";
-	case 53:
+  case 53:
     return "SMIMEA";
-	case 55:
+  case 55:
     return "HIP";
-	case 59:
+  case 59:
     return "CDS";
-	case 60:
+  case 60:
     return "CDNSKEY";
-	case 61:
+  case 61:
     return "OPENPGPKEY";
-	case 62:
+  case 62:
     return "CSYNC";
-	case 63:
+  case 63:
     return "ZONEMD";
-	case 249:
+  case 249:
     return "TKEY";
-	case 250:
+  case 250:
     return "TSIG";
-	case 251:
+  case 251:
     return "IXFR";
-	case 252:
+  case 252:
     return "AXFR";
-	case 255:
+  case 255:
     return "*";
-	case 256:
+  case 256:
     return "URI";
-	case 257:
+  case 257:
     return "CAA";
-	case 32768:
+  case 32768:
     return "TA";
-	case 32769:
+  case 32769:
     return "DLV";
   }
 

--- a/osquery/tables/system/windows/dns_cache.cpp
+++ b/osquery/tables/system/windows/dns_cache.cpp
@@ -135,13 +135,13 @@ QueryData genDnsCache(QueryContext& context) {
   QueryData results;
 
   PDNSCACHEENTRY pEntry = (PDNSCACHEENTRY)malloc(sizeof(DNSCACHEENTRY));
-  HINSTANCE hLib = LoadLibrary(TEXT("DNSAPI.dll"));
+  HINSTANCE hLib = LoadLibraryEx(TEXT("DNSAPI.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   DNS_GET_CACHE_DATA_TABLE DnsGetCacheDataTable =
     (DNS_GET_CACHE_DATA_TABLE)GetProcAddress(hLib, "DnsGetCacheDataTable");
 
   int stat = DnsGetCacheDataTable(pEntry);
   pEntry = pEntry->pNext;
-  while (pEntry)
+  while (pEntry != nullptr)
   {
     Row r;
 

--- a/osquery/tables/system/windows/dns_cache.cpp
+++ b/osquery/tables/system/windows/dns_cache.cpp
@@ -1,0 +1,160 @@
+/**
+ *  Copyright (c) 2020-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/system/system.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/utils/conversions/windows/strings.h>
+
+namespace osquery {
+namespace tables {
+
+typedef struct _DNS_CACHE_ENTRY
+{
+  struct _DNS_CACHE_ENTRY* pNext; // Pointer to next entry
+  PWSTR pszName; // DNS Record Name
+  unsigned short wType; // DNS Record Type
+  unsigned short wDataLength; // Not referenced
+  unsigned long dwFlags; // DNS Record Flags
+} DNSCACHEENTRY, *PDNSCACHEENTRY;
+
+typedef int(WINAPI *DNS_GET_CACHE_DATA_TABLE)(PDNSCACHEENTRY);
+
+std::string dnsTypeToString(unsigned short wType) {
+  switch (wType)
+  {
+	case 1:
+    return "A";
+	case 2:
+    return "NS";
+	case 5:
+    return "CNAME";
+	case 6:
+    return "SOA";
+	case 12:
+    return "PTR";
+	case 13:
+    return "HINFO";
+	case 15:
+    return "MX";
+	case 16:
+    return "TXT";
+	case 17:
+    return "RP";
+	case 18:
+    return "AFSDB";
+	case 24:
+    return "SIG";
+	case 25:
+    return "KEY";
+	case 28:
+    return "AAAA";
+	case 29:
+    return "LOC";
+	case 33:
+    return "SRV";
+	case 35:
+    return "NAPTR";
+	case 36:
+    return "KX";
+	case 37:
+    return "CERT";
+	case 39:
+    return "DNAME";
+	case 41:
+    return "OPT";
+	case 42:
+    return "APL";
+	case 43:
+    return "DS";
+	case 44:
+    return "SSHFP";
+	case 45:
+    return "IPSECKEY";
+	case 46:
+    return "RRSIG";
+	case 47:
+    return "NSEC";
+	case 48:
+    return "DNSKEY";
+	case 49:
+    return "DHCID";
+	case 50:
+    return "NSEC3";
+	case 51:
+    return "NSEC3PARAM";
+	case 52:
+    return "TLSA";
+	case 53:
+    return "SMIMEA";
+	case 55:
+    return "HIP";
+	case 59:
+    return "CDS";
+	case 60:
+    return "CDNSKEY";
+	case 61:
+    return "OPENPGPKEY";
+	case 62:
+    return "CSYNC";
+	case 63:
+    return "ZONEMD";
+	case 249:
+    return "TKEY";
+	case 250:
+    return "TSIG";
+	case 251:
+    return "IXFR";
+	case 252:
+    return "AXFR";
+	case 255:
+    return "*";
+	case 256:
+    return "URI";
+	case 257:
+    return "CAA";
+	case 32768:
+    return "TA";
+	case 32769:
+    return "DLV";
+  }
+
+  std::stringstream ss;
+  ss << wType;
+  return ss.str();
+}
+
+QueryData genDnsCache(QueryContext& context) {
+  QueryData results;
+
+  PDNSCACHEENTRY pEntry = (PDNSCACHEENTRY)malloc(sizeof(DNSCACHEENTRY));
+  HINSTANCE hLib = LoadLibrary(TEXT("DNSAPI.dll"));
+  DNS_GET_CACHE_DATA_TABLE DnsGetCacheDataTable =
+    (DNS_GET_CACHE_DATA_TABLE)GetProcAddress(hLib, "DnsGetCacheDataTable");
+
+  int stat = DnsGetCacheDataTable(pEntry);
+  pEntry = pEntry->pNext;
+  while (pEntry)
+  {
+    Row r;
+
+    r["name"] = wstringToString(pEntry->pszName);
+    r["type"] = dnsTypeToString(pEntry->wType);
+    r["flags"] = INTEGER(pEntry->dwFlags);
+
+    results.push_back(r);
+    pEntry = pEntry->pNext;
+  }
+  free(pEntry);
+
+  return results;
+}
+}
+}

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -285,6 +285,7 @@ function(generateNativeTables)
     "windows/windows_optional_features.table:windows"
     "windows/connectivity.table:windows"
     "windows/userassist.table:windows"
+    "windows/dns_cache.table:windows"
     "windows/hvci_status.table:windows"
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,freebsd"

--- a/specs/windows/dns_cache.table
+++ b/specs/windows/dns_cache.table
@@ -1,0 +1,11 @@
+table_name("dns_cache")
+description("DNS Cache.")
+schema([
+    Column("name", TEXT, "DNS record name"),
+    Column("type", TEXT, "DNS record type"),
+    Column("flags", INTEGER, "DNS record flags"),
+])
+implementation("dns_cache@genDnsCache")
+examples([
+  "select * from dns_cache",
+])

--- a/specs/windows/dns_cache.table
+++ b/specs/windows/dns_cache.table
@@ -1,5 +1,5 @@
 table_name("dns_cache")
-description("DNS Cache.")
+description("Enumerate the DNS cache using the undocumented DnsGetCacheDataTable function in dnsapi.dll.")
 schema([
     Column("name", TEXT, "DNS record name"),
     Column("type", TEXT, "DNS record type"),


### PR DESCRIPTION
This PR adds a new table named `dns_cache` for Windows that utilizes the undocumented `DnsGetCacheDataTable` call in `dnsapi.dll` that will return a list of currently cached DNS names and record types. There is also a `flags` column included from the results returned by `DnsGetCacheDataTable` for which I can't say I understand the exact usage of, but it is included in case it may be of use to someone who understands the meaning of this field.