### PR TITLE
Remove ExecStartPre from systemd service unit -- do not create empty config file

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -5,7 +5,6 @@ After=network.service syslog.service
 [Service]
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
-ExecStartPre=/bin/sh -c "if [ ! -f $CONFIG_FILE ]; then echo {} > $CONFIG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"
 ExecStart=/usr/bin/osqueryd \


### PR DESCRIPTION
osquery can start without a configuration file and will start even if the specified config file does not exist, so there is no need to create an empty config before starting the service. This PR addresses https://github.com/osquery/osquery/issues/6381.

Presumably this `ExecStartPre` command was added to suppress the warning that osquery logs if it cannot open the config file specified with the `--config_path` flag. If that is true, a better way to handle that may be to create a small shell script that only starts `osqueryd` with either/both of the `--flagfile` and `--config_path` flags if the corresponding files exist.

Fixes: #6381