### PR TITLE
database: Remove read only concept

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -521,9 +521,6 @@ void Initializer::start() const {
 
   if (!isWatcher()) {
     setDatabaseAllowOpen();
-    // A daemon must always have R/W access to the database.
-    setDatabaseRequireWrite(isDaemon());
-
     auto status = initDatabasePlugin();
     if (!status.ok()) {
       auto retcode = (isWorker()) ? EXIT_CATASTROPHIC : EXIT_FAILURE;

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -166,9 +166,6 @@ class DatabasePlugin : public Plugin {
   bool checkDB();
 
  protected:
-  /// Check if the database requires write.
-  bool requireWrite() const;
-
   /// Check if the database allows opening.
   bool allowOpen() const;
 
@@ -176,9 +173,6 @@ class DatabasePlugin : public Plugin {
   bool checkingDB() const;
 
  protected:
-  /// The database was opened in a ReadOnly mode.
-  bool read_only_{false};
-
   /// Original requested path on disk.
   std::string path_;
 };
@@ -250,9 +244,6 @@ void resetDatabase();
 
 /// Allow callers to scan each column family and print each value.
 void dumpDatabase();
-
-/// Require all database accesses to open a read and write handle.
-void setDatabaseRequireWrite(bool require_write = true);
 
 /**
  * @brief Allow database usage.


### PR DESCRIPTION
This removes a confusing feature of "falling back" to a read only version of the backing persistent storage/database. In the cases where someone requests persistent storage (aka default usage of `osqueryd`, or `osqueryi` with an explicit `nodisable_database` or `database_path` set) we should not 'behind the scenes' fall back to an in-memory version if an error occurs. Additionally, the read only support for RocksDB has not been well tested by our project.