### PR TITLE
libs: Set glog and gflags includes as SYSTEM

### DIFF
--- a/libraries/cmake/source/gflags/CMakeLists.txt
+++ b/libraries/cmake/source/gflags/CMakeLists.txt
@@ -20,7 +20,7 @@ function(gflagsMain)
     gflags_static
   )
 
-  target_include_directories(thirdparty_gflags INTERFACE
+  target_include_directories(thirdparty_gflags SYSTEM INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/submodule/include"
   )
 endfunction()

--- a/libraries/cmake/source/glog/CMakeLists.txt
+++ b/libraries/cmake/source/glog/CMakeLists.txt
@@ -34,7 +34,7 @@ function(googleLogMain)
 
   # Small hack to set glog's includes as SYSTEM
   get_target_property(glog_include_directory glog INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(glog SYSTEM PUBLIC ${glog_include_directory})
+  target_include_directories(glog SYSTEM INTERFACE ${glog_include_directory})
 
   add_library(thirdparty_glog INTERFACE)
   target_link_libraries(thirdparty_glog INTERFACE

--- a/libraries/cmake/source/glog/CMakeLists.txt
+++ b/libraries/cmake/source/glog/CMakeLists.txt
@@ -32,6 +32,10 @@ function(googleLogMain)
   get_target_property(gflags_include_directory thirdparty_gflags INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(glog PRIVATE "${gflags_include_directory}")
 
+  # Small hack to set glog's includes as SYSTEM
+  get_target_property(glog_include_directory glog INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(glog SYSTEM PUBLIC ${glog_include_directory})
+
   add_library(thirdparty_glog INTERFACE)
   target_link_libraries(thirdparty_glog INTERFACE
     glog


### PR DESCRIPTION
I am looking through `compile_commands.json` for third party library headers included with `-I`. I would like for them all to be `-isystem`.

This is a stepping stone towards adding `-Wconversion` to our code.