### PR TITLE
CMake detect MAJOR_IN_SYSMACROS/MKDEV for librpm

### DIFF
--- a/libraries/cmake/source/librpm/CMakeLists.txt
+++ b/libraries/cmake/source/librpm/CMakeLists.txt
@@ -142,20 +142,20 @@ function(librpmMain)
   # uses CMake instead of autotools, with a git-committed `config.h`.
   # This mirrors detection done by autoconf/headers.m4 as CMake code.
   #
-  if(UNIX)
+  if(DEFINED PLATFORM_LINUX)
     CHECK_SYMBOL_EXISTS(major "sys/mkdev.h" MAJOR_IN_MKDEV)
     CHECK_SYMBOL_EXISTS(major "sys/sysmacros.h" MAJOR_IN_SYSMACROS) 
     if(MAJOR_IN_MKDEV)
       target_compile_definitions(thirdparty_librpm PRIVATE
         MAJOR_IN_MKDEV=1
       )
-    endif(MAJOR_IN_MKDEV)
+    endif()
     if(MAJOR_IN_SYSMACROS)
       target_compile_definitions(thirdparty_librpm PRIVATE
         MAJOR_IN_SYSMACROS=1
       )
-    endif(MAJOR_IN_SYSMACROS)
-  endif(UNIX)
+    endif()
+  endif()
 
   target_link_libraries(thirdparty_librpm PUBLIC
     thirdparty_berkeley-db

--- a/libraries/cmake/source/librpm/CMakeLists.txt
+++ b/libraries/cmake/source/librpm/CMakeLists.txt
@@ -131,6 +131,32 @@ function(librpmMain)
     SYSCONFDIR="/usr/local/etc"
   )
 
+  # Starting in glibc 2.25, the macros `major` and `minor` were moved
+  # from `<sys/types.h>` to `<sys/sysmacros.h>`, to stop leaking these
+  # common words into the global namespace of those including <stdlib.h>
+  #
+  # https://sourceware.org/bugzilla/show_bug.cgi?format=multiple&id=19239
+  #
+  # The macros MAJOR_IN_MKDEV and MAJOR_IN_SYSMACROS would be defined if
+  # necessary by autoconfig, and put in `config.h`. But osquery build
+  # uses CMake instead of autotools, with a git-committed `config.h`.
+  # This mirrors detection done by autoconf/headers.m4 as CMake code.
+  #
+  if(UNIX)
+    CHECK_SYMBOL_EXISTS(major "sys/mkdev.h" MAJOR_IN_MKDEV)
+    CHECK_SYMBOL_EXISTS(major "sys/sysmacros.h" MAJOR_IN_SYSMACROS) 
+    if(MAJOR_IN_MKDEV)
+      target_compile_definitions(thirdparty_librpm PRIVATE
+        MAJOR_IN_MKDEV=1
+      )
+    endif(MAJOR_IN_MKDEV)
+    if(MAJOR_IN_SYSMACROS)
+      target_compile_definitions(thirdparty_librpm PRIVATE
+        MAJOR_IN_SYSMACROS=1
+      )
+    endif(MAJOR_IN_SYSMACROS)
+  endif(UNIX)
+
   target_link_libraries(thirdparty_librpm PUBLIC
     thirdparty_berkeley-db
     thirdparty_openssl


### PR DESCRIPTION
Starting in glibc 2.25, the macros `major` and `minor` were moved
from `<sys/types.h>` to `<sys/sysmacros.h>`, to stop leaking these
common words into the global namespace of those including <stdlib.h>

https://sourceware.org/bugzilla/show_bug.cgi?format=multiple&id=19239

The macros MAJOR_IN_MKDEV and MAJOR_IN_SYSMACROS would be defined if
necessary by autoconfig, and put in `config.h`. But osquery build
uses CMake instead of autotools, with a git-committed `config.h`.
This generally is all right across Ubuntu variations, as an automake
for one will likely make a config.h that works on others. However
the glibc change makes a "one-size-fits-all-Ubuntu" config impossible.

This mirrors detection done by autoconf/headers.m4 as CMake code.
It is a relatively simple patch, which unblocks building of librpm
on (K)ubuntu 20 while still working on Ubuntu 18.