### PR TITLE
detangle: Move osquery shutdown logic outside of Initializer

### DIFF
--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -52,7 +52,7 @@ class CarverTests : public testing::Test {
 
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -117,9 +117,6 @@ DECLARE_string(pack_delimiter);
 const std::string kExecutingQuery{"executing_query"};
 const std::string kFailedQueries{"failed_queries"};
 
-/// The time osquery was started.
-std::atomic<size_t> kStartTime;
-
 // The config may be accessed and updated asynchronously; use mutexes.
 Mutex config_hash_mutex_;
 Mutex config_refresh_mutex_;
@@ -375,14 +372,6 @@ void Config::addPack(const std::string& name,
   } else {
     addSinglePack(name, obj);
   }
-}
-
-size_t Config::getStartTime() {
-  return kStartTime;
-}
-
-void Config::setStartTime(size_t st) {
-  kStartTime = st;
 }
 
 void Config::removePack(const std::string& pack) {

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -27,8 +27,10 @@
 #include <osquery/logger.h>
 #include <osquery/packs.h>
 #include <osquery/registry.h>
+#include <osquery/shutdown.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
+
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/system/time.h>
@@ -511,7 +513,7 @@ Status Config::refresh() {
       }
       VLOG(1) << "Requesting shutdown after dumping config";
       // Don't force because the config plugin may have started services.
-      Initializer::requestShutdown();
+      requestShutdown();
       return Status::success();
     }
     status = update(response[0]);

--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -131,12 +131,6 @@ class Config : private boost::noncopyable {
     return valid_;
   }
 
