### PR TITLE
refactor: Rename database APIs to not use DatabasePlugin class

### DIFF
--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -58,8 +58,8 @@ class CarverTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     working_dir_ =
         fs::temp_directory_path() /

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -58,8 +58,8 @@ class ConfigTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     Config::get().reset();
   }

--- a/osquery/config/tests/packs.cpp
+++ b/osquery/config/tests/packs.cpp
@@ -41,8 +41,8 @@ class PacksTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -421,8 +421,8 @@ void Initializer::initWatcher() const {
   // The watcher should not log into or use a persistent database.
   // The watcher already disabled database usage.
   if (isWatcher()) {
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 
   // The watcher takes a list of paths to autoload extensions from.
@@ -516,12 +516,12 @@ void Initializer::start() const {
   }
 
   if (!isWatcher()) {
-    DatabasePlugin::setAllowOpen(true);
+    setDatabaseAllowOpen();
     // A daemon must always have R/W access to the database.
-    DatabasePlugin::setRequireWrite(isDaemon());
+    setDatabaseRequireWrite(isDaemon());
 
     for (size_t i = 1; i <= kDatabaseMaxRetryCount; i++) {
-      if (DatabasePlugin::initPlugin().ok()) {
+      if (initDatabasePlugin().ok()) {
         break;
       }
 
@@ -671,7 +671,7 @@ int Initializer::shutdown(int retcode) const {
 
   // Hopefully release memory used by global string constructors in gflags.
   GFLAGS_NAMESPACE::ShutDownCommandLineFlags();
-  DatabasePlugin::shutdown();
+  shutdownDatabase();
 
   // Cancel the alarm.
   alarm_runnable.interrupt();

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -31,8 +31,8 @@ class QueryTests : public testing::Test {
   QueryTests() {
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -25,8 +25,8 @@ protected:
    platformSetup();
    registryAndPluginInit();
    FLAGS_disable_database = true;
-   DatabasePlugin::setAllowOpen(true);
-   DatabasePlugin::initPlugin();
+   setDatabaseAllowOpen();
+   initDatabasePlugin();
  }
 };
 

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -33,8 +33,8 @@ class WatcherTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     Config::get().reset();
   }

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -473,13 +473,15 @@ Status initDatabasePlugin() {
       kDBInitialized = true;
       return status;
     }
-    LOG(WARNING) << "Failed to activate database plugin " << boost::io::quoted(plugin) << ": " << status.what();
+    LOG(WARNING) << "Failed to activate database plugin "
+                 << boost::io::quoted(plugin) << ": " << status.what();
   }
 
   // If the database did not setUp override the active plugin.
   auto const status = RegistryFactory::get().setActive("database", "ephemeral");
   if (!status.ok()) {
-    LOG(ERROR) << "Failed to activate database plugin \"ephemeral\": " << status.what();
+    LOG(ERROR) << "Failed to activate database plugin \"ephemeral\": "
+               << status.what();
   }
   kDBInitialized = status.ok();
   return status;

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -16,9 +16,6 @@
 #include <osquery/core/plugins/plugin.h>
 
 namespace osquery {
-// A list of key/str pairs; used for write batching with setDatabaseBatch
-using DatabaseStringValueList =
-    std::vector<std::pair<std::string, std::string>>;
 
 class Status;
 /**
@@ -66,6 +63,10 @@ const int kDbCurrentVersion = 2;
  * logs until the logger plugin-specific thread decided to flush.
  */
 extern const std::string kLogs;
+
+// A list of key/str pairs; used for write batching with setDatabaseBatch
+using DatabaseStringValueList =
+    std::vector<std::pair<std::string, std::string>>;
 
 /**
  * @brief An osquery backing storage (database) type that persists executions.
@@ -164,43 +165,15 @@ class DatabasePlugin : public Plugin {
   /// Database-specific workflow: perform an initialize, then reset.
   bool checkDB();
 
-  /// Require all DBHandle accesses to open a read and write handle.
-  static void setRequireWrite(bool rw) {
-    kDBRequireWrite = rw;
-  }
+ protected:
+  /// Check if the database requires write.
+  bool requireWrite() const;
 
-  /// Allow DBHandle creations.
-  static void setAllowOpen(bool ao) {
-    kDBAllowOpen = ao;
-  }
+  /// Check if the database allows opening.
+  bool allowOpen() const;
 
- public:
-  /// Control availability of the RocksDB handle (default false).
-  static std::atomic<bool> kDBAllowOpen;
-
-  /// The database must be opened in a R/W mode (default false).
-  static std::atomic<bool> kDBRequireWrite;
-
-  /// An internal mutex around database sanity checking.
-  static std::atomic<bool> kDBChecking;
-
-  /// An internal status protecting database access.
-  static std::atomic<bool> kDBInitialized;
-
- public:
-  /**
-   * @brief Allow the initializer to check the active database plugin.
-   *
-   * Unlink the initializer's Initializer::initActivePlugin helper method, the
-   * database plugin should always be within the core. There is no need to
-   * discover the active plugin via the registry or extensions API.
-   *
-   * The database should setUp in preparation for accesses.
-   */
-  static Status initPlugin();
-
-  /// Allow shutdown before exit.
-  static void shutdown();
+  /// Check if the DB is being checked ;)
+  bool checkingDB() const;
 
  protected:
   /// The database was opened in a ReadOnly mode.
@@ -277,6 +250,28 @@ void resetDatabase();
 
 /// Allow callers to scan each column family and print each value.
 void dumpDatabase();
+
+/// Require all database accesses to open a read and write handle.
+void setDatabaseRequireWrite(bool require_write = true);
+
+/// Allow database usage creations.
+void setDatabaseAllowOpen(bool allow_open = true);
+
+/**
+ * @brief Allow a caller to check the active database plugin.
+ *
+ * There is no need to discover the active plugin via the registry or
+ * extensions API.
+ *
+ * The database should setUp in preparation for accesses.
+ */
+Status initDatabasePlugin();
+
+/// Check if the database has been initialized successfully.
+bool databaseInitialized();
+
+/// Allow shutdown before exit.
+void shutdownDatabase();
 
 Status ptreeToRapidJSON(const std::string& in, std::string& out);
 

--- a/osquery/database/tests/database.cpp
+++ b/osquery/database/tests/database.cpp
@@ -32,8 +32,8 @@ class DatabaseTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -30,8 +30,8 @@ class SchedulerTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     logging_ = FLAGS_disable_logging;
     FLAGS_disable_logging = true;

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -34,8 +34,8 @@ class DistributedTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 
  protected:

--- a/osquery/events/tests/darwin/fsevents_tests.cpp
+++ b/osquery/events/tests/darwin/fsevents_tests.cpp
@@ -50,8 +50,8 @@ class FSEventsTests : public testing::Test {
     registryAndPluginInit();
 
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     // FSEvents will use data from the config and config parsers.
     Registry::get().registry("config_parser")->setUp();

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -58,8 +58,8 @@ class EventsDatabaseTests : public ::testing::Test {
     registryAndPluginInit();
 
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     RegistryFactory::get().registry("config_parser")->setUp();
     optimize_ = FLAGS_events_optimize;

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -30,8 +30,8 @@ class EventsTests : public ::testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     RegistryFactory::get().registry("config_parser")->setUp();
   }

--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -37,8 +37,8 @@ class INotifyTests : public testing::Test {
     registryAndPluginInit();
 
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     // INotify will use data from the config and config parsers.
     Registry::get().registry("config_parser")->setUp();

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -45,8 +45,8 @@ class ExtensionsTest : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
       socket_path =

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -485,7 +485,7 @@ size_t queuedSenders() {
 }
 
 void relayStatusLogs(bool async) {
-  if (FLAGS_disable_logging || !DatabasePlugin::kDBInitialized) {
+  if (FLAGS_disable_logging || !databaseInitialized()) {
     // The logger plugins may not be setUp if logging is disabled.
     // If the database is not setUp, or is in a reset, status logs continue
     // to buffer.

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -38,8 +38,8 @@ class LoggerTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     // Backup the logging status, then disable.
     FLAGS_disable_logging = false;

--- a/osquery/main/harnesses/fuzz_utils.cpp
+++ b/osquery/main/harnesses/fuzz_utils.cpp
@@ -23,8 +23,8 @@ int osqueryFuzzerInitialize(int* argc, char*** argv) {
   osquery::registryAndPluginInit();
 
   FLAGS_disable_database = true;
-  osquery::DatabasePlugin::setAllowOpen(true);
-  osquery::DatabasePlugin::initPlugin();
+  osquery::setDatabaseAllowOpen();
+  osquery::initDatabasePlugin();
 
   auto* db = osquery::SQLiteDBManager::instance().get()->db();
 

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -74,7 +74,7 @@ int profile(int argc, char* argv[]) {
   }
 
   // Perform some duplication from Initializer with respect to database setup.
-  osquery::DatabasePlugin::setAllowOpen(true);
+  osquery::setDatabaseAllowOpen();
   osquery::RegistryFactory::get().setActive("database", "ephemeral");
 
   auto dbc = osquery::SQLiteDBManager::get();

--- a/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
@@ -34,8 +34,8 @@ class NumericMonitoringTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -33,8 +33,8 @@ class EnrollTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     deleteDatabaseValue(kPersistentSettings, "nodeKey");
     deleteDatabaseValue(kPersistentSettings, "nodeKeyTime");

--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -56,8 +56,8 @@ class TLSTransportsTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 
   void startServer(const std::string& server_cert = {}) {

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -29,8 +29,8 @@ class VirtualTableTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/system/network/tests/host_identity.cpp
+++ b/osquery/system/network/tests/host_identity.cpp
@@ -28,7 +28,7 @@ class HostIdentityTests : public testing::Test {
     FLAGS_disable_database = true;
     platformSetup();
     registryAndPluginInit();
-    DatabasePlugin::initPlugin();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -35,8 +35,8 @@ class FileEventsTableTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     Config::get().reset();
 

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -107,8 +107,8 @@ class NetworkingTablesTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/tables/system/tests/posix/augeas_tests.cpp
+++ b/osquery/tables/system/tests/posix/augeas_tests.cpp
@@ -31,8 +31,8 @@ class AugeasTests : public testing::Test {
     FLAGS_augeas_lenses =
         (osquery::getTestConfigDirectory() / "augeas/lenses").string();
 
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -39,8 +39,8 @@ class SystemsTablesTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/tables/system/tests/windows/certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/certificates_tests.cpp
@@ -30,8 +30,8 @@ class CertificatesTablesTest : public testing::Test {
     registryAndPluginInit();
 
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -29,8 +29,8 @@ class RegistryTablesTest : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/plugins/config/parsers/tests/decorators_tests.cpp
+++ b/plugins/config/parsers/tests/decorators_tests.cpp
@@ -32,8 +32,8 @@ class DecoratorsConfigParserPluginTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     // Read config content manually.
     readFile(getTestConfigDirectory() / "test_parse_items.conf", content_);

--- a/plugins/config/parsers/tests/events_parser_tests.cpp
+++ b/plugins/config/parsers/tests/events_parser_tests.cpp
@@ -32,8 +32,8 @@ class EventsConfigParserPluginTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/plugins/config/parsers/tests/file_paths_tests.cpp
+++ b/plugins/config/parsers/tests/file_paths_tests.cpp
@@ -34,8 +34,8 @@ class FilePathsConfigParserPluginTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     // Read config content manually.
     readFile(getTestConfigDirectory() / "test_parse_items.conf", content_);

--- a/plugins/config/parsers/tests/options_tests.cpp
+++ b/plugins/config/parsers/tests/options_tests.cpp
@@ -30,8 +30,8 @@ class OptionsConfigParserPluginTests : public testing::Test {
 
     // Force registry to use ephemeral database plugin
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/plugins/config/parsers/tests/views_tests.cpp
+++ b/plugins/config/parsers/tests/views_tests.cpp
@@ -31,8 +31,8 @@ class ViewsConfigParserPluginTests : public testing::Test {
 
       // Force registry to use ephemeral database plugin
       FLAGS_disable_database = true;
-      DatabasePlugin::setAllowOpen(true);
-      DatabasePlugin::initPlugin();
+      setDatabaseAllowOpen();
+      initDatabasePlugin();
     }
   }
 };

--- a/plugins/config/tests/tls_config_tests.cpp
+++ b/plugins/config/tests/tls_config_tests.cpp
@@ -40,8 +40,8 @@ class TLSConfigTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     ASSERT_TRUE(TLSServerRunner::start());
     TLSServerRunner::setClientConfig();

--- a/plugins/database/rocksdb.cpp
+++ b/plugins/database/rocksdb.cpp
@@ -74,7 +74,7 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 }
 
 Status RocksDBDatabasePlugin::setUp() {
-  if (!DatabasePlugin::kDBAllowOpen) {
+  if (!allowOpen()) {
     LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
@@ -128,7 +128,7 @@ Status RocksDBDatabasePlugin::setUp() {
     return Status(1, "Cannot read RocksDB path: " + path_);
   }
 
-  if (!DatabasePlugin::kDBChecking) {
+  if (!checkingDB()) {
     VLOG(1) << "Opening RocksDB handle: " << path_;
   }
 
@@ -148,12 +148,12 @@ Status RocksDBDatabasePlugin::setUp() {
   if (!s.ok() || db_ == nullptr) {
     LOG(INFO) << "Rocksdb open failed (" << s.code() << ":" << s.subcode()
               << ") " << s.ToString();
-    if (kDBRequireWrite) {
+    if (requireWrite()) {
       // A failed open in R/W mode is a runtime error.
       return Status(1, s.ToString());
     }
 
-    if (!DatabasePlugin::kDBChecking) {
+    if (!checkingDB()) {
       LOG(INFO) << "Opening RocksDB failed: Continuing with read-only support";
     }
     // Also disable event publishers.

--- a/plugins/database/sqlite.cpp
+++ b/plugins/database/sqlite.cpp
@@ -32,7 +32,7 @@ const std::map<std::string, std::string> kDBSettings = {
 };
 
 Status SQLiteDatabasePlugin::setUp() {
-  if (!DatabasePlugin::kDBAllowOpen) {
+  if (!allowOpen()) {
     LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
@@ -44,7 +44,7 @@ Status SQLiteDatabasePlugin::setUp() {
     return Status(1, "Cannot read database path: " + path_);
   }
 
-  if (!DatabasePlugin::kDBChecking) {
+  if (!checkingDB()) {
     VLOG(1) << "Opening database handle: " << path_;
   }
 
@@ -59,13 +59,13 @@ Status SQLiteDatabasePlugin::setUp() {
       nullptr);
 
   if (result != SQLITE_OK || db_ == nullptr) {
-    if (DatabasePlugin::kDBRequireWrite) {
+    if (requireWrite()) {
       close();
       // A failed open in R/W mode is a runtime error.
       return Status(1, "Cannot open database: " + std::to_string(result));
     }
 
-    if (!DatabasePlugin::kDBChecking) {
+    if (!checkingDB()) {
       VLOG(1) << "Opening database failed: Continuing with read-only support";
     }
 

--- a/plugins/database/tests/utils.cpp
+++ b/plugins/database/tests/utils.cpp
@@ -40,8 +40,8 @@ void DatabasePluginTests::SetUp() {
   platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
-  DatabasePlugin::setAllowOpen(true);
-  DatabasePlugin::initPlugin();
+  setDatabaseAllowOpen();
+  initDatabasePlugin();
 
   auto& rf = RegistryFactory::get();
   existing_plugin_ = rf.getActive("database");

--- a/plugins/logger/tests/aws_kinesis_logger_tests.cpp
+++ b/plugins/logger/tests/aws_kinesis_logger_tests.cpp
@@ -37,8 +37,8 @@ class AwsLoggerTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/plugins/logger/tests/buffered_tests.cpp
+++ b/plugins/logger/tests/buffered_tests.cpp
@@ -57,8 +57,8 @@ class BufferedLogForwarderTests : public Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 
  public:

--- a/plugins/logger/tests/filesystem_logger.cpp
+++ b/plugins/logger/tests/filesystem_logger.cpp
@@ -41,8 +41,8 @@ class FilesystemLoggerTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
 
     auto logger_path = fs::temp_directory_path() /
         fs::unique_path("osquery.filesystem_logger_tests.%%%%.%%%%.logs");

--- a/plugins/logger/tests/kafka_producer_tests.cpp
+++ b/plugins/logger/tests/kafka_producer_tests.cpp
@@ -80,8 +80,8 @@ class KafkaProducerPluginTest : public ::testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 };
 

--- a/plugins/logger/tests/tls_logger_tests.cpp
+++ b/plugins/logger/tests/tls_logger_tests.cpp
@@ -26,8 +26,8 @@ class TLSLoggerTests : public testing::Test {
     platformSetup();
     registryAndPluginInit();
     FLAGS_disable_database = true;
-    DatabasePlugin::setAllowOpen(true);
-    DatabasePlugin::initPlugin();
+    setDatabaseAllowOpen();
+    initDatabasePlugin();
   }
 
  public:

--- a/plugins/remote/enroll/tests/tls_enroll_tests.cpp
+++ b/plugins/remote/enroll/tests/tls_enroll_tests.cpp
@@ -51,8 +51,8 @@ void TLSEnrollTests::SetUp() {
   platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
-  DatabasePlugin::setAllowOpen(true);
-  DatabasePlugin::initPlugin();
+  setDatabaseAllowOpen();
+  initDatabasePlugin();
 
   // Start a server.
   ASSERT_TRUE(TLSServerRunner::start());

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -329,8 +329,8 @@ void setUpEnvironment() {
   platformSetup();
   registryAndPluginInit();
   FLAGS_disable_database = true;
-  DatabasePlugin::setAllowOpen(true);
-  DatabasePlugin::initPlugin();
+  setDatabaseAllowOpen();
+  initDatabasePlugin();
 }
 
 } // namespace table_tests

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -122,8 +122,7 @@ void initTesting() {
 }
 
 void shutdownTesting() {
-  DatabasePlugin::shutdown();
-
+  shutdownDatabase();
   platformTeardown();
 }
 

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -115,8 +115,8 @@ void initTesting() {
 
   // Tests need a database plugin.
   // Set up the database instance for the unittests.
-  DatabasePlugin::setAllowOpen(true);
-  DatabasePlugin::initPlugin();
+  setDatabaseAllowOpen();
+  initDatabasePlugin();
 
   platformSetup();
 }


### PR DESCRIPTION
This is a stepping stone towards fixing some database (meaning the storage layer) logic. I first want to stop using `DatabasePlugin::` throughout the code.