### PR TITLE
Add AWS regions

### DIFF
--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -89,20 +89,14 @@ const std::string kEc2MetadataUrl =
 const std::string kHypervisorUuid = "/sys/hypervisor/uuid";
 
 /// Map of AWS region name to AWS::Region enum.
-static const std::set<std::string> kAwsRegions = {"us-east-1",
-                                                  "us-west-1",
-                                                  "us-west-2",
-                                                  "eu-west-1",
-                                                  "eu-central-1",
-                                                  "ap-southeast-1",
-                                                  "ap-southeast-2",
-                                                  "ap-northeast-1",
-                                                  "ap-northeast-2",
-                                                  "sa-east-1",
-                                                  "ap-south-1",
-                                                  "us-east-2",
-                                                  "ca-central-1",
-                                                  "eu-west-2"};
+static const std::set<std::string> kAwsRegions = {
+    "af-south-1",     "ap-east-1",     "ap-northeast-1", "ap-northeast-2",
+    "ap-northeast-3", "ap-south-1",    "ap-southeast-1", "ap-southeast-2",
+    "ca-central-1",   "cn-north-1",    "cn-northwest-1", "eu-central-1",
+    "eu-north-1",     "eu-south-1",    "eu-west-1",      "eu-west-2",
+    "eu-west-3",      "me-south-1",    "sa-east-1",      "us-east-1",
+    "us-east-2",      "us-gov-east-1", "us-gov-west-1",  "us-west-1",
+    "us-west-2"};
 
 // Default AWS region to use when no region set in flags or profile
 static RegionName kDefaultAWSRegion = Aws::Region::US_EAST_1;


### PR DESCRIPTION
Support additional AWS regions.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
