### PR TITLE
Fix #6536 Leak in psidToString 

### DIFF
--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -20,7 +20,9 @@ std::string psidToString(PSID sid) {
     VLOG(1) << "ConvertSidToString failed with " << GetLastError();
     return std::string("");
   }
-  return std::string(sidOut);
+  std::string sidString(sidOut);
+  LocalFree(sidOut);
+  return sidString;
 }
 
 uint32_t getUidFromSid(PSID sid) {


### PR DESCRIPTION
### Description

psidToString calls ConvertSidToStringSidA but never calls LocalFree on the allocated LPTSTR . #6536