### PR TITLE
Add `sigurl` to get the YARA signature from https server for scan 

### DIFF
--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -66,6 +66,7 @@ int YARACallback(YR_SCAN_CONTEXT* context,
  * Pseudo-code:
  *   getParser("yara")->getKey("yara");
  */
+
 class YARAConfigParserPlugin : public ConfigParserPlugin {
  public:
   /// Request a single "yara" top level key.
@@ -78,11 +79,17 @@ class YARAConfigParserPlugin : public ConfigParserPlugin {
     return rules_;
   }
 
+  std::set<std::string>& url_allow_set() {
+    return url_allow_set_;
+  }
+
   Status setUp() override;
 
  private:
   // Store compiled rules in a map (group => rules).
   std::map<std::string, YR_RULES*> rules_;
+
+  std::set<std::string> url_allow_set_;
 
   /// Store the signatures and file_paths and compile the rules.
   Status update(const std::string& source, const ParserConfig& config) override;

--- a/specs/yara/yara.table
+++ b/specs/yara/yara.table
@@ -13,6 +13,8 @@ schema([
         additional=True, hidden=True),
     Column("strings", TEXT, "Matching strings"),
     Column("tags", TEXT, "Matching tags"),
+    Column("sigurl", TEXT, "Signature url",
+        additional=True, hidden=True)
 ])
 implementation("yara@genYara")
 examples([


### PR DESCRIPTION
The PR adds a new column `sigurl` that can be used to pass the url from where the YARA signature can be downloaded for the scan. The signature urls need to be pre-registered with the configuration file. 
```
 // Configuration file for registering the URL's 
 "yara": { 
   "signature_urls": { 
     "sig_url_1": "https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar", 
     "sig_url_2": "https://raw.githubusercontent.com/Yara-Rules/rules/master/crypto/crypto_signatures.yar", 
     "sig_url_3": "https://raw.githubusercontent.com/Yara-Rules/rules/master/malware/APT_APT3102.yar"
   }
 }
```
The feature will be disabled by default and can be enabled with a hidden flag `enable_yara_sigurl`. It also forces all the strings to be private, if the rules are downloaded from url unless . The private string will not show up in the yara table. the feature can be disabled with `disable_yara_string_private` flag.  A query with signature urls:

```
osquery> select * from yara where path like '%' and sigurl='sig_url_2';
+-------------------------+--------------+-------+-----------+---------+---------+---------+------+-----------+
| path                    | matches      | count | sig_group | sigfile | sigrule | strings | tags | sigurl    |
+-------------------------+--------------+-------+-----------+---------+---------+---------+------+-----------+
| CMakeCache.txt          | Big_Numbers1 | 1     |           |         |         |         |      | sig_url_2 |
+-------------------------+--------------+-------+-----------+---------+---------+---------+------+-----------+
```
<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
