### PR TITLE
Set global output function for Thrift 

### DIFF
--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -345,16 +345,8 @@ void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
         std::make_shared<extensions::ExtensionManagerProcessor>(handler);
   }
   // Set the global output function for thrift
-  GlobalOutput.setOutputFunction([](const char* message) -> void {
-    time_t now;
-    char dbgtime[26];
-    time(&now);
-    THRIFT_CTIME_R(&now, dbgtime);
-    dbgtime[24] = 0;
-    std::stringstream ss;
-    ss << "Thrift: " << dbgtime << " " << message;
-    VLOG(1) << ss.str();
-  });
+  GlobalOutput.setOutputFunction(
+      [](const char* message) -> void { VLOG(1) << "Thrift: " << message; });
 }
 
 void ExtensionRunnerInterface::stopServer() {

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -39,6 +39,7 @@
 
 namespace osquery {
 
+using namespace apache::thrift;
 using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
 using namespace apache::thrift::server;
@@ -343,6 +344,17 @@ void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
     server_->processor =
         std::make_shared<extensions::ExtensionManagerProcessor>(handler);
   }
+  // Set the global output function for thrift
+  GlobalOutput.setOutputFunction([](const char* message) -> void {
+    time_t now;
+    char dbgtime[26];
+    time(&now);
+    THRIFT_CTIME_R(&now, dbgtime);
+    dbgtime[24] = 0;
+    std::stringstream ss;
+    ss << "Thrift: " << dbgtime << " " << message;
+    VLOG(1) << ss.str();
+  });
 }
 
 void ExtensionRunnerInterface::stopServer() {


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

The PR sets the global output function for the Thrift server. This prevents throwing up the error log on `stderr` while testing the Thrift socket. It also enables the error logging in the verbose mode as suggested by @Smjert.

Related to #6152 

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
