### PR TITLE
Improve descriptions for table: processes

### DIFF
--- a/specs/processes.table
+++ b/specs/processes.table
@@ -39,8 +39,8 @@ extended_schema(WINDOWS, [
 extended_schema(DARWIN, [
     Column("upid", BIGINT, "A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
-    Column("cpu_type", INTEGER, "A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system."),
-    Column("cpu_subtype", INTEGER, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
+    Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation (Type 1 or Type 2)."),
+    Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -39,7 +39,7 @@ extended_schema(WINDOWS, [
 extended_schema(DARWIN, [
     Column("upid", BIGINT, "A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
-    Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation (Type 1 or Type 2)."),
+    Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)


### PR DESCRIPTION
The cpu_type and cpu_subtype description in the processes table is a duplicate of upid and uppid. Kindly review.

This PR fixes #6351