### PR TITLE
CMake: Fix and cleanup compile flags

### DIFF
--- a/osquery/sdk/CMakeLists.txt
+++ b/osquery/sdk/CMakeLists.txt
@@ -17,6 +17,7 @@ function(generateOsquerySdkPluginsdk)
   add_osquery_library(osquery_sdk_pluginsdk EXCLUDE_FROM_ALL empty_register_foreign_tables.cpp)
 
   target_link_libraries(osquery_sdk_pluginsdk INTERFACE
+    osquery_cxx_settings
     osquery_headers
     osquery_config
     osquery_dispatcher


### PR DESCRIPTION
Add a description to the function preparing the targets carrying the
main compiler and linker flags.

Convert CMake default flags to the ones we use, instead of overriding
them later via targets.
This can also avoid having us use the wrong CRT on Windows if we forget to link
against osquery_cxx_settings.

Reduce the "overriding <flagX> with <flagY>" messages on Windows by
removing the warning level from the default flags, and adding that
to the specific osquery_<c|cxx>_settings target, so that non internal
targets can choose their own level.

Minor cleanups

Fix osquery/osquery#6509
