### PR TITLE
ci: Fix pip upgrade warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ include(cmake/toolchain.cmake)
 
 project(osquery)
 
-# Small change to test CI
-
 if(OSQUERY_BUILD_TESTS)
   enable_testing()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ include(cmake/toolchain.cmake)
 
 project(osquery)
 
+# Small change to test CI
+
 if(OSQUERY_BUILD_TESTS)
   enable_testing()
 endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -287,6 +287,7 @@ jobs:
     - powershell: |
         cmake --version
         $python3_path = ((Get-Item C:\hostedtoolcache\windows\Python\3*\x64) | Sort-Object -Descending)[0].FullName
+        & $python3_path\python -m pip install --upgrade pip
         & $python3_path\python -m pip install setuptools psutil timeout_decorator thrift==0.11.0 osquery pywin32
       displayName: Install tests prerequisites
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -287,7 +287,7 @@ jobs:
     - powershell: |
         cmake --version
         $python3_path = ((Get-Item C:\hostedtoolcache\windows\Python\3*\x64) | Sort-Object -Descending)[0].FullName
-        & $python3_path\python -m pip install --upgrade pip
+        & $python3_path\python -m pip install --upgrade pip --no-warn-script-location
         & $python3_path\python -m pip install setuptools psutil timeout_decorator thrift==0.11.0 osquery pywin32
       displayName: Install tests prerequisites
 


### PR DESCRIPTION
Pip is warning us that a newer version is available.

```
Installing collected packages: psutil, timeout-decorator, six, thrift, argparse, future, osquery, pywin32
    Running setup.py install for timeout-decorator: started
    Running setup.py install for timeout-decorator: finished with status 'done'
    Running setup.py install for thrift: started
    Running setup.py install for thrift: finished with status 'done'
    Running setup.py install for future: started
    Running setup.py install for future: finished with status 'done'
Successfully installed argparse-1.4.0 future-0.18.2 osquery-3.0.6 psutil-5.7.2 pywin32-228 six-1.15.0 thrift-0.11.0 timeout-decorator-0.4.1
python.exe : WARNING: You are using pip version 20.1.1; however, version 20.2 is available.
At D:\a\_temp\e56a42ad-24b7-444f-a585-4f96f7940dbd.ps1:5 char:1
+ & $python3_path\python -m pip install setuptools psutil timeout_decor ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (WARNING: You ar...2 is available.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
##[error]PowerShell exited with code '1'.
```

One solution is to upgrade `pip` before using it.