### PR TITLE
rpm: Fix memory leaks in rpm_package_files

### DIFF
--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -227,12 +227,14 @@ void genRpmPackageFiles(RowYield& yield, QueryContext& context) {
     if (file_count <= 0) {
       logger.vlog(1, "RPM package " + package_name + " contains 0 files");
       rpmfiFree(fi);
+      rpmtdFree(td);
       continue;
     } else if (file_count > MAX_RPM_FILES) {
       logger.vlog(1,
                   "RPM package " + package_name + " contains over " +
                       std::to_string(MAX_RPM_FILES) + " files");
       rpmfiFree(fi);
+      rpmtdFree(td);
       continue;
     }
 
@@ -253,6 +255,9 @@ void genRpmPackageFiles(RowYield& yield, QueryContext& context) {
       auto digest = rpmfiFDigestHex(fi, &digest_algo);
       if (digest_algo == PGPHASHALGO_SHA256) {
         r["sha256"] = (digest != nullptr) ? digest : "";
+      }
+      if (digest != nullptr) {
+        free(digest);
       }
 
       yield(std::move(r));


### PR DESCRIPTION
There are two leaky situations in the `rpm_package_files` table. One almost always occurs, the failure to free the `malloc`ed `digest` and the other in rare situations where we continue early without freeing `td`.

See https://github.com/osquery/osquery/issues/6532.