-  /// Get start time of config.
-  static size_t getStartTime();
-
-  /// Set the start time if the config.
-  static void setStartTime(size_t st);
-
   /**
    * @brief Add a pack to the osquery schedule
    */

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -54,7 +54,7 @@ extern void saveScheduleDenylist(const std::map<std::string, size_t>& denylist);
 class ConfigTests : public testing::Test {
  public:
   ConfigTests() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/config/tests/packs.cpp
+++ b/osquery/config/tests/packs.cpp
@@ -37,7 +37,7 @@ extern size_t getMachineShard(const std::string& hostname = "",
 class PacksTests : public testing::Test {
  public:
   PacksTests() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -13,17 +13,48 @@ function(osqueryCoreMain)
   endif()
 
   generateOsqueryCore()
+  generateOsqueryCoreInit()
+endfunction()
+
+function(generateOsqueryCoreInit)
+  set(source_files
+    init.cpp
+    watcher.cpp
+  )
+
+  add_osquery_library(osquery_core_init EXCLUDE_FROM_ALL
+    ${source_files}
+  )
+
+  set(dependencies
+    osquery_headers
+    osquery_config
+    osquery_core
+    osquery_extensions
+  )
+
+  target_link_libraries(osquery_core_init PUBLIC
+    osquery_cxx_settings
+
+    ${dependencies}
+  )
+
+  set(public_header_files
+    watcher.h
+  )
+
+  generateIncludeNamespace(osquery_core_init "osquery/core" "FILE_ONLY" ${public_header_files})
+
+  add_test(NAME osquery_core_tests_watcherpermissionstests-test COMMAND osquery_core_tests_watcherpermissionstests-test)
 endfunction()
 
 function(generateOsqueryCore)
   set(source_files
     flags.cpp
-    init.cpp
     query.cpp
     shutdown.cpp
     system.cpp
     tables.cpp
-    watcher.cpp
   )
 
   if(DEFINED PLATFORM_POSIX)
@@ -45,7 +76,6 @@ function(generateOsqueryCore)
 
   set(dependencies
     osquery_headers
-    osquery_config
     osquery_core_plugins
     osquery_core_sql
     osquery_filesystem
@@ -57,7 +87,6 @@ function(generateOsqueryCore)
     osquery_utils_system_systemutils
     osquery_utils_system_time
     osquery_logger
-    osquery_extensions
     thirdparty_gflags
     thirdparty_glog
     thirdparty_openssl
@@ -72,10 +101,6 @@ function(generateOsqueryCore)
     osquery_cxx_settings
 
     ${dependencies}
-  )
-
-  set(public_header_files
-    watcher.h
   )
 
   if(DEFINED PLATFORM_WINDOWS)
@@ -93,7 +118,6 @@ function(generateOsqueryCore)
   add_test(NAME osquery_core_tests_flagstests-test COMMAND osquery_core_tests_flagstests-test)
   add_test(NAME osquery_core_tests_systemtests-test COMMAND osquery_core_tests_systemtests-test)
   add_test(NAME osquery_core_tests_tablestests-test COMMAND osquery_core_tests_tablestests-test)
-  add_test(NAME osquery_core_tests_watcherpermissionstests-test COMMAND osquery_core_tests_watcherpermissionstests-test)
   add_test(NAME osquery_core_tests_querytests-test COMMAND osquery_core_tests_querytests-test)
   add_test(NAME osquery_core_tests_processtests-test COMMAND osquery_core_tests_processtests-test)
 

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -20,6 +20,7 @@ function(generateOsqueryCore)
     flags.cpp
     init.cpp
     query.cpp
+    shutdown.cpp
     system.cpp
     tables.cpp
     watcher.cpp

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -28,13 +28,13 @@ function(generateOsqueryCore)
 
   if(DEFINED PLATFORM_POSIX)
     list(APPEND source_files
-      posix/initializer.cpp
+      posix/platform.cpp
     )
 
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND source_files
       windows/handle.cpp
-      windows/initializer.cpp
+      windows/platform.cpp
       windows/wmi.cpp
     )
   endif()

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -199,7 +199,7 @@ Initializer::Initializer(int& argc,
   std::srand(static_cast<unsigned int>(
       chrono_clock::now().time_since_epoch().count()));
   // The config holds the initialization time for easy access.
-  Config::setStartTime(getUnixTime());
+  setStartTime(getUnixTime());
 
   isWorker_ = hasWorkerVariable();
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -426,7 +426,7 @@ void Initializer::initWatcher() const {
 
   // The watcher takes a list of paths to autoload extensions from.
   // The loadExtensions call will populate the watcher's list of extensions.
-  osquery::loadExtensions();
+  watcher.loadExtensions();
 
   // Add a watcher service thread to start/watch an optional worker and list
   // of optional extensions from the autoload paths.

--- a/osquery/core/posix/platform.cpp
+++ b/osquery/core/posix/platform.cpp
@@ -10,11 +10,11 @@
 
 namespace osquery {
 
-void Initializer::platformSetup() {
+void platformSetup() {
   /* No platform-specific logic is needed on POSIX. */
 }
 
-void Initializer::platformTeardown() {
+void platformTeardown() {
   /* No platform-specific logic is needed on POSIX. */
 }
 } // namespace osquery

--- a/osquery/core/shutdown.cpp
+++ b/osquery/core/shutdown.cpp
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/data_logger.h>
+#include <osquery/shutdown.h>
+
+#include <mutex>
+#include <string>
+
+namespace osquery {
+
+namespace {
+
+struct ShutdownData {
+  /// The main thread can wait for a request from anywhere in the codebase.
+  std::condition_variable request_signal;
+
+  /// Mutex for the request signal.
+  std::mutex request_mutex;
+
+  /// A request to shutdown may only be issued once.
+  bool requested{false};
+
+  /// The current requested return code for the process.
+  std::sig_atomic_t retcode{0};
+};
+
+struct ShutdownData kShutdownData;
+} // namespace
+
+int getShutdownExitCode() {
+  return kShutdownData.retcode;
+}
+
+void setShutdownExitCode(int retcode) {
+  kShutdownData.retcode = retcode;
+}
+
+void waitForShutdown() {
+  std::unique_lock<std::mutex> lock(kShutdownData.request_mutex);
+  kShutdownData.request_signal.wait(lock,
+                                    [] { return kShutdownData.requested; });
+}
+
+void requestShutdown(int retcode) {
+  static std::once_flag thrown;
+  std::call_once(thrown, [&retcode]() {
+    // Can be called from any thread, attempt a graceful shutdown.
+    std::unique_lock<std::mutex> lock(kShutdownData.request_mutex);
+
+    setShutdownExitCode(retcode);
+    kShutdownData.requested = true;
+    kShutdownData.request_signal.notify_all();
+  });
+}
+
+void requestShutdown(int retcode, const std::string& message) {
+  LOG(ERROR) << message;
+  systemLog(message);
+  requestShutdown(retcode);
+}
+} // namespace osquery

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -97,12 +97,18 @@ FLAG(string,
 
 FLAG(bool, utc, true, "Convert all UNIX times to UTC");
 
+namespace {
+
 const std::vector<std::string> kPlaceholderHardwareUUIDList{
     "00000000-0000-0000-0000-000000000000",
     "03000200-0400-0500-0006-000700080009",
     "03020100-0504-0706-0809-0a0b0c0d0e0f",
     "10000000-0000-8000-0040-000000000000",
 };
+
+/// The time osquery was started.
+std::atomic<size_t> kStartTime{0};
+} // namespace
 
 #ifdef WIN32
 struct tm* gmtime_r(time_t* t, struct tm* result) {
@@ -571,6 +577,14 @@ Status setThreadName(const std::string& name) {
 #else
   return Status::failure("setThreadName not supported on this OS");
 #endif
+}
+
+void setStartTime(size_t st) {
+  kStartTime = st;
+}
+
+size_t getStartTime() {
+  return kStartTime;
 }
 
 bool checkPlatform(const std::string& platform) {

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -21,7 +21,7 @@ DECLARE_bool(disable_database);
 class TablesTests : public testing::Test {
 protected:
  void SetUp() {
-   Initializer::platformSetup();
+   platformSetup();
    registryAndPluginInit();
    FLAGS_disable_database = true;
    DatabasePlugin::setAllowOpen(true);

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -28,7 +28,7 @@ DECLARE_bool(disable_database);
 class WatcherTests : public testing::Test {
  protected:
   WatcherTests() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/core/tests/windows/wmi_tests.cpp
+++ b/osquery/core/tests/windows/wmi_tests.cpp
@@ -26,7 +26,7 @@ namespace osquery {
 class WmiTests : public testing::Test {
  protected:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
   }
 };
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -304,7 +304,7 @@ void WatcherRunner::watchExtensions() {
 }
 
 size_t WatcherRunner::delayedTime() const {
-  return Config::getStartTime() + FLAGS_watchdog_delay;
+  return getStartTime() + FLAGS_watchdog_delay;
 }
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -118,8 +118,13 @@ class Watcher : private boost::noncopyable {
     return worker_status_;
   }
 
-  /// Add extensions autoloadable paths.
-  void addExtensionPath(const std::string& path);
+  /**
+   * @brief Call the loadExtensions global method.
+   *
+   * The watcher is the only 'user' of autoloadable extensions. It will start
+   * each process and optionally monitor the performance.
+   */
+  void loadExtensions();
 
   /// Lock access to extensions.
   void lock() {
@@ -221,9 +226,6 @@ class Watcher : private boost::noncopyable {
   /// Keep a list of resolved extension paths and their managed pids.
   ExtensionMap extensions_;
 
-  /// Paths to autoload extensions.
-  std::vector<std::string> extensions_paths_;
-
   /// Bind the fate of the watcher to the worker.
   std::atomic<bool> restart_worker_{true};
 
@@ -242,26 +244,6 @@ class Watcher : private boost::noncopyable {
 
  private:
   friend class WatcherRunner;
-};
-
-/**
- * @brief A scoped locker for iterating over watcher extensions.
- *
- * A lock must be used if any part of osquery wants to enumerate the autoloaded
- * extensions or autoloadable extension paths a Watcher may be monitoring.
- * A signal or WatcherRunner thread may stop or start extensions.
- */
-class WatcherExtensionsLocker {
- public:
-  /// Construct and gain watcher lock.
-  WatcherExtensionsLocker() {
-    Watcher::get().lock();
-  }
-
-  /// Destruct and release watcher lock.
-  ~WatcherExtensionsLocker() {
-    Watcher::get().unlock();
-  }
 };
 
 /**

--- a/osquery/core/windows/platform.cpp
+++ b/osquery/core/windows/platform.cpp
@@ -13,7 +13,7 @@
 
 namespace osquery {
 
-void Initializer::platformSetup() {
+void platformSetup() {
   // Initialize the COM libraries utilized by Windows WMI calls.
   auto ret = ::CoInitializeEx(0, COINIT_MULTITHREADED);
   if (ret != S_OK) {
@@ -21,7 +21,7 @@ void Initializer::platformSetup() {
   }
 }
 
-void Initializer::platformTeardown() {
+void platformTeardown() {
   // Before we shutdown, we must insure to free the COM libs in windows
   ::CoUninitialize();
 }

--- a/osquery/database/tests/database.cpp
+++ b/osquery/database/tests/database.cpp
@@ -26,7 +26,7 @@ DECLARE_bool(disable_database);
 class DatabaseTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -21,6 +21,8 @@
 #include <osquery/process/process.h>
 #include <osquery/profiler/code_profiler.h>
 #include <osquery/query.h>
+#include <osquery/shutdown.h>
+
 #include <osquery/utils/system/time.h>
 
 #include "osquery/dispatcher/scheduler.h"
@@ -139,7 +141,7 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
       std::string message = "Error adding new results to database for query " +
                             name + ": " + status.what();
       // If the database is not available then the daemon cannot continue.
-      Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
+      requestShutdown(EXIT_CATASTROPHIC, message);
     }
   } else {
     diff_results.added = std::move(sql.rowsTyped());
@@ -161,7 +163,7 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
     // If log directory is not available, then the daemon shouldn't continue.
     std::string message = "Error logging the results of query: " + name + ": " +
                           status.toString();
-    Initializer::requestShutdown(EXIT_CATASTROPHIC, message);
+    requestShutdown(EXIT_CATASTROPHIC, message);
   }
   return status;
 }

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -26,7 +26,7 @@ DECLARE_uint64(schedule_reload);
 
 class SchedulerTests : public testing::Test {
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -30,7 +30,7 @@ DECLARE_string(distributed_tls_write_endpoint);
 class DistributedTests : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -122,7 +122,7 @@ void EventSubscriberPlugin::genTable(RowYield& yield, QueryContext& context) {
         stop = std::min(stop, expr);
       }
     }
-  } else if (Initializer::isDaemon() && FLAGS_events_optimize) {
+  } else if (isDaemon() && FLAGS_events_optimize) {
     // If the daemon is querying a subscriber without a 'time' constraint and
     // allows optimization, only emit events since the last query.
     std::string query_name;

--- a/osquery/events/tests/darwin/fsevents_tests.cpp
+++ b/osquery/events/tests/darwin/fsevents_tests.cpp
@@ -45,7 +45,7 @@ class FSEventsTests : public testing::Test {
   void SetUp() override {
     fs::create_directories(real_test_dir);
 
-    kToolType = ToolType::TEST;
+    setToolType(ToolType::TEST);
     registryAndPluginInit();
 
     FLAGS_disable_database = true;

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -363,8 +363,8 @@ TEST_F(EventsDatabaseTests, test_optimize) {
   }
 
   // Lie about the tool type to enable optimizations.
-  auto default_type = kToolType;
-  kToolType = ToolType::DAEMON;
+  auto default_type = getToolType();
+  setToolType(ToolType::DAEMON);
   FLAGS_events_optimize = true;
 
   // Must also define an executing query.
@@ -394,7 +394,7 @@ TEST_F(EventsDatabaseTests, test_optimize) {
   EXPECT_EQ(std::to_string(sub->optimize_time_), content);
 
   // Restore the tool type.
-  kToolType = default_type;
+  setToolType(default_type);
 }
 
 TEST_F(EventsDatabaseTests, test_expire_check) {

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -24,7 +24,7 @@ DECLARE_bool(disable_database);
 class EventsTests : public ::testing::Test {
  protected:
   void SetUp() override {
-    kToolType = ToolType::TEST;
+    setToolType(ToolType::TEST);
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -32,7 +32,7 @@ const int kMaxEventLatency = 3000;
 class INotifyTests : public testing::Test {
  protected:
   void SetUp() override {
-    kToolType = ToolType::TEST;
+    setToolType(ToolType::TEST);
     registryAndPluginInit();
 
     FLAGS_disable_database = true;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -16,7 +16,6 @@
 #include <boost/optional.hpp>
 
 #include <osquery/core.h>
-#include <osquery/core/watcher.h>
 #include <osquery/extensions/interface.h>
 #include <osquery/filesystem/fileops.h>
 #include <osquery/filesystem/filesystem.h>
@@ -38,21 +37,26 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-// Millisecond latency between initializing manager pings.
-const size_t kExtensionInitializeLatency = 20;
-
 enum class ExtendableType {
   EXTENSION = 1,
 };
 
 using ExtendableTypeSet = std::map<ExtendableType, std::set<std::string>>;
 
+namespace {
+
+/// Map of acceptable file extensions for extension binaries.
 const std::map<PlatformType, ExtendableTypeSet> kFileExtensions{
     {PlatformType::TYPE_WINDOWS,
      {{ExtendableType::EXTENSION, {".exe", ".ext"}}}},
     {PlatformType::TYPE_LINUX, {{ExtendableType::EXTENSION, {".ext"}}}},
     {PlatformType::TYPE_OSX, {{ExtendableType::EXTENSION, {".ext"}}}},
 };
+
+/// Millisecond latency between initializing manager pings.
+const size_t kExtensionInitializeLatency{20};
+
+} // namespace
 
 CLI_FLAG(bool, disable_extensions, false, "Disable extension API");
 
@@ -371,19 +375,16 @@ void initShellSocket(const std::string& homedir) {
   }
 }
 
-void loadExtensions() {
+std::set<std::string> loadExtensions() {
   // Disabling extensions will disable autoloading.
   if (FLAGS_disable_extensions) {
-    return;
+    return {};
   }
 
   // Optionally autoload extensions, sanitize the binary path and inform
   // the osquery watcher to execute the extension when started.
-  auto status = loadExtensions(
+  return loadExtensions(
       fs::path(FLAGS_extensions_autoload).make_preferred().string());
-  if (!status.ok()) {
-    VLOG(1) << "Could not autoload extensions: " << status.what();
-  }
 }
 
 static bool isFileSafe(std::string& path, ExtendableType type) {
@@ -437,20 +438,21 @@ static bool isFileSafe(std::string& path, ExtendableType type) {
   return true;
 }
 
-Status loadExtensions(const std::string& loadfile) {
+std::set<std::string> loadExtensions(const std::string& loadfile) {
+  std::set<std::string> autoload_binaries;
   if (!FLAGS_extension.empty()) {
     // This is a shell-only development flag for quickly loading/using a single
     // extension. It bypasses the safety check.
-    Watcher::get().addExtensionPath(FLAGS_extension);
+    autoload_binaries.insert(FLAGS_extension);
   }
 
   std::string autoload_paths;
-  if (!readFile(loadfile, autoload_paths).ok()) {
-    return Status(1, "Failed reading: " + loadfile);
+  auto status = readFile(loadfile, autoload_paths);
+  if (!status.ok()) {
+    VLOG(1) << "Could not autoload extensions: " << status.what();
   }
 
   // The set of binaries to auto-load, after safety is confirmed.
-  std::set<std::string> autoload_binaries;
   for (auto& path : osquery::split(autoload_paths, "\n")) {
     if (isDirectory(path)) {
       std::vector<std::string> paths;
@@ -465,12 +467,7 @@ Status loadExtensions(const std::string& loadfile) {
     }
   }
 
-  for (const auto& binary : autoload_binaries) {
-    // After the path is sanitized the watcher becomes responsible for
-    // forking and executing the extension binary.
-    Watcher::get().addExtensionPath(binary);
-  }
-  return Status::success();
+  return autoload_binaries;
 }
 
 Status startExtension(const std::string& name, const std::string& version) {
@@ -566,6 +563,7 @@ Status startExtension(const std::string& manager_path,
           << sdk_version << ") registered";
   return Status(0, std::to_string(uuid));
 }
+
 Status ExternalSQLPlugin::query(const std::string& query,
                                 QueryData& results,
                                 bool use_cache) const {

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -24,8 +24,10 @@
 #include <osquery/logger.h>
 #include <osquery/process/process.h>
 #include <osquery/registry.h>
+#include <osquery/shutdown.h>
 #include <osquery/sql.h>
 #include <osquery/system.h>
+
 #include <osquery/utils/config/default_paths.h>
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
@@ -244,7 +246,7 @@ void ExtensionWatcher::exitFatal(int return_code) {
   // Exit the extension.
   // We will save the wanted return code and raise an interrupt.
   // This interrupt will be handled by the main thread then join the watchers.
-  Initializer::requestShutdown(return_code);
+  requestShutdown(return_code);
 }
 
 void ExtensionWatcher::watch() {

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -15,8 +15,9 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
-#include <osquery/system.h>
+#include <osquery/shutdown.h>
 #include <osquery/sql.h>
+#include <osquery/system.h>
 
 #include "osquery/extensions/interface.h"
 
@@ -57,7 +58,7 @@ Status ExtensionInterface::call(const std::string& registry,
 void ExtensionInterface::shutdown() {
   // Request a graceful shutdown of the Thrift listener.
   VLOG(1) << "Extension " << uuid_ << " requested shutdown";
-  Initializer::requestShutdown(EXIT_SUCCESS);
+  requestShutdown(EXIT_SUCCESS);
 }
 
 ExtensionList ExtensionManagerInterface::extensions() {

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -41,7 +41,7 @@ const int kTimeout = 3000;
 class ExtensionsTest : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/include/osquery/extensions.h
+++ b/osquery/include/osquery/extensions.h
@@ -20,9 +20,6 @@ DECLARE_string(extensions_autoload);
 DECLARE_string(extensions_timeout);
 DECLARE_bool(disable_extensions);
 
-/// A millisecond internal applied to extension initialization.
-extern const size_t kExtensionInitializeLatency;
-
 /**
  * @brief Helper struct for managing extension metadata.
  *
@@ -83,7 +80,7 @@ Status pingExtension(const std::string& path);
 Status applyExtensionDelay(std::function<Status(bool& stop)> predicate);
 
 /**
- * @brief Request the extensions API to autoload any appropriate extensions.
+ * @brief Read the autoload flags and return a set of autoload paths.
  *
  * Extensions may be 'autoloaded' using the `extensions_autoload` command line
  * argument. loadExtensions should be called before any plugin or registry item
@@ -93,32 +90,14 @@ Status applyExtensionDelay(std::function<Status(bool& stop)> predicate);
  * path with file ownership equivalent or greater (root) than the osquery
  * process requesting autoload.
  */
-void loadExtensions();
+std::set<std::string> loadExtensions();
 
 /**
- * @brief Load extensions from a delimited search path string.
+ * @brief Load extensions from a specific search path.
  *
- * @param loadfile Path to file containing newline delimited file paths
+ * @param loadfile Path to file containing newline delimited file paths.
  */
-Status loadExtensions(const std::string& loadfile);
-
-/**
- * @brief Request the extensions API to autoload any appropriate modules.
- *
- * Extension modules are shared libraries that add Plugins to the osquery
- * core's registry at runtime.
- */
-void loadModules();
-
-/**
- * @brief Load extension modules from a delimited search path string.
- *
- * @param loadfile Path to file containing newline delimited file paths
- */
-Status loadModules(const std::string& loadfile);
-
-/// Load all modules in a directory.
-Status loadModuleFile(const std::string& path);
+std::set<std::string> loadExtensions(const std::string& loadfile);
 
 /**
  * @brief Initialize the extensions socket path variable for osqueryi.

--- a/osquery/include/osquery/shutdown.h
+++ b/osquery/include/osquery/shutdown.h
@@ -1,0 +1,65 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <csignal>
+#include <string>
+
+namespace osquery {
+
+/**
+ * @brief The requested exit code.
+ *
+ * Use requestShutdown to request shutdown in most cases.
+ */
+int getShutdownExitCode();
+
+/**
+ * @brief Set the requested exit code.
+ *
+ * Use requestShutdown to request shutdown in most cases.
+ */
+void setShutdownExitCode(int retcode);
+
+/**
+ * @brief Wait until a #requestShutdown is issued.
+ *
+ * The #requestShutdown method is called in a signal handler or service
+ * stop event. It may also be called by osquery internal components if an
+ * unrecoverable error occurs.
+ *
+ * This method should be called before Initializer::shutdown.
+ */
+void waitForShutdown();
+
+/**
+ * @brief Forcefully request the application to stop.
+ *
+ * Since all osquery tools may implement various 'dispatched' services in the
+ * form of event handler threads or thrift service and client pools, a stop
+ * request should behave nicely and request these services stop.
+ *
+ * Use shutdown whenever you would normally call stdlib exit.
+ *
+ * @param retcode the requested return code for the process.
+ */
+void requestShutdown(int retcode = EXIT_SUCCESS);
+
+/**
+ * @brief Forcefully request the application to stop.
+ *
+ * See #requestShutdown, this overloaded alternative allows the caller to
+ * also log a reason/message to the system log. This is intended for extreme
+ * failure cases and thus requires an explicit error code.
+ *
+ * @param retcode the request return code for the process.
+ * @param system_log A log line to write to the system's log.
+ */
+void requestShutdown(int retcode, const std::string& system_log);
+} // namespace osquery

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -99,41 +99,14 @@ class Initializer : private boost::noncopyable {
    */
   int shutdown(int retcode) const;
 
-  /**
-   * @brief Wait until a #requestShutdown is issued.
-   *
-   * The #requestShutdown method is called in a signal handler or service
-   * stop event. It may also be called by osquery internal components if an
-   * unrecoverable error occurs.
-   *
-   * This method should be called before #shutdown.
-   */
+  /// For compatibility. See the global method waitForShutdown.
   void waitForShutdown() const;
 
  public:
-  /**
-   * @brief Forcefully request the application to stop.
-   *
-   * Since all osquery tools may implement various 'dispatched' services in the
-   * form of event handler threads or thrift service and client pools, a stop
-   * request should behave nicely and request these services stop.
-   *
-   * Use shutdown whenever you would normally call stdlib exit.
-   *
-   * @param retcode the requested return code for the process.
-   */
+  /// For compatibility. See the global method requestShutdown.
   static void requestShutdown(int retcode = EXIT_SUCCESS);
 
-  /**
-   * @brief Forcefully request the application to stop.
-   *
-   * See #requestShutdown, this overloaded alternative allows the caller to
-   * also log a reason/message to the system log. This is intended for extreme
-   * failure cases and thus requires an explicit error code.
-   *
-   * @param retcode the request return code for the process.
-   * @param system_log A log line to write to the system's log.
-   */
+  /// For compatibility. See the global method requestShutdown.
   static void requestShutdown(int retcode, const std::string& system_log);
 
   /// Exit immediately without requesting the dispatcher to stop.

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -126,16 +126,6 @@ class Initializer : private boost::noncopyable {
    */
   static void platformTeardown();
 
-  /// Check the program is the osquery daemon.
-  static bool isDaemon() {
-    return kToolType == ToolType::DAEMON;
-  }
-
-  /// Check the program is the osquery shell.
-  static bool isShell() {
-    return kToolType == ToolType::SHELL;
-  }
-
   /**
    * @brief Check if a process is an osquery worker.
    *

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -267,5 +267,11 @@ bool isUserAdmin();
  */
 Status setThreadName(const std::string& name);
 
+/// Get the osquery tool start time.
+size_t getStartTime();
+
+/// Set the osquery tool start time.
+void setStartTime(size_t st);
+
 bool checkPlatform(const std::string& platform);
 } // namespace osquery

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -113,20 +113,6 @@ class Initializer : private boost::noncopyable {
   static void shutdownNow(int retcode = EXIT_SUCCESS);
 
   /**
-   * @brief Initialize any platform dependent libraries or objects
-   *
-   * On windows, we require the COM libraries be initialized just once
-   */
-  static void platformSetup();
-
-  /**
-   * @brief Before ending, tear down any platform specific setup
-   *
-   * On windows, we require the COM libraries be initialized just once
-   */
-  static void platformTeardown();
-
-  /**
    * @brief Check if a process is an osquery worker.
    *
    * By default an osqueryd process will fork/exec then set an environment
@@ -272,6 +258,20 @@ size_t getStartTime();
 
 /// Set the osquery tool start time.
 void setStartTime(size_t st);
+
+/**
+ * @brief Initialize any platform dependent libraries or objects.
+ *
+ * On windows, we require the COM libraries be initialized just once.
+ */
+void platformSetup();
+
+/**
+ * @brief Before ending, tear down any platform specific setup.
+ *
+ * On windows, we require the COM libraries be initialized just once.
+ */
+void platformTeardown();
 
 bool checkPlatform(const std::string& platform);
 } // namespace osquery

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -219,7 +219,7 @@ void setVerboseLevel() {
     /* We use a different default for the log level if running as a daemon or if
      * running as a shell. If the flag was set we just use that in both cases.
      */
-    if (Flag::isDefault("logger_min_status") && Initializer::isShell()) {
+    if (Flag::isDefault("logger_min_status") && isShell()) {
       FLAGS_minloglevel = google::GLOG_WARNING;
     } else {
       FLAGS_minloglevel = Flag::getInt32Value("logger_min_status");
@@ -325,7 +325,7 @@ void BufferedLogSink::send(google::LogSeverity severity,
   }
 
   // The daemon will relay according to the schedule.
-  if (enabled_ && !Initializer::isDaemon()) {
+  if (enabled_ && !isDaemon()) {
     relayStatusLogs(FLAGS_logger_status_sync);
   }
 }

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -34,7 +34,7 @@ DECLARE_bool(logger_numerics);
 class LoggerTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -476,8 +476,8 @@ TEST_F(LoggerTests, test_recursion) {
   EXPECT_EQ(3U, plugin->statuses);
 
   // Try again with the tool type as a daemon.
-  auto tool_type = kToolType;
-  kToolType = ToolType::DAEMON;
+  auto tool_type = getToolType();
+  setToolType(ToolType::DAEMON);
   LOG(WARNING) << "recurse";
 
   // The daemon calls the status relay within the scheduler.
@@ -488,7 +488,7 @@ TEST_F(LoggerTests, test_recursion) {
   EXPECT_EQ(4U, plugin->statuses);
   relayStatusLogs(true);
   EXPECT_EQ(5U, plugin->statuses);
-  kToolType = tool_type;
+  setToolType(tool_type);
 
   EXPECT_EQ(0U, queuedStatuses());
   EXPECT_EQ(0U, queuedSenders());

--- a/osquery/main/CMakeLists.txt
+++ b/osquery/main/CMakeLists.txt
@@ -36,6 +36,7 @@ function(generateOsqueryMain)
     osquery_cxx_settings
     osquery_headers
     osquery_core
+    osquery_core_init
     osquery_core_plugins
     osquery_core_sql
     osquery_database

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -178,7 +178,7 @@ int startOsquery(int argc, char* argv[]) {
 
   // Only worker processes should start a daemon or shell.
   if (!runner.isWatcher()) {
-    if (runner.isDaemon()) {
+    if (isDaemon()) {
       startDaemon(runner);
     } else {
       retcode = startShell(runner, argc, argv);

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -23,6 +23,7 @@
 #include <osquery/system.h>
 #include <osquery/utils/config/default_paths.h>
 #include <osquery/utils/system/system.h>
+#include <osquery/shutdown.h>
 
 DECLARE_string(flagfile);
 
@@ -295,7 +296,7 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
     // Give the main thread a chance to shutdown gracefully before exiting
     UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 3, kServiceShutdownWait);
 
-    Initializer::requestShutdown();
+    requestShutdown();
     auto thread = OpenThread(SYNCHRONIZE, false, kLegacyThreadId);
     if (thread != nullptr) {
       WaitForSingleObjectEx(thread, INFINITE, FALSE);

--- a/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
@@ -30,7 +30,7 @@ DECLARE_bool(disable_database);
 class NumericMonitoringTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -29,7 +29,7 @@ DECLARE_bool(disable_database);
 class EnrollTests : public testing::Test {
  public:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -52,7 +52,7 @@ class TLSTransportsTests : public testing::Test {
   }
 
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/sdk/CMakeLists.txt
+++ b/osquery/sdk/CMakeLists.txt
@@ -20,6 +20,7 @@ function(generateOsquerySdkPluginsdk)
     osquery_cxx_settings
     osquery_headers
     osquery_config
+    osquery_core_init
     osquery_dispatcher
     osquery_events_eventsregistry
     osquery_experimental_eventsstream_registry

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -209,7 +209,7 @@ Status mockGetQueryTables(std::string copy_q,
 }
 
 Status getQueryTables(const std::string& q, std::vector<std::string>& tables) {
-  if (kToolType == ToolType::TEST) {
+  if (getToolType() == ToolType::TEST) {
     // We 'mock' this functionality for internal tests.
     return mockGetQueryTables(q, tables);
   }

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -24,7 +24,7 @@ extern void escapeNonPrintableBytesEx(std::string& data);
 class SQLTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
   }
 };

--- a/osquery/sql/tests/sqlite_hashing_tests.cpp
+++ b/osquery/sql/tests/sqlite_hashing_tests.cpp
@@ -16,7 +16,7 @@ namespace osquery {
 class SQLiteHashingTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
   }
 };

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -24,7 +24,7 @@ namespace osquery {
 class SQLiteUtilTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     Flag::updateValue("enable_tables",
                       "test_table,time,process_events,osquery_info,file,users,"

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -25,7 +25,7 @@ DECLARE_bool(disable_database);
 class VirtualTableTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -970,7 +970,7 @@ static int xFilter(sqlite3_vtab_cursor* pVtabCursor,
 
   // Provide a helpful reference to table documentation within the shell.
   if ((!user_based_satisfied || !required_satisfied || !events_satisfied)) {
-    if (Initializer::isShell()) {
+    if (isShell()) {
       LOG(WARNING) << "Please see the table documentation: "
                    << table_doc(pVtab->content->name);
     }

--- a/osquery/system/network/tests/host_identity.cpp
+++ b/osquery/system/network/tests/host_identity.cpp
@@ -25,7 +25,7 @@ class HostIdentityTests : public testing::Test {
  public:
   void SetUp() override {
     FLAGS_disable_database = true;
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     DatabasePlugin::initPlugin();
   }

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -29,7 +29,7 @@ class FileEventSubscriber;
 class FileEventsTableTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -103,7 +103,7 @@ QueryData parseEtcProtocolsContent(const std::string& content);
 class NetworkingTablesTests : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/osquery/tables/system/tests/posix/augeas_tests.cpp
+++ b/osquery/tables/system/tests/posix/augeas_tests.cpp
@@ -22,7 +22,7 @@ namespace tables {
 class AugeasTests : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -30,7 +30,7 @@ namespace tables {
 class SystemsTablesTests : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/tables/system/tests/windows/certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/certificates_tests.cpp
@@ -25,7 +25,7 @@ namespace tables {
 class CertificatesTablesTest : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     FLAGS_disable_database = true;

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -23,7 +23,7 @@ namespace tables {
 class RegistryTablesTest : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/osquery/tables/utility/CMakeLists.txt
+++ b/osquery/tables/utility/CMakeLists.txt
@@ -19,6 +19,7 @@ function(generateTablesUtilityUtilitytable)
     osquery_cxx_settings
     osquery_config
     osquery_core
+    osquery_core_init
     osquery_filesystem
     osquery_process
     osquery_utils_macros

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -210,7 +210,7 @@ QueryData genOsqueryInfo(QueryContext& context) {
       (pingExtension(FLAGS_extensions_socket).ok()) ? "active" : "inactive";
   r["build_platform"] = STR(OSQUERY_BUILD_PLATFORM);
   r["build_distro"] = STR(OSQUERY_BUILD_DISTRO);
-  r["start_time"] = INTEGER(Config::getStartTime());
+  r["start_time"] = INTEGER(getStartTime());
   if (Initializer::isWorker()) {
     r["watcher"] = INTEGER(PlatformProcess::getLauncherProcess()->pid());
   } else {

--- a/osquery/utils/info/tool_type.cpp
+++ b/osquery/utils/info/tool_type.cpp
@@ -7,3 +7,29 @@
  */
 
 #include <osquery/utils/info/tool_type.h>
+
+namespace osquery {
+
+namespace {
+
+/// Current tool type.
+ToolType kToolType{ToolType::UNKNOWN};
+
+} // namespace
+
+void setToolType(ToolType tool) {
+  kToolType = tool;
+}
+
+ToolType getToolType() {
+  return kToolType;
+}
+
+bool isDaemon() {
+  return kToolType == ToolType::DAEMON;
+}
+
+bool isShell() {
+  return kToolType == ToolType::SHELL;
+}
+} // namespace osquery

--- a/osquery/utils/info/tool_type.h
+++ b/osquery/utils/info/tool_type.h
@@ -9,21 +9,31 @@
 #pragma once
 
 namespace osquery {
-  /**
-   * @brief A helpful tool type to report when logging, print help, or debugging.
-   *
-   * The Initializer class attempts to detect the ToolType using the tool name
-   * and some compile time options.
-   */
-  enum class ToolType {
-    UNKNOWN = 0,
-    SHELL,
-    DAEMON,
-    TEST,
-    EXTENSION,
-    SHELL_DAEMON,
-  };
 
-  /// The osquery tool type for runtime decisions.
-  extern ToolType kToolType;
+/**
+ * @brief A helpful tool type to report when logging, print help, or debugging.
+ *
+ * The Initializer class attempts to detect the ToolType using the tool name
+ * and some compile time options.
+ */
+enum class ToolType {
+  UNKNOWN = 0,
+  SHELL,
+  DAEMON,
+  TEST,
+  EXTENSION,
+  SHELL_DAEMON,
+};
+
+/// Set the osquery tool type for runtime behavior decisions.
+void setToolType(ToolType tool);
+
+/// Get the osquery tool type for runtime behavior decisions.
+ToolType getToolType();
+
+/// Check the program is the osquery daemon.
+bool isDaemon();
+
+/// Check the program is the osquery shell.
+bool isShell();
 }

--- a/osquery/worker/ipc/linux/tests/worker_table_container_tests.cpp
+++ b/osquery/worker/ipc/linux/tests/worker_table_container_tests.cpp
@@ -27,7 +27,7 @@ class WorkerTableContainerTests : public testing::Test {
     FLAGS_minloglevel = google::GLOG_INFO;
     FLAGS_alsologtostderr = true;
     FLAGS_v = 1;
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
   }
 };

--- a/plugins/config/parsers/tests/decorators_tests.cpp
+++ b/plugins/config/parsers/tests/decorators_tests.cpp
@@ -26,7 +26,7 @@ DECLARE_bool(logger_numerics);
 class DecoratorsConfigParserPluginTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/plugins/config/parsers/tests/events_parser_tests.cpp
+++ b/plugins/config/parsers/tests/events_parser_tests.cpp
@@ -25,7 +25,7 @@ DECLARE_bool(disable_database);
 class EventsConfigParserPluginTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/plugins/config/parsers/tests/file_paths_tests.cpp
+++ b/plugins/config/parsers/tests/file_paths_tests.cpp
@@ -28,7 +28,7 @@ DECLARE_bool(disable_database);
 class FilePathsConfigParserPluginTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/plugins/config/parsers/tests/options_tests.cpp
+++ b/plugins/config/parsers/tests/options_tests.cpp
@@ -24,7 +24,7 @@ FLAG(bool, test_options_race_parser, false, "");
 class OptionsConfigParserPluginTests : public testing::Test {
  protected:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
 
     // Force registry to use ephemeral database plugin

--- a/plugins/config/parsers/tests/views_tests.cpp
+++ b/plugins/config/parsers/tests/views_tests.cpp
@@ -25,7 +25,7 @@ class ViewsConfigParserPluginTests : public testing::Test {
     static bool initialized = false;
     if (!initialized) {
       initialized = true;
-      Initializer::platformSetup();
+      platformSetup();
       registryAndPluginInit();
 
       // Force registry to use ephemeral database plugin

--- a/plugins/config/tests/tls_config_tests.cpp
+++ b/plugins/config/tests/tls_config_tests.cpp
@@ -36,7 +36,7 @@ DECLARE_bool(disable_database);
 class TLSConfigTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/database/tests/utils.cpp
+++ b/plugins/database/tests/utils.cpp
@@ -36,7 +36,7 @@ class EphemeralDatabasePluginTests : public DatabasePluginTests {
 CREATE_DATABASE_TESTS(EphemeralDatabasePluginTests);
 
 void DatabasePluginTests::SetUp() {
-  Initializer::platformSetup();
+  platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
   DatabasePlugin::setAllowOpen(true);

--- a/plugins/logger/tests/aws_kinesis_logger_tests.cpp
+++ b/plugins/logger/tests/aws_kinesis_logger_tests.cpp
@@ -33,7 +33,7 @@ DECLARE_bool(disable_database);
 class AwsLoggerTests : public testing::Test {
  protected:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/logger/tests/buffered_tests.cpp
+++ b/plugins/logger/tests/buffered_tests.cpp
@@ -53,7 +53,7 @@ MATCHER_P(MatchesStatus, expected, "") {
 class BufferedLogForwarderTests : public Test {
  protected:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/logger/tests/filesystem_logger.cpp
+++ b/plugins/logger/tests/filesystem_logger.cpp
@@ -37,7 +37,7 @@ DECLARE_bool(logger_numerics);
 class FilesystemLoggerTests : public testing::Test {
  public:
   void SetUp() override {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/logger/tests/kafka_producer_tests.cpp
+++ b/plugins/logger/tests/kafka_producer_tests.cpp
@@ -76,7 +76,7 @@ class MockKafkaProducerPlugin : public KafkaProducerPlugin {
 class KafkaProducerPluginTest : public ::testing::Test {
  protected:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/logger/tests/syslog_logger_tests.cpp
+++ b/plugins/logger/tests/syslog_logger_tests.cpp
@@ -18,7 +18,7 @@ namespace osquery {
 class SyslogLoggerTests : public testing::Test {
 protected:
  void SetUp() {
-   Initializer::platformSetup();
+   platformSetup();
    registryAndPluginInit();
  }
 };

--- a/plugins/logger/tests/tls_logger_tests.cpp
+++ b/plugins/logger/tests/tls_logger_tests.cpp
@@ -22,7 +22,7 @@ DECLARE_bool(disable_database);
 class TLSLoggerTests : public testing::Test {
  protected:
   void SetUp() {
-    Initializer::platformSetup();
+    platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
     DatabasePlugin::setAllowOpen(true);

--- a/plugins/remote/enroll/tests/tls_enroll_tests.cpp
+++ b/plugins/remote/enroll/tests/tls_enroll_tests.cpp
@@ -47,7 +47,7 @@ class TLSEnrollTests : public testing::Test {
 };
 
 void TLSEnrollTests::SetUp() {
-  Initializer::platformSetup();
+  platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
   DatabasePlugin::setAllowOpen(true);

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -325,7 +325,7 @@ void validate_container_rows(const std::string& table_name,
 }
 
 void setUpEnvironment() {
-  Initializer::platformSetup();
+  platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
   DatabasePlugin::setAllowOpen(true);

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -117,13 +117,13 @@ void initTesting() {
   DatabasePlugin::setAllowOpen(true);
   DatabasePlugin::initPlugin();
 
-  Initializer::platformSetup();
+  platformSetup();
 }
 
 void shutdownTesting() {
   DatabasePlugin::shutdown();
 
-  Initializer::platformTeardown();
+  platformTeardown();
 }
 
 ScheduledQuery getOsqueryScheduledQuery() {

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -55,7 +55,7 @@ using chrono_clock = std::chrono::high_resolution_clock;
 void initTesting() {
   Config::setStartTime(getUnixTime());
 
-  kToolType = ToolType::TEST;
+  setToolType(ToolType::TEST);
   if (osquery::isPlatform(PlatformType::TYPE_OSX)) {
     kTestWorkingDirectory = "/private/tmp/osquery-tests";
   } else {

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -53,7 +53,7 @@ DECLARE_bool(disable_database);
 using chrono_clock = std::chrono::high_resolution_clock;
 
 void initTesting() {
-  Config::setStartTime(getUnixTime());
+  setStartTime(getUnixTime());
 
   setToolType(ToolType::TEST);
   if (osquery::isPlatform(PlatformType::TYPE_OSX)) {


### PR DESCRIPTION
The goal is to have less inter-dependency within osquery components.
This is the first of several changes that take small steps towards a
simpler dependency graph.

Later we can revisit the directory structure to see if we can convey
what components are intended to be widely used and what components
are specialized.

See https://github.com/osquery/osquery/issues/5990.