### PR TITLE
Azure Pipelines: Update compiler version used to v142

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,7 +268,7 @@ jobs:
     displayName: "Windows Release"
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
     timeoutInMinutes: 120
 
@@ -318,7 +318,7 @@ jobs:
 
     - powershell: |
         (New-Object System.Net.WebClient).DownloadFile(`
-        "https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip",`
+        "https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip",`
         "$env:TEMP\ninja-win.zip")
 
         mkdir "C:\Program Files\Ninja"
@@ -327,7 +327,7 @@ jobs:
       displayName: "Install Ninja"
 
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cmake -G Ninja ^
         -DCMAKE_C_COMPILER=cl.exe ^
         -DCMAKE_CXX_COMPILER=cl.exe ^
@@ -347,7 +347,7 @@ jobs:
       displayName: sccache
 
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cmake --build . -j 3
         if %errorlevel% neq 0 exit /b %errorlevel%
         sccache.exe --stop-server

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -2,7 +2,7 @@ osquery supports many flavors of Linux, macOS, and Windows.
 
 While osquery runs on a large number of operating systems, we only provide build instructions for a select few.
 
-The supported compilers are: the osquery toolchain (LLVM/Clang 9.0.1) on Linux, MSVC v141 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
+The supported compilers are: the osquery toolchain (LLVM/Clang 9.0.1) on Linux, MSVC v142 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
 
 # Prerequisites
 
@@ -93,8 +93,8 @@ Note: It may be easier to install these prerequisites using [Chocolatey](https:/
 
 - [CMake](https://cmake.org/) (>= 3.14.6): the MSI installer is recommended. During installation, select the option to add it to the system `PATH` for all users. If there is any older version of CMake installed (e.g., using Chocolatey), uninstall that version first!  Do not install CMake using the Visual Studio Installer, because it contains an older version than required.
 - Visual Studio 2019 (2 options)
-  1. [Visual Studio 2019 Build Tools Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16) (without Visual Studio): In the installer choose the "C++ build tools" workload, then on the right, under "Optional", select "MSVC v141 - VS 2017 C++", "MSVC v142 - VS 2017 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".
-  2. [Visual Studio 2019 Community Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16): In the installer choose the "Desktop development with C++" workload, then on the right, under "Optional", select "MSVC v141 - VS 2017 C++", "MSVC v142 - VS 2017 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".
+  1. [Visual Studio 2019 Build Tools Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16) (without Visual Studio): In the installer choose the "C++ build tools" workload, then on the right, under "Optional", select "MSVC v142 - VS 2019 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".
+  2. [Visual Studio 2019 Community Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16): In the installer choose the "Desktop development with C++" workload, then on the right, under "Optional", select "MSVC v142 - VS 2019 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".
 - [Git for Windows](https://github.com/git-for-windows/git/releases/latest): Select "checkout as-is, commit as-is". Later check "Enable symbolic links" support.
 - [Python 3](https://www.python.org/downloads/windows/), specifically the 64-bit version.
 - [Wix Toolset](https://wixtoolset.org/releases/)
@@ -122,7 +122,7 @@ cd osquery
 
 # Configure
 mkdir build; cd build
-cmake -G "Visual Studio 16 2019" -A x64 -T v141 ..
+cmake -G "Visual Studio 16 2019" -A x64 ..
 
 # Build
 cmake --build . --config RelWithDebInfo -j10 # Number of projects to build in parallel
@@ -315,14 +315,14 @@ Chocolatey package by overriding the CMake `PACKAGING_SYSTEM` variable similar t
 To create a default MSI package use the following:
 
 ```sh
-cmake -G "Visual Studio 16 2019" -A x64 -T v141 ..
+cmake -G "Visual Studio 16 2019" -A x64 ..
 cmake --build . --config Release --target package
 ```
 
 To instead generate a Chocolatey package, use the following:
 
 ```sh
-cmake -DPACKAGING_SYSTEM=NuGet -G "Visual Studio 16 2019" -A x64 -T v141 ..
+cmake -DPACKAGING_SYSTEM=NuGet -G "Visual Studio 16 2019" -A x64 ..
 cmake --build . --config Release --target package
 ```
 


### PR DESCRIPTION
Also update the Windows Server version used from 2016 to 2019,
update Ninja to the latest stable and update the docs.

Note: the dependency on the VS2017 compiler was due to build errors we had when rewriting CMake for experimental, which was itself using VS2017; the build error were most likely caused by boost old version.
The new compiler builds and works fine now, so lets update!
