### PR TITLE
systemd: Limit osqueryd CPU usage to 20%

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/osqueryd \
 Restart=on-failure
 KillMode=control-group
 KillSignal=SIGTERM
+CPUQuota=10%
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/osqueryd \
 Restart=on-failure
 KillMode=control-group
 KillSignal=SIGTERM
-CPUQuota=10%
+CPUQuota=20%
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With newer versions of systemd, this will prevent `osqueryd` from using more than 20% of a single CPU.

I tested this at 10% with audit enabled and with pegging the CPU with process creations (200/s) and audit does lose more data (about 9-10% data loss actually). I tested at 20% and there is no data loss.