### PR TITLE
Fix incorrect readFile params in createPidFile

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -351,7 +351,7 @@ Status createPidFile() {
   if (pathExists(pidfile_path).ok()) {
     // if it exists, check if that pid is running.
     std::string content;
-    auto read_status = readFile(pidfile_path, content, true);
+    auto read_status = readFile(pidfile_path, content);
     if (!read_status.ok()) {
       return Status(1, "Could not read pidfile: " + read_status.toString());
     }


### PR DESCRIPTION
Fixes #6581. In PR #6569 I fixed the readFile function to respect the requested read size. This tickled a bug in the createPidFile function which was incorrectly using the readFile API. The original intent of the call to readFile was to pass dry_run = true meaning "don't actually read file contents." This stopped working when there was a size param inserted in the API and the 'true' became a requested read size of 1. Now that we respect the size in readFile, createPidFile was getting a short read. In this PR I remove the 'true' entirely because there was also a different change that uses the data from pidfile made later so it actually depends on dry_run being false. Gotta love it when bugs are stacked 3 deep.