### PR TITLE
build: Support ASAN for boost coroutine2 using ucontext

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -205,6 +205,13 @@ function(setupBuildFlags)
         -fsanitize-coverage=edge,indirect-calls
       )
 
+      # Support ASAN within coroutines2.
+      # Note that __ucontext__ is orders of magnitude slower than __fcontext__.
+      target_compile_definitions(cxx_settings INTERFACE
+        BOOST_USE_UCONTEXT
+        BOOST_USE_ASAN
+      )
+
       # Require at least address (may be refactored out)
       target_link_options(cxx_settings INTERFACE
         -fsanitize=address

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -676,6 +676,10 @@ endfunction()
 function(generateBoostContext)
   set(library_root "${BOOST_ROOT}/libs/context")
 
+  set(source_files
+    "${library_root}/src/execution_context.cpp"
+  )
+
   if(DEFINED PLATFORM_LINUX)
     set(asm_source_file_list
       "${library_root}/src/asm/jump_x86_64_sysv_elf_gas.S"
@@ -710,8 +714,14 @@ function(generateBoostContext)
     endif()
   endforeach()
 
+  if(OSQUERY_ENABLE_ADDRESS_SANITIZER)
+    list(APPEND source_files
+      "${library_root}/src/fiber.cpp"
+    )
+  endif()
+
   add_library(thirdparty_boost_context STATIC
-    "${library_root}/src/execution_context.cpp"
+    ${source_files}
     ${asm_source_file_list}
   )
 


### PR DESCRIPTION
```
./osquery/sql/tests/osquery_sql_tests_virtualtabletests-test
Running main() from /home/teddy/git/osquery-prod/build/libs/src/patched-source/googletest/src/googletest/src/gtest_main.cc
[==========] Running 23 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 23 tests from VirtualTableTests
[ RUN      ] VirtualTableTests.test_tableplugin_columndefinition
[       OK ] VirtualTableTests.test_tableplugin_columndefinition (3 ms)
[ RUN      ] VirtualTableTests.test_extension_tableplugin_columndefinition
[       OK ] VirtualTableTests.test_extension_tableplugin_columndefinition (0 ms)
[ RUN      ] VirtualTableTests.test_tableplugin_options
[       OK ] VirtualTableTests.test_tableplugin_options (0 ms)
[ RUN      ] VirtualTableTests.test_tableplugin_moreoptions
[       OK ] VirtualTableTests.test_tableplugin_moreoptions (0 ms)
[ RUN      ] VirtualTableTests.test_tableplugin_additionalonly
[       OK ] VirtualTableTests.test_tableplugin_additionalonly (1 ms)
[ RUN      ] VirtualTableTests.test_tableplugin_aliases
[       OK ] VirtualTableTests.test_tableplugin_aliases (0 ms)
[ RUN      ] VirtualTableTests.test_sqlite3_attach_vtable
[       OK ] VirtualTableTests.test_sqlite3_attach_vtable (92 ms)
[ RUN      ] VirtualTableTests.test_sqlite3_table_joins
[       OK ] VirtualTableTests.test_sqlite3_table_joins (91 ms)
[ RUN      ] VirtualTableTests.test_constraints_stacking
[       OK ] VirtualTableTests.test_constraints_stacking (99 ms)
[ RUN      ] VirtualTableTests.test_json_extract
[       OK ] VirtualTableTests.test_json_extract (88 ms)
[ RUN      ] VirtualTableTests.test_null_values
[       OK ] VirtualTableTests.test_null_values (88 ms)
[ RUN      ] VirtualTableTests.test_table_cache
[       OK ] VirtualTableTests.test_table_cache (91 ms)
[ RUN      ] VirtualTableTests.test_table_results_cache
[       OK ] VirtualTableTests.test_table_results_cache (89 ms)
[ RUN      ] VirtualTableTests.test_table_results_cache_colcheck
[       OK ] VirtualTableTests.test_table_results_cache_colcheck (90 ms)
[ RUN      ] VirtualTableTests.test_yield_generator
==9306==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
[       OK ] VirtualTableTests.test_yield_generator (91 ms)
[ RUN      ] VirtualTableTests.test_like_constraints
[       OK ] VirtualTableTests.test_like_constraints (95 ms)
[ RUN      ] VirtualTableTests.test_indexing_costs
[       OK ] VirtualTableTests.test_indexing_costs (100 ms)
[ RUN      ] VirtualTableTests.test_used_columns
[       OK ] VirtualTableTests.test_used_columns (92 ms)
[ RUN      ] VirtualTableTests.test_used_columns_with_alias
[       OK ] VirtualTableTests.test_used_columns_with_alias (92 ms)
[ RUN      ] VirtualTableTests.test_used_columns_bitset
[       OK ] VirtualTableTests.test_used_columns_bitset (92 ms)
[ RUN      ] VirtualTableTests.test_used_columns_bitset_with_alias
[       OK ] VirtualTableTests.test_used_columns_bitset_with_alias (95 ms)
[ RUN      ] VirtualTableTests.test_used_columns_default
[       OK ] VirtualTableTests.test_used_columns_default (94 ms)
[ RUN      ] VirtualTableTests.test_noindex_constraints
[       OK ] VirtualTableTests.test_noindex_constraints (94 ms)
[----------] 23 tests from VirtualTableTests (1578 ms total)

[----------] Global test environment tear-down
[==========] 23 tests from 1 test case ran. (1578 ms total)
[  PASSED  ] 23 tests.
```