### PR TITLE
Fix process_open_sockets type error on darwin

### DIFF
--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -148,9 +148,14 @@ void genSocketDescriptor(int pid, int descriptor, QueryData& results) {
   if (si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6) {
     Row r;
 
+    // sqlite is signed 64bit, but soi_so is unsigned. If it's above
+    // LLONG_MAX, may as well drop it. That's all we did prior.
+    if (si.psi.soi_so <= LLONG_MAX) {
+      r["socket"] = BIGINT(si.psi.soi_so);
+    }
+
     r["pid"] = INTEGER(pid);
     r["fd"] = BIGINT(descriptor);
-    r["socket"] = BIGINT(si.psi.soi_so);
     r["path"] = "";
 
     // Darwin/OSX SOCKINFO_TCP is not IPPROTO_TCP

--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -148,11 +148,10 @@ void genSocketDescriptor(int pid, int descriptor, QueryData& results) {
   if (si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6) {
     Row r;
 
-    // sqlite is signed 64bit, but soi_so is unsigned. If it's above
-    // LLONG_MAX, may as well drop it. That's all we did prior.
-    if (si.psi.soi_so <= LLONG_MAX) {
-      r["socket"] = BIGINT(si.psi.soi_so);
-    }
+    // NOTE: the "socket" column has unclear meaning for these
+    // protocols. si.psi.soi_so is a kernel memory pointer, so we no
+    // longer resolve it. See discussion in
+    // https://github.com/osquery/osquery/pull/6546
 
     r["pid"] = INTEGER(pid);
     r["fd"] = BIGINT(descriptor);
@@ -185,6 +184,7 @@ void genSocketDescriptor(int pid, int descriptor, QueryData& results) {
     r["local_port"] = "0";
     r["remote_address"] = "";
     r["remote_port"] = "0";
+
     if ((char*)si.psi.soi_proto.pri_un.unsi_addr.ua_sun.sun_path != nullptr) {
       r["path"] = si.psi.soi_proto.pri_un.unsi_addr.ua_sun.sun_path;
     } else {


### PR DESCRIPTION
On darwin, `soi_so` is an unsigned 64bit number. sqlite, however, is
signed. Current behavior is to emit a warning, and drop the column.
It's not clear we have a good fix for the type mismatch, so comment and
drop it in the virtual table instead.

Relates to: #6319
