### PR TITLE
tables: Only populate table cache with star-like selects

### DIFF
--- a/osquery/include/osquery/tables.h
+++ b/osquery/include/osquery/tables.h
@@ -579,6 +579,9 @@ struct QueryContext {
   /// Check if any of the given columns is used by the query
   bool isAnyColumnUsed(std::initializer_list<std::string> colNames) const;
 
+  /// Check if this is a star-select or similar.
+  bool defaultColumnsUsed() const;
+
   inline bool isAnyColumnUsed(UsedColumnsBitset desiredBitset) const {
     return !colsUsedBitset || (*colsUsedBitset & desiredBitset).any();
   }

--- a/osquery/include/osquery/tables.h
+++ b/osquery/include/osquery/tables.h
@@ -911,6 +911,7 @@ class TablePlugin : public Plugin {
   FRIEND_TEST(VirtualTableTests, test_tableplugin_statement);
   FRIEND_TEST(VirtualTableTests, test_indexing_costs);
   FRIEND_TEST(VirtualTableTests, test_table_results_cache);
+  FRIEND_TEST(VirtualTableTests, test_table_results_cache_colcheck);
   FRIEND_TEST(VirtualTableTests, test_yield_generator);
 };
 

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -577,12 +577,19 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   EXPECT_EQ(results.size(), 1U);
   EXPECT_EQ(cache->generates_, 3U);
 
-  // Run the query again, the virtual table cache will be returned.
+  // Run the query again, but select all columns explicitly.
+  results.clear();
+  statement = "SELECT i, d from table_cache;";
+  queryInternal(statement, results, dbc);
+  EXPECT_EQ(results.size(), 1U);
+  EXPECT_EQ(cache->generates_, 3U);
+
+  // Run the query again, but do not star-select.
   results.clear();
   statement = "SELECT i from table_cache;";
   queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
-  EXPECT_EQ(cache->generates_, 3U);
+  EXPECT_EQ(cache->generates_, 4U);
 
   // Now with constraints that invalidate the cache results.
   results.clear();
@@ -590,7 +597,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
   // The table should NOT have used the cache.
-  EXPECT_EQ(cache->generates_, 4U);
+  EXPECT_EQ(cache->generates_, 5U);
 }
 
 TEST_F(VirtualTableTests, test_table_results_cache_colcheck) {
@@ -1119,8 +1126,8 @@ TEST_F(VirtualTableTests, test_used_columns_default) {
     auto status = queryInternal("SELECT * FROM colsUsedDefault", results, dbc);
     EXPECT_TRUE(status.ok());
     ASSERT_EQ(results.size(), 1U);
-    EXPECT_EQ(results[0].find("col1"), "value1");
-    EXPECT_EQ(results[0].find("col2"), "value2");
+    EXPECT_EQ(results[0]["col1"], "value1");
+    EXPECT_EQ(results[0]["col2"], "value2");
   }
 
   {
@@ -1129,8 +1136,8 @@ TEST_F(VirtualTableTests, test_used_columns_default) {
         queryInternal("SELECT col1 FROM colsUsedDefault", results, dbc);
     EXPECT_TRUE(status.ok());
     ASSERT_EQ(results.size(), 1U);
-    EXPECT_EQ(results[0].find("col1"), results[0].end());
-    EXPECT_EQ(results[0].find("col2"), results[0].end());
+    EXPECT_TRUE(results[0]["col1"].empty());
+    EXPECT_TRUE(results[0]["col2"].empty());
   }
 }
 

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -557,7 +557,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
 
-  // The table should have used the cache.
+  // The table should not have used the cache.
   EXPECT_EQ(cache->generates_, 2U);
 
   // Now request that caching be used.
@@ -577,14 +577,57 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   EXPECT_EQ(results.size(), 1U);
   EXPECT_EQ(cache->generates_, 3U);
 
-  // Once last time with constraints that invalidate the cache results.
+  // Run the query again, the virtual table cache will be returned.
+  results.clear();
+  statement = "SELECT i from table_cache;";
+  queryInternal(statement, results, dbc);
+  EXPECT_EQ(results.size(), 1U);
+  EXPECT_EQ(cache->generates_, 3U);
+
+  // Now with constraints that invalidate the cache results.
   results.clear();
   statement = "SELECT * from table_cache where i = '1';";
   queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
-
   // The table should NOT have used the cache.
   EXPECT_EQ(cache->generates_, 4U);
+}
+
+TEST_F(VirtualTableTests, test_table_results_cache_colcheck) {
+  // Get a database connection.
+  auto tables = RegistryFactory::get().registry("table");
+  auto cache = std::make_shared<tableCacheTablePlugin>();
+  tables->add("table_cache_cols", cache);
+  auto dbc = SQLiteDBManager::getUnique();
+  attachTableInternal(
+      "table_cache_cols", cache->columnDefinition(false), dbc, false);
+
+  // Request that caching be used.
+  dbc->useCache(true);
+
+  QueryData results;
+  std::string statement = "SELECT i from table_cache_cols;";
+  auto status = queryInternal(statement, results, dbc);
+
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ(results.size(), 1U);
+  EXPECT_EQ(cache->generates_, 1U);
+
+  // Run the query again, the virtual table cache will be populated.
+  results.clear();
+  statement = "SELECT * from table_cache_cols;";
+  queryInternal(statement, results, dbc);
+  EXPECT_EQ(results.size(), 1U);
+  // The table should not have used the cache.
+  EXPECT_EQ(cache->generates_, 2U);
+
+  // Run the query again, the virtual table cache will be used.
+  results.clear();
+  statement = "SELECT * from table_cache_cols;";
+  queryInternal(statement, results, dbc);
+  EXPECT_EQ(results.size(), 1U);
+  // Results from cache.
+  EXPECT_EQ(cache->generates_, 2U);
 }
 
 class yieldTablePlugin : public TablePlugin {
@@ -1034,6 +1077,61 @@ TEST_F(VirtualTableTests, test_used_columns_bitset_with_alias) {
   EXPECT_EQ(results[0].find("col2"), results[0].end());
   EXPECT_EQ(results[0].find("col3"), results[0].end());
   EXPECT_EQ(results[0]["aliasToCol2"], "value2");
+}
+
+class colsUsedDefaultTablePlugin : public TablePlugin {
+ private:
+  TableColumns columns() const override {
+    return {
+        std::make_tuple("col1", TEXT_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("col2", TEXT_TYPE, ColumnOptions::DEFAULT),
+    };
+  }
+
+ public:
+  TableRows generate(QueryContext& context) override {
+    auto r = make_table_row();
+    if (context.defaultColumnsUsed()) {
+      r["col1"] = "value1";
+      r["col2"] = "value2";
+    }
+
+    TableRows result;
+    result.push_back(std::move(r));
+    return result;
+  }
+
+ private:
+  FRIEND_TEST(VirtualTableTests, test_used_columns_default);
+};
+
+TEST_F(VirtualTableTests, test_used_columns_default) {
+  // Add testing table to the registry.
+  auto tables = RegistryFactory::get().registry("table");
+  auto colsUsedDefault = std::make_shared<colsUsedDefaultTablePlugin>();
+  tables->add("colsUsedDefault", colsUsedDefault);
+  auto dbc = SQLiteDBManager::getUnique();
+  attachTableInternal(
+      "colsUsedDefault", colsUsedDefault->columnDefinition(false), dbc, false);
+
+  {
+    QueryData results;
+    auto status = queryInternal("SELECT * FROM colsUsedDefault", results, dbc);
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(results.size(), 1U);
+    EXPECT_EQ(results[0].find("col1"), "value1");
+    EXPECT_EQ(results[0].find("col2"), "value2");
+  }
+
+  {
+    QueryData results;
+    auto status =
+        queryInternal("SELECT col1 FROM colsUsedDefault", results, dbc);
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(results.size(), 1U);
+    EXPECT_EQ(results[0].find("col1"), results[0].end());
+    EXPECT_EQ(results[0].find("col2"), results[0].end());
+  }
 }
 
 /*


### PR DESCRIPTION
This is a prototype fix for #6510. ~~I wrote the test code without running it.~~

This has one limitation in that if you were to populate the table cache with:

```sql
select * from some_table;
```

You would expect a cache-hit with:

```sql
select some_col from some_table;
```

But cache-hits are only allowed with star (or similar) selects.