### PR TITLE
refactor: Change the include path for osquery/core/plugins

### DIFF
--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -14,9 +14,9 @@
 #include <memory>
 #include <vector>
 
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
 #include <osquery/core/sql/query_performance.h>
-#include <osquery/plugins/plugin.h>
 #include <osquery/utils/expected/expected.h>
 #include <osquery/utils/json/json.h>
 

--- a/osquery/core/plugins/CMakeLists.txt
+++ b/osquery/core/plugins/CMakeLists.txt
@@ -29,7 +29,7 @@ function(generateOsqueryCorePlugins)
     sql.h
   )
 
-  generateIncludeNamespace(osquery_core_plugins "osquery/plugins" "FILE_ONLY" ${public_header_files})
+  generateIncludeNamespace(osquery_core_plugins "osquery/core/plugins" "FILE_ONLY" ${public_header_files})
 endfunction()
 
 osqueryCorePluginsMain()

--- a/osquery/core/plugins/logger.h
+++ b/osquery/core/plugins/logger.h
@@ -11,7 +11,7 @@
 
 #include <string>
 
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/utils/status/status.h>
 
 namespace osquery {

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -27,9 +27,9 @@
 
 #pragma once
 
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/sql/column.h>
 #include <osquery/core/sql/query_data.h>
-#include <osquery/plugins/plugin.h>
 #include <osquery/utils/status/status.h>
 
 namespace osquery {

--- a/osquery/core/tables.h
+++ b/osquery/core/tables.h
@@ -23,9 +23,9 @@
 #include <sqlite3.h>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
 #include <osquery/core/sql/column.h>
-#include <osquery/plugins/plugin.h>
 
 #include <gtest/gtest_prod.h>
 

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 
 namespace osquery {
 // A list of key/str pairs; used for write batching with setDatabaseBatch

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -10,11 +10,11 @@
 #include <sstream>
 #include <utility>
 
+#include <osquery/core/plugins/logger.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/distributed/distributed.h>
 #include <osquery/logger/logger.h>
-#include <osquery/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 #include <osquery/sql/sql.h>
 #include <osquery/utils/json/json.h>

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
-#include <osquery/plugins/plugin.h>
 #include <osquery/utils/status/status.h>
 
 namespace osquery {

--- a/osquery/experimental/events_stream/events_stream_registry.h
+++ b/osquery/experimental/events_stream/events_stream_registry.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
-#include <osquery/plugins/plugin.h>
 #include <osquery/utils/expected/expected.h>
 
 #include <osquery/numeric_monitoring/numeric_monitoring.h>

--- a/osquery/extensions/extensions.h
+++ b/osquery/extensions/extensions.h
@@ -11,7 +11,7 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/flags.h>
-#include <osquery/plugins/sql.h>
+#include <osquery/core/plugins/sql.h>
 #include <osquery/registry/registry_interface.h>
 
 namespace osquery {

--- a/osquery/logger/data_logger.h
+++ b/osquery/logger/data_logger.h
@@ -16,9 +16,9 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/flags.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
 #include <osquery/logger/logger.h>
-#include <osquery/plugins/plugin.h>
 
 namespace osquery {
 

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -19,6 +19,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <osquery/core/flags.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/events/events.h>
@@ -26,7 +27,6 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/data_logger.h>
 #include <osquery/numeric_monitoring/numeric_monitoring.h>
-#include <osquery/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 
 #include <osquery/core/flagalias.h>

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -11,11 +11,11 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/core/plugins/logger.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/data_logger.h>
-#include <osquery/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/system/time.h>

--- a/osquery/numeric_monitoring/plugin_interface.cpp
+++ b/osquery/numeric_monitoring/plugin_interface.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/registry/registry_factory.h>
 
 #include "osquery/numeric_monitoring/plugin_interface.h"

--- a/osquery/numeric_monitoring/plugin_interface.h
+++ b/osquery/numeric_monitoring/plugin_interface.h
@@ -13,8 +13,8 @@
 #include <string>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
-#include <osquery/plugins/plugin.h>
 #include <osquery/utils/expected/expected.h>
 
 #include <osquery/numeric_monitoring/numeric_monitoring.h>

--- a/osquery/registry/registry.h
+++ b/osquery/registry/registry.h
@@ -9,6 +9,6 @@
 
 #pragma once
 
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/registry/registry_factory.h>
 #include <osquery/registry/registry_interface.h>

--- a/osquery/registry/registry_interface.h
+++ b/osquery/registry/registry_interface.h
@@ -19,7 +19,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <osquery/core/core.h>
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/utils/mutex.h>
 
 namespace osquery {

--- a/osquery/remote/enroll/enroll.h
+++ b/osquery/remote/enroll/enroll.h
@@ -13,7 +13,7 @@
 #include <string>
 
 #include <osquery/core/flags.h>
-#include <osquery/plugins/plugin.h>
+#include <osquery/core/plugins/plugin.h>
 #include <osquery/utils/json/json.h>
 
 namespace osquery {

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -15,7 +15,7 @@
 #include <osquery/registry/registry.h>
 #include <osquery/sql/sql.h>
 
-#include <osquery/plugins/sql.h>
+#include <osquery/core/plugins/sql.h>
 
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/info/tool_type.h>

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -10,7 +10,7 @@
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/sql/virtual_table.h"
 
-#include <osquery/plugins/sql.h>
+#include <osquery/core/plugins/sql.h>
 
 #include <osquery/utils/conversions/castvariant.h>
 

--- a/plugins/logger/aws_firehose.h
+++ b/plugins/logger/aws_firehose.h
@@ -21,9 +21,8 @@
 #include <aws/firehose/model/Record.h>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
-#include <osquery/plugins/logger.h>
-
 
 namespace osquery {
 

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -20,9 +20,8 @@
 #include <aws/kinesis/model/PutRecordsRequestEntry.h>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
-#include <osquery/plugins/logger.h>
-
 
 namespace osquery {
 DECLARE_uint64(aws_kinesis_period);

--- a/plugins/logger/aws_log_forwarder.h
+++ b/plugins/logger/aws_log_forwarder.h
@@ -16,9 +16,9 @@
 #include <vector>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
 #include <osquery/logger/logger.h>
-#include <osquery/plugins/logger.h>
 
 #include <osquery/utils/aws/aws_util.h>
 

--- a/plugins/logger/buffered.h
+++ b/plugins/logger/buffered.h
@@ -16,8 +16,8 @@
 #include <thread>
 #include <vector>
 
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
-#include <osquery/plugins/logger.h>
 
 namespace osquery {
 

--- a/plugins/logger/filesystem_logger.h
+++ b/plugins/logger/filesystem_logger.h
@@ -12,8 +12,8 @@
 #include <exception>
 
 #include <osquery/core/flagalias.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/filesystem/filesystem.h>
-#include <osquery/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 
 namespace osquery {

--- a/plugins/logger/kafka_producer.h
+++ b/plugins/logger/kafka_producer.h
@@ -15,8 +15,8 @@
 #include <librdkafka/rdkafka.h>
 
 #include <osquery/core/core.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
-#include <osquery/plugins/logger.h>
 
 namespace osquery {
 

--- a/plugins/logger/stdout.h
+++ b/plugins/logger/stdout.h
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/plugins/logger.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 
 namespace osquery {

--- a/plugins/logger/syslog_logger.h
+++ b/plugins/logger/syslog_logger.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <osquery/plugins/logger.h>
+#include <osquery/core/plugins/logger.h>
 #include <osquery/registry/registry_factory.h>
 
 namespace osquery {

--- a/plugins/logger/tls_logger.h
+++ b/plugins/logger/tls_logger.h
@@ -11,8 +11,8 @@
 
 #include "plugins/logger/buffered.h"
 
+#include <osquery/core/plugins/logger.h>
 #include <osquery/dispatcher/dispatcher.h>
-#include <osquery/plugins/logger.h>
 
 namespace osquery {
 

--- a/plugins/logger/windows_event_log.h
+++ b/plugins/logger/windows_event_log.h
@@ -14,7 +14,7 @@
 // clang-format on
 
 #include <osquery/core/flags.h>
-#include <osquery/plugins/logger.h>
+#include <osquery/core/plugins/logger.h>
 
 namespace osquery {
 


### PR DESCRIPTION
The previous include path for `osquery/core/plugins` was `osquery/plugins`. We want this to instead match the layout on disk to assist with IDEs and other tools.