### PR TITLE
docs: Replace slackin with Slack shared invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,10 @@ You can see who the _core team_ is by viewing the [team
 page](https://github.com/orgs/osquery/teams) on the osquery GitHub
 organization.
 
-If you need help, both the core team and community members are on the
-osquery [Slack](https://osquery.slack.com). Feel free to register
-using the following [link](https://slack.osquery.io/) if you haven't
-done so yet and get in touch with us.  The `#code-review` Slack
-channel has been set up to handle urgent review needs as well as
-questions about your PR. Note: prefer to keep discussion about code
-changes in the GitHub pull request thread.
+If you need help, both the core team and community members are on the osquery [Slack](https://osquery.slack.com).
+Feel free to register using the following [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+The `#code-review` Slack channel has been set up to handle urgent review needs as well as questions about your PR.
+Note: prefer to keep discussion about code changes in the GitHub pull request thread.
 
 The osquery team also hosts regular office hours where the community
 is invited to discuss osquery development with the core team. You are

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Available for Linux, macOS, Windows, and FreeBSD.
 - Stack Overflow: https://stackoverflow.com/questions/tagged/osquery
 - Table Schema: https://osquery.io/schema
 - Query Packs: [https://osquery.io/packs](https://github.com/osquery/osquery/tree/master/packs)
-- Slack: [![Slack Status](https://osquery-slack.herokuapp.com/badge.svg)](https://osquery-slack.herokuapp.com)
+- Slack: [Request an auto-invite!](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw)
 - Build Status: [![Build Status](https://dev.azure.com/trailofbits/osquery/_apis/build/status/osquery?branchName=master)](https://dev.azure.com/trailofbits/osquery/_build/latest?definitionId=6&branchName=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/13317/badge.svg)](https://scan.coverity.com/projects/osquery) [![Documentation Status](https://readthedocs.org/projects/osquery/badge/?version=latest)](https://osquery.readthedocs.io/en/latest/?badge=latest)
 - CII Best Practices: [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3125/badge)](https://bestpractices.coreinfrastructure.org/projects/3125)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ This document aggregates security issues (weaknesses and vulnerabilities) affect
 ```
 
 There are several types of issues that do not include a CVE or reporter.
-If you find a security issue and believe a CVE should be assigned, please contact a [member of the TSC](https://github.com/osquery/osquery/blob/master/CONTRIBUTING.md#technical-steering-committee) in the [osquery Slack](https://osquery-slack.herokuapp.com), we are happy to submit the request and provide attribution to you.
+If you find a security issue and believe a CVE should be assigned, please contact a [member of the TSC](https://github.com/osquery/osquery/blob/master/CONTRIBUTING.md#technical-steering-committee) in the osquery [Slack](https://osquery.slack.com), we are happy to submit the request and provide attribution to you.
 Specifically, we will use the GitHub Security Advisory features for CVE requests.
 The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/osquery/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,10 +6,9 @@ free to reach out on osquery Slack.
 
 ## Slack
 
-You can register on our Slack at https://slack.osquery.io if you haven't done so yet. Before posting
-to the `general` channel take a look at other available channels where your question might be a
-better fit. If you have a question about a vendor solution post **only** on the vendor specific
-channel.
+You can register on our Slack using our [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+Before posting to the `general` channel take a look at other available channels where your question might be a better fit.
+If you have a question about a vendor solution post **only** on the vendor specific channel.
 
 ## Documentation
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -30,7 +30,7 @@ Additionally, osquery's codebase is made up of high-performance, modular compone
 
 ## Getting Help
 
-If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/osquery/osquery/issues). Keep in touch with osquery developers and users in our Slack [https://osquery-slack.herokuapp.com/](https://osquery-slack.herokuapp.com/).
+If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/osquery/osquery/issues). Keep in touch with osquery developers and users in our Slack: [Join osquery](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
 
 ## Documentation
 

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -430,7 +430,7 @@ function New-ChocolateyPackage() {
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/osquery/osquery</projectSourceUrl>
     <docsUrl>https://osquery.readthedocs.io/en/stable</docsUrl>
-    <mailingListUrl>https://osquery-slack.herokuapp.com/</mailingListUrl>
+    <mailingListUrl>https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw</mailingListUrl>
     <bugTrackerUrl>https://github.com/osquery/osquery/issues</bugTrackerUrl>
     <tags>InfoSec Tools</tags>
     <summary>


### PR DESCRIPTION
The old slackin Heroku app is no longer supported, but we now have an official way to allow public invites.