### PR TITLE
linux: process_events: add single quotes to prevent spaces from changing semantics

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -278,7 +278,10 @@ Status AuditProcessEventSubscriber::ProcessExecveEventData(
       row["cmdline"] += ' ';
     }
 
+    // Shell syntax, use to prevent spaces from changing semantics
+    row["cmdline"] += "'";
     row["cmdline"] += DecodeAuditPathValues(arg.second);
+    row["cmdline"] += "'";
   }
 
   row["cmdline_size"] = std::to_string(row["cmdline"].size());


### PR DESCRIPTION
process_events.cpp cmdline parse , add ' , use to prevent spaces from changing semantics

In the following situation，when people exec bash -c "python3 -m http.server"
the cmdline would be logged as bash -c python3 -m http.server , which cause semantic changes.

Wrapping parameters with single quotes can prevent most situations