### PR TITLE
Add version comparison functions

### DIFF
--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -23,6 +23,7 @@ function(generateOsquerySql)
     sqlite_math.cpp
     sqlite_operations.cpp
     sqlite_util.cpp
+    sqlite_version.cpp
     virtual_sqlite_table.cpp
     virtual_table.cpp
   )
@@ -47,7 +48,9 @@ function(generateOsquerySql)
     osquery_hashing
     osquery_process
     osquery_utils
+    osquery_utils_conversions
     osquery_utils_system_errno
+    osquery_utils_versioning_semantic
     thirdparty_boost
     thirdparty_googletest_headers
     thirdparty_sqlite

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -289,7 +289,7 @@ static inline void openOptimized(sqlite3*& db) {
   registerFilesystemExtensions(db);
   registerHashingExtensions(db);
   registerEncodingExtensions(db);
-  registerVersionExtensions(db);
+  registerVersionExtensions(db); 
 }
 
 void SQLiteDBInstance::init() {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -289,7 +289,7 @@ static inline void openOptimized(sqlite3*& db) {
   registerFilesystemExtensions(db);
   registerHashingExtensions(db);
   registerEncodingExtensions(db);
-  registerVersionExtensions(db); 
+  registerVersionExtensions(db);
 }
 
 void SQLiteDBInstance::init() {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -289,6 +289,7 @@ static inline void openOptimized(sqlite3*& db) {
   registerFilesystemExtensions(db);
   registerHashingExtensions(db);
   registerEncodingExtensions(db);
+  registerVersionExtensions(db);
 }
 
 void SQLiteDBInstance::init() {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -456,6 +456,11 @@ void registerEncodingExtensions(sqlite3* db);
 void registerFilesystemExtensions(sqlite3* db);
 
 /**
+ * @brief Register version-related 'custom' functions.
+ */
+void registerVersionExtensions(sqlite3* db);
+
+/**
  * @brief Generate the data for auto-constructed sqlite tables
  *
  * When auto-constructed sqlite tables are queried, this function

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -26,21 +26,24 @@ int version_collate(void* userdata, // UNUSED
                     const void* a,
                     int blen,
                     const void* b) {
-  auto aVer = tryTo<SemanticVersion>(a);
+
+  std::string aStr((const char*)a);
+  auto aVer = tryTo<SemanticVersion>(aStr);
   if (aVer.isError()) {
     LOG(INFO) << "Unable to collate <<" << a
               << ">> as version. Treating as equal\n";
     return 0;
   }
 
-  auto bVer = tryTo<SemanticVersion>(b);
+  std::string bStr((const char*)b);
+  auto bVer = tryTo<SemanticVersion>(bStr);
   if (bVer.isError()) {
     LOG(INFO) << "Unable to collate <<" << b
               << ">> as version. Treating as equal\n";
     return 0;
   }
 
-  return aVer.compare(bVer);
+  return aVer.get().compare(bVer.get());
 }
 
 void registerVersionExtensions(sqlite3* db) {

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -1,0 +1,55 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <assert.h>
+
+#include <osquery/logger.h>
+#include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/versioning/semantic.h>
+
+#include <string>
+
+#include <sqlite3.h>
+
+namespace osquery {
+
+// The collating function must return an integer that is negative,
+// zero, or positive if the first string is less than, equal to, or
+// greater than the second, respectively
+int version_collate(void* userdata, // UNUSED
+                    int alen,
+                    const void* a,
+                    int blen,
+                    const void* b) {
+  auto aVer = tryTo<SemanticVersion>(a);
+  if (aVer.isError()) {
+    LOG(INFO) << "Unable to collate <<" << a
+              << ">> as version. Treating as equal\n";
+    return 0;
+  }
+
+  auto bVer = tryTo<SemanticVersion>(b);
+  if (bVer.isError()) {
+    LOG(INFO) << "Unable to collate <<" << b
+              << ">> as version. Treating as equal\n";
+    return 0;
+  }
+
+  return aVer.compare(bVer);
+}
+
+void registerVersionExtensions(sqlite3* db) {
+  sqlite3_create_collation(
+      db,
+      "VERSION",
+      SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
+      nullptr,
+      version_collate);
+}
+
+} // namespace osquery

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -30,7 +30,7 @@ int version_collate(void* userdata, // UNUSED
   std::string aStr((const char*)a);
   auto aVer = tryTo<SemanticVersion>(aStr);
   if (aVer.isError()) {
-    LOG(INFO) << "Unable to collate <<" << a
+    LOG(INFO) << "Unable to collate <<" << aStr
               << ">> as version. Treating as equal\n";
     return 0;
   }
@@ -38,7 +38,7 @@ int version_collate(void* userdata, // UNUSED
   std::string bStr((const char*)b);
   auto bVer = tryTo<SemanticVersion>(bStr);
   if (bVer.isError()) {
-    LOG(INFO) << "Unable to collate <<" << b
+    LOG(INFO) << "Unable to collate <<" << bStr
               << ">> as version. Treating as equal\n";
     return 0;
   }

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -26,7 +26,6 @@ int version_collate(void* userdata, // UNUSED
                     const void* a,
                     int blen,
                     const void* b) {
-
   std::string aStr((const char*)a);
   auto aVer = tryTo<SemanticVersion>(aStr);
   if (aVer.isError()) {

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -421,4 +421,34 @@ TEST_F(SQLTests, test_sql_ssdeep_compare) {
   EXPECT_EQ(d[0]["test_int"], "68");
 }
 #endif
+
+TEST_F(SQLTests, test_version_collate) {
+  QueryData d;
+  auto status = query("create temp table test_version(v string);", d);
+  ASSERT_TRUE(status.ok());
+
+  auto status = query("insert into 'test_version' values('1');", d);
+  ASSERT_TRUE(status.ok());
+
+  auto status = query("insert into 'test_version' values('1.2.0');", d);
+  ASSERT_TRUE(status.ok());
+
+  auto status = query("insert into 'test_version' values('1.11.0');", d);
+  ASSERT_TRUE(status.ok());
+
+  auto status = query("select * from test_version ORDER BY v;", d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 3U);
+  EXPECT_EQ(d[0]["v"], "1");
+  EXPECT_EQ(d[1]["v"], "1.11.0");
+  EXPECT_EQ(d[2]["v"], "1.2.0");
+
+  auto status =
+      query("select * from test_version ORDER BY v COLLATE VERSION;", d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 3U);
+  EXPECT_EQ(d[0]["v"], "1");
+  EXPECT_EQ(d[1]["v"], "1.2.0");
+  EXPECT_EQ(d[2]["v"], "1.11.0");
+}
 } // namespace osquery

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -443,8 +443,7 @@ TEST_F(SQLTests, test_version_collate) {
   EXPECT_EQ(d[1]["v"], "1.11.0");
   EXPECT_EQ(d[2]["v"], "1.2.0");
 
-  status =
-      query("select * from test_version ORDER BY v COLLATE VERSION;", d);
+  status = query("select * from test_version ORDER BY v COLLATE VERSION;", d);
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(d.size(), 3U);
   EXPECT_EQ(d[0]["v"], "1");
@@ -452,9 +451,10 @@ TEST_F(SQLTests, test_version_collate) {
   EXPECT_EQ(d[2]["v"], "1.11.0");
 }
 
-  TEST_F(SQLTests, test_version_collate_in_table) {
+TEST_F(SQLTests, test_version_collate_in_table) {
   QueryData d;
-  auto status = query("create temp table test_version_2(v string COLLATE VERSION);", d);
+  auto status =
+      query("create temp table test_version_2(v string COLLATE VERSION);", d);
   ASSERT_TRUE(status.ok());
 
   status = query("insert into 'test_version_2' values('2');", d);
@@ -474,5 +474,27 @@ TEST_F(SQLTests, test_version_collate) {
   EXPECT_EQ(d[2]["v"], "2.11.0");
 }
 
-  
+TEST_F(SQLTests, test_version_comparisons) {
+  QueryData d;
+
+  auto status =
+      query("select '2.1.1.1' > '1.1.1.1' COLLATE VERSION as test;", d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  status = query("select '2.11.1.1' > '2.2.1.1' COLLATE VERSION as test;", d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+
+  status = query(
+      "select '0.5.5-22-g85b16ae' > '0.5.5-3-ga7b9229' COLLATE VERSION as "
+      "test;",
+      d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "1");
+}
+
 } // namespace osquery

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -427,23 +427,23 @@ TEST_F(SQLTests, test_version_collate) {
   auto status = query("create temp table test_version(v string);", d);
   ASSERT_TRUE(status.ok());
 
-  auto status = query("insert into 'test_version' values('1');", d);
+  status = query("insert into 'test_version' values('1');", d);
   ASSERT_TRUE(status.ok());
 
-  auto status = query("insert into 'test_version' values('1.2.0');", d);
+  status = query("insert into 'test_version' values('1.2.0');", d);
   ASSERT_TRUE(status.ok());
 
-  auto status = query("insert into 'test_version' values('1.11.0');", d);
+  status = query("insert into 'test_version' values('1.11.0');", d);
   ASSERT_TRUE(status.ok());
 
-  auto status = query("select * from test_version ORDER BY v;", d);
+  status = query("select * from test_version ORDER BY v;", d);
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(d.size(), 3U);
   EXPECT_EQ(d[0]["v"], "1");
   EXPECT_EQ(d[1]["v"], "1.11.0");
   EXPECT_EQ(d[2]["v"], "1.2.0");
 
-  auto status =
+  status =
       query("select * from test_version ORDER BY v COLLATE VERSION;", d);
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(d.size(), 3U);
@@ -451,4 +451,28 @@ TEST_F(SQLTests, test_version_collate) {
   EXPECT_EQ(d[1]["v"], "1.2.0");
   EXPECT_EQ(d[2]["v"], "1.11.0");
 }
+
+  TEST_F(SQLTests, test_version_collate_in_table) {
+  QueryData d;
+  auto status = query("create temp table test_version_2(v string COLLATE VERSION);", d);
+  ASSERT_TRUE(status.ok());
+
+  status = query("insert into 'test_version_2' values('2');", d);
+  ASSERT_TRUE(status.ok());
+
+  status = query("insert into 'test_version_2' values('2.11.0');", d);
+  ASSERT_TRUE(status.ok());
+
+  status = query("insert into 'test_version_2' values('2.2.0');", d);
+  ASSERT_TRUE(status.ok());
+
+  status = query("select * from test_version_2 ORDER BY v;", d);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(d.size(), 3U);
+  EXPECT_EQ(d[0]["v"], "2");
+  EXPECT_EQ(d[1]["v"], "2.2.0");
+  EXPECT_EQ(d[2]["v"], "2.11.0");
+}
+
+  
 } // namespace osquery

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -19,7 +19,7 @@ using boost::io::quoted;
 Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     const std::string& str) {
   auto version = SemanticVersion{};
-  
+
   auto const major_number_pos = str.find(SemanticVersion::separator);
   {
     if (major_number_pos == std::string::npos) {
@@ -37,7 +37,7 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     }
     version.major = major_exp.take();
   }
-  
+
   auto const minor_number_pos =
       str.find(SemanticVersion::separator, major_number_pos + 1);
   {
@@ -57,8 +57,8 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     version.minor = minor_exp.take();
   }
 
-    auto const patch_number_pos =
-        str.find_first_not_of("0123456789", minor_number_pos + 1);
+  auto const patch_number_pos =
+      str.find_first_not_of("0123456789", minor_number_pos + 1);
   {
     auto patches_exp = tryTo<unsigned>(
         str.substr(minor_number_pos + 1, patch_number_pos - minor_number_pos));
@@ -72,61 +72,56 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
 
   // patch_number_pos represents the trailing separator, if it is
   // npos, then there is no build.
-  if (patch_number_pos == std::string::npos )    {
+  if (patch_number_pos == std::string::npos) {
     return version;
   }
-  
 
   auto const build_number_pos =
-    str.find_first_not_of("0123456789", patch_number_pos + 1);
+      str.find_first_not_of("0123456789", patch_number_pos + 1);
   {
     auto build_exp = tryTo<unsigned>(
         str.substr(patch_number_pos + 1, build_number_pos - patch_number_pos));
     // build is optional. If we can't parse it, ignore this.
     if (!build_exp.isError()) {
-    version.build = build_exp.take();
+      version.build = build_exp.take();
     }
   }
 
-
-  
-return version;
+  return version;
 }
 
-  bool SemanticVersion::gt(const SemanticVersion & other) {
-    if (major > other.major) {
-      return true;
-    }
-
-    if (major < other.major) {
-      return false;
-    }
-
-    if (minor > other.minor) {
-	return true;
-      }
-
-    if (minor < other.minor) {
-      return false;
-    }
-
-    if (patches > other.patches) {
-      return true;
-	}
-
-    if (patches < other.patches) {
-      return false;
-    }
-
-    // Just return the comparison on build.
-    return build > other.build;
+bool SemanticVersion::gt(const SemanticVersion& other) {
+  if (major > other.major) {
+    return true;
   }
 
-  bool SemanticVersion::eq(const SemanticVersion & other) {
-    return  major == other.major && 
-      minor == other.minor &&
-      patches == other.patches &&
-      build == other.build;
+  if (major < other.major) {
+    return false;
   }
+
+  if (minor > other.minor) {
+    return true;
+  }
+
+  if (minor < other.minor) {
+    return false;
+  }
+
+  if (patches > other.patches) {
+    return true;
+  }
+
+  if (patches < other.patches) {
+    return false;
+  }
+
+  // Just return the comparison on build.
+  return build > other.build;
+}
+
+bool SemanticVersion::eq(const SemanticVersion& other) {
+  return major == other.major && minor == other.minor &&
+         patches == other.patches && build == other.build;
+}
 
 } // namespace osquery

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/io/detail/quoted_manip.hpp>
 
+#include <iostream>
+
 namespace osquery {
 
 using boost::io::quoted;
@@ -17,6 +19,7 @@ using boost::io::quoted;
 Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     const std::string& str) {
   auto version = SemanticVersion{};
+  
   auto const major_number_pos = str.find(SemanticVersion::separator);
   {
     if (major_number_pos == std::string::npos) {
@@ -34,6 +37,7 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     }
     version.major = major_exp.take();
   }
+  
   auto const minor_number_pos =
       str.find(SemanticVersion::separator, major_number_pos + 1);
   {
@@ -52,9 +56,10 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     }
     version.minor = minor_exp.take();
   }
-  {
+
     auto const patch_number_pos =
         str.find_first_not_of("0123456789", minor_number_pos + 1);
+  {
     auto patches_exp = tryTo<unsigned>(
         str.substr(minor_number_pos + 1, patch_number_pos - minor_number_pos));
     if (patches_exp.isError()) {
@@ -64,7 +69,64 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     }
     version.patches = patches_exp.take();
   }
-  return version;
+
+  // patch_number_pos represents the trailing separator, if it is
+  // npos, then there is no build.
+  if (patch_number_pos == std::string::npos )    {
+    return version;
+  }
+  
+
+  auto const build_number_pos =
+    str.find_first_not_of("0123456789", patch_number_pos + 1);
+  {
+    auto build_exp = tryTo<unsigned>(
+        str.substr(patch_number_pos + 1, build_number_pos - patch_number_pos));
+    // build is optional. If we can't parse it, ignore this.
+    if (!build_exp.isError()) {
+    version.build = build_exp.take();
+    }
+  }
+
+
+  
+return version;
 }
+
+  bool SemanticVersion::gt(const SemanticVersion & other) {
+    if (major > other.major) {
+      return true;
+    }
+
+    if (major < other.major) {
+      return false;
+    }
+
+    if (minor > other.minor) {
+	return true;
+      }
+
+    if (minor < other.minor) {
+      return false;
+    }
+
+    if (patches > other.patches) {
+      return true;
+	}
+
+    if (patches < other.patches) {
+      return false;
+    }
+
+    // Just return the comparison on build.
+    return build > other.build;
+  }
+
+  bool SemanticVersion::eq(const SemanticVersion & other) {
+    return  major == other.major && 
+      minor == other.minor &&
+      patches == other.patches &&
+      build == other.build;
+  }
 
 } // namespace osquery

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -90,33 +90,41 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
   return version;
 }
 
-bool SemanticVersion::gt(const SemanticVersion& other) {
+int SemanticVersion::compare(const SemanticVersion& other) {
   if (major > other.major) {
-    return true;
+    return 1;
   }
 
   if (major < other.major) {
-    return false;
+    return -1;
   }
 
   if (minor > other.minor) {
-    return true;
+    return 1;
   }
 
   if (minor < other.minor) {
-    return false;
+    return -1;
   }
 
   if (patches > other.patches) {
-    return true;
+    return 1;
   }
 
   if (patches < other.patches) {
-    return false;
+    return -1;
   }
 
-  // Just return the comparison on build.
-  return build > other.build;
+  if (build > other.build) {
+    return 1;
+  }
+
+  if (build < other.build) {
+    return -1;
+  }
+
+  // May as well return equal...
+  return 0;
 }
 
 bool SemanticVersion::eq(const SemanticVersion& other) {

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -91,6 +91,10 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
 }
 
 int SemanticVersion::compare(const SemanticVersion& other) {
+  if (eq(other)) {
+    return 0;
+  }
+
   if (major > other.major) {
     return 1;
   }

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -32,6 +32,12 @@ class SemanticVersion {
   bool operator<(const SemanticVersion& other) {
     return !gt(other);
   }
+  bool operator>=(const SemanticVersion& other) {
+    return eq(other) || gt(other);
+  }
+  bool operator<=(const SemanticVersion& other) {
+    return eq(other) || !gt(other);
+  }
 
  public:
   static constexpr auto separator = '.';

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -21,22 +21,24 @@ class SemanticVersion {
   unsigned build = 0;
 
  public:
-  bool gt(const SemanticVersion&);
+  int compare(const SemanticVersion&);
   bool eq(const SemanticVersion&);
-  bool operator=(const SemanticVersion& other) {
+
+ public:
+  bool operator==(const SemanticVersion& other) {
     return eq(other);
   }
   bool operator>(const SemanticVersion& other) {
-    return gt(other);
+    return compare(other) > 0;
   }
   bool operator<(const SemanticVersion& other) {
-    return !gt(other);
+    return compare(other) < 0;
   }
   bool operator>=(const SemanticVersion& other) {
-    return eq(other) || gt(other);
+    return compare(other) >= 0;
   }
   bool operator<=(const SemanticVersion& other) {
-    return eq(other) || !gt(other);
+    return compare(other) <= 0;
   }
 
  public:

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -28,6 +28,9 @@ class SemanticVersion {
   bool operator==(const SemanticVersion& other) {
     return eq(other);
   }
+  bool operator!=(const SemanticVersion& other) {
+    return !eq(other);
+  }
   bool operator>(const SemanticVersion& other) {
     return compare(other) > 0;
   }

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -18,8 +18,16 @@ class SemanticVersion {
   unsigned major = 0;
   unsigned minor = 0;
   unsigned patches = 0;
+  unsigned build = 0;
 
- public:
+public:
+  bool gt(const  SemanticVersion &);
+  bool eq(const  SemanticVersion &);
+  bool operator=(const  SemanticVersion & other) {      return eq(other);    }
+  bool operator>(const  SemanticVersion & other) {      return gt(other);    }
+  bool operator<(const  SemanticVersion & other) {      return !gt(other);    }
+
+ public: 
   static constexpr auto separator = '.';
 
  public:

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -20,14 +20,20 @@ class SemanticVersion {
   unsigned patches = 0;
   unsigned build = 0;
 
-public:
-  bool gt(const  SemanticVersion &);
-  bool eq(const  SemanticVersion &);
-  bool operator=(const  SemanticVersion & other) {      return eq(other);    }
-  bool operator>(const  SemanticVersion & other) {      return gt(other);    }
-  bool operator<(const  SemanticVersion & other) {      return !gt(other);    }
+ public:
+  bool gt(const SemanticVersion&);
+  bool eq(const SemanticVersion&);
+  bool operator=(const SemanticVersion& other) {
+    return eq(other);
+  }
+  bool operator>(const SemanticVersion& other) {
+    return gt(other);
+  }
+  bool operator<(const SemanticVersion& other) {
+    return !gt(other);
+  }
 
- public: 
+ public:
   static constexpr auto separator = '.';
 
  public:

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -121,8 +121,8 @@ TEST_F(SemanticVersionTests, equals) {
   auto v2 = v2exp.get();
 
   EXPECT_TRUE(v1.eq(v2));
-  EXPECT_TRUE(v1 = v2);
-  EXPECT_TRUE(v2 = v1);
+  //EXPECT_TRUE(v1 == v2);
+  //EXPECT_TRUE(v2 == v1);
   EXPECT_TRUE(v1 <= v2);
   EXPECT_TRUE(v1 >= v2);
 }

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -5,6 +5,8 @@
  *  This source code is licensed in accordance with the terms specified in
  *  the LICENSE file found in the root directory of this source tree.
  */
+#include <tuple>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -21,6 +23,8 @@ TEST_F(SemanticVersionTests, pass) {
   EXPECT_EQ(exp.get().major, 1u);
   EXPECT_EQ(exp.get().minor, 6u);
   EXPECT_EQ(exp.get().patches, 9u);
+  EXPECT_EQ(exp.get().build, 0u);
+
 }
 
 TEST_F(SemanticVersionTests, pass_2) {
@@ -29,6 +33,7 @@ TEST_F(SemanticVersionTests, pass_2) {
   EXPECT_EQ(exp.get().major, 7u);
   EXPECT_EQ(exp.get().minor, 25u);
   EXPECT_EQ(exp.get().patches, 999u);
+      EXPECT_EQ(exp.get().build, 0u);
 }
 
 TEST_F(SemanticVersionTests, pass_suffix) {
@@ -37,7 +42,27 @@ TEST_F(SemanticVersionTests, pass_suffix) {
   EXPECT_EQ(exp.get().major, 0u);
   EXPECT_EQ(exp.get().minor, 8u);
   EXPECT_EQ(exp.get().patches, 2u);
+  EXPECT_EQ(exp.get().build, 50u);
 }
+
+  TEST_F(SemanticVersionTests, pass_git_format) {
+  auto exp = tryTo<SemanticVersion>("0.5.5-19-ga7b9229");
+  ASSERT_TRUE(exp.isValue());
+  EXPECT_EQ(exp.get().major, 0u);
+  EXPECT_EQ(exp.get().minor, 5u);
+  EXPECT_EQ(exp.get().patches, 5u);
+  EXPECT_EQ(exp.get().build, 19u);
+}
+
+  TEST_F(SemanticVersionTests, pass_despite_bad_build) {
+    auto exp = tryTo<SemanticVersion>("0.1.2-somenote");
+  ASSERT_TRUE(exp.isValue());
+  EXPECT_EQ(exp.get().major, 0u);
+  EXPECT_EQ(exp.get().minor, 1u);
+  EXPECT_EQ(exp.get().patches, 2u);
+  EXPECT_EQ(exp.get().build, 0u);
+}
+
 
 TEST_F(SemanticVersionTests, fail_major) {
   auto exp = tryTo<SemanticVersion>("a4.5.9");
@@ -86,6 +111,50 @@ TEST_F(SemanticVersionTests, fail_two_digits) {
   ASSERT_TRUE(exp.isError());
   EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
 }
+
+    TEST_F(SemanticVersionTests, equals) {
+    auto v1exp = tryTo<SemanticVersion>("1.1.1");
+    auto v2exp = tryTo<SemanticVersion>("1.1.1.0");
+
+    ASSERT_TRUE(v1exp.isValue());
+    ASSERT_TRUE(v2exp.isValue());
+
+    auto v1 = v1exp.get();
+    auto v2 = v2exp.get();
+
+    EXPECT_TRUE(v1.eq(v2));
+    EXPECT_TRUE(v1=v2);
+  }
+
+  TEST_F(SemanticVersionTests, comparisons) {
+    std::vector<std::tuple<std::string, std::string> > tests;
+    tests.push_back(std::make_tuple("1.1.1.1", "2.1.1.1"));
+    tests.push_back(std::make_tuple("1.1.1.1", "1.2.1.1"));
+    tests.push_back(std::make_tuple("1.1.1.1", "1.1.2.1"));
+    tests.push_back(std::make_tuple("1.1.1.1", "1.1.1.2"));
+    tests.push_back(std::make_tuple("0.5.5-19-g85b16ae", "0.5.5-22-g85b16ae")); // git tags
+    tests.push_back(std::make_tuple("2.6.32-74-generic-pae", "4.15.0-74-generic" )); // kernel
+    tests.push_back(std::make_tuple("2.6.32-74.142", "4.15.0-74.84" )); // dpkg
+
+
+    for (int i = 0; i < tests.size(); i++) {
+      auto v1exp = tryTo<SemanticVersion>(std::get<0>(tests[i]));
+      auto v2exp = tryTo<SemanticVersion>(std::get<1>(tests[i]));
+
+      ASSERT_TRUE(v1exp.isValue());
+      ASSERT_TRUE(v2exp.isValue());
+
+      auto v1 = v1exp.get();
+      auto v2 = v2exp.get();
+
+      EXPECT_FALSE(v1.eq(v2));
+      EXPECT_FALSE(v2.eq(v1));
+      EXPECT_TRUE(v1 < v2);
+      EXPECT_FALSE(v1 > v2);
+    }
+ }
+
+
 
 } // namespace
 } // namespace osquery

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -24,7 +24,6 @@ TEST_F(SemanticVersionTests, pass) {
   EXPECT_EQ(exp.get().minor, 6u);
   EXPECT_EQ(exp.get().patches, 9u);
   EXPECT_EQ(exp.get().build, 0u);
-
 }
 
 TEST_F(SemanticVersionTests, pass_2) {
@@ -33,7 +32,7 @@ TEST_F(SemanticVersionTests, pass_2) {
   EXPECT_EQ(exp.get().major, 7u);
   EXPECT_EQ(exp.get().minor, 25u);
   EXPECT_EQ(exp.get().patches, 999u);
-      EXPECT_EQ(exp.get().build, 0u);
+  EXPECT_EQ(exp.get().build, 0u);
 }
 
 TEST_F(SemanticVersionTests, pass_suffix) {
@@ -45,7 +44,7 @@ TEST_F(SemanticVersionTests, pass_suffix) {
   EXPECT_EQ(exp.get().build, 50u);
 }
 
-  TEST_F(SemanticVersionTests, pass_git_format) {
+TEST_F(SemanticVersionTests, pass_git_format) {
   auto exp = tryTo<SemanticVersion>("0.5.5-19-ga7b9229");
   ASSERT_TRUE(exp.isValue());
   EXPECT_EQ(exp.get().major, 0u);
@@ -54,15 +53,14 @@ TEST_F(SemanticVersionTests, pass_suffix) {
   EXPECT_EQ(exp.get().build, 19u);
 }
 
-  TEST_F(SemanticVersionTests, pass_despite_bad_build) {
-    auto exp = tryTo<SemanticVersion>("0.1.2-somenote");
+TEST_F(SemanticVersionTests, pass_despite_bad_build) {
+  auto exp = tryTo<SemanticVersion>("0.1.2-somenote");
   ASSERT_TRUE(exp.isValue());
   EXPECT_EQ(exp.get().major, 0u);
   EXPECT_EQ(exp.get().minor, 1u);
   EXPECT_EQ(exp.get().patches, 2u);
   EXPECT_EQ(exp.get().build, 0u);
 }
-
 
 TEST_F(SemanticVersionTests, fail_major) {
   auto exp = tryTo<SemanticVersion>("a4.5.9");
@@ -112,9 +110,35 @@ TEST_F(SemanticVersionTests, fail_two_digits) {
   EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
 }
 
-    TEST_F(SemanticVersionTests, equals) {
-    auto v1exp = tryTo<SemanticVersion>("1.1.1");
-    auto v2exp = tryTo<SemanticVersion>("1.1.1.0");
+TEST_F(SemanticVersionTests, equals) {
+  auto v1exp = tryTo<SemanticVersion>("1.1.1");
+  auto v2exp = tryTo<SemanticVersion>("1.1.1.0");
+
+  ASSERT_TRUE(v1exp.isValue());
+  ASSERT_TRUE(v2exp.isValue());
+
+  auto v1 = v1exp.get();
+  auto v2 = v2exp.get();
+
+  EXPECT_TRUE(v1.eq(v2));
+  EXPECT_TRUE(v1 = v2);
+}
+
+TEST_F(SemanticVersionTests, comparisons) {
+  std::vector<std::tuple<std::string, std::string>> tests;
+  tests.push_back(std::make_tuple("1.1.1.1", "2.1.1.1"));
+  tests.push_back(std::make_tuple("1.1.1.1", "1.2.1.1"));
+  tests.push_back(std::make_tuple("1.1.1.1", "1.1.2.1"));
+  tests.push_back(std::make_tuple("1.1.1.1", "1.1.1.2"));
+  tests.push_back(
+      std::make_tuple("0.5.5-19-g85b16ae", "0.5.5-22-g85b16ae")); // git tags
+  tests.push_back(
+      std::make_tuple("2.6.32-74-generic-pae", "4.15.0-74-generic")); // kernel
+  tests.push_back(std::make_tuple("2.6.32-74.142", "4.15.0-74.84")); // dpkg
+
+  for (int i = 0; i < tests.size(); i++) {
+    auto v1exp = tryTo<SemanticVersion>(std::get<0>(tests[i]));
+    auto v2exp = tryTo<SemanticVersion>(std::get<1>(tests[i]));
 
     ASSERT_TRUE(v1exp.isValue());
     ASSERT_TRUE(v2exp.isValue());
@@ -122,39 +146,12 @@ TEST_F(SemanticVersionTests, fail_two_digits) {
     auto v1 = v1exp.get();
     auto v2 = v2exp.get();
 
-    EXPECT_TRUE(v1.eq(v2));
-    EXPECT_TRUE(v1=v2);
+    EXPECT_FALSE(v1.eq(v2));
+    EXPECT_FALSE(v2.eq(v1));
+    EXPECT_TRUE(v1 < v2);
+    EXPECT_FALSE(v1 > v2);
   }
-
-  TEST_F(SemanticVersionTests, comparisons) {
-    std::vector<std::tuple<std::string, std::string> > tests;
-    tests.push_back(std::make_tuple("1.1.1.1", "2.1.1.1"));
-    tests.push_back(std::make_tuple("1.1.1.1", "1.2.1.1"));
-    tests.push_back(std::make_tuple("1.1.1.1", "1.1.2.1"));
-    tests.push_back(std::make_tuple("1.1.1.1", "1.1.1.2"));
-    tests.push_back(std::make_tuple("0.5.5-19-g85b16ae", "0.5.5-22-g85b16ae")); // git tags
-    tests.push_back(std::make_tuple("2.6.32-74-generic-pae", "4.15.0-74-generic" )); // kernel
-    tests.push_back(std::make_tuple("2.6.32-74.142", "4.15.0-74.84" )); // dpkg
-
-
-    for (int i = 0; i < tests.size(); i++) {
-      auto v1exp = tryTo<SemanticVersion>(std::get<0>(tests[i]));
-      auto v2exp = tryTo<SemanticVersion>(std::get<1>(tests[i]));
-
-      ASSERT_TRUE(v1exp.isValue());
-      ASSERT_TRUE(v2exp.isValue());
-
-      auto v1 = v1exp.get();
-      auto v2 = v2exp.get();
-
-      EXPECT_FALSE(v1.eq(v2));
-      EXPECT_FALSE(v2.eq(v1));
-      EXPECT_TRUE(v1 < v2);
-      EXPECT_FALSE(v1 > v2);
-    }
- }
-
-
+}
 
 } // namespace
 } // namespace osquery

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -110,6 +110,46 @@ TEST_F(SemanticVersionTests, fail_two_digits) {
   EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
 }
 
+TEST_F(SemanticVersionTests, operators) {
+  // Test operator plumbing. The more indepth tests are on compare
+  auto v1_1_1 = tryTo<SemanticVersion>("1.1.1");
+  auto v1_1_1_0 = tryTo<SemanticVersion>("1.1.1.0");
+  auto v1_1_1_1 = tryTo<SemanticVersion>("1.1.1.1");
+  auto v1_2_1_1 = tryTo<SemanticVersion>("1.2.1.1");
+  auto v1_11_1 = tryTo<SemanticVersion>("1.11.1");
+
+  // equals should equal
+  EXPECT_TRUE(v1_1_1.get().eq(v1_1_1_0.get()));
+  EXPECT_TRUE(v1_1_1.get() == v1_1_1_0.get());
+  EXPECT_FALSE(v1_1_1.get() != v1_1_1_0.get());
+
+  // Not equals
+  EXPECT_FALSE(v1_1_1.get().eq(v1_1_1_1.get()));
+  EXPECT_FALSE(v1_1_1.get() == v1_1_1_1.get());
+  EXPECT_TRUE(v1_1_1.get() != v1_1_1_1.get());
+
+  // with equal values
+  EXPECT_FALSE(v1_1_1.get() < v1_1_1_0.get());
+  EXPECT_TRUE(v1_1_1.get() <= v1_1_1_0.get());
+  EXPECT_FALSE(v1_1_1.get() > v1_1_1_0.get());
+  EXPECT_TRUE(v1_1_1.get() >= v1_1_1_0.get());
+
+  // with trivial compare, would pass lexiraphical
+  EXPECT_TRUE(v1_1_1_1.get() < v1_2_1_1.get());
+  EXPECT_TRUE(v1_1_1_1.get() <= v1_2_1_1.get());
+  EXPECT_FALSE(v1_1_1_1.get() > v1_2_1_1.get());
+  EXPECT_FALSE(v1_1_1_1.get() >= v1_2_1_1.get());
+
+  // with non-trivial values, needs numeric
+  EXPECT_TRUE(v1_2_1_1.get() < v1_11_1.get());
+  EXPECT_TRUE(v1_2_1_1.get() <= v1_11_1.get());
+  EXPECT_FALSE(v1_2_1_1.get() > v1_11_1.get());
+  EXPECT_FALSE(v1_2_1_1.get() >= v1_11_1.get());
+}
+TEST_F(SemanticVersionTests, operator_le) {}
+TEST_F(SemanticVersionTests, operator_gt) {}
+TEST_F(SemanticVersionTests, operator_ge) {}
+
 TEST_F(SemanticVersionTests, equals) {
   auto v1exp = tryTo<SemanticVersion>("1.1.1");
   auto v2exp = tryTo<SemanticVersion>("1.1.1.0");
@@ -121,10 +161,14 @@ TEST_F(SemanticVersionTests, equals) {
   auto v2 = v2exp.get();
 
   EXPECT_TRUE(v1.eq(v2));
-  //EXPECT_TRUE(v1 == v2);
-  //EXPECT_TRUE(v2 == v1);
+  EXPECT_TRUE(v2.eq(v1));
+  EXPECT_TRUE(v1 == v2);
+  EXPECT_TRUE(v2 == v1);
   EXPECT_TRUE(v1 <= v2);
   EXPECT_TRUE(v1 >= v2);
+
+  EXPECT_EQ(v1.compare(v2), 0);
+  EXPECT_EQ(v2.compare(v1), 0);
 }
 
 TEST_F(SemanticVersionTests, comparisons) {
@@ -149,12 +193,8 @@ TEST_F(SemanticVersionTests, comparisons) {
     auto v1 = v1exp.get();
     auto v2 = v2exp.get();
 
-    EXPECT_FALSE(v1.eq(v2));
-    EXPECT_FALSE(v2.eq(v1));
-    EXPECT_TRUE(v1 < v2);
-    EXPECT_TRUE(v1 <= v2);
-    EXPECT_FALSE(v1 > v2);
-    EXPECT_FALSE(v1 >= v2);
+    EXPECT_EQ(v1.compare(v2), -1);
+    EXPECT_EQ(v2.compare(v1), 1);
   }
 }
 

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -122,6 +122,9 @@ TEST_F(SemanticVersionTests, equals) {
 
   EXPECT_TRUE(v1.eq(v2));
   EXPECT_TRUE(v1 = v2);
+  EXPECT_TRUE(v2 = v1);
+  EXPECT_TRUE(v1 <= v2);
+  EXPECT_TRUE(v1 >= v2);
 }
 
 TEST_F(SemanticVersionTests, comparisons) {
@@ -149,7 +152,9 @@ TEST_F(SemanticVersionTests, comparisons) {
     EXPECT_FALSE(v1.eq(v2));
     EXPECT_FALSE(v2.eq(v1));
     EXPECT_TRUE(v1 < v2);
+    EXPECT_TRUE(v1 <= v2);
     EXPECT_FALSE(v1 > v2);
+    EXPECT_FALSE(v1 >= v2);
   }
 }
 


### PR DESCRIPTION
Expands the existing `SemanticVersion` to include a `build` number and implements comparison operators. Include a custom collating function utilizing them. 

A common ask inside osquery is to do version comparisons, is some app version greater or less than X. sqlite compares strings using a [collating sequence](https://www.sqlite.org/datatype3.html#collation), and it supports defining custom ones. This adds a collating function, called `version`, that supports version comparisons. 

The included tests show a couple of examples. To call them out here:

```sql
select * from test_version where v > '1.2' COLLATE VERSION;
select '2.11.1.1' > '2.2.1.1' COLLATE VERSION;
```

Additionally, that collate designation can be added to the underlying schema

Replaces: #5230