### PR TITLE
bug: Fix typed_row table caching

### DIFF
--- a/tools/codegen/templates/typed_row.h.in
+++ b/tools/codegen/templates/typed_row.h.in
@@ -66,9 +66,9 @@ ${ :end-for }$\
   virtual Status serialize(JSON& doc, rapidjson::Value& obj) const override {
 ${ for column in schema: }$\
 ${   if column.type.affinity == "TEXT_TYPE": }$\
-    doc.addRef("${ write(column.name) }$", ${ write(column.name) }$_col);
+    doc.addRef("${ write(column.name) }$", ${ write(column.name) }$_col, obj);
 ${   :else: }$\
-    doc.add("${ write(column.name) }$", ${ write(column.name) }$_col);
+    doc.add("${ write(column.name) }$", ${ write(column.name) }$_col, obj);
 ${   :end-if  }$\
 ${ :end-for }$\
 


### PR DESCRIPTION
There was an issue found in #6450.

This serialize method is not working correctly, the columns should be added to the object passed to serialize, which is then added to the array-type document.