### PR TITLE
Fix last_connected column in wifi_networks on Catalina

### DIFF
--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -27,8 +27,7 @@ static const std::string kAirPortPreferencesPath =
 
 // In 10.14 and prior, there was an "auto_login" key.
 const std::map<std::string, std::string> kKnownWifiNetworkKeysPreCatalina = {
-    {"auto_login", "AutoLogin"},
-    {"last_connected", "LastConnected"}};
+    {"auto_login", "AutoLogin"}, {"last_connected", "LastConnected"}};
 
 const std::map<std::string, std::string> kKnownCommonWifiNetworkKeys = {
     {"ssid", "SSID"},
@@ -60,7 +59,8 @@ Status getKnownWifiNetworkKeys(std::map<std::string, std::string>& keys) {
 
   // Then include the common keys (not unique to any particular macOS version):
   // C++17 equivalent: keys.merge(kKnownCommonWifiNetworkKeys);
-  keys.insert(kKnownCommonWifiNetworkKeys.begin(), kKnownCommonWifiNetworkKeys.end());
+  keys.insert(kKnownCommonWifiNetworkKeys.begin(),
+              kKnownCommonWifiNetworkKeys.end());
 
   return Status(0, "ok");
 }

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -25,7 +25,7 @@ static const std::string kAirPortPreferencesPath =
     "/Library/Preferences/SystemConfiguration/"
     "com.apple.airport.preferences.plist";
 
-const std::map<std::string, std::string> kKnownWifiNetworkKeys = {
+const std::map<std::string, std::string> kKnownWifiNetworkKeysPreCatalina = {
     {"ssid", "SSID"},
     {"network_name", "SSIDString"},
     {"security_type", "SecurityType"},
@@ -39,11 +39,40 @@ const std::map<std::string, std::string> kKnownWifiNetworkKeys = {
     {"disabled", "Disabled"},
     {"temporarily_disabled", "TemporarilyDisabled"}};
 
-// Check if we are running on OS X 10.9, where the key in plist is different
+// The name of the "last_connected" key changed in 10.15, and the 
+// "auto_login" key no longer exists.
+const std::map<std::string, std::string> kKnownWifiNetworkKeys = {
+    {"ssid", "SSID"},
+    {"network_name", "SSIDString"},
+    {"security_type", "SecurityType"},
+    {"roaming_profile", "RoamingProfileType"},
+    {"auto_login", "AutoLogin"}, // actually no longer present since Catalina
+    {"last_connected", "LastAutoJoinAt"},
+    {"captive_portal", "Captive"},
+    {"roaming", "SPRoaming"},
+    {"passpoint", "Passpoint"},
+    {"possibly_hidden", "PossiblyHiddenNetwork"},
+    {"disabled", "Disabled"},
+    {"temporarily_disabled", "TemporarilyDisabled"}};
+
+// Check if we are running on macOS 10.15 or later. Keys have changed.
+Status getKnownWifiNetworkKeys(std::map<std::string, std::string>& keys) {
+    auto qd = SQL::selectAllFrom("os_version");
+  if (qd.size() != 1) {
+    return Status(-1, "Couldn't determine macOS version");
+  }
+
+  keys = (qd.front().at("major") < "11" && qd.front().at("minor") < "15")
+            ? kKnownWifiNetworkKeysPreCatalina
+            : kKnownWifiNetworkKeys;
+  return Status(0, "ok");
+}
+
+// Check if we are running on macOS 10.9, where the top-level key in the plist was different
 Status getKnownNetworksKey(std::string& key) {
   auto qd = SQL::selectAllFrom("os_version");
   if (qd.size() != 1) {
-    return Status(-1, "Couldn't determine OS X version");
+    return Status(-1, "Couldn't determine macOS version");
   }
 
   key = (qd.front().at("major") == "10" && qd.front().at("minor") == "9")
@@ -75,8 +104,15 @@ void parseNetworks(const CFDictionaryRef& network, QueryData& results) {
     return;
   }
 
+  std::map<std::string, std::string> keys;
+  auto status = getKnownWifiNetworkKeys(keys);
+  if (!status.ok()) {
+    VLOG(1) << status.getMessage();
+    return;
+  }
+
   Row r;
-  for (const auto& kv : kKnownWifiNetworkKeys) {
+  for (const auto& kv : keys) {
     auto key = CFStringCreateWithCString(
         kCFAllocatorDefault, kv.second.c_str(), kCFStringEncodingUTF8);
     CFTypeRef value = nullptr;

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -29,7 +29,7 @@ static const std::string kAirPortPreferencesPath =
 const std::map<std::string, std::string> kKnownWifiNetworkKeysPreCatalina = {
     {"auto_login", "AutoLogin"}, {"last_connected", "LastConnected"}};
 
-const std::map<std::string, std::string> kKnownCommonWifiNetworkKeys = {
+const std::map<std::string, std::string> kKnownWifiNetworkKeysCommon = {
     {"ssid", "SSID"},
     {"network_name", "SSIDString"},
     {"security_type", "SecurityType"},
@@ -58,9 +58,9 @@ Status getKnownWifiNetworkKeys(std::map<std::string, std::string>& keys) {
              : kKnownWifiNetworkKeysPostCatalina;
 
   // Then include the common keys (not unique to any particular macOS version):
-  // C++17 equivalent: keys.merge(kKnownCommonWifiNetworkKeys);
-  keys.insert(kKnownCommonWifiNetworkKeys.begin(),
-              kKnownCommonWifiNetworkKeys.end());
+  // C++17 equivalent: keys.merge(kKnownWifiNetworkKeysCommon);
+  keys.insert(kKnownWifiNetworkKeysCommon.begin(),
+              kKnownWifiNetworkKeysCommon.end());
 
   return Status(0, "ok");
 }

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -39,7 +39,7 @@ const std::map<std::string, std::string> kKnownWifiNetworkKeysPreCatalina = {
     {"disabled", "Disabled"},
     {"temporarily_disabled", "TemporarilyDisabled"}};
 
-// The name of the "last_connected" key changed in 10.15, and the 
+// The name of the "last_connected" key changed in 10.15, and the
 // "auto_login" key no longer exists.
 const std::map<std::string, std::string> kKnownWifiNetworkKeys = {
     {"ssid", "SSID"},
@@ -57,18 +57,19 @@ const std::map<std::string, std::string> kKnownWifiNetworkKeys = {
 
 // Check if we are running on macOS 10.15 or later. Keys have changed.
 Status getKnownWifiNetworkKeys(std::map<std::string, std::string>& keys) {
-    auto qd = SQL::selectAllFrom("os_version");
+  auto qd = SQL::selectAllFrom("os_version");
   if (qd.size() != 1) {
     return Status(-1, "Couldn't determine macOS version");
   }
 
   keys = (qd.front().at("major") < "11" && qd.front().at("minor") < "15")
-            ? kKnownWifiNetworkKeysPreCatalina
-            : kKnownWifiNetworkKeys;
+             ? kKnownWifiNetworkKeysPreCatalina
+             : kKnownWifiNetworkKeys;
   return Status(0, "ok");
 }
 
-// Check if we are running on macOS 10.9, where the top-level key in the plist was different
+// Check if we are running on macOS 10.9, where the top-level key in the plist
+//  was different
 Status getKnownNetworksKey(std::string& key) {
   auto qd = SQL::selectAllFrom("os_version");
   if (qd.size() != 1) {

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -10,15 +10,24 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>
 #include <gtest/gtest.h>
+
 #include <osquery/config/tests/test_utils.h>
+#include <osquery/core/system.h>
 #include <osquery/core/sql/query_data.h>
+#include <osquery/registry/registry_factory.h>
 
 namespace osquery {
 namespace tables {
 
 void parseNetworks(const CFDictionaryRef& network, QueryData& results);
 
-class WifiNetworksTest : public testing::Test {};
+class WifiNetworksTest : public testing::Test {
+ protected:
+  void SetUp() {
+    platformSetup();
+    registryAndPluginInit();
+  }
+};
 
 TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   std::string path = (getTestConfigDirectory() / "test_airport.plist").string();
@@ -27,8 +36,8 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
       [NSDictionary dictionaryWithContentsOfFile:@(path.c_str())];
   ASSERT_GE((long)CFDictionaryGetCount(plist), 1);
   std::string key = "KnownNetworks";
-  auto cfkey = CFStringCreateWithCString(kCFAllocatorDefault, key.c_str(),
-                                         kCFStringEncodingUTF8);
+  auto cfkey = CFStringCreateWithCString(
+      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
   auto networks = (CFDictionaryRef)CFDictionaryGetValue(plist, cfkey);
 
   CFRelease(cfkey);
@@ -36,8 +45,8 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   QueryData results;
   auto count = CFDictionaryGetCount(networks);
   ASSERT_EQ((long)count, 2);
-  std::vector<const void *> keys(count);
-  std::vector<const void *> values(count);
+  std::vector<const void*> keys(count);
+  std::vector<const void*> values(count);
   CFDictionaryGetKeysAndValues(networks, keys.data(), values.data());
 
   for (CFIndex i = 0; i < count; i++) {
@@ -90,8 +99,8 @@ TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {
       [NSDictionary dictionaryWithContentsOfFile:@(path.c_str())];
   ASSERT_GE((long)CFDictionaryGetCount(plist), 1);
   std::string key = "RememberedNetworks";
-  auto cfkey = CFStringCreateWithCString(kCFAllocatorDefault, key.c_str(),
-                                         kCFStringEncodingUTF8);
+  auto cfkey = CFStringCreateWithCString(
+      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
   auto networks = (CFArrayRef)CFDictionaryGetValue(plist, cfkey);
 
   CFRelease(cfkey);

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -12,8 +12,8 @@
 #include <gtest/gtest.h>
 
 #include <osquery/config/tests/test_utils.h>
-#include <osquery/core/system.h>
 #include <osquery/core/sql/query_data.h>
+#include <osquery/core/system.h>
 #include <osquery/registry/registry_factory.h>
 
 namespace osquery {

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -43,6 +43,7 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   for (CFIndex i = 0; i < count; i++) {
     parseNetworks((CFDictionaryRef)values[i], results);
   }
+  ASSERT_GT(results.size(), 0);
 
   Row expected1 = {
       {"ssid", "2890d228 3487"},
@@ -104,6 +105,7 @@ TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {
         (CFDictionaryRef)CFArrayGetValueAtIndex((CFArrayRef)networks, i),
         results);
   }
+  ASSERT_GT(results.size(), 0);
 
   Row expected1 = {
       {"ssid", "2890d228 3487"},


### PR DESCRIPTION
I've added a macOS version check, and if the version is 10.15 or above, it references a changed key name for the field in the plist that fills the `last_connected` column, restoring the functionality of that column.

Related to #6235