### PR TITLE
Fix readFile to observe requested read size

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -121,7 +121,8 @@ Status readFile(const fs::path& path,
 
   off_t file_size = static_cast<off_t>(handle.fd->size());
 
-  if (handle.fd->isSpecialFile() && size > 0) {
+  if (size > 0 &&
+      (handle.fd->isSpecialFile() || static_cast<off_t>(size) < file_size)) {
     file_size = static_cast<off_t>(size);
   }
 

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -184,6 +184,14 @@ TEST_F(FilesystemTests, test_read_limit) {
   EXPECT_TRUE(status.ok());
 }
 
+TEST_F(FilesystemTests, test_read_size) {
+  std::string content;
+  size_t s = 3;
+  auto status = readFile(fake_directory_ / "root.txt", content, s);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(content.size(), s);
+}
+
 TEST_F(FilesystemTests, test_list_files_missing_directory) {
   std::vector<std::string> results;
   auto status = listFilesInDirectory("/foo/bar", results);


### PR DESCRIPTION
The readFile function in the filesystem package takes a size param, however this size param is ignored unless the file is a "special" file (I suppose a device file). This change fixes the readFile function to observe the requested read size.