### PR TITLE
database: Change reset interval from 5m to 1hr

### DIFF
--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -38,7 +38,7 @@ FLAG(uint64, schedule_max_drift, 60, "Max time drift in seconds");
 
 FLAG(uint64,
      schedule_reload,
-     300,
+     3600,
      "Interval in seconds to reload database arenas");
 
 FLAG(uint64, schedule_epoch, 0, "Epoch for scheduled queries");


### PR DESCRIPTION
One of the reasons osquery creates small SSTs is because write buffers are flushed to immutable tables every 5 minutes. We are addressing this by compacting the SSTs but a side effect is more CPU time spent when databases are opened. We mitigate that with longer reset periods. We still want a reset until we can more deeply understand the effect of very-long persistent handles. 