### PR TITLE
Implement new Linux table systemd_units, listing systemd units

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -53,7 +53,7 @@ function(generateOsqueryTablesSystemSystemtable)
     list(APPEND source_files
       freenux/cpu_time.cpp
       linux/dbus/methods/listunitsmethodhandler.cpp
-      linux/dbus/methods/getproperty.cpp
+      linux/dbus/methods/getstringproperty.cpp
       linux/dbus/uniquedbusconnection.cpp
       linux/dbus/uniquedbusmessage.cpp
       linux/acpi_tables.cpp
@@ -90,6 +90,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/users.cpp
       linux/selinux_settings.cpp
       linux/apparmor_profiles.cpp
+      linux/systemd_units.cpp
     )
 
   elseif(DEFINED PLATFORM_MACOS)
@@ -309,7 +310,7 @@ function(generateOsqueryTablesSystemSystemtable)
     list(APPEND platform_public_header_files
       linux/dbus/methods/dbusmethod.h
       linux/dbus/methods/listunitsmethodhandler.h
-      linux/dbus/methods/getproperty.h
+      linux/dbus/methods/getstringproperty.h
       linux/dbus/uniquedbusconnection.h
       linux/dbus/uniquedbusmessage.h
       linux/dbus/uniqueresource.h

--- a/osquery/tables/system/linux/dbus/methods/dbusmethod.h
+++ b/osquery/tables/system/linux/dbus/methods/dbusmethod.h
@@ -18,7 +18,7 @@
 namespace osquery {
 
 template <typename MethodHandler, typename... ArgumentList>
-class DbusMethod final : private MethodHandler {
+class DbusMethod final : public MethodHandler {
  public:
   using Output = typename MethodHandler::Output;
   using MethodHandler::parseReply;

--- a/osquery/tables/system/linux/dbus/methods/getstringproperty.cpp
+++ b/osquery/tables/system/linux/dbus/methods/getstringproperty.cpp
@@ -7,11 +7,11 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/tables/system/linux/dbus/methods/getproperty.h>
+#include <osquery/tables/system/linux/dbus/methods/getstringproperty.h>
 
 namespace osquery {
 
-Status GetPropertyMethodHandler::parseReply(
+Status GetStringPropertyMethodHandler::parseReply(
     Output& output, const UniqueDbusMessage& reply) const {
   output = {};
 

--- a/osquery/tables/system/linux/dbus/methods/getstringproperty.h
+++ b/osquery/tables/system/linux/dbus/methods/getstringproperty.h
@@ -18,7 +18,7 @@
 
 namespace osquery {
 
-class GetPropertyMethodHandler {
+class GetStringPropertyMethodHandler {
  public:
   constexpr static auto kDestination{"org.freedesktop.systemd1"};
   constexpr static auto kInterface{"org.freedesktop.DBus.Properties"};
@@ -28,12 +28,12 @@ class GetPropertyMethodHandler {
   Status parseReply(Output& output, const UniqueDbusMessage& reply) const;
 
  protected:
-  GetPropertyMethodHandler() = default;
-  virtual ~GetPropertyMethodHandler() = default;
+  GetStringPropertyMethodHandler() = default;
+  virtual ~GetStringPropertyMethodHandler() = default;
 };
 
-using GetPropertyMethod = DbusMethod<GetPropertyMethodHandler,
-                                     const std::string&,
-                                     const std::string&>;
+using GetStringPropertyMethod = DbusMethod<GetStringPropertyMethodHandler,
+                                           const std::string&,
+                                           const std::string&>;
 
 } // namespace osquery

--- a/osquery/tables/system/linux/startup_items.cpp
+++ b/osquery/tables/system/linux/startup_items.cpp
@@ -14,7 +14,7 @@
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
-#include <osquery/tables/system/linux/dbus/methods/getproperty.h>
+#include <osquery/tables/system/linux/dbus/methods/getstringproperty.h>
 #include <osquery/tables/system/linux/dbus/methods/listunitsmethodhandler.h>
 #include <osquery/tables/system/linux/dbus/uniquedbusconnection.h>
 #include <osquery/utils/conversions/split.h>
@@ -98,7 +98,7 @@ Status genSystemdItems(QueryData& results) {
     return status;
   }
 
-  GetPropertyMethod get_property_method;
+  GetStringPropertyMethod get_string_property_method;
 
   for (const auto& unit : unit_list) {
     Row row = {};
@@ -107,11 +107,11 @@ Status genSystemdItems(QueryData& results) {
     row["status"] = unit.active_state;
 
     std::string unit_path;
-    status = get_property_method.call(unit_path,
-                                      connection,
-                                      unit.path,
-                                      "org.freedesktop.systemd1.Unit",
-                                      "FragmentPath");
+    status = get_string_property_method.call(unit_path,
+                                             connection,
+                                             unit.path,
+                                             "org.freedesktop.systemd1.Unit",
+                                             "FragmentPath");
     if (!status.ok()) {
       return status;
     }
@@ -119,11 +119,11 @@ Status genSystemdItems(QueryData& results) {
     row["path"] = unit_path;
 
     std::string source_path;
-    status = get_property_method.call(source_path,
-                                      connection,
-                                      unit.path,
-                                      "org.freedesktop.systemd1.Unit",
-                                      "SourcePath");
+    status = get_string_property_method.call(source_path,
+                                             connection,
+                                             unit.path,
+                                             "org.freedesktop.systemd1.Unit",
+                                             "SourcePath");
     if (!status.ok()) {
       return status;
     }
@@ -131,11 +131,11 @@ Status genSystemdItems(QueryData& results) {
     row["source"] = source_path;
 
     std::string username;
-    status = get_property_method.call(username,
-                                      connection,
-                                      unit.path,
-                                      "org.freedesktop.systemd1.Service",
-                                      "User");
+    status = get_string_property_method.call(username,
+                                             connection,
+                                             unit.path,
+                                             "org.freedesktop.systemd1.Service",
+                                             "User");
 
     static_cast<void>(status);
     row["username"] = username;

--- a/osquery/tables/system/linux/systemd_units.cpp
+++ b/osquery/tables/system/linux/systemd_units.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/tables.h>
+#include <osquery/sql/dynamic_table_row.h>
+#include <osquery/tables/system/linux/dbus/methods/getstringproperty.h>
+#include <osquery/tables/system/linux/dbus/methods/listunitsmethodhandler.h>
+
+namespace osquery {
+
+namespace tables {
+
+namespace {
+struct PropertyQueryDesc final {
+  std::string property_name;
+  std::string column_name;
+  std::string interface;
+};
+
+const std::vector<PropertyQueryDesc> kStringPropertyQueryList = {
+    {"FragmentPath", "fragment_path", "org.freedesktop.systemd1.Unit"},
+    {"SourcePath", "source_path", "org.freedesktop.systemd1.Unit"},
+    {"User", "user", "org.freedesktop.systemd1.Service"},
+};
+} // namespace
+
+TableRows genSystemdUnits(QueryContext& context) {
+  UniqueDbusConnection connection;
+  auto status = UniqueDbusConnection::create(connection, true);
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to generate the systemd unit list: "
+               << status.getMessage();
+    return {};
+  }
+
+  ListUnitsMethod::Output unit_list;
+  ListUnitsMethod list_units_method;
+  status = list_units_method.call(
+      unit_list, connection, "/org/freedesktop/systemd1");
+
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to generate the systemd unit list: "
+               << status.getMessage();
+    return {};
+  }
+
+  TableRows results;
+
+  for (const auto& unit : unit_list) {
+    auto row = make_table_row();
+
+    row["id"] = TEXT(unit.id);
+    row["description"] = TEXT(unit.description);
+    row["load_state"] = TEXT(unit.load_state);
+    row["active_state"] = TEXT(unit.active_state);
+    row["sub_state"] = TEXT(unit.sub_state);
+    row["following"] = TEXT(unit.following);
+    row["object_path"] = TEXT(unit.path);
+    row["job_id"] = BIGINT(unit.job_id);
+    row["job_type"] = TEXT(unit.job_type);
+    row["job_path"] = TEXT(unit.job_path);
+
+    for (const auto& query : kStringPropertyQueryList) {
+      std::string property_value;
+      GetStringPropertyMethod get_string_property_method;
+      status = get_string_property_method.call(property_value,
+                                               connection,
+                                               unit.path,
+                                               query.interface,
+                                               query.property_name);
+
+      if (!status.ok() && query.property_name != "User") {
+        LOG(ERROR) << "Failed to query the property " << query.property_name
+                   << " on the following systemd unit: " << unit.path;
+      }
+
+      row[query.column_name] = TEXT(property_value);
+    }
+
+    results.push_back(std::move(row));
+  }
+
+  return results;
+}
+
+} // namespace tables
+
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -175,6 +175,7 @@ function(generateNativeTables)
     "linux/selinux_settings.table:linux"
     "linux/apparmor_profiles.table:linux"
     "linux/apparmor_events.table:linux"
+    "linux/systemd_units.table:linux"
     "linwin/intel_me_info.table:linux,windows"
     "linwin/ec2_instance_metadata.table:linux,windows"
     "linwin/ec2_instance_tags.table:linux,windows"

--- a/specs/linux/systemd_units.table
+++ b/specs/linux/systemd_units.table
@@ -1,0 +1,19 @@
+table_name("systemd_units")
+description("Track systemd units.")
+schema([
+    Column("id", TEXT, "Unique unit identifier"),
+    Column("description", TEXT, "Unit description"),
+    Column("load_state", TEXT, "Reflects whether the unit definition was properly loaded"),
+    Column("active_state", TEXT, "The high-level unit activation state, i.e. generalization of SUB"),
+    Column("sub_state", TEXT, "The low-level unit activation state, values depend on unit type"),
+    Column("following", TEXT, "The name of another unit that this unit follows in state"),
+    Column("object_path", TEXT, "The object path for this unit"),
+    Column("job_id", BIGINT, "Next queued job id"),
+    Column("job_type", TEXT, "Job type"),
+    Column("job_path", TEXT, "The object path for the job"),
+    Column("fragment_path", TEXT, "The unit file path this unit was read from, if there is any"),
+    Column("user", TEXT, "The configured user, if any"),
+    Column("source_path", TEXT, "Path to the (possibly generated) unit configuration file"),
+])
+attributes(strongly_typed_rows=True)
+implementation("system/systemd_units@genSystemdUnits")

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -178,6 +178,7 @@ function(generateTestsIntegrationTablesTestsTest)
       socket_events.cpp
       startup_items.cpp
       syslog_events.cpp
+      systemd_units.cpp
       yara_events.cpp
       yara.cpp
     )

--- a/tests/integration/tables/systemd_units.cpp
+++ b/tests/integration/tables/systemd_units.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for systemd_units
+// Spec file: specs/linux/systemd_units.table
+
+#include <dbus/dbus.h>
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class SystemdUnitsTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(SystemdUnitsTest, test_sanity) {
+  auto const data = execute_query("select * from systemd_units");
+
+  ValidationMap row_map = {
+      {"id", NormalType},
+      {"description", NormalType},
+      {"load_state", NormalType},
+      {"active_state", NormalType},
+      {"sub_state", NormalType},
+      {"following", NormalType},
+      {"object_path", NormalType},
+      {"job_id", NormalType},
+      {"job_type", NormalType},
+      {"job_path", NormalType},
+      {"fragment_path", NormalType},
+      {"user", NormalType},
+      {"source_path", NormalType},
+  };
+
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
This PR implements a new Linux table named systemd_units that lists the loaded systemd units.

```
+-------------------------------+-----------------------------------------+------------+--------------+-----------+-----------+----------------------------------------------------------------------+--------+----------+----------+---------------------------------------------------+------+----------------------+
| id                            | description                             | load_state | active_state | sub_state | following | object_path                                                          | job_id | job_type | job_path | fragment_path                                     | user | source_path          |
+-------------------------------+-----------------------------------------+------------+--------------+-----------+-----------+----------------------------------------------------------------------+--------+----------+----------+---------------------------------------------------+------+----------------------+
| sys-kernel-tracing.mount      | Kernel Trace File System                | loaded     | active       | mounted   |           | /org/freedesktop/systemd1/unit/sys_2dkernel_2dtracing_2emount        | 0      |          | /        | /lib/systemd/system/sys-kernel-tracing.mount      |      | /proc/self/mountinfo |
| sys-fs-fuse-connections.mount | FUSE Control File System                | loaded     | active       | mounted   |           | /org/freedesktop/systemd1/unit/sys_2dfs_2dfuse_2dconnections_2emount | 0      |          | /        | /lib/systemd/system/sys-fs-fuse-connections.mount |      | /proc/self/mountinfo |
| sys-kernel-config.mount        | Kernel Configuration File System         | loaded     | active       | mounted   |           | /org/freedesktop/systemd1/unit/sys_2dkernel_2dconfig_2emount          | 0      |          | /        | /lib/systemd/system/sys-kernel-config.mount        |      | /proc/self/mountinfo |
| user@1000.service             | User Manager for UID 1000               | loaded     | active       | running   |           | /org/freedesktop/systemd1/unit/user_401000_2eservice                 | 0      |          | /        | /lib/systemd/system/user@.service                 | 1000 |                      |
| hddtemp.service               | LSB: disk temperature monitoring daemon | loaded     | active       | exited    |           | /org/freedesktop/systemd1/unit/hddtemp_2eservice                     | 0      |          | /        | /run/systemd/generator.late/hddtemp.service       |      | /etc/init.d/hddtemp  |
+-------------------------------+-----------------------------------------+------------+--------------+-----------+-----------+----------------------------------------------------------------------+--------+----------+----------+---------------------------------------------------+------+----------------------+
```

Requires: https://github.com/osquery/osquery/pull/6562