### PR TITLE
Apply scheduler_timeout correctly

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -299,7 +299,7 @@ which does not define an interval.
 
 `--schedule_timeout=0`
 
-Limit the schedule, 0 for no limit. Optionally limit the `osqueryd`'s life by adding a schedule limit in seconds. This should only be used for testing.
+Limit the schedule, 0 for no limit. Optionally limit the `osqueryd`'s life by adding a schedule limit in seconds as a duration. This should only be used for testing.
 
 `--disable_tables=table_name1,table_name2`
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -248,8 +248,7 @@ void SchedulerRunner::start() {
 
   // Scheduler ended.
   if (!interrupted()) {
-    LOG(INFO) << "The scheduler ended after " << FLAGS_schedule_timeout
-              << " seconds";
+    LOG(INFO) << "The scheduler ended after " << timeout_ << " seconds";
     requestShutdown();
   }
 }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -239,6 +239,11 @@ void SchedulerRunner::start() {
       break;
     }
   }
+
+  // Scheduler ended.
+  LOG(INFO) << "The scheduler ended after " << FLAGS_schedule_timeout
+            << " seconds";
+  requestShutdown();
 }
 
 std::chrono::milliseconds SchedulerRunner::getCurrentTimeDrift() const
@@ -247,7 +252,9 @@ std::chrono::milliseconds SchedulerRunner::getCurrentTimeDrift() const
 }
 
 void startScheduler() {
-  startScheduler(static_cast<unsigned long int>(FLAGS_schedule_timeout), 1);
+  startScheduler(
+      static_cast<unsigned long int>(FLAGS_schedule_timeout + getUnixTime()),
+      1);
 }
 
 void startScheduler(unsigned long int timeout, size_t interval) {

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -32,7 +32,10 @@
 
 namespace osquery {
 
-FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit");
+FLAG(uint64,
+     schedule_timeout,
+     0,
+     "Limit the schedule to a duration in seconds, 0 for no limit");
 
 FLAG(uint64, schedule_max_drift, 60, "Max time drift in seconds");
 

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -59,7 +59,7 @@ class SchedulerRunner : public InternalRunnable {
   const std::chrono::milliseconds interval_;
 
   /// Maximum number of steps.
-  const unsigned long int timeout_;
+  unsigned long int timeout_;
 
   /// Accumulated for some time time drift to compensate.
   /// It will be either reduced during compensation process or

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -243,9 +243,8 @@ TEST_F(SchedulerTests, test_scheduler_drift_accumulation) {
   Config::get().update({{"data", config}});
 
   // Run the scheduler for 1 second with a second interval.
-  SchedulerRunner runner(static_cast<unsigned long int>(3),
-                         size_t{0},
-                         std::chrono::seconds{10});
+  SchedulerRunner runner(
+      static_cast<unsigned long int>(3), size_t{0}, std::chrono::seconds{10});
   runner.start();
 
   EXPECT_GE(runner.getCurrentTimeDrift(), std::chrono::milliseconds{1});

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -170,7 +170,7 @@ TEST_F(SchedulerTests, test_scheduler) {
   Config::get().update({{"data", config}});
 
   // Run the scheduler for 1 second with a second interval.
-  SchedulerRunner runner(static_cast<unsigned long int>(now + 1), 1);
+  SchedulerRunner runner(static_cast<unsigned long int>(1), 1);
   runner.start();
 
   // If a query was executed the cache step will have been advanced.
@@ -205,7 +205,7 @@ TEST_F(SchedulerTests, test_scheduler_zero_drift) {
 
   // Run the scheduler for 1 second with a second interval.
   SchedulerRunner runner(
-      static_cast<unsigned long int>(now), size_t{1}, std::chrono::seconds{10});
+      static_cast<unsigned long int>(1), size_t{1}, std::chrono::seconds{10});
   runner.start();
 
   EXPECT_EQ(runner.getCurrentTimeDrift(), std::chrono::milliseconds::zero());
@@ -243,7 +243,7 @@ TEST_F(SchedulerTests, test_scheduler_drift_accumulation) {
   Config::get().update({{"data", config}});
 
   // Run the scheduler for 1 second with a second interval.
-  SchedulerRunner runner(static_cast<unsigned long int>(now + 3),
+  SchedulerRunner runner(static_cast<unsigned long int>(3),
                          size_t{0},
                          std::chrono::seconds{10});
   runner.start();
@@ -262,7 +262,7 @@ TEST_F(SchedulerTests, test_scheduler_reload) {
   auto backup_reload = FLAGS_schedule_reload;
 
   // Start the scheduler;
-  auto expire = static_cast<unsigned long int>(getUnixTime() + 1);
+  auto expire = static_cast<unsigned long int>(1);
   FLAGS_schedule_reload = 1;
   SchedulerRunner runner(expire, 1);
   FLAGS_schedule_reload = backup_reload;

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -242,7 +242,7 @@ TEST_F(SchedulerTests, test_scheduler_drift_accumulation) {
   })config";
   Config::get().update({{"data", config}});
 
-  // Run the scheduler for 1 second with a second interval.
+  // Run the scheduler for 3 seconds with no interval.
   SchedulerRunner runner(
       static_cast<unsigned long int>(3), size_t{0}, std::chrono::seconds{10});
   runner.start();

--- a/plugins/config/tests/tls_config_tests.cpp
+++ b/plugins/config/tests/tls_config_tests.cpp
@@ -116,9 +116,8 @@ TEST_F(TLSConfigTests, test_runner_and_scheduler) {
   Config::get().load();
 
   // Start a scheduler runner for 3 seconds.
-  auto t = static_cast<unsigned long int>(getUnixTime());
   ASSERT_TRUE(
-      Dispatcher::addService(std::make_shared<SchedulerRunner>(t + 1, 1)).ok());
+      Dispatcher::addService(std::make_shared<SchedulerRunner>(1, 1)).ok());
   // Reload our instance config.
   ASSERT_TRUE(Config::get().load().ok());
 


### PR DESCRIPTION
Previously, we were not applying `--scheduler_timeout` correctly. This should be the number of seconds for the scheduler to run. After the schedule is completed the daemon should stop.