### PR TITLE
Change the submodule cache to be unique for each windows job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -311,8 +311,8 @@ jobs:
 
     - task: CacheBeta@2
       inputs:
-        key: submodules | Windows | $(SubmoduleCacheVersion) | $(Build.SourceVersion)
-        restoreKeys: submodules | Windows | $(SubmoduleCacheVersion)
+        key: submodules | Windows$(System.JobName) | $(SubmoduleCacheVersion) | $(Build.SourceVersion)
+        restoreKeys: submodules | Windows$(System.JobName) | $(SubmoduleCacheVersion)
         path: $(Build.SourcesDirectory)/.git/modules
       displayName: Submodule cache
 


### PR DESCRIPTION
### Description

Change the submodule cache key for the windows 32 and 64 bit builds.