### PR TITLE
shell: Return early if relative flags are used

### DIFF
--- a/osquery/core/shutdown.cpp
+++ b/osquery/core/shutdown.cpp
@@ -12,6 +12,7 @@
 
 #include <mutex>
 #include <string>
+#include <atomic>
 
 namespace osquery {
 

--- a/osquery/core/shutdown.cpp
+++ b/osquery/core/shutdown.cpp
@@ -10,9 +10,9 @@
 #include <osquery/core/shutdown.h>
 #include <osquery/logger/data_logger.h>
 
+#include <atomic>
 #include <mutex>
 #include <string>
-#include <atomic>
 
 namespace osquery {
 

--- a/osquery/core/shutdown.h
+++ b/osquery/core/shutdown.h
@@ -40,6 +40,14 @@ void setShutdownExitCode(int retcode);
 void waitForShutdown();
 
 /**
+ * @brief Check if something has requested a shutdown.
+ *
+ * This function is not very helpful and should be avoided. It exists to assist
+ * tools outside of the daemon such as the shell.
+ */
+bool shutdownRequested();
+
+/**
  * @brief Forcefully request the application to stop.
  *
  * Since all osquery tools may implement various 'dispatched' services in the


### PR DESCRIPTION
It's sort of annoying for `--database_dump`, `--config_check`, etc to only return with an exit code in `osqueryd`. The shell should mimic this behavior.