### PR TITLE
Add `sigrules` to pass YARA signature with query

### DIFF
--- a/osquery/tables/yara/tests/yara_tests.cpp
+++ b/osquery/tables/yara/tests/yara_tests.cpp
@@ -66,6 +66,39 @@ class YARATest : public testing::Test {
     fs::remove_all(file_to_scan);
     return r;
   }
+
+  Row scanString(const std::string& rule_defs) {
+    YR_RULES* rules = nullptr;
+    int result = yr_initialize();
+    EXPECT_TRUE(result == ERROR_SUCCESS);
+
+    Status status = compileFromString(rule_defs, &rules);
+    EXPECT_TRUE(status.ok()) << status.what();
+
+    Row r;
+    r["count"] = "0";
+    r["matches"] = "";
+
+    const auto file_to_scan =
+        fs::temp_directory_path() /
+        fs::unique_path("osquery.tests.yara.%%%%.%%%%.bin");
+    {
+      std::ofstream test_file(file_to_scan.string());
+      test_file << "test\n";
+    }
+
+    result = yr_rules_scan_file(rules,
+                                file_to_scan.string().c_str(),
+                                SCAN_FLAGS_FAST_MODE,
+                                YARACallback,
+                                (void*)&r,
+                                0);
+    EXPECT_TRUE(result == ERROR_SUCCESS) << " yara error code: " << result;
+
+    yr_rules_destroy(rules);
+    fs::remove_all(file_to_scan);
+    return r;
+  }
 };
 
 TEST_F(YARATest, test_match_true) {
@@ -95,6 +128,18 @@ TEST_F(YARATest, should_skip_file) {
   EXPECT_TRUE(yaraShouldSkipFile("/any/file/here", S_IFBLK));
   EXPECT_TRUE(yaraShouldSkipFile("/any/file/here", S_IFIFO));
 #endif
+}
+
+TEST_F(YARATest, test_match_string_true) {
+  Row r = scanString(alwaysTrue);
+  // expect count 1
+  EXPECT_TRUE(r["count"] == "1");
+}
+
+TEST_F(YARATest, test_match_string_false) {
+  Row r = scanString(alwaysFalse);
+  // expect count 0
+  EXPECT_TRUE(r["count"] == "0");
 }
 
 } // namespace osquery

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -38,6 +38,8 @@ void YARACompilerCallback(int error_level,
                           const char* message,
                           void* user_data) {
   std::stringstream ss;
+  // file_name will be nullptr on compiling YARA rules from
+  // string. It checks the file_name and generate the logs.
   if (file_name == nullptr)
     ss << "YARA rule string ";
   else

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -42,6 +42,24 @@ void YARACompilerCallback(int error_level,
   }
 }
 
