### PR TITLE
tests: Fix flaky test_2_daemon_with_option

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -684,8 +684,7 @@ class CleanChildProcesses:
 
 def expectTrue(functional, interval=1, attempts=10):
     """Helper function to run a function with expected latency"""
-    delay = 0
-    for i in range(0, attempts):
+    for _ in range(0, attempts):
         if functional():
             return True
         time.sleep(interval)
@@ -705,19 +704,6 @@ def getTestDirectory(base):
     path = os.path.join(base, "test-dir" + str(random.randint(1000, 9999)))
     utils.reset_dir(path)
     return path
-
-
-# Grab the latest info log
-def getLatestInfoLog(base):
-    info_path = os.path.join(base, "osqueryd.INFO")
-    if os.name != "nt":
-        return info_path
-    query = "select path from file where path like '{}' ORDER BY mtime DESC LIMIT 1;".format(info_path+'%')
-    osqueryi = OsqueryWrapper(getLatestOsqueryBinary('osqueryi'))
-    results = osqueryi.run_query(query)
-    if len(results) > 0:
-        return results[0]["path"]
-    return ""
 
 
 def loadThriftFromBuild(build_dir):

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -43,16 +43,15 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
         self.assertTrue(daemon.isAlive())
 
+        info_path = os.path.join(logger_path, "osqueryd.INFO")
         def info_exists():
-            info_path = test_base.getLatestInfoLog(logger_path)
             return os.path.exists(info_path)
 
         # Wait for the daemon to flush to GLOG.
         test_base.expectTrue(info_exists)
 
         # Assign the variable after we have assurances it exists
-        info_path = test_base.getLatestInfoLog(logger_path)
-        self.assertTrue(os.path.exists(info_path))
+        self.assertTrue(info_exists())
 
         # Lastly, verify that we have permission to read the file
         data = ''
@@ -168,10 +167,9 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(daemon.isAlive())
 
         # Wait for the daemon to write the info log to disk before continuing
+        info_path = os.path.join(logger_path, "osqueryd.INFO")
         def info_exists():
-            info_path = test_base.getLatestInfoLog(logger_path)
             return os.path.exists(info_path)
-        info_path = test_base.getLatestInfoLog(logger_path)
 
         def results_exists():
             return os.path.exists(results_path)

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -7,6 +7,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
+import glob
 import os
 import signal
 import shutil
@@ -43,9 +44,9 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
         self.assertTrue(daemon.isAlive())
 
-        info_path = os.path.join(logger_path, "osqueryd.INFO")
+        info_path = os.path.join(logger_path, "osqueryd.INFO*")
         def info_exists():
-            return os.path.exists(info_path)
+            return len(glob.glob(info_path)) > 0
 
         # Wait for the daemon to flush to GLOG.
         test_base.expectTrue(info_exists)
@@ -55,7 +56,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Lastly, verify that we have permission to read the file
         data = ''
-        with open(info_path, 'r') as fh:
+        with open(glob.glob(info_path)[0], 'r') as fh:
             try:
                 data = fh.read()
             except:
@@ -163,14 +164,14 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
                 "verbose": True,
             })
 
-        results_path = os.path.join(logger_path, "osqueryd.results.log")
         self.assertTrue(daemon.isAlive())
 
         # Wait for the daemon to write the info log to disk before continuing
-        info_path = os.path.join(logger_path, "osqueryd.INFO")
+        info_path = os.path.join(logger_path, "osqueryd.INFO*")
         def info_exists():
-            return os.path.exists(info_path)
+            return len(glob.glob(info_path)) > 0
 
+        results_path = os.path.join(logger_path, "osqueryd.results.log")
         def results_exists():
             return os.path.exists(results_path)
 
@@ -178,6 +179,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         test_base.expectTrue(info_exists)
         test_base.expectTrue(results_exists)
 
+        info_path = glob.glob(info_path)[0]
         # Both log files should exist, the results should have the given mode.
         for pth in [info_path, results_path]:
             self.assertTrue(os.path.exists(pth))


### PR DESCRIPTION
I see that `test_2_daemon_with_option` tends to be flaky, for example https://github.com/osquery/osquery/runs/1050124927

I think it is because we are over-complicating the search for `osqueryd.INFO`. We do not need to use `osqueryi` to enumerate these files, instead we can look for the well known symlink. This puts the search for the file existence under the retry logic. It will not remove the non-determinism but it should help protect from false positive errors.