### PR TITLE
process_events.cpp  cmdline parse , add  single quotes ' , use to prevent spaces from changing semantics

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -275,10 +275,13 @@ Status AuditProcessEventSubscriber::ProcessExecveEventData(
     }
 
     if (row["cmdline"].size() > 0) {
-      row["cmdline"] += ' ';
+      row["cmdline"] += " ";
     }
 
+    // Shell syntax, use to prevent spaces from changing semantics
+    row["cmdline"] += "'";
     row["cmdline"] += DecodeAuditPathValues(arg.second);
+    row["cmdline"] += "'";
   }
 
   row["cmdline_size"] = std::to_string(row["cmdline"].size());


### PR DESCRIPTION
process_events.cpp  cmdline parse , add ' , use to prevent spaces from changing semantics

In the following situation，when people exec `bash -c "python3 -m http.server" `
the cmdline would be logged as `bash -c python3 -m http.server` , which cause semantic changes.

Wrapping parameters with single quotes can prevent most situations