### PR TITLE
bug: Apply watcher delay each time the worker is started

### DIFF
--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -15,6 +15,7 @@
 #include <osquery/core/system.h>
 #include <osquery/core/tables.h>
 #include <osquery/registry/registry.h>
+#include <osquery/utils/system/time.h>
 
 #include "osquery/core/watcher.h"
 #include "osquery/tests/test_util.h"
@@ -296,6 +297,10 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
   r["resident_size"] = INTEGER(100);
   runner.setProcessRow({r});
 
+  // Set the worker start time.
+  auto start_time = Watcher::get().workerStartTime();
+  Watcher::get().workerStartTime(getUnixTime() - 1);
+
   // Check the fake process sanity, which records the state at t=0.
   EXPECT_TRUE(runner.isChildSane(fake_test_process));
 
@@ -316,5 +321,6 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
   EXPECT_FALSE(runner.watch(fake_test_process));
 
   FLAGS_watchdog_delay = delay;
+  Watcher::get().workerStartTime(start_time);
 }
 } // namespace osquery

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -332,7 +332,7 @@ void WatcherRunner::watchExtensions() {
 }
 
 size_t WatcherRunner::delayedTime() const {
-  return getStartTime() + FLAGS_watchdog_delay;
+  return Watcher::get().worker_start_time_ + FLAGS_watchdog_delay;
 }
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {
@@ -547,6 +547,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
 void WatcherRunner::createWorker() {
   auto& watcher = Watcher::get();
+  watcher.worker_start_time_ = getUnixTime();
 
   {
     WatcherExtensionsLocker locker;

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -332,7 +332,7 @@ void WatcherRunner::watchExtensions() {
 }
 
 size_t WatcherRunner::delayedTime() const {
-  return Watcher::get().worker_start_time_ + FLAGS_watchdog_delay;
+  return Watcher::get().workerStartTime() + FLAGS_watchdog_delay;
 }
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {
@@ -547,7 +547,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
 void WatcherRunner::createWorker() {
   auto& watcher = Watcher::get();
-  watcher.worker_start_time_ = getUnixTime();
+  watcher.workerStartTime(getUnixTime());
 
   {
     WatcherExtensionsLocker locker;

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -221,6 +221,9 @@ class Watcher : private boost::noncopyable {
   /// Keep the single worker process/thread ID for inspection.
   std::shared_ptr<PlatformProcess> worker_;
 
+  /// Time the worker was started.
+  size_t worker_start_time_{0};
+
   /// Number of worker restarts NOT induced by a watchdog process.
   size_t worker_restarts_{0};
 

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -210,6 +210,14 @@ class Watcher : private boost::noncopyable {
     worker_restarts_++;
   }
 
+  void workerStartTime(size_t start_time) {
+    worker_start_time_ = start_time;
+  }
+
+  size_t workerStartTime() {
+    return worker_start_time_;
+  }
+
  private:
   /// Performance state for the worker process.
   PerformanceState state_;
@@ -248,6 +256,7 @@ class Watcher : private boost::noncopyable {
 
  private:
   friend class WatcherRunner;
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
 };
 
 /**


### PR DESCRIPTION
This fixes an unintended effect of the `--watchdog_delay` only being applied to the first worker start. This delay was intended to be applied to each restart of the worker. The goal is to allow a worker to do process and memory intensive work during start up.