### PR TITLE
syslog: Replace fstream with custom non-blocking getline

### DIFF
--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -56,6 +56,70 @@ const std::vector<std::string> kCsvFields = {
     "time", "host", "severity", "facility", "tag", "message"};
 const size_t kErrorThreshold = 10;
 
+Status NonBlockingFStream::openReadOnly(const std::string& path) {
+  fd_ = ::open(path.c_str(), O_RDWR | O_NONBLOCK);
+  if (fd_ < 0) {
+    return Status::failure("Error opening stream for reading: " + path);
+  }
+  return Status::success();
+}
+
+Status NonBlockingFStream::getline(std::string& output) {
+  output.clear();
+
+  // Poll for available data with a near-instant delay.
+  // It is the caller's responsibility to yeild context.
+  fd_set set;
+  struct timeval timeout = {0, 200};
+  FD_ZERO(&set);
+  FD_SET(fd_, &set);
+  int rv = ::select(FD_SETSIZE, &set, nullptr, nullptr, &timeout);
+  if (rv <= 0) {
+    // No data.
+    return Status::failure("No data to read");
+  }
+
+  // Read starting where we left off (if there was a previous read).
+  auto buffer_data = buffer_.data() + offset_;
+  // Only read up to the capacity of the vector buffer.
+  auto max_read = buffer_.capacity() - offset_;
+  auto bytes_read = ::read(fd_, buffer_data, max_read);
+  if (bytes_read <= 0) {
+    return Status::failure("Not enough data available");
+  }
+
+  offset_ += bytes_read;
+
+  auto buffer_end = static_cast<char*>(memchr(buffer_data, '\n', bytes_read));
+  if (buffer_end == nullptr) {
+    if (offset_ == buffer_.capacity()) {
+      // This is a problem we cannot handle.
+      offset_ = 0;
+      return Status::failure("Too much data");
+    }
+    // Wait for the next read.
+    return Status::success();
+  }
+
+  size_t line_size = buffer_end - buffer_.data();
+  output.reserve(line_size);
+  std::copy(buffer_.data(), buffer_end, std::back_inserter(output));
+  offset_ = offset_ - line_size - 1;
+  if (offset_ > 0) {
+    // Shift bytes down.
+    memcpy(buffer_.data(), buffer_end, offset_);
+  }
+  return Status::success();
+}
+
+Status NonBlockingFStream::close() {
+  if (fd_ != -1) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+  return Status();
+}
+
 Status SyslogEventPublisher::setUp() {
   if (!FLAGS_enable_syslog) {
     return Status(1, "Publisher disabled via configuration");
@@ -83,16 +147,11 @@ Status SyslogEventPublisher::setUp() {
     return s;
   }
 
-  // Opening with both flags appears to be the only way to open the pipe
-  // without blocking for a writer. We won't ever write to the pipe, but we
-  // don't want to block here and will instead block waiting for a read in the
-  // run() method
-  readStream_.open(FLAGS_syslog_pipe_path,
-                   std::ifstream::in | std::ifstream::out);
-  if (!readStream_.good()) {
-    return Status(1,
-                  "Error opening pipe for reading: " + FLAGS_syslog_pipe_path);
+  s = readStream_.openReadOnly(FLAGS_syslog_pipe_path);
+  if (!s.ok()) {
+    return s;
   }
+
   VLOG(1) << "Successfully opened pipe for syslog ingestion: "
           << FLAGS_syslog_pipe_path;
 
@@ -100,7 +159,7 @@ Status SyslogEventPublisher::setUp() {
 }
 
 Status SyslogEventPublisher::createPipe(const std::string& path) {
-  if (mkfifo(FLAGS_syslog_pipe_path.c_str(), kPipeMode) != 0) {
+  if (mkfifo(path.c_str(), kPipeMode) != 0) {
     return Status(1, "Error in mkfifo: " + std::string(strerror(errno)));
   }
 
@@ -155,15 +214,14 @@ Status SyslogEventPublisher::run() {
   // (see InterruptableRunnable::pause()) between runs. In case something goes
   // weird and there is a huge amount of input, we limit how many logs we
   // take in per run to avoid pegging the CPU.
+
+  std::string line;
   for (size_t i = 0; i < FLAGS_syslog_rate_limit; ++i) {
-    if (readStream_.rdbuf()->in_avail() == 0) {
-      // If there is no pending data, we have flushed everything and can wait
-      // until the next time EventFactory calls run(). This also allows the
-      // thread to join when it is stopped by EventFactory.
-      return Status::success();
+    if (!readStream_.getline(line) || line.empty()) {
+      // Not enough data was available, fall through an wait.
+      break;
     }
-    std::string line;
-    std::getline(readStream_, line);
+
     auto ec = createEventContext();
     Status status = populateEventContext(line, ec);
     if (status.ok()) {
@@ -218,4 +276,4 @@ bool SyslogEventPublisher::shouldFire(const SyslogSubscriptionContextRef& sc,
                                       const SyslogEventContextRef& ec) const {
   return true;
 }
-}
+} // namespace osquery

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -57,6 +57,10 @@ const std::vector<std::string> kCsvFields = {
 const size_t kErrorThreshold = 10;
 
 Status NonBlockingFStream::openReadOnly(const std::string& path) {
+  if (fd_ != -1) {
+    return Status::failure("Stream already open");
+  }
+
   fd_ = ::open(path.c_str(), O_RDWR | O_NONBLOCK);
   if (fd_ < 0) {
     return Status::failure("Error opening stream for reading: " + path);
@@ -241,6 +245,7 @@ Status SyslogEventPublisher::run() {
 }
 
 void SyslogEventPublisher::tearDown() {
+  readStream_.close();
   unlockPipe();
 }
 

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -57,6 +57,8 @@ const std::vector<std::string> kCsvFields = {
 const size_t kErrorThreshold = 10;
 
 Status NonBlockingFStream::openReadOnly(const std::string& path) {
+  WriteLock lock(fd_mutex_);
+
   if (fd_ != -1) {
     return Status::failure("Stream already open");
   }
@@ -77,6 +79,8 @@ Status NonBlockingFStream::getline(std::string& output) {
   }
 
   if (buffer_end == nullptr) {
+    WriteLock lock(fd_mutex_);
+
     // Poll for available data with a near-instant delay.
     // It is the caller's responsibility to yeild context.
     fd_set set;
@@ -124,6 +128,8 @@ Status NonBlockingFStream::getline(std::string& output) {
 }
 
 Status NonBlockingFStream::close() {
+  WriteLock lock(fd_mutex_);
+
   if (fd_ != -1) {
     ::close(fd_);
     fd_ = -1;

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <osquery/events.h>
+#include <osquery/utils/mutex.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -59,10 +60,12 @@ class NonBlockingFStream : public boost::noncopyable {
  public:
   NonBlockingFStream() {
     buffer_.reserve(2048);
+    buffer_.assign(2048, 0);
   }
 
   explicit NonBlockingFStream(size_t capacity) {
     buffer_.reserve(capacity);
+    buffer_.assign(capacity, 0);
   }
 
   ~NonBlockingFStream() {
@@ -95,6 +98,9 @@ class NonBlockingFStream : public boost::noncopyable {
  private:
   /// The managed descriptor for the stream.
   int fd_{-1};
+
+  /// Mutex for fd accesses.
+  Mutex fd_mutex_;
 
   /// Push/pop buffer for reading a line and dequeuing.
   std::vector<char> buffer_;

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
-#include <stdio.h>
-
-#include <fstream>
-#include <map>
-
 #include <osquery/events.h>
+
+#include <boost/noncopyable.hpp>
+
+#include <map>
+#include <vector>
+
+#include <stdio.h>
 
 namespace osquery {
 
@@ -43,6 +45,71 @@ struct SyslogEventContext : public EventContext {
 
 using SyslogEventContextRef = std::shared_ptr<SyslogEventContext>;
 using SyslogSubscriptionContextRef = std::shared_ptr<SyslogSubscriptionContext>;
+
+/**
+ * @brief Implement a non-blocking-read of a pipe.
+ *
+ * The goal is to abstract a managed buffer and stream-like-object to implement
+ * a version of std::getline that does not block.
+ *
+ * Limitations include undefined behavior (dropping the initial bytes) when a
+ * line would overflow the reserved internal buffer.
+ */
+class NonBlockingFStream : public boost::noncopyable {
+ public:
+  NonBlockingFStream() {
+    buffer_.reserve(2048);
+  }
+
+  explicit NonBlockingFStream(size_t capacity) {
+    buffer_.reserve(capacity);
+  }
+
+  ~NonBlockingFStream() {
+    close();
+  }
+
+  /// Open for reading and writing to avoid blocking a pipe read.
+  Status openReadOnly(const std::string& path);
+
+  /// Close the managed fstream, called on destruction.
+  Status close();
+
+  /**
+   * @brief Read a complete line or nothing into output.
+   *
+   * The output buffer will be cleared everytime. Data will only be written if
+   * a complete line was dequeued from the managed stream. If too much data is
+   * written and our internal buffer overflows then no data will be output.
+   *
+   * Overflowing the internal buffer does not break the reading. If this occures
+   * then expect a line to be truncated and only yeild the max bytes.
+   */
+  Status getline(std::string& output);
+
+  /// Inspect the internal offset.
+  size_t offset() {
+    return offset_;
+  }
+
+ private:
+  /// The managed descriptor for the stream.
+  int fd_{-1};
+
+  /// Push/pop buffer for reading a line and dequeuing.
+  std::vector<char> buffer_;
+
+  /**
+   * @brief Offset into the buffer for the next read.
+   *
+   * If a call to getline did not find a '\n', then the next call will continue
+   * to dequeue where the previous getline left off.
+   */
+  size_t offset_{0};
+
+ private:
+  FRIEND_TEST(SyslogTests, test_nonblockingfstream);
+};
 
 /**
  * @brief Event publisher for syslog lines forwarded through rsyslog
@@ -113,7 +180,7 @@ class SyslogEventPublisher
   /**
    * @brief Input stream for reading from the pipe.
    */
-  std::fstream readStream_;
+  NonBlockingFStream readStream_;
 
   /**
    * @brief Counter used to shut down thread when too many errors occur.
@@ -201,4 +268,4 @@ class RsyslogCsvSeparator {
  private:
   bool last_;
 };
-}
+} // namespace osquery

--- a/osquery/events/tests/linux/syslog_tests.cpp
+++ b/osquery/events/tests/linux/syslog_tests.cpp
@@ -115,6 +115,40 @@ TEST_F(SyslogTests, test_nonblockingfstream) {
   s = nbfs.getline(output);
   EXPECT_FALSE(s.ok());
   EXPECT_EQ(0, nbfs.offset());
+
+  // Need to clear the newline here.
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+
+  // Write multiple strings.
+  fill = std::string(9, 'A');
+  fill.push_back('\n');
+  fill += std::string(9, 'A');
+  fill.push_back('\n');
+
+  bytes_written = write(fd, fill.data(), fill.size());
+  ASSERT_EQ(20, bytes_written);
+
+  // Read the first
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(10, nbfs.offset());
+
+  {
+    std::string expected(9, 'A');
+    EXPECT_EQ(expected, output);
+  }
+
+  // Read the second
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+
+  {
+    std::string expected(9, 'A');
+    EXPECT_EQ(expected, output);
+  }
 }
 
 TEST_F(SyslogTests, test_populate_event_context) {

--- a/osquery/events/tests/linux/syslog_tests.cpp
+++ b/osquery/events/tests/linux/syslog_tests.cpp
@@ -6,25 +6,116 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <vector>
+#include <osquery/events/linux/syslog.h>
+#include <osquery/tests/test_util.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/tokenizer.hpp>
 
 #include <gtest/gtest.h>
 
-#include <boost/tokenizer.hpp>
+#include <vector>
 
-#include "osquery/events/linux/syslog.h"
-#include "osquery/tests/test_util.h"
+namespace fs = boost::filesystem;
 
 namespace osquery {
 
 class SyslogTests : public testing::Test {
  public:
+  void SetUp() override {
+    test_working_dir_ = fs::temp_directory_path() /
+                        fs::unique_path("osquery.test_working_dir.%%%%.%%%%");
+    fs::create_directories(test_working_dir_);
+  }
+
+  void TearDown() override {
+    fs::remove_all(test_working_dir_);
+  }
+
   std::vector<std::string> splitCsv(std::string line) {
     boost::tokenizer<RsyslogCsvSeparator> tokenizer(line);
     std::vector<std::string> result(tokenizer.begin(), tokenizer.end());
     return result;
   }
+
+ protected:
+  fs::path test_working_dir_;
 };
+
+TEST_F(SyslogTests, test_nonblockingfstream) {
+  auto pipe_path = test_working_dir_ / "pipe";
+  auto ret = mkfifo(pipe_path.string().c_str(), 0660);
+  ASSERT_EQ(ret, 0);
+  ret = chmod(pipe_path.string().c_str(), 0660);
+  ASSERT_EQ(ret, 0);
+
+  NonBlockingFStream nbfs(20);
+  auto s = nbfs.openReadOnly(pipe_path.string());
+  EXPECT_TRUE(s.ok());
+
+  auto fd = open(pipe_path.string().c_str(), O_WRONLY | O_NONBLOCK);
+  ASSERT_GT(fd, 0);
+
+  std::string fill(19, 'A');
+  fill.push_back('\n');
+  auto bytes_written = write(fd, fill.data(), fill.size());
+  ASSERT_EQ(20, bytes_written);
+
+  std::string output;
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+
+  {
+    std::string expected;
+    std::copy(fill.begin(), fill.end() - 1, std::back_inserter(expected));
+    EXPECT_EQ(expected, output);
+  }
+
+  fill = std::string(10, 'A');
+  bytes_written = write(fd, fill.data(), fill.size());
+  ASSERT_EQ(10, bytes_written);
+
+  // We did not write a newline, the stream should buffer but not write.
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(10, nbfs.offset());
+  EXPECT_TRUE(output.empty());
+
+  // Write another byte and a newline.
+  fill = std::string(1, 'A');
+  fill.push_back('\n');
+  bytes_written = write(fd, fill.data(), fill.size());
+  ASSERT_EQ(2, bytes_written);
+
+  // Now the buffer should dequeue.
+  s = nbfs.getline(output);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+
+  {
+    fill = std::string(11, 'A');
+    fill.push_back('\n');
+    std::string expected;
+    std::copy(fill.begin(), fill.end() - 1, std::back_inserter(expected));
+    EXPECT_EQ(expected, output);
+  }
+
+  // Nothing to read (failure)
+  s = nbfs.getline(output);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+
+  // Write too much
+  fill = std::string(20, 'A');
+  fill.push_back('\n');
+  bytes_written = write(fd, fill.data(), fill.size());
+  ASSERT_EQ(21, bytes_written);
+
+  s = nbfs.getline(output);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(0, nbfs.offset());
+}
 
 TEST_F(SyslogTests, test_populate_event_context) {
   std::string line =


### PR DESCRIPTION
This is an initial attempt to take the awesome work from #5969 and #5232, and minify it. The original bug report is #4810.

The goal is to have a non-blocking, mostly accurate, fast enough, minimalistic `std::getline`.

There may be areas for improvement from a performance and accuracy point of view. Areas to consider, copying data from the internal buffer out to the caller, line 106; the rare/exceptional case of shifting any left over data, line 110; giving up trying to handle a line larger than 2048 bytes, line 96; others?