### PR TITLE
Fixed handling of invalid array bound error with EvtNext function

### DIFF
--- a/osquery/tables/system/windows/windows_eventlog.cpp
+++ b/osquery/tables/system/windows/windows_eventlog.cpp
@@ -247,15 +247,20 @@ void genWindowsEventLog(RowYield& yield, QueryContext& context) {
   if (hasXpath) {
     auto xpaths = context.constraints["xpath"].getAll(EQUALS);
     auto xpath = *xpaths.begin();
-    pt::ptree propTree;
-    std::stringstream ss;
-    ss << xpath;
-    pt::read_xml(ss, propTree);
-    auto channel = propTree.get("QueryList.Query.Select.<xmlattr>.Path", "");
-    if (!channel.empty()) {
-      xpath_set.insert(std::make_pair(channel, xpath));
-    } else {
-      LOG(WARNING) << "Invalid xpath format: " << xpath;
+    try {
+      pt::ptree propTree;
+      std::stringstream ss;
+      ss << xpath;
+      pt::read_xml(ss, propTree);
+      auto channel = propTree.get("QueryList.Query.Select.<xmlattr>.Path", "");
+      if (!channel.empty()) {
+        xpath_set.insert(std::make_pair(channel, xpath));
+      } else {
+        LOG(WARNING) << "Invalid xpath format: " << xpath;
+      }
+    } catch (std::exception& e) {
+      LOG(WARNING) << "Failed to parse the xpath xml string " << e.what();
+      return;
     }
 
   } else if (context.hasConstraint("channel", EQUALS)) {

--- a/osquery/tables/system/windows/windows_eventlog.cpp
+++ b/osquery/tables/system/windows/windows_eventlog.cpp
@@ -85,24 +85,24 @@ Status parseWelXml(QueryContext& context, std::wstring& xml_event, Row& row) {
 void renderQueryResults(QueryContext& context,
                         EVT_HANDLE queryResults,
                         RowYield& yield) {
-  uint32_t kNumEventsBlock = 1024;
-  uint32_t _position = 0;
+  uint32_t numEventsBlock = 1024;
+  uint32_t position = 0;
+  std::vector<EVT_HANDLE> events(numEventsBlock);
 
   // The batch size should be more than 32. It is not documented
   // but `EvtNext` should not fail (RPC_S_INVALID_BOUND error)
   // with low batch size.
-  while (kNumEventsBlock > 32) {
-    std::vector<EVT_HANDLE> events(kNumEventsBlock);
+  while (numEventsBlock > 32) {
     unsigned long numEvents = 0;
     // Retrieve the events one block at a time
     auto ret = EvtNext(
-        queryResults, kNumEventsBlock, events.data(), INFINITE, 0, &numEvents);
+        queryResults, numEventsBlock, events.data(), INFINITE, 0, &numEvents);
     while (ret != FALSE) {
       for (unsigned long i = 0; i < numEvents; i++) {
         unsigned long renderedBuffSize = 0;
         unsigned long renderedBuffUsed = 0;
         unsigned long propCount = 0;
-        _position += 1;
+        position += 1;
         if (!EvtRender(nullptr,
                        events[i],
                        EvtRenderEventXml,
@@ -144,12 +144,8 @@ void renderQueryResults(QueryContext& context,
         }
       }
 
-      ret = EvtNext(queryResults,
-                    kNumEventsBlock,
-                    events.data(),
-                    INFINITE,
-                    0,
-                    &numEvents);
+      ret = EvtNext(
+          queryResults, numEventsBlock, events.data(), INFINITE, 0, &numEvents);
     }
 
     // While reading a batch of large event log reports `EvtNext` may
@@ -157,12 +153,16 @@ void renderQueryResults(QueryContext& context,
     // chunk of events. This is an unusual behavior and not documented.
     // The fix reduces the batch size to half and retries `EvtNext`
     if (RPC_S_INVALID_BOUND == GetLastError()) {
-      kNumEventsBlock = kNumEventsBlock / 2;
+      numEventsBlock = numEventsBlock / 2;
+
+      // Resize the events vector to the current batch size
+      events.resize(numEventsBlock);
+
       // `EvtNext` may update the event position in query handler on
       // failure with RPC_S_INVALID_BOUND error. `EvtSeek` reset the
       // position before calling EvtNext with lower batch size.
       if (!EvtSeek(
-              queryResults, _position, nullptr, 0, EvtSeekRelativeToFirst)) {
+              queryResults, position, nullptr, 0, EvtSeekRelativeToFirst)) {
         VLOG(1) << "EvtSeek failed with error " << GetLastError();
       }
       continue;


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->
While reading the event log records in batches the windows function `EvtNext` returns with invalid array bound error (`RPC_S_INVALID_BOUND`). This is unusual behavior and causes inconsistency in the results of `windows_eventlog` table. 

The fix handles the error by reseting the query handler at the previous best position and retrying the `EvtNext` with reduced batch size. 

Related to #6650 

Query result with the fixes:
```
osquery> select eventid,count(*) from windows_eventlog where channel="Security" group by eventid;
+---------+----------+
| eventid | count(*) |
+---------+----------+
| 1100    | 1        |
| 4608    | 1        |
| 4616    | 2        |
| 4624    | 26       |
| 4625    | 36198    |
| 4634    | 4        |
| 4647    | 1        |
| 4648    | 4        |
| 4672    | 24       |
| 4688    | 10       |
| 4776    | 2        |
| 4798    | 11       |
| 4799    | 7        |
| 4826    | 1        |
| 4902    | 1        |
| 5024    | 1        |
| 5033    | 1        |
| 5058    | 3        |
| 5059    | 1        |
| 5061    | 3        |
+---------+----------+
osquery> select eventid,count(*) from windows_eventlog where channel="Security" and eventid=4625;
+---------+----------+
| eventid | count(*) |
+---------+----------+
| 4625    | 36156    |
+---------+----------+
```
There is still slight differences in the event count for `eventid` 4625. It could be due to the different xpath getting used in both the query and losing some of the events. 