### PR TITLE
Fix call to LocalFree() on uninit ptr inside getUidFromSid()

### DIFF
--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -27,7 +27,7 @@ std::string psidToString(PSID sid) {
 
 uint32_t getUidFromSid(PSID sid) {
   auto const uid_default = static_cast<uint32_t>(-1);
-  LPSTR sidString;
+  LPSTR sidString = nullptr;
   if (ConvertSidToStringSidA(sid, &sidString) == 0) {
     VLOG(1) << "getUidFromSid failed ConvertSidToStringSid error " +
                    std::to_string(GetLastError());


### PR DESCRIPTION
On my windows test host I was encountering falling calls to ConvertSidToStringSidA() inside getUidFromSid(). Following a failed call we call LocalFree() on a potentially uninitialized pointer sidString. This was resulting in a segfault. Initializing the pointer to null fixes the crash. 