### PR TITLE
Improve performance and accuracy of Windows registry querying

### DIFF
--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -47,6 +47,34 @@ TEST_F(RegistryTablesTest, test_registry_existing_key) {
   EXPECT_TRUE(results.size() > 0);
 }
 
+TEST_F(RegistryTablesTest, test_expand_registry_globs) {
+  std::set<std::string> results;
+  auto s = expandRegistryGlobs(kTestSpecificKey + kRegSep + '%', results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_FALSE(results.empty());
+
+  // Calls should reset the output variable.
+  s = expandRegistryGlobs("", results);
+  EXPECT_TRUE(results.empty());
+}
+
+TEST_F(RegistryTablesTest, test_query_multiple_registry_keys) {
+  QueryData test_results;
+  auto s = queryMultipleRegistryKeys({kTestKey}, test_results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_FALSE(test_results.empty());
+
+  QueryData test_specific_results;
+  s = queryMultipleRegistryKeys({kTestSpecificKey}, test_specific_results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_FALSE(test_specific_results.empty());
+
+  QueryData results;
+  s = queryMultipleRegistryKeys({kTestKey, kTestSpecificKey}, results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_EQ(results.size(), test_results.size() + test_specific_results.size());
+}
+
 TEST_F(RegistryTablesTest, test_registry_non_existing_key) {
   QueryData results;
   auto ret = queryKey(kInvalidTestKey, results);

--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -45,9 +45,7 @@ const std::vector<std::string> kIEBrowserHelperKeys = {
 
 static inline Status getBHOs(QueryData& results) {
   QueryData regQueryResults;
-  auto ret =
-      queryMultipleRegistryKeys(kIEBrowserHelperKeys, "", regQueryResults);
-
+  auto ret = queryMultipleRegistryKeys(kIEBrowserHelperKeys, regQueryResults);
   if (!ret.ok()) {
     return ret;
   }

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -466,6 +466,7 @@ static inline Status populateAllKeysRecursive(
 
 Status expandRegistryGlobs(const std::string& pattern,
                            std::set<std::string>& results) {
+  results.clear();
   auto pathElems = osquery::split(pattern, kRegSep);
   if (pathElems.size() == 0) {
     return Status::success();

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -84,55 +84,17 @@ const std::vector<std::string> kClassKeys = {
 const std::vector<std::string> kClassExecSubKeys = {
     "InProcServer%", "InProcHandler%", "LocalServer%"};
 
-Status queryMultipleRegistryKeys(const std::vector<std::string>& regexes,
-                                 const std::string& additionalConstraints,
+QueryData genRegistry(QueryContext& context);
+
+Status queryMultipleRegistryKeys(const std::vector<std::string>& keys,
                                  QueryData& results) {
-  auto dbc = SQLiteDBManager::get();
-  std::string query(
-      "SELECT key, path, name, type, data, mtime FROM registry WHERE ");
-
-  if (!additionalConstraints.empty()) {
-    query += additionalConstraints + " AND ";
+  QueryContext qc;
+  for (size_t i = 0; i < keys.size(); i++) {
+    struct Constraint c(LIKE, keys[i]);
+    qc.constraints["key"].add(c);
   }
 
-  // Construct all of the registry key globs
-  query += "(key LIKE ";
-  std::vector<std::string> questions(regexes.size(), "?");
-  query += osquery::join(questions, " OR key LIKE ");
-  query += ")";
-
-  sqlite3_stmt* stmt = nullptr;
-  auto ret = sqlite3_prepare_v2(
-      dbc->db(), query.c_str(), static_cast<int>(query.size()), &stmt, nullptr);
-  if (ret != SQLITE_OK) {
-    return Status(1, "Failed to prepare sql query");
-  }
-  for (size_t i = 0; i < regexes.size(); i++) {
-    sqlite3_bind_text(
-        stmt, static_cast<int>(i + 1), regexes[i].c_str(), -1, SQLITE_STATIC);
-  }
-
-  // The registry table schema has exactly 6 columns
-  if (sqlite3_column_count(stmt) != 6) {
-    return Status(1, "registry query returned invalid number of columns");
-  }
-
-  while (sqlite3_step(stmt) == SQLITE_ROW) {
-    Row r;
-    r["key"] = SQL_TEXT(sqlite3_column_text(stmt, 0));
-    r["path"] = SQL_TEXT(sqlite3_column_text(stmt, 1));
-    r["name"] = SQL_TEXT(sqlite3_column_text(stmt, 2));
-    r["type"] = SQL_TEXT(sqlite3_column_text(stmt, 3));
-    r["data"] = SQL_TEXT(sqlite3_column_text(stmt, 4));
-    r["mtime"] = BIGINT(sqlite3_column_int64(stmt, 5));
-    results.push_back(r);
-  }
-
-  ret = sqlite3_finalize(stmt);
-  if (ret != SQLITE_OK) {
-    return Status(1,
-                  "Failed to finalize statement with " + std::to_string(ret));
-  }
+  results = genRegistry(qc);
   return Status::success();
 }
 
@@ -143,9 +105,7 @@ Status getClassName(const std::string& clsId, std::string& rClsName) {
   }
 
   QueryData regQueryResults;
-  std::string constraint("name = '" + kDefaultRegName + "'");
-  auto ret = queryMultipleRegistryKeys(keys, constraint, regQueryResults);
-
+  auto ret = queryMultipleRegistryKeys(keys, regQueryResults);
   if (!ret.ok()) {
     return ret;
   }
@@ -154,8 +114,13 @@ Status getClassName(const std::string& clsId, std::string& rClsName) {
   }
 
   for (const auto& row : regQueryResults) {
-    if (!row.at("data").empty()) {
-      rClsName = row.at("data");
+    auto data_it = row.find("data");
+    auto name_it = row.find("name");
+    if (data_it == row.end() || name_it == row.end()) {
+      continue;
+    }
+    if (!data_it->second.empty() && name_it->second == kDefaultRegName) {
+      rClsName = data_it->second;
       return Status::success();
     }
   }
@@ -173,17 +138,22 @@ Status getClassExecutables(const std::string& clsId,
   }
 
   QueryData regQueryResults;
-  auto ret = queryMultipleRegistryKeys(resolvedKeys, "", regQueryResults);
+  auto ret = queryMultipleRegistryKeys(resolvedKeys, regQueryResults);
   if (!ret.ok()) {
     return ret;
   }
   if (regQueryResults.empty()) {
-    return Status(1, "ClsId not found in registry");
+    return Status(1, "ClsId executables not found in registry");
   }
 
   for (const auto& r : regQueryResults) {
-    if (r.at("name") == kDefaultRegName) {
-      results.push_back(r.at("data"));
+    auto name_it = r.find("name");
+    auto data_it = r.find("data");
+    if (data_it == r.end() || name_it == r.end()) {
+      continue;
+    }
+    if (name_it->second == kDefaultRegName) {
+      results.push_back(data_it->second);
     }
   }
   return Status::success();
@@ -306,6 +276,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
       r["name"] = wstringToString(achKey.get());
       r["path"] = keyPath + kRegSep + wstringToString(achKey.get());
       r["mtime"] = std::to_string(osquery::filetimeToUnixtime(ftLastWriteTime));
+      r["data"] = "";
       results.push_back(r);
     }
   }
@@ -366,6 +337,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
       r["type"] = "UNKNOWN";
     }
     r["mtime"] = std::to_string(osquery::filetimeToUnixtime(ftLastWriteTime));
+    r["data"] = "";
 
     if (bpDataBuff != nullptr) {
       /// REG_LINK is a Unicode string, which in Windows is wchar_t
@@ -423,7 +395,6 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
             wstringToString(reinterpret_cast<wchar_t*>(bpDataBuff.get()));
         break;
       default:
-        r["data"] = "";
         break;
       }
       ZeroMemory(bpDataBuff.get(), cbMaxValueData);
@@ -567,7 +538,9 @@ QueryData genRegistry(QueryContext& context) {
     }
     if (context.hasConstraint("key", LIKE)) {
       for (const auto& key : context.constraints["key"].getAll(LIKE)) {
-        auto status = expandRegistryGlobs(key, keys);
+        std::set<std::string> keys_like;
+        auto status = expandRegistryGlobs(key, keys_like);
+        keys.insert(keys_like.begin(), keys_like.end());
         if (!status.ok()) {
           LOG(INFO) << "Failed to expand globs: " + status.getMessage();
         }
@@ -581,12 +554,14 @@ QueryData genRegistry(QueryContext& context) {
     if (context.hasConstraint("path", LIKE)) {
       for (const auto& path : context.constraints["path"].getAll(LIKE)) {
         Status status;
+        std::set<std::string> path_like;
         if (boost::ends_with(path, kSQLGlobRecursive)) {
-          status = expandRegistryGlobs(path, keys);
+          status = expandRegistryGlobs(path, path_like);
         } else {
           status = expandRegistryGlobs(
-              path.substr(0, path.find_last_of(kRegSep)), keys);
+              path.substr(0, path.find_last_of(kRegSep)), path_like);
         }
+        keys.insert(path_like.begin(), path_like.end());
         if (!status.ok()) {
           LOG(INFO) << "Failed to expand globs: " + status.getMessage();
         }

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -65,13 +65,12 @@ Status getClassExecutables(const std::string& clsId,
                            std::vector<std::string>& results);
 
 /*
- * @brief Expand a globbing pattern into a set of registry keys to
- * query
+ * @brief Expand a globbing pattern into a set of registry keys to query.
  *
  * @param pattern The SQL globbing pattern, e.g.
  * 'HKEY_LOCAL_MACHINE\%\Microsoft' or 'HKEY_USERS\%\SOFTWARE\%%'
  * @param results A set that will be populated with all registry keys matching
- * the glob pattern
+ * the glob pattern. The set will be initially cleared.
  * @return Failure if the max recursive depth is reached, otherwise success
  */
 Status expandRegistryGlobs(const std::string& pattern,

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -29,18 +29,10 @@ Status queryKey(const std::string& keyPath, QueryData& results);
 /*
  * @brief Helper function to query multiple registry keys
  *
- * @param regexes a vector of registry key regexes to query
- * @param additionalConstaints a string of hard-coded constraints for the query
+ * @param keys a vector of registry keys to query using LIKE (caller adds %).
  * @param results a container to receive the results of the query
- *
- * This function binds the regexes to the query statement to ensure parameters
- * are all properly escaped. It is the responsibility of the caller to parse
- * through the QueryData object and extrct relevant data.
- * Note: Ensure that the `additionalConstraints` field, if used, _does not_
- * contain any user supplied data.
  */
-Status queryMultipleRegistryKeys(const std::vector<std::string>& regexes,
-                                 const std::string& additionalConstraints,
+Status queryMultipleRegistryKeys(const std::vector<std::string>& keys,
                                  QueryData& results);
 
 /*


### PR DESCRIPTION
This improves the performance of querying the Windows registry when using `queryMultipleRegistryKeys`. It also improves the accuracy for when SQL statements merge their LIKE operators into a single call of `genRegistry`. It looks like there was a bug in the registry globbing that assumed the result parameter would be fresh/empty.