### PR TITLE
events: Only fire if publisher exists

### DIFF
--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -125,12 +125,13 @@ TEST_F(EventsTests, test_event_publisher_types) {
   auto pub = std::make_shared<FakeEventPublisher>();
   EXPECT_EQ(pub->type(), "FakePublisher");
 
-  EventFactory::registerEventPublisher(pub);
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
   auto pub2 = EventFactory::getEventPublisher("FakePublisher");
   EXPECT_EQ(pub->type(), pub2->type());
 
   // It is possible to deregister by base event publisher type.
-  auto status = EventFactory::deregisterEventPublisher(pub2);
+  status = EventFactory::deregisterEventPublisher(pub2);
   EXPECT_TRUE(status.ok());
   // And attempting to deregister by type afterward will fail.
   status = EventFactory::deregisterEventPublisher(pub->type());
@@ -180,12 +181,13 @@ TEST_F(EventsTests, test_create_subscription) {
 
   auto pub = std::make_shared<BasicEventPublisher>();
   pub->setName(basic_publisher_type);
-  EventFactory::registerEventPublisher(pub);
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   // Make sure a subscription cannot be added for a non-existent event type.
   // Note: It normally would not make sense to create a blank subscription.
   auto subscription = Subscription::create("FakeSubscriber");
-  auto status = EventFactory::addSubscription("FakePublisher", subscription);
+  status = EventFactory::addSubscription("FakePublisher", subscription);
   EXPECT_FALSE(status.ok());
 
   // In this case we can still add a blank subscription to an existing event
@@ -205,11 +207,11 @@ TEST_F(EventsTests, test_multiple_subscriptions) {
 
   auto pub = std::make_shared<BasicEventPublisher>();
   pub->setName(basic_publisher_type);
-  EventFactory::registerEventPublisher(pub);
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   auto subscription = Subscription::create("subscriber");
-  auto status =
-      EventFactory::addSubscription(basic_publisher_type, subscription);
+  status = EventFactory::addSubscription(basic_publisher_type, subscription);
   status = EventFactory::addSubscription(basic_publisher_type, subscription);
   EXPECT_TRUE(status.ok());
 
@@ -220,7 +222,7 @@ TEST_F(EventsTests, test_multiple_subscriptions) {
 }
 
 struct TestSubscriptionContext : public SubscriptionContext {
-  int smallest;
+  int smallest{0};
 };
 
 class TestEventPublisher
@@ -266,10 +268,11 @@ class TestEventPublisher
 TEST_F(EventsTests, test_create_custom_event_publisher) {
   auto basic_pub = std::make_shared<BasicEventPublisher>();
   basic_pub->setName("BasicPublisher");
-  EventFactory::registerEventPublisher(basic_pub);
+  auto status = EventFactory::registerEventPublisher(basic_pub);
+  ASSERT_TRUE(status.ok());
 
   auto pub = std::make_shared<TestEventPublisher>();
-  auto status = EventFactory::registerEventPublisher(pub);
+  status = EventFactory::registerEventPublisher(pub);
   ASSERT_TRUE(status.ok());
 
   // These event types have unique event type IDs
@@ -406,10 +409,12 @@ TEST_F(EventsTests, test_event_subscriber) {
 
 TEST_F(EventsTests, test_event_subscriber_subscribe) {
   auto pub = std::make_shared<FakeEventPublisher>();
-  EventFactory::registerEventPublisher(pub);
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EventFactory::registerEventSubscriber(sub);
+  status = EventFactory::registerEventSubscriber(sub);
+  ASSERT_TRUE(status.ok());
 
   // Don't overload the normal `init` Subscription member.
   sub->lateInit();
@@ -418,10 +423,13 @@ TEST_F(EventsTests, test_event_subscriber_subscribe) {
 
   auto ec = pub->createEventContext();
   pub->fire(ec, 0);
-
   EXPECT_TRUE(sub->bellHathTolled);
 
-  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  sub->bellHathTolled = false;
+  EventFactory::fire<FakeEventPublisher>(ec);
+  EXPECT_TRUE(sub->bellHathTolled);
+
+  status = EventFactory::deregisterEventSubscriber(sub->getName());
   EXPECT_TRUE(status.ok());
   status = EventFactory::deregisterEventPublisher(pub->type());
   EXPECT_TRUE(status.ok());
@@ -429,10 +437,12 @@ TEST_F(EventsTests, test_event_subscriber_subscribe) {
 
 TEST_F(EventsTests, test_event_subscriber_context) {
   auto pub = std::make_shared<FakeEventPublisher>();
-  EventFactory::registerEventPublisher(pub);
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EventFactory::registerEventSubscriber(sub);
+  status = EventFactory::registerEventSubscriber(sub);
+  ASSERT_TRUE(status.ok());
 
   sub->laterInit();
   pub->configure();
@@ -442,7 +452,7 @@ TEST_F(EventsTests, test_event_subscriber_context) {
 
   EXPECT_TRUE(sub->contextBellHathTolled);
 
-  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  status = EventFactory::deregisterEventSubscriber(sub->getName());
   EXPECT_TRUE(status.ok());
   status = EventFactory::deregisterEventPublisher(pub->type());
   EXPECT_TRUE(status.ok());
@@ -569,10 +579,11 @@ TEST_F(EventsTests, test_event_toggle_subscribers) {
   EXPECT_FALSE(sub2->disabled);
 
   // Registering a disabled subscriber will put it into a paused state.
-  EventFactory::registerEventSubscriber(sub);
+  auto status = EventFactory::registerEventSubscriber(sub);
+  EXPECT_TRUE(status.ok());
   EXPECT_EQ(sub->state(), EventState::EVENT_PAUSED);
 
-  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  status = EventFactory::deregisterEventSubscriber(sub->getName());
   EXPECT_TRUE(status.ok());
 }
-}
+} // namespace osquery

--- a/osquery/include/osquery/events.h
+++ b/osquery/include/osquery/events.h
@@ -868,7 +868,11 @@ class EventFactory : private boost::noncopyable {
   template <typename PUB>
   static void fire(const EventContextRef& ec) {
     auto event_pub = getEventPublisher(getType<PUB>());
-    event_pub->fire(ec);
+    if (event_pub != nullptr) {
+      // A publisher may not exist anymore if an OS event callback is fired
+      // during process teardown. A publisher cannot-be-found log is generated.
+      event_pub->fire(ec);
+    }
   }
 
   /**


### PR DESCRIPTION
This guards against a rare situation where an OS callback, such as `FSEvents` is fired very late in process execution. If this happens, the osquery process is already terminating and deallocating structures. Practically, we see these errors in CI. 

See the instances in #6024, where a log "cannot find publisher" is created.