### PR TITLE
Change "Symlink loop" message from warning to  verbose

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -308,7 +308,7 @@ static bool checkForLoops(std::set<int>& dsym_inos, std::string path) {
   if (dsym_inos.find(d_stat.st_ino) == dsym_inos.end()) {
     dsym_inos.insert(d_stat.st_ino);
   } else {
-    VLOG(1) << "Symlink loop detected possibly involving: " << path;
+    VLOG(1) << "Symlink loop detected. Ignoring: " << path;
     return true;
   }
   return false;

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -308,7 +308,7 @@ static bool checkForLoops(std::set<int>& dsym_inos, std::string path) {
   if (dsym_inos.find(d_stat.st_ino) == dsym_inos.end()) {
     dsym_inos.insert(d_stat.st_ino);
   } else {
-    LOG(WARNING) << "Symlink loop detected possibly involving: " << path;
+    VLOG(1) << "Symlink loop detected possibly involving: " << path;
     return true;
   }
   return false;


### PR DESCRIPTION
Symlink loops seem quite common on macOS. And, the occasionally crop up on other platforms. As we seem to handle this fine, change from a warning to a verbose.

(there may be disagreement here, feel free to speak up.)

Fixes: #6462 