### PR TITLE
file_events: Add configuration flag

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -1,6 +1,6 @@
 # File Integrity Monitoring with osquery
 
-File integrity monitoring (FIM) is available for Linux and macOS using inotify and FSEvents. The daemon reads a list of files/directories from the osquery configuration. The actions (and hashes when appropriate) to those selected files populate the [`file_events`](https://osquery.io/schema/current/#file_events) table.
+File integrity monitoring (FIM) is available for Linux and macOS using inotify and FSEvents. The daemon reads a list of files/directories from the osquery configuration. The actions (and hashes when appropriate) to those selected files populate the [`file_events`](https://osquery.io/schema/current/#file_events) table. This guide assumes that events are running (`--disable_events=false`) and that the file_events table has been enabled with `--enable_file_events=true`.
 
 To get started with FIM, you must first identify which files and directories you wish to monitor. Then use *fnmatch*-style, or filesystem globbing, patterns to represent the target paths. You may use standard wildcards `*`/`**` or SQL-style wildcards `*%*`:
 

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -19,6 +19,7 @@ function(generateOsqueryEvents)
   if(DEFINED PLATFORM_LINUX)
     list(APPEND source_files
       audit_flags.cpp
+      file_events_flags.cpp
       linux/auditdnetlink.cpp
       linux/auditeventpublisher.cpp
       linux/inotify.cpp
@@ -39,6 +40,7 @@ function(generateOsqueryEvents)
   elseif(DEFINED PLATFORM_MACOS)
     list(APPEND source_files
       audit_flags.cpp
+      file_events_flags.cpp
       darwin/diskarbitration.cpp
       darwin/event_taps.cpp
       darwin/fsevents.cpp

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -12,6 +12,7 @@
 #include <boost/filesystem.hpp>
 
 #include <osquery/config/config.h>
+#include <osquery/core/flags.h>
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
@@ -31,6 +32,7 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
+FLAG(bool, enable_file_events, false, "Enables the file_events publisher");
 
 std::map<FSEventStreamEventFlags, std::string> kMaskActions = {
     {kFSEventStreamEventFlagItemChangeOwner, "ATTRIBUTES_MODIFIED"},
@@ -145,6 +147,10 @@ void FSEventsEventPublisher::stop() {
 }
 
 void FSEventsEventPublisher::tearDown() {
+  if (!FLAGS_enable_file_events) {
+    return;
+  }
+
   stop();
 
   // Do not keep a reference to the run loop.
@@ -211,6 +217,10 @@ void FSEventsEventPublisher::buildExcludePathsSet() {
 }
 
 void FSEventsEventPublisher::configure() {
+  if (!FLAGS_enable_file_events) {
+    return;
+  }
+
   // Rebuild the watch paths.
   stop();
 
@@ -233,6 +243,10 @@ void FSEventsEventPublisher::configure() {
 }
 
 Status FSEventsEventPublisher::run() {
+  if (!FLAGS_enable_file_events) {
+    return Status(1, "Publisher disabled via configuration");
+  }
+
   // The run entrypoint executes in a dedicated thread.
   bool needs_reset = false;
   {

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -32,7 +32,8 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
-FLAG(bool, enable_file_events, false, "Enables the file_events publisher");
+
+DECLARE_bool(enable_file_events);
 
 std::map<FSEventStreamEventFlags, std::string> kMaskActions = {
     {kFSEventStreamEventFlagItemChangeOwner, "ATTRIBUTES_MODIFIED"},

--- a/osquery/events/file_events_flags.cpp
+++ b/osquery/events/file_events_flags.cpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/flags.h>
+
+namespace osquery {
+
+FLAG(bool, enable_file_events, false, "Enables the file_events publisher");
+
+} // namespace osquery

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -16,6 +16,7 @@
 #include <boost/filesystem.hpp>
 
 #include <osquery/config/config.h>
+#include <osquery/core/flags.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry_factory.h>
@@ -26,6 +27,7 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
+FLAG(bool, enable_file_events, false, "Enables the file_events publisher");
 
 static const size_t kINotifyMaxEvents = 512;
 static const size_t kINotifyEventSize =
@@ -53,6 +55,10 @@ const uint32_t kFileAccessMasks = IN_OPEN | IN_ACCESS;
 REGISTER(INotifyEventPublisher, "event_publisher", "inotify");
 
 Status INotifyEventPublisher::setUp() {
+  if (!FLAGS_enable_file_events) {
+    return Status(1, "Publisher disabled via configuration");
+  }
+
   inotify_handle_ = ::inotify_init();
   // If this does not work throw an exception.
   if (inotify_handle_ == -1) {
@@ -150,6 +156,10 @@ void INotifyEventPublisher::buildExcludePathsSet() {
 }
 
 void INotifyEventPublisher::configure() {
+  if (!FLAGS_enable_file_events) {
+    return;
+  }
+
   if (inotify_handle_ == -1) {
     // This publisher has not been setup correctly.
     return;
@@ -193,6 +203,10 @@ void INotifyEventPublisher::configure() {
 }
 
 void INotifyEventPublisher::tearDown() {
+  if (!FLAGS_enable_file_events) {
+    return;
+  }
+
   if (inotify_handle_ > -1) {
     ::close(inotify_handle_);
   }
@@ -219,6 +233,10 @@ void INotifyEventPublisher::handleOverflow() {
 }
 
 Status INotifyEventPublisher::run() {
+  if (!FLAGS_enable_file_events) {
+    return Status(1, "Publisher disabled via configuration");
+  }
+
   struct pollfd fds[1];
   fds[0].fd = getHandle();
   fds[0].events = POLLIN;

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -27,7 +27,8 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
-FLAG(bool, enable_file_events, false, "Enables the file_events publisher");
+
+DECLARE_bool(enable_file_events);
 
 static const size_t kINotifyMaxEvents = 512;
 static const size_t kINotifyEventSize =

--- a/osquery/events/tests/darwin/fsevents_tests.cpp
+++ b/osquery/events/tests/darwin/fsevents_tests.cpp
@@ -28,6 +28,7 @@ namespace osquery {
 int kMaxEventLatency = 3000;
 
 DECLARE_bool(verbose);
+DECLARE_bool(enable_file_events);
 
 class FSEventsTests : public testing::Test {
  public:
@@ -43,6 +44,9 @@ class FSEventsTests : public testing::Test {
 
  protected:
   void SetUp() override {
+    enable_file_events_backup_ = FLAGS_enable_file_events;
+    FLAGS_enable_file_events = true;
+
     fs::create_directories(real_test_dir);
 
     setToolType(ToolType::TEST);
@@ -58,6 +62,8 @@ class FSEventsTests : public testing::Test {
   void TearDown() override {
     fs::remove_all(real_test_path);
     fs::remove_all(real_test_dir);
+
+    FLAGS_enable_file_events = enable_file_events_backup_;
   }
 
   void StartEventLoop() {
@@ -124,6 +130,7 @@ class FSEventsTests : public testing::Test {
   size_t count{0};
   std::shared_ptr<FSEventsEventPublisher> event_pub_{nullptr};
   std::thread temp_thread_;
+  bool enable_file_events_backup_{false};
 
  public:
   /// Trigger path is the current test's eventing sink (accessed anywhere).

--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -15,6 +15,7 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+#include <osquery/core/flags.h>
 #include <osquery/core/tables.h>
 #include <osquery/database/database.h>
 #include <osquery/events/events.h>
@@ -26,12 +27,18 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
+DECLARE_bool(enable_file_events);
 
 const int kMaxEventLatency = 3000;
 
 class INotifyTests : public testing::Test {
+  bool enable_file_events_backup{false};
+
  protected:
   void SetUp() override {
+    enable_file_events_backup = FLAGS_enable_file_events;
+    FLAGS_enable_file_events = true;
+
     setToolType(ToolType::TEST);
     registryAndPluginInit();
     initDatabasePluginForTesting();
@@ -57,6 +64,8 @@ class INotifyTests : public testing::Test {
   }
 
   void TearDown() override {
+    FLAGS_enable_file_events = enable_file_events_backup;
+
     // End the event loops, and join on the threads.
     removePath(real_test_dir);
     removePath(real_test_path);


### PR DESCRIPTION
This allows Linux users to configure the **process_file_events** table without enabling **file_events** by mistake. Solves issue #5584