+// yr_initialize maintains a reference count and avoid
+// re-initialization
+Status yaraInitilize(void) {
+  auto result = yr_initialize();
+  if (result != ERROR_SUCCESS) {
+    return Status::failure("Fail to initialize YARA " + std::to_string(result));
+  }
+  return Status::success();
+}
+
+Status yaraFinalize(void) {
+  auto result = yr_finalize();
+  if (result != ERROR_SUCCESS) {
+    return Status::failure("Fail to finalize YARA " + std::to_string(result));
+  }
+  return Status::success();
+}
+
 /**
  * Compile a single rule file and load it into rule pointer.
  */

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -17,7 +17,7 @@
 
 namespace osquery {
 
-DECLARE_bool(disable_yara_string_private);
+DECLARE_bool(enable_yara_string);
 
 bool yaraShouldSkipFile(const std::string& path, mode_t st_mode) {
   // avoid special files /dev/x , /proc/x, FIFO's named-pipes, etc.
@@ -37,11 +37,15 @@ void YARACompilerCallback(int error_level,
                           const YR_RULE* rule,
                           const char* message,
                           void* user_data) {
-  auto name = (file_name != nullptr) ? std::string(file_name) : std::string("");
+  std::stringstream ss;
+  if (file_name == nullptr)
+    ss << "YARA rule string ";
+  else
+    ss << "YARA rule file " << file_name;
   if (error_level == YARA_ERROR_LEVEL_ERROR) {
-    VLOG(1) << name << "(" << line_number << "): error: " << message;
+    VLOG(1) << ss.str() << "(" << line_number << "): error: " << message;
   } else {
-    VLOG(1) << name << "(" << line_number << "): warning: " << message;
+    VLOG(1) << ss.str() << "(" << line_number << "): warning: " << message;
   }
 }
 
@@ -50,7 +54,8 @@ void YARACompilerCallback(int error_level,
 Status yaraInitilize(void) {
   auto result = yr_initialize();
   if (result != ERROR_SUCCESS) {
-    return Status::failure("Fail to initialize YARA " + std::to_string(result));
+    return Status::failure("Failed to initialize YARA " +
+                           std::to_string(result));
   }
   return Status::success();
 }
@@ -58,7 +63,7 @@ Status yaraInitilize(void) {
 Status yaraFinalize(void) {
   auto result = yr_finalize();
   if (result != ERROR_SUCCESS) {
-    return Status::failure("Fail to finalize YARA " + std::to_string(result));
+    return Status::failure("Failed to finalize YARA " + std::to_string(result));
   }
   return Status::success();
 }
@@ -68,10 +73,11 @@ Status yaraFinalize(void) {
  */
 Status compileSingleFile(const std::string& file, YR_RULES** rules) {
   YR_COMPILER* compiler = nullptr;
+
   int result = yr_compiler_create(&compiler);
   if (result != ERROR_SUCCESS) {
-    VLOG(1) << "Could not create compiler: " + std::to_string(result);
-    return Status(1, "Could not create compiler: " + std::to_string(result));
+    return Status::failure("Could not create compiler: " +
+                           std::to_string(result));
   }
 
   yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
@@ -88,7 +94,8 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
   result = yr_rules_load(file.c_str(), &tmp_rules);
   if (result != ERROR_SUCCESS && result != ERROR_INVALID_FILE) {
     yr_compiler_destroy(compiler);
-    return Status(1, "Error loading YARA rules: " + std::to_string(result));
+    return Status::failure("Error loading YARA rules: " +
+                           std::to_string(result));
   } else if (result == ERROR_SUCCESS) {
     *rules = tmp_rules;
   } else {
@@ -110,7 +117,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
     if (errors > 0) {
       yr_compiler_destroy(compiler);
       // Errors printed via callback.
-      return Status(1, "Compilation errors");
+      return Status::failure("Compilation errors");
     }
   }
 
@@ -120,7 +127,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
 
     if (result != ERROR_SUCCESS) {
       yr_compiler_destroy(compiler);
-      return Status(1, "Insufficient memory to get YARA rules");
+      return Status::failure("Insufficient memory to get YARA rules");
     }
   }
 
@@ -140,7 +147,8 @@ Status compileFromString(const std::string& rule_defs, YR_RULES** rules) {
 
   auto result = yr_compiler_create(&compiler);
   if (result != ERROR_SUCCESS) {
-    return Status(1, " - Could not create compiler: " + std::to_string(result));
+    return Status::failure("Could not create compiler: " +
+                           std::to_string(result));
   }
 
   yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
@@ -148,18 +156,18 @@ Status compileFromString(const std::string& rule_defs, YR_RULES** rules) {
   result = yr_compiler_add_string(compiler, rule_defs.c_str(), nullptr);
   if (result > 0) {
     yr_compiler_destroy(compiler);
-    return Status::failure(" - Compilation error " + std::to_string(result));
+    return Status::failure("Compilation error " + std::to_string(result));
   }
 
   result = yr_compiler_get_rules(compiler, *(&rules));
   if (result != ERROR_SUCCESS) {
     yr_compiler_destroy(compiler);
-    return Status::failure(" - Insufficient memory to get YARA rules");
+    return Status::failure("Insufficient memory to get YARA rules");
   }
 
   // The yara rule strings are set to private unless it is disabled. This
   // will protect from data exfiltration
-  if (!FLAGS_disable_yara_string_private) {
+  if (!FLAGS_enable_yara_string) {
     YR_RULE* rule = nullptr;
     yr_rules_foreach((*rules), rule) {
       if (rule->strings) {

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -35,10 +35,11 @@ void YARACompilerCallback(int error_level,
                           const YR_RULE* rule,
                           const char* message,
                           void* user_data) {
+  auto name = (file_name != nullptr) ? std::string(file_name) : std::string("");
   if (error_level == YARA_ERROR_LEVEL_ERROR) {
-    VLOG(1) << file_name << "(" << line_number << "): error: " << message;
+    VLOG(1) << name << "(" << line_number << "): error: " << message;
   } else {
-    VLOG(1) << file_name << "(" << line_number << "): warning: " << message;
+    VLOG(1) << name << "(" << line_number << "): warning: " << message;
   }
 }
 
@@ -140,8 +141,6 @@ Status compileFromString(const std::string& rule_defs, YR_RULES** rules) {
   }
 
   yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
-
-  VLOG(1) << "Loading YARA signature string: " << rule_defs;
 
   auto errors = yr_compiler_add_string(compiler, rule_defs.c_str(), nullptr);
 

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -35,6 +35,8 @@ void YARACompilerCallback(int error_level,
 
 Status compileSingleFile(const std::string& file, YR_RULES** rule);
 
+Status compileFromString(const std::string& buffer, YR_RULES** rules);
+
 Status handleRuleFiles(const std::string& category,
                        const pt::ptree& rule_files,
                        std::map<std::string, YR_RULES*>& rules);

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -33,6 +33,10 @@ void YARACompilerCallback(int error_level,
                           const char* message,
                           void* user_data);
 
+Status yaraInitilize(void);
+
+Status yaraFinalize(void);
+
 Status compileSingleFile(const std::string& file, YR_RULES** rule);
 
 Status compileFromString(const std::string& buffer, YR_RULES** rules);

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -19,6 +19,7 @@
 #ifdef CONCAT
 #undef CONCAT
 #endif
+
 #include <yara.h>
 
 namespace pt = boost::property_tree;

--- a/specs/yara/yara.table
+++ b/specs/yara/yara.table
@@ -19,5 +19,5 @@ examples([
   "select * from yara where path = '/etc/passwd'",
   "select * from yara where path LIKE '/etc/%'",
   "select * from yara where path = '/etc/passwd' and sigfile = '/etc/osquery/yara/test.yara'",
-  "select * from yara where path = '/etc/passwd' and sigrules = 'rule always_true { condition: true }'",
+  "select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }'",
 ])

--- a/specs/yara/yara.table
+++ b/specs/yara/yara.table
@@ -9,6 +9,8 @@ schema([
         additional=True),
     Column("sigfile", TEXT, "Signature file used",
         additional=True),
+	Column("sigrule", TEXT, "Signature strings used",
+        additional=True),
     Column("strings", TEXT, "Matching strings"),
     Column("tags", TEXT, "Matching tags"),
 ])
@@ -17,4 +19,5 @@ examples([
   "select * from yara where path = '/etc/passwd'",
   "select * from yara where path LIKE '/etc/%'",
   "select * from yara where path = '/etc/passwd' and sigfile = '/etc/osquery/yara/test.yara'",
+  "select * from yara where path = '/etc/passwd' and sigrules = 'rule always_true { condition: true }'",
 ])

--- a/specs/yara/yara.table
+++ b/specs/yara/yara.table
@@ -10,7 +10,7 @@ schema([
     Column("sigfile", TEXT, "Signature file used",
         additional=True),
 	Column("sigrule", TEXT, "Signature strings used",
-        additional=True),
+        additional=True, hidden=True),
     Column("strings", TEXT, "Matching strings"),
     Column("tags", TEXT, "Matching tags"),
 ])

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -23,26 +23,24 @@ class yara : public testing::Test {
 };
 
 TEST_F(yara, test_sanity) {
-  // 1. Query data
-  auto const data = execute_query("select * from yara where path = ''");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"path", NormalType}
-  //      {"matches", NormalType}
-  //      {"count", IntType}
-  //      {"sig_group", NormalType}
-  //      {"sigfile", NormalType}
-  //      {"strings", NormalType}
-  //      {"tags", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+  // Query data from yara table
+#if !defined(WINDOWS)
+  auto const data = execute_query(
+      "select * from yara where path like '%' and sigrules = "
+      "'rule always_true { condition: true }'");
+
+  ASSERT_GE(data.size(), 0ul);
+  ValidationMap row_map = {{"path", NormalType},
+                           {"matches", NormalType},
+                           {"count", IntType},
+                           {"sig_group", NormalType},
+                           {"sigfile", NormalType},
+                           {"sigrules", NormalType},
+                           {"strings", NormalType},
+                           {"tags", NormalType}};
+
+  validate_rows(data, row_map);
+#endif
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -26,7 +26,7 @@ TEST_F(yara, test_sanity) {
   // Query data from yara table
 #if !defined(WINDOWS)
   auto const data = execute_query(
-      "select * from yara where path like '%' and sigrules = "
+      "select * from yara where path like '%' and sigrule = "
       "'rule always_true { condition: true }'");
 
   ASSERT_GE(data.size(), 0ul);

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -23,22 +23,26 @@ class yara : public testing::Test {
 };
 
 TEST_F(yara, test_sanity) {
-  // Query data from yara table
-  auto const data = execute_query(
-      "select * from yara where path like '%' and sigrule = "
-      "'rule always_true { condition: true }'");
-
-  ASSERT_GE(data.size(), 0ul);
-  ValidationMap row_map = {{"path", NormalType},
-                           {"matches", NormalType},
-                           {"count", IntType},
-                           {"sig_group", NormalType},
-                           {"sigfile", NormalType},
-                           {"sigrule", NormalType},
-                           {"strings", NormalType},
-                           {"tags", NormalType}};
-
-  validate_rows(data, row_map);
+  // 1. Query data
+  auto const data = execute_query("select * from yara where path = ''");
+  // 2. Check size before validation
+  // ASSERT_GE(data.size(), 0ul);
+  // ASSERT_EQ(data.size(), 1ul);
+  // ASSERT_EQ(data.size(), 0ul);
+  // 3. Build validation map
+  // See helper.h for avaialbe flags
+  // Or use custom DataCheck object
+  // ValidationMap row_map = {
+  //      {"path", NormalType}
+  //      {"matches", NormalType}
+  //      {"count", IntType}
+  //      {"sig_group", NormalType}
+  //      {"sigfile", NormalType}
+  //      {"strings", NormalType}
+  //      {"tags", NormalType}
+  //}
+  // 4. Perform validation
+  // validate_rows(data, row_map);
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -24,7 +24,6 @@ class yara : public testing::Test {
 
 TEST_F(yara, test_sanity) {
   // Query data from yara table
-#if !defined(WINDOWS)
   auto const data = execute_query(
       "select * from yara where path like '%' and sigrule = "
       "'rule always_true { condition: true }'");
@@ -35,12 +34,11 @@ TEST_F(yara, test_sanity) {
                            {"count", IntType},
                            {"sig_group", NormalType},
                            {"sigfile", NormalType},
-                           {"sigrules", NormalType},
+                           {"sigrule", NormalType},
                            {"strings", NormalType},
                            {"tags", NormalType}};
 
   validate_rows(data, row_map);
-#endif
 }
 
 } // namespace table_tests


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

The PR adds a new column `sigrules` that can be used to pass a small set of YARA signature with the query. 

```
osquery> select * from yara where path = '/etc/passwd' and sigrules = 'rule always_true { condition: true }';
+-------------+-------------+-------+-----------+---------+--------------------------------------+---------+------+
| path        | matches     | count | sig_group | sigfile | sigrules                             | strings | tags |
+-------------+-------------+-------+-----------+---------+--------------------------------------+---------+------+
| /etc/passwd | always_true | 1     |           |         | rule always_true { condition: true } |         |      |
+-------------+-------------+-------+-----------+---------+--------------------------------------+---------+------+
```

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
