### PR TITLE
Manual copyright changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
 <img alt="osquery logo" width="200"
-src="https://github.com/facebook/osquery/raw/master/docs/img/logo-2x-dark.png" />
+src="https://github.com/osquery/osquery/raw/master/docs/img/logo-2x-dark.png" />
 </p>
 
 <p align="center">
@@ -17,7 +17,7 @@ Available for Linux, macOS, Windows, and FreeBSD.
 - Documentation: https://osquery.readthedocs.org
 - Stack Overflow: https://stackoverflow.com/questions/tagged/osquery
 - Table Schema: https://osquery.io/schema
-- Query Packs: [https://osquery.io/packs](https://github.com/facebook/osquery/tree/master/packs)
+- Query Packs: [https://osquery.io/packs](https://github.com/osquery/osquery/tree/master/packs)
 - Slack: [![Slack Status](https://osquery-slack.herokuapp.com/badge.svg)](https://osquery-slack.herokuapp.com)
 - Build Status: [![Build Status](https://dev.azure.com/trailofbits/osquery/_apis/build/status/osquery?branchName=master)](https://dev.azure.com/trailofbits/osquery/_build/latest?definitionId=6&branchName=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/13317/badge.svg)](https://scan.coverity.com/projects/osquery) [![Documentation Status](https://readthedocs.org/projects/osquery/badge/?version=latest)](https://osquery.readthedocs.io/en/latest/?badge=latest)
 - CII Best Practices: [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3125/badge)](https://bestpractices.coreinfrastructure.org/projects/3125)

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -399,7 +399,7 @@ function(generatePackageTarget)
       set(CPACK_NUGET_PACKAGE_AUTHORS "${CPACK_PACKAGE_NAME}")
       set(CPACK_NUGET_PACKAGE_TITLE "${CPACK_PACKAGE_NAME}")
       set(CPACK_NUGET_PACKAGE_OWNERS "${CPACK_PACKAGE_NAME}")
-      set(CPACK_NUGET_PACKAGE_COPYRIGHT "Copyright (c) 2014-present, Facebook, Inc. All rights reserved.")
+      set(CPACK_NUGET_PACKAGE_COPYRIGHT "Copyright (c) 2014-present, The osquery authors. See LICENSE.")
       set(CPACK_NUGET_PACKAGE_LICENSEURL "${OSQUERY_REPO}blob/master/LICENSE")
       set(CPACK_NUGET_PACKAGE_ICONURL "${OSQUERY_REPO}blob/master/tools/osquery.ico")
       set(CPACK_NUGET_PACKAGE_DESCRIPTION_SUMMARY "

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## ReadTheDocs Wiki
 
-The ReadTheDocs wiki (https://osquery.readthedocs.org/en/stable) is generated using a RTD-configured osquery project and associated GitHub Service. This Service is documented by RTD and more-or-less setup automatically with the project. RTD generates documentation for every version (git tag). It calls the most recent tag 'stable', the most recent commit to master 'devel', and includes links to every past version. The project settings and sidebar for RTD is kept in the root as [mkdocs.yml](https://github.com/facebook/osquery/blob/master/mkdocs.yml).
+The ReadTheDocs wiki (https://osquery.readthedocs.org/en/stable) is generated using a RTD-configured osquery project and associated GitHub Service. This Service is documented by RTD and more-or-less setup automatically with the project. RTD generates documentation for every version (git tag). It calls the most recent tag 'stable', the most recent commit to master 'devel', and includes links to every past version. The project settings and sidebar for RTD is kept in the root as [mkdocs.yml](https://github.com/osquery/osquery/blob/master/mkdocs.yml).
 
 ### Adding a new page
 
@@ -11,7 +11,7 @@ New wiki pages should be organized into one of the following categories:
 - **Deployment**: Tool concepts and all the wonderful goodies of making osquery useful.
 - **Development**: Help and guides for starting with osquery development and build.
 
-Make a new "filename.md" within the category folder within `/docs/wiki/CATEGORY/`. Then add the friendly page title and path to [mkdocs.yml](https://github.com/facebook/osquery/blob/master/mkdocs.yml), in the order the page should appear within the wiki sidebar.
+Make a new "filename.md" within the category folder within `/docs/wiki/CATEGORY/`. Then add the friendly page title and path to [mkdocs.yml](https://github.com/osquery/osquery/blob/master/mkdocs.yml), in the order the page should appear within the wiki sidebar.
 
 ### Wiki style tips
 
@@ -28,7 +28,7 @@ The output HTML documentation is written to `./build/docs/html/`. Use `index.htm
 
 ## Tables and Packs
 
-Table schema, the osquery user API, is created using the Python-based ".spec" files in [`./specs`](https://github.com/facebook/osquery/tree/master/specs). More documentation on how specs work can be found in the [Creating New Tables](http://osquery.readthedocs.org/en/stable/development/creating-tables/) developer documentation. These files are used to build osquery, but can be parsed to create JSON-based API schema. This JSON is published to the homepage at [https://osquery.io/schema/].
+Table schema, the osquery user API, is created using the Python-based ".spec" files in [`./specs`](https://github.com/osquery/osquery/tree/master/specs). More documentation on how specs work can be found in the [Creating New Tables](http://osquery.readthedocs.org/en/stable/development/creating-tables/) developer documentation. These files are used to build osquery, but can be parsed to create JSON-based API schema. This JSON is published to the homepage at [https://osquery.io/schema/].
 
 Use: `./tools/codegen/genapi.py` to generate the amalgamated schema. To generate a "change log" between tags, use the same script but use `--diff` and supply the two JSON inputs.
 

--- a/docs/doxygen/mainpage.md
+++ b/docs/doxygen/mainpage.md
@@ -1,4 +1,4 @@
 @mainpage osquery api documentation
 
 This is the generated public api documentation for osquery. For more free-form
-documentation, see the GitHub wiki: https://github.com/facebook/osquery/wiki.
+documentation, see the GitHub wiki: https://github.com/osquery/osquery/wiki.

--- a/docs/wiki/development/creating-tables.md
+++ b/docs/wiki/development/creating-tables.md
@@ -90,7 +90,14 @@ As indicated in the spec file, our implementation will be in a function called `
 Here is that code for `./osquery/tables/utility/time_example.cpp`:
 
 ```cpp
-// Copyright 2004-present Facebook. All Rights Reserved.
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
 
 #include <ctime>
 #include <osquery/core/tables.h>
@@ -132,7 +139,14 @@ You may add small unit tests using GTest, but each table *should* have an integr
 Create a file `./tests/integration/tables/time_example.cpp`.
 
 ```cpp
-// Copyright 2004-present Facebook. All Rights Reserved.
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
 
 #include <osquery/tests/integration/tables/helper.h>
 

--- a/osquery/core/plugins/sql.cpp
+++ b/osquery/core/plugins/sql.cpp
@@ -1,5 +1,13 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+/**
  * @brief The osquery SQL implementation is managed as a plugin.
  *
  * The osquery RegistryFactory creates a Registry type called "sql", then

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) 2014-present, The osquery authors
- * Copyright 2018 Alex Ionescu.
  *
  * This source code is licensed as defined by the LICENSE file found in the
  * root directory of this source tree.

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -1,19 +1,29 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ * Copyright (c) 2014-present, The osquery authors
+ * Copyright 2018 Alex Ionescu.
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+/**
  * @brief The osquery SQL implementation is managed as a plugin.
  *
- * The osquery RegistryFactory creates a Registry type called "sql", then
- * requires a single plugin registration also called "sql". Calls within
- * the application use boilerplate methods that wrap Registry::call%s to this
- * well-known registry and registry item name.
+ * The osquery RegistryFactory creates a Registry type called "sql",
+ * then requires a single plugin registration also called "sql". Calls
+ * within the application use boilerplate methods that wrap
+ * Registry::call%s to this well-known registry and registry item
+ * name.
  *
- * Abstracting the SQL implementation behind the osquery registry allows
- * the SDK (libosquery) to describe how the SQL implementation is used without
- * having dependencies on the thrird-party code.
+ * Abstracting the SQL implementation behind the osquery registry
+ * allows the SDK (libosquery) to describe how the SQL implementation
+ * is used without having dependencies on the thrird-party code.
  *
- * When osqueryd/osqueryi are built libosquery_additional, the library which
- * provides the core plugins and core virtual tables, includes SQLite as
- * the SQL implementation.
+ * When osqueryd/osqueryi are built libosquery_additional, the library
+ * which provides the core plugins and core virtual tables, includes
+ * SQLite as the SQL implementation.
  */
 
 #pragma once

--- a/osquery/devtools/devtools.h
+++ b/osquery/devtools/devtools.h
@@ -1,9 +1,10 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
  *
- *  This source code is licensed in accordance with the terms specified in
- *  the LICENSE file found in the root directory of this source tree.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #pragma once
@@ -33,7 +34,11 @@ DECLARE_bool(disable_events);
  * @brief Run an interactive SQL query shell.
  *
  * @code{.cpp}
- *   // Copyright 2004-present Facebook. All Rights Reserved.
+ *   // Copyright (c) 2014-present, The osquery authors
+ *   //
+ *   // This source code is licensed as defined by the LICENSE file
+ *   // found in the root directory of this source tree.
+ *
  *   #include <osquery/core/core.h>
  *   #include <osquery/devtools.h>
  *

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1140,12 +1140,12 @@ inline void meta_version(struct callback_data* p) {
 }
 
 inline void meta_show(struct callback_data* p) {
-  // The show/summary meta command is provided to help with general debugging.
-  // All of this information is 'duplicate', and can be found with better
-  // detail within osquery virtual tables.
+  // The show/summary meta command is provided to help with general
+  // debugging.  All of this information is 'duplicate', and can be
+  // found with better detail within osquery virtual tables.
   print_bold("osquery");
   printf(
-      " - being built, with love, at Facebook\n"
+      " - being built, with love.\n"
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
   meta_version(p);
 

--- a/osquery/extensions/thrift/osquery.thrift
+++ b/osquery/extensions/thrift/osquery.thrift
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+// Copyright (c) 2014-present, The osquery authors
+//
+// This source code is licensed as defined by the LICENSE file found in the
+// root directory of this source tree.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 namespace cpp osquery.extensions
 namespace py osquery.extensions

--- a/osquery/tables/system/efi_misc.h
+++ b/osquery/tables/system/efi_misc.h
@@ -1,10 +1,11 @@
-/*
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  Copyright (c) 2004, Intel Corporation
- *  All rights reserved.
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ * Copyright (c) 2004, Intel Corporation
  *
- *  This source code is licensed in accordance with the terms specified in
- *  the LICENSE file found in the root directory of this source tree.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #pragma once

--- a/osquery/tables/system/linux/portage.cpp
+++ b/osquery/tables/system/linux/portage.cpp
@@ -1,10 +1,13 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
  *
- *  This source code is licensed in accordance with the terms specified in
- *  the LICENSE file found in the root directory of this source tree.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
  *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+/**
  *  Portage support by J.O. Aho <trizt@aho.hk>
  */
 

--- a/osquery/tables/system/windows/kva_speculative_info.cpp
+++ b/osquery/tables/system/windows/kva_speculative_info.cpp
@@ -1,10 +1,11 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  Copyright 2018 Alex Ionescu.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
+ * Copyright 2018 Alex Ionescu.
  *
- *  This source code is licensed in accordance with the terms specified in
- *  the LICENSE file found in the root directory of this source tree.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #include <ntstatus.h>

--- a/specs/curl.table
+++ b/specs/curl.table
@@ -12,5 +12,5 @@ schema([
 ])
 implementation("networking/curl@genCurl")
 examples([
-  "select url, round_trip_time, response_code from curl where url = 'https://github.com/facebook/osquery'",
+  "select url, round_trip_time, response_code from curl where url = 'https://github.com/osquery/osquery'",
 ])

--- a/tools/ci/scripts/install_openssl_formula_dependencies.ps1
+++ b/tools/ci/scripts/install_openssl_formula_dependencies.ps1
@@ -1,9 +1,10 @@
 <#
-  Copyright (c) 2014-present, Facebook, Inc.
-  All rights reserved.
+  Copyright (c) 2014-present, The osquery authors
 
-  This source code is licensed in accordance with the terms specified in
-  the LICENSE file found in the root directory of this source tree.
+  This source code is licensed as defined by the LICENSE file found in the
+  root directory of this source tree.
+
+  SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 #>
 
 #

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-"""
-Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+"""
 Generate a complete table specification for the website
 
 This script will generate JSON output as expected by the osquery website given

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-"""
-Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+"""
 Generate a new website version metadata file based on a new release version
 
 Usage:

--- a/tools/deployment/copyright.debian
+++ b/tools/deployment/copyright.debian
@@ -4,7 +4,7 @@ Source: https://github.com/osquery/osquery
 
 Files: *
 License: Apache 2.0 or GPL 2.0
-Copyright: Copyright (C) 2014-present, Facebook, Inc.
+Copyright: Copyright (c) 2014-present, The osquery authors. See LICENSE
 
 Files: share/osquery/lenses/*
 Copyright: Copyright (C) 2007-2016 David Lutterkort, Augeas Lenses authors.

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -422,7 +422,8 @@ function New-ChocolateyPackage() {
     <title>osquery</title>
     <authors>osquery</authors>
     <owners>osquery</owners>
-    <copyright>Copyright (c) 2014-present, Facebook, Inc. All rights reserved.</copyright>
+    <copyright>Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the
+# root directory of this source tree.</copyright>
     <projectUrl>https://osquery.io</projectUrl>
     <iconUrl>https://github.com/osquery/osquery/blob/master/tools/osquery.ico</iconUrl>
     <licenseUrl>https://github.com/osquery/osquery/blob/master/LICENSE</licenseUrl>

--- a/tools/deployment/osqueryctl
+++ b/tools/deployment/osqueryctl
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-#  Copyright (c) 2014-present, Facebook, Inc.
-#  All rights reserved.
+# Copyright (c) 2014-present, The osquery authors
 #
-#  This source code is licensed as defined on the LICENSE file found in the
-#  root directory of this source tree.
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 set -e
 

--- a/tools/windows_resources.rc.in
+++ b/tools/windows_resources.rc.in
@@ -10,7 +10,8 @@
 #define VER_COMPANYNAME_STR         "Facebook"
 #define VER_FILEDESCRIPTION_STR     "osquery daemon and shell"
 #define VER_INTERNALNAME_STR        "osquery"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, Facebook, Inc. All rights reserved."
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the
+# root directory of this source tree."
 #define VER_ORIGINALFILENAME_STR    "osqueryd.exe"
 #define VER_PRODUCTNAME_STR         "osquery"
 

--- a/tools/windows_resources.rc.in
+++ b/tools/windows_resources.rc.in
@@ -10,8 +10,7 @@
 #define VER_COMPANYNAME_STR         "Facebook"
 #define VER_FILEDESCRIPTION_STR     "osquery daemon and shell"
 #define VER_INTERNALNAME_STR        "osquery"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the
-# root directory of this source tree."
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the root directory of this source tree."
 #define VER_ORIGINALFILENAME_STR    "osqueryd.exe"
 #define VER_PRODUCTNAME_STR         "osquery"
 


### PR DESCRIPTION
Update the remaining copyright notices that were unscripted oddballs, and missed in #6589

These are predominately ones that feature additional additional authors. I kept them, but I don't know if we can include them in the broader "osquery authors" flag.

This also adjusts several of the oneline copyright blocks.

And updates a several old github URLs.