### PR TITLE
Enable YARA table on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ function(importLibraries)
     "Linux,Darwin:ssdeep-cpp"
     "Linux,Darwin,Windows:thrift"
     "Linux:util-linux"
-    "Linux,Darwin:yara"
+    "Linux,Darwin,Windows:yara"
     "Linux,Darwin,Windows:zlib"
     "Linux,Darwin,Windows:zstd"
     "Linux,Darwin,Windows:openssl"

--- a/libraries/cmake/source/yara/CMakeLists.txt
+++ b/libraries/cmake/source/yara/CMakeLists.txt
@@ -48,7 +48,6 @@ function(yaraMain)
     "${library_root}/modules/elf/elf.c"
     "${library_root}/modules/hash/hash.c"
     "${library_root}/modules/macho/macho.c"
-    "${library_root}/modules/magic/magic.c"
     "${library_root}/modules/math/math.c"
     "${library_root}/modules/module_list"
     "${library_root}/modules/pe/pe.c"
@@ -58,11 +57,19 @@ function(yaraMain)
   )
 
   if(DEFINED PLATFORM_WINDOWS)
-    target_sources(thirdparty_yara PRIVATE "${library_root}/proc/windows.c")
+    target_sources(thirdparty_yara PRIVATE
+      "${library_root}/proc/windows.c"
+    )
   elseif(DEFINED PLATFORM_LINUX)
-    target_sources(thirdparty_yara PRIVATE "${library_root}/proc/linux.c")
+    target_sources(thirdparty_yara PRIVATE
+      "${library_root}/proc/linux.c"
+      "${library_root}/modules/magic/magic.c"
+    )
   elseif(DEFINED PLATFORM_MACOS)
-    target_sources(thirdparty_yara PRIVATE "${library_root}/proc/mach.c")
+    target_sources(thirdparty_yara PRIVATE
+      "${library_root}/proc/mach.c"
+      "${library_root}/modules/magic/magic.c"
+    )
   else()
     message(FATAL_ERROR "Unsupported platform")
   endif()
@@ -90,8 +97,6 @@ function(yaraMain)
     HAVE_DLFCN_H=1
     LT_OBJDIR=\".libs/\"
     HAVE_LIBM=1
-    HAVE_MEMMEM=1
-    HAVE_TIMEGM=1
     HAVE_STDBOOL_H=1
     HAVE_CLOCK_GETTIME=1
     HAVE_SCAN_PROC_IMPL=1
@@ -109,17 +114,36 @@ function(yaraMain)
   if(DEFINED PLATFORM_LINUX)
     target_compile_definitions(thirdparty_yara PRIVATE
       USE_LINUX_PROC
+      HAVE_MEMMEM=1
+      HAVE_TIMEGM=1
+    )
+
+    target_link_libraries(thirdparty_yara PUBLIC
+      thirdparty_openssl
+      thirdparty_libmagic
     )
   elseif(DEFINED PLATFORM_MACOS)
     target_compile_definitions(thirdparty_yara PRIVATE
       USE_MACH_PROC
+      HAVE_MEMMEM=1
+      HAVE_TIMEGM=1
+    )
+
+    target_link_libraries(thirdparty_yara PUBLIC
+      thirdparty_openssl
+      thirdparty_libmagic
+    )
+  elseif(DEFINED PLATFORM_WINDOWS)
+    target_compile_definitions(thirdparty_yara PRIVATE
+      USE_WINDOWS_PROC
+      HAVE_MEMMEM=0
+      HAVE_TIMEGM=0
+    )
+
+    target_link_libraries(thirdparty_yara PUBLIC
+      thirdparty_openssl
     )
   endif()
-
-  target_link_libraries(thirdparty_yara PUBLIC
-    thirdparty_openssl
-    thirdparty_libmagic
-  )
 
   target_link_libraries(thirdparty_yara PRIVATE
     thirdparty_c_settings

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -28,6 +28,10 @@ function(generateOsqueryTablesTableimplementations)
       osquery_tables_yara_yaratable
       osquery_tables_lldpd_llpdtable
     )
+  elseif(DEFINED PLATFORM_WINDOWS)
+    target_link_libraries(osquery_tables_tableimplementations INTERFACE
+      osquery_tables_yara_yaratable
+    )
   endif()
 
   if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS)

--- a/osquery/tables/yara/CMakeLists.txt
+++ b/osquery/tables/yara/CMakeLists.txt
@@ -15,7 +15,7 @@ endfunction()
 
 function(generateOsqueryTablesYaraYaratable)
 
-  if(PLATFORM_WINDOWS OR PLATFORM_FREEBSD)
+  if(DEFINED PLATFORM_FREEBSD)
     add_osquery_library(osquery_tables_yara_yaratable INTERFACE)
     return()
   endif()

--- a/osquery/tables/yara/tests/CMakeLists.txt
+++ b/osquery/tables/yara/tests/CMakeLists.txt
@@ -7,9 +7,7 @@
 function(osqueryTablesYaraTestsMain)
 
   # We deviate from what there's in the BUCK file because compiling empty sources doesn't work
-  if(DEFINED PLATFORM_POSIX)
-    generateOsqueryTablesYaraTestsTest()
-  endif()
+  generateOsqueryTablesYaraTestsTest()
 endfunction()
 
 function(generateOsqueryTablesYaraTestsTest)

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -291,7 +291,7 @@ function(generateNativeTables)
     "windows/hvci_status.table:windows"
     "windows/shimcache.table:windows"
     "yara/yara_events.table:linux,macos"
-    "yara/yara.table:linux,macos,freebsd"
+    "yara/yara.table:linux,macos,freebsd,windows"
   )
 
   foreach(spec_descriptor ${platform_dependent_spec_files})

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -130,7 +130,6 @@ function(generateTestsIntegrationTablesTestsTest)
       ulimit_info.cpp
       usb_devices.cpp
       user_events.cpp
-      yara.cpp
       yum_sources.cpp
     )
 
@@ -176,6 +175,7 @@ function(generateTestsIntegrationTablesTestsTest)
       startup_items.cpp
       syslog_events.cpp
       yara_events.cpp
+      yara.cpp
     )
 
     list(APPEND source_files ${platform_source_files})
@@ -251,6 +251,7 @@ function(generateTestsIntegrationTablesTestsTest)
       xprotect_meta.cpp
       xprotect_reports.cpp
       yara_events.cpp
+      yara.cpp
     )
 
     list(APPEND source_files ${platform_source_files})
@@ -300,6 +301,7 @@ function(generateTestsIntegrationTablesTestsTest)
       wmi_filter_consumer_binding.cpp
       wmi_script_event_consumers.cpp
       hvci_status.cpp
+      yara.cpp
     )
 
     list(APPEND source_files ${platform_source_files})


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

The PR enables the on-demand Yara table on Windows. Currently, it is only supported on macOS and Linux.