### PR TITLE
bug: Set thread names correctly on macOS and Linux

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -544,20 +544,21 @@ DropPrivileges::~DropPrivileges() {
 
 Status setThreadName(const std::string& name) {
 #if defined(__APPLE__)
-  int return_code = pthread_setname_np(name.c_str());
+  int return_code = pthread_setname_np(name.substr(0, 15).c_str());
   return return_code == 0
              ? Status::success()
              : Status::failure("pthread_setname_np failed with error " +
                                std::to_string(return_code));
 #elif defined(__linux__)
-  int return_code = pthread_setname_np(pthread_self(), name.c_str());
+  int return_code =
+      pthread_setname_np(pthread_self(), name.substr(0, 15).c_str());
   return return_code == 0
              ? Status::success()
              : Status::failure("pthread_setname_np failed with error " +
                                std::to_string(return_code));
 #elif defined(__FreeBSD__)
   // FreeBSD silently ignores errors and does not return an error code
-  pthread_set_name_np(pthread_self(), name.c_str());
+  pthread_set_name_np(pthread_self(), name.substr(0, 15).c_str());
   return Status::success();
 #elif defined(WIN32)
   // SetThreadDescription is available in builds newer than 1607 of windows 10

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -782,7 +782,7 @@ Status EventFactory::run(const std::string& type_id) {
     return Status(1, "Cannot restart an event publisher");
   }
 
-  setThreadName(publisher->name());
+  setThreadName("pub:" + type_id);
   VLOG(1) << "Starting event publisher run loop: " + type_id;
   publisher->hasStarted(true);
   publisher->state(EventState::EVENT_RUNNING);


### PR DESCRIPTION
Thread names are limited to 16 characters include the ending `\0`.