### PR TITLE
Fix image column within drivers table on Windows

### DIFF
--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -75,6 +75,23 @@ TEST_F(RegistryTablesTest, test_query_multiple_registry_keys) {
   EXPECT_EQ(results.size(), test_results.size() + test_specific_results.size());
 }
 
+TEST_F(RegistryTablesTest, test_query_multiple_registry_paths) {
+  QueryData test_results;
+  auto s = queryMultipleRegistryPaths({kTestKey}, test_results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_FALSE(test_results.empty());
+
+  QueryData test_specific_results;
+  s = queryMultipleRegistryPaths({kTestSpecificKey}, test_specific_results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_FALSE(test_specific_results.empty());
+
+  QueryData results;
+  s = queryMultipleRegistryPaths({kTestKey, kTestSpecificKey}, results);
+  ASSERT_TRUE(s.ok());
+  EXPECT_EQ(results.size(), test_results.size() + test_specific_results.size());
+}
+
 TEST_F(RegistryTablesTest, test_registry_non_existing_key) {
   QueryData results;
   auto ret = queryKey(kInvalidTestKey, results);

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -17,16 +17,16 @@
 #include <cfgmgr32.h>
 // clang-format on
 
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/regex.hpp>
-
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
-
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/core/windows/wmi.h>
 #include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/utils/conversions/windows/windows_time.h>
+#include <osquery/tables/system/windows/registry.h>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/regex.hpp>
 
 namespace osquery {
 namespace tables {
@@ -169,14 +169,19 @@ Status getDeviceProperty(const device_infoset_t& infoset,
 }
 
 std::string getDriverImagePath(const std::string& service_key) {
-  SQL sql("SELECT data FROM registry WHERE path = '" + service_key +
-          "\\ImagePath'");
+  QueryData results;
+  queryMultipleRegistryPaths({service_key + kRegSep + "ImagePath"}, results);
 
-  if (sql.rows().empty() || sql.rows().at(0).count("data") == 0) {
+  if (results.empty()) {
     return "";
   }
 
-  auto path = sql.rows().at(0).at("data");
+  auto data_it = results[0].find("data");
+  if (data_it == results[0].end()) {
+    return "";
+  }
+
+  auto path = data_it->second;
   if (path.empty()) {
     return "";
   }
@@ -186,16 +191,16 @@ std::string getDriverImagePath(const std::string& service_key) {
 
 Status genServiceKeyMap(
     std::map<std::string, std::string>& services_image_map) {
-  // Attempt to get all of the services image paths in the default location
-  SQL sql("SELECT key, data FROM registry WHERE path LIKE'" + kServiceKeyPath +
-          "%\\ImagePath'");
+  QueryData results;
+  queryMultipleRegistryPaths({kServiceKeyPath + '%' + kRegSep + "ImagePath"},
+                             results);
 
   // Something went wrong
-  if (sql.rows().empty()) {
+  if (results.empty()) {
     return Status::failure("Failed to retrieve services image path cache");
   }
 
-  for (auto& row : sql.rows()) {
+  for (auto& row : results) {
     auto key_it = row.find("key");
     auto data_it = row.find("data");
     if (key_it == row.end() || data_it == row.end()) {
@@ -265,7 +270,7 @@ QueryData genDrivers(QueryContext& context) {
       // If the image map doesn't exist in the cache, manually look it up
       auto svc_key_it = svc_image_map.find(svc_key);
       if (svc_key_it != svc_image_map.end()) {
-        r["image"] = svc_image_map[svc_key_it->second];
+        r["image"] = svc_key_it->second;
       } else {
         // Manual lookups of the service keys image path are _very_ slow
         VLOG(1) << r["service"]

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -98,6 +98,18 @@ Status queryMultipleRegistryKeys(const std::vector<std::string>& keys,
   return Status::success();
 }
 
+Status queryMultipleRegistryPaths(const std::vector<std::string>& paths,
+                                  QueryData& results) {
+  QueryContext qc;
+  for (size_t i = 0; i < paths.size(); i++) {
+    struct Constraint c(LIKE, paths[i]);
+    qc.constraints["path"].add(c);
+  }
+
+  results = genRegistry(qc);
+  return Status::success();
+}
+
 Status getClassName(const std::string& clsId, std::string& rClsName) {
   std::vector<std::string> keys;
   for (const auto& key : kClassKeys) {

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -36,6 +36,15 @@ Status queryMultipleRegistryKeys(const std::vector<std::string>& keys,
                                  QueryData& results);
 
 /*
+ * @brief Helper function to query multiple registry paths
+ *
+ * @param paths a vector of registry paths to query using LIKE (caller adds %).
+ * @param results a container to receive the results of the query
+ */
+Status queryMultipleRegistryPaths(const std::vector<std::string>& paths,
+                                  QueryData& results);
+
+/*
  * @brief Get the name of a class from it's Class ID
  *
  * @param clsId the class ID, e.g. "{0000002F-0000-0000-C000-000000000046}"


### PR DESCRIPTION
This supersedes https://github.com/osquery/osquery/pull/6059.

There is a bug in the `drivers` table that prevents `image` from being populated. A value is mistakenly used as a key.

This PR also improves the accuracy of the table by fixing an error in SQL. And the PR improves the table performance by bypassing the SQL/SQLite abstractions.

The user and system time end up at about 50% of the previous implementation.