### PR TITLE
curl_certificate: Implement configurable timeout through WHERE clause

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -270,6 +270,7 @@ function(setupBuildFlags)
       wevtapi.lib
       shell32.lib
       gdi32.lib
+      mswsock.lib
     )
 
     set(osquery_windows_common_defines

--- a/specs/curl_certificate.table
+++ b/specs/curl_certificate.table
@@ -31,6 +31,7 @@ schema([
     Column("name_constraints", TEXT, "Name Constraints"),
     Column("policy_constraints", TEXT, "Policy Constraints"),
     Column("dump_certificate", INTEGER, "Set this value to '1' to dump certificate", additional=True, hidden=True),
+    Column("timeout", INTEGER, "Set this value to the timeout in seconds to complete the TLS handshake (default 4s, use 0 for no timeout)", additional=True, hidden=True),
     Column("pem", TEXT, "Certificate PEM format")
 ])
 implementation("curl_certificate@genTLSCertificate")


### PR DESCRIPTION
to Fix #6615 i've updated curl_certificates to have a timeout so it doesn't hang forever. It works by setting up the socket, setting a recv timeout, connecting, and then passing the socket into BIO to complete the TLS handshake.

I've tested this on Mac, Windows, and Linux and should provide feature parity with the old BIO-based implementation (supports ipv6 and ipv4).  I've added an optional timeout parameter to the table that allows the user to set a timeout in seconds for their query.  It defaults to 3s.

@theopolis this is ready for review now.