### PR TITLE
Fix Windows build removing non existing C11 conformance

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -20,7 +20,15 @@ function(setupBuildFlags)
   add_library(c_settings INTERFACE)
 
   target_compile_features(cxx_settings INTERFACE cxx_std_14)
-  target_compile_features(c_settings INTERFACE c_std_11)
+
+  # There's no specific C11 conformance on MSVC
+  # and recent versions of CMake add the /std:c11 flag to the command line
+  # which makes librdkafka compilation fail due to _Thread_local not being defined,
+  # even if it's a C11 keyword.
+  # For some reason the compiler does not complain about the incorrect flag.
+  if(NOT DEFINED PLATFORM_WINDOWS)
+    target_compile_features(c_settings INTERFACE c_std_11)
+  endif()
 
   if(DEFINED PLATFORM_POSIX)
 


### PR DESCRIPTION
thirdparty_librdkafka_c was failing to compile
due to the C11 keyword _Thread_local not being recognized.

Note: This began failing recently due to a CMake update in the Windows agent which "respects" our request to use C11.