### PR TITLE
Fix logging of `GLOG_WARNING`

### DIFF
--- a/osquery/worker/logging/glog/glog_logger.cpp
+++ b/osquery/worker/logging/glog/glog_logger.cpp
@@ -29,6 +29,10 @@ void GLOGLogger::log(int severity, const std::string& message) {
     LOG(INFO) << message;
     break;
   }
+  case google::GLOG_WARNING: {
+    LOG(WARNING) << message;
+    break;
+  }
   case google::GLOG_FATAL: {
     LOG(FATAL) << message;
     break;


### PR DESCRIPTION
Add missing GLOG_WARNING type

In #6209 a logging abstraction was added. However, it omitted the
GLOG_WARNING this caused some logs to be dropped, with the severity not
supported.