### PR TITLE
carver: Refactor carver to use the Scheduler

### DIFF
--- a/osquery/carver/CMakeLists.txt
+++ b/osquery/carver/CMakeLists.txt
@@ -12,6 +12,7 @@ function(osqueryCarverMain)
   endif()
 
   generateOsqueryCarver()
+  generateOsqueryCarverUtils()
 endfunction()
 
 function(generateOsqueryCarver)
@@ -22,8 +23,8 @@ function(generateOsqueryCarver)
   target_link_libraries(osquery_carver PUBLIC
     osquery_cxx_settings
     osquery_core
-    osquery_core_plugins
-    osquery_core_sql
+    osquery_carver_utils
+    osquery_dispatcher
     osquery_distributed
     osquery_filesystem
     osquery_hashing
@@ -41,6 +42,28 @@ function(generateOsqueryCarver)
   generateIncludeNamespace(osquery_carver "osquery/carver" "FILE_ONLY" ${public_header_files})
 
   add_test(NAME osquery_carver_tests-test COMMAND osquery_carver_tests-test)
+endfunction()
+
+
+function(generateOsqueryCarverUtils)
+  add_osquery_library(osquery_carver_utils EXCLUDE_FROM_ALL
+    carver_utils.cpp
+  )
+
+  target_link_libraries(osquery_carver_utils PUBLIC
+    osquery_cxx_settings
+    osquery_core
+    osquery_database
+    osquery_utils
+    thirdparty_boost
+    thirdparty_gflags
+  )
+
+  set(public_header_files
+    carver_utils.h
+  )
+
+  generateIncludeNamespace(osquery_carver_utils "osquery/carver" "FILE_ONLY" ${public_header_files})
 endfunction()
 
 osqueryCarverMain()

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -13,9 +13,8 @@
 #include <osquery/remote/utility.h>
 // clang-format on
 
-#include <boost/algorithm/string.hpp>
-
 #include <osquery/carver/carver.h>
+#include <osquery/carver/carver_utils.h>
 #include <osquery/database/database.h>
 #include <osquery/distributed/distributed.h>
 #include <osquery/filesystem/fileops.h>
@@ -23,10 +22,10 @@
 #include <osquery/hashing/hashing.h>
 #include <osquery/logger/logger.h>
 #include <osquery/remote/serializers/json.h>
+#include <osquery/utils/conversions/split.h>
 #include <osquery/core/system.h>
 #include <osquery/utils/base64.h>
 #include <osquery/utils/json/json.h>
-
 #include <osquery/utils/system/system.h>
 #include <osquery/utils/system/time.h>
 
@@ -56,59 +55,73 @@ CLI_FLAG(uint32,
          "Size of blocks used for POSTing data back to remote endpoints");
 
 CLI_FLAG(bool,
-         disable_carver,
-         true,
-         "Disable the osquery file carver (default true)");
-
-CLI_FLAG(bool,
-         carver_disable_function,
-         FLAGS_disable_carver,
-         "Disable the osquery file carver function (default true)");
-
-CLI_FLAG(bool,
          carver_compression,
          false,
          "Compress archives using zstd prior to upload (default false)");
 
+DECLARE_bool(disable_carver);
 DECLARE_uint64(read_max);
 
-/// Helper function to update values related to a carve
-void updateCarveValue(const std::string& guid,
-                      const std::string& key,
-                      const std::string& value) {
-  std::string carve;
-  auto s = getDatabaseValue(kCarveDbDomain, kCarverDBPrefix + guid, carve);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to update status of carve in database " << guid;
-    return;
-  }
+std::atomic<bool> CarverRunnable::running_{false};
 
-  JSON tree;
-  s = tree.fromString(carve);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to parse carve entries: " << s.what();
-    return;
-  }
+void CarverRunnable::start() {
+  std::vector<std::string> carves;
+  scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
 
-  tree.add(key, value);
+  for (const auto& key : carves) {
+    std::string carve;
+    auto s = getDatabaseValue(kCarves, key, carve);
+    if (!s.ok()) {
+      VLOG(1) << "Failed to retrieve carve key: " << key;
+      deleteDatabaseValue(kCarves, key);
+      continue;
+    }
 
-  std::string out;
-  s = tree.toString(out);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to serialize carve entries: " << s.what();
-  }
+    JSON tree;
+    s = tree.fromString(carve);
+    if (!s.ok() || !tree.doc().IsObject()) {
+      deleteDatabaseValue(kCarves, key);
+      VLOG(1) << "Failed to parse carve entries: " << s.getMessage();
+      continue;
+    }
 
-  s = setDatabaseValue(kCarveDbDomain, kCarverDBPrefix + guid, out);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to update status of carve in database " << guid;
+    auto& doc = tree.doc();
+    if (!doc.HasMember("status") || !doc["status"].IsString()) {
+      // Malformed data.
+      deleteDatabaseValue(kCarves, key);
+      continue;
+    }
+
+    std::string guid(doc["carve_guid"].GetString());
+    std::string status(doc["status"].GetString());
+    if (status == kCarverStatusSuccess) {
+      uint64_t start_time(doc["time"].GetUint());
+      auto delta = getUnixTime() - start_time;
+      if (delta > 86400) {
+        // Expire results after 1 day.
+        VLOG(1) << "Expiring successful carve metadata for GUID: " << guid;
+        deleteDatabaseValue(kCarves, key);
+        continue;
+      }
+    } else if (status != kCarverStatusScheduled) {
+      continue;
+    }
+
+    // Schedule the carve.
+    updateCarveValue(guid, "status", "STARTING");
+    std::set<std::string> paths;
+    for (const auto& path : osquery::split(doc["path"].GetString(), ",")) {
+      paths.insert(path);
+    }
+
+    auto requestId = Distributed::getCurrentRequestId();
+    doCarve(paths, guid, requestId);
   }
 }
 
 Carver::Carver(const std::set<std::string>& paths,
                const std::string& guid,
-               const std::string& requestId)
-    : InternalRunnable("Carver") {
-  status_ = Status(0, "Ok");
+               const std::string& requestId) {
   for (const auto& p : paths) {
     carvePaths_.insert(fs::path(p));
   }
@@ -118,14 +131,15 @@ Carver::Carver(const std::set<std::string>& paths,
 
   // Stash the work ID to be POSTed with the carve initial request
   requestId_ = requestId;
+}
 
+Status Carver::createPaths() {
   // TODO: Adding in a manifest file of all carved files might be nice.
   carveDir_ =
       fs::temp_directory_path() / fs::path(kCarvePathPrefix + carveGuid_);
   auto ret = fs::create_directory(carveDir_);
   if (!ret) {
-    status_ = Status(1, "Failed to create carve file store");
-    return;
+    return Status::failure("Failed to create carve file store");
   }
 
   // Store the path to our archive for later exfiltration
@@ -135,34 +149,36 @@ Carver::Carver(const std::set<std::string>& paths,
 
   // Update the DB to reflect that the carve is pending.
   updateCarveValue(carveGuid_, "status", "PENDING");
+  return Status::success();
 };
 
 Carver::~Carver() {
   fs::remove_all(carveDir_);
 }
 
-void Carver::start() {
-  // If status_ is not Ok, the creation of our tmp FS failed
-  if (!status_.ok()) {
-    LOG(WARNING) << "Carver has not been properly constructed";
-    return;
+Status Carver::carve() {
+  auto s = createPaths();
+  if (!s.ok()) {
+    updateCarveValue(carveGuid_, "status", "CREATE PATHS FAILED");
+    return s;
   }
+
   const auto carvedFiles = carveAll();
-  status_ = archive(carvedFiles, archivePath_, FLAGS_carver_block_size);
-  if (!status_.ok()) {
-    VLOG(1) << "Failed to create carve archive: " << status_.getMessage();
+  s = archive(carvedFiles, archivePath_, FLAGS_carver_block_size);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to create carve archive: " << s.getMessage();
     updateCarveValue(carveGuid_, "status", "ARCHIVE FAILED");
-    return;
+    return s;
   }
 
   fs::path uploadPath;
   if (FLAGS_carver_compression) {
     uploadPath = compressPath_;
-    status_ = compress(archivePath_, compressPath_);
-    if (!status_.ok()) {
-      VLOG(1) << "Failed to compress carve archive: " << status_.getMessage();
+    s = compress(archivePath_, compressPath_);
+    if (!s.ok()) {
+      VLOG(1) << "Failed to compress carve archive: " << s.getMessage();
       updateCarveValue(carveGuid_, "status", "COMPRESS FAILED");
-      return;
+      return s;
     }
   } else {
     uploadPath = archivePath_;
@@ -181,12 +197,13 @@ void Carver::start() {
   }
   updateCarveValue(carveGuid_, "sha256", uploadHash);
 
-  status_ = postCarve(uploadPath);
-  if (!status_.ok()) {
-    VLOG(1) << "Failed to post carve: " << status_.getMessage();
+  s = postCarve(uploadPath);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to post carve: " << s.getMessage();
     updateCarveValue(carveGuid_, "status", "DATA POST FAILED");
-    return;
+    return s;
   }
+  return Status::success();
 };
 
 std::set<fs::path> Carver::carveAll() {
@@ -305,41 +322,13 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
     }
   }
 
-  updateCarveValue(carveGuid_, "status", "SUCCESS");
+  updateCarveValue(carveGuid_, "status", kCarverStatusSuccess);
   return Status::success();
 };
 
-Status carvePaths(const std::set<std::string>& paths) {
-  Status s;
-  auto guid = generateNewUUID();
-
-  JSON tree;
-  tree.add("carve_guid", guid);
-  tree.add("time", getUnixTime());
-  tree.add("status", "STARTING");
-  tree.add("sha256", "");
-  tree.add("size", -1);
-
-  if (paths.size() > 1) {
-    tree.add("path", boost::algorithm::join(paths, ","));
-  } else {
-    tree.add("path", *(paths.begin()));
+void scheduleCarves() {
+  if (!FLAGS_disable_carver && !CarverRunnable::running()) {
+    Dispatcher::addService(std::make_shared<CarverRunner<Carver>>());
   }
-
-  std::string out;
-  s = tree.toString(out);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to serialize carve paths: " << s.what();
-    return s;
-  }
-
-  s = setDatabaseValue(kCarveDbDomain, kCarverDBPrefix + guid, out);
-  if (!s.ok()) {
-    return s;
-  } else {
-    auto requestId = Distributed::getCurrentRequestId();
-    Dispatcher::addService(std::make_shared<Carver>(paths, guid, requestId));
-  }
-  return s;
 }
 } // namespace osquery

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -125,6 +125,9 @@ void CarverRunnable::start() {
     auto requestId = Distributed::getCurrentRequestId();
     doCarve(paths, guid, requestId);
   }
+
+  // All pending carves have been started.
+  kCarverPendingCarves = false;
 }
 
 Carver::Carver(const std::set<std::string>& paths,
@@ -335,7 +338,8 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
 };
 
 void scheduleCarves() {
-  if (!FLAGS_disable_carver && !CarverRunnable::running()) {
+  if (!FLAGS_disable_carver && kCarverPendingCarves &&
+      !CarverRunnable::running()) {
     Dispatcher::addService(std::make_shared<CarverRunner<Carver>>());
   }
 }

--- a/osquery/carver/carver.h
+++ b/osquery/carver/carver.h
@@ -9,99 +9,152 @@
 
 #pragma once
 
-#include <set>
-#include <string>
-
 #include <osquery/dispatcher/dispatcher.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/utils/status/status.h>
 
+#include <atomic>
+#include <set>
+#include <string>
+
 namespace osquery {
 
-/// Database domain where we store carve table entries
-const std::string kCarveDbDomain = "carves";
+class CarverRunnable : public InternalRunnable {
+ public:
+  CarverRunnable() : InternalRunnable("CarverRunnable") {
+    running_ = true;
+  }
 
-/// Prefix used for the temp FS where carved files are stored
-const std::string kCarvePathPrefix = "osquery_carve_";
+  ~CarverRunnable() {
+    running_ = false;
+  }
 
-/// Prefix applied to the file carve tar archive.
-const std::string kCarveNamePrefix = "carve_";
+  /// Scan all carve requests and carve them serially.
+  void start() override;
 
-/// Database prefix used to directly access and manipulate our carver entries
-const std::string kCarverDBPrefix = "carves.";
+  virtual Status doCarve(const std::set<std::string>& paths,
+                         const std::string& guid,
+                         const std::string& requestId) = 0;
 
-class Carver : public InternalRunnable {
+  /// Check if a carver runner exists.
+  static bool running() {
+    return running_;
+  }
+
+ private:
+  /**
+   * @brief Static state to check if a Carver runner is dispatched.
+   *
+   * Expect that a carver runner will run as long as there are pending carves.
+   * Afterwards it will end and need to be dispatched again.
+   */
+  static std::atomic<bool> running_;
+};
+
+template <typename T>
+class CarverRunner : public CarverRunnable {
+ public:
+  CarverRunner() : CarverRunnable() {}
+
+  /**
+   * @brief The entry point to creating and calling the Carver.
+   *
+   * This is implemented to allow faking the carver within tests.
+   */
+  Status doCarve(const std::set<std::string>& paths,
+                 const std::string& guid,
+                 const std::string& requestId) override {
+    carves_++;
+    T carve(paths, guid, requestId);
+    return carve.carve();
+  }
+
+  /**
+   * @brief A helper function to inspect the number of carves attempted.
+   *
+   * This is not the "total number" of carves, since this carver runner is
+   * ephemeral. Once this runner is finished executing the requested carves it
+   * will end. The next runner will reset the count of carves at 0.
+   */
+  size_t carves() {
+    return carves_;
+  }
+
+ private:
+  /// Count the number of carves.
+  size_t carves_{0};
+};
+
+class Carver {
  public:
   Carver(const std::set<std::string>& paths,
          const std::string& guid,
          const std::string& requestId);
 
-  ~Carver();
+  virtual ~Carver();
 
-  /*
-   * @brief A helper function to perform a start to finish carve
+  /**
+   * @brief A helper function to perform a start to finish carve.
    *
-   * This function walks through the carve, compress, and exfil functions
+   * This function walks through the carve, compress, and post functions
    * in one fell swoop. Use of this class should largely happen through
    * this function.
    */
-  void start() override;
+  Status carve();
+
+  /// Create the archive and compression paths.
+  Status createPaths();
 
  protected:
-  /*
-   * @brief A helper function that 'carves' all files from disk
+  /**
+   * @brief A helper function that 'carves' all files from disk.
    *
    * This function copies all source files to a temporary directory and returns
    * a list of all destination files.
    */
   std::set<boost::filesystem::path> carveAll();
 
-  /*
-   * @brief A helper function that does a blockwise copy from src to dst
+  /**
+   * @brief A helper function that does a blockwise copy from src to dst.
    *
    * This function copies the source file to the destination file, doing so
-   * by blocks specified with FLAGS_carver_block_size (defaults to 8K)
+   * by blocks specified with FLAGS_carver_block_size (defaults to 8K).
    */
   Status blockwiseCopy(PlatformFile& src, PlatformFile& dst);
 
-  /*
+  /**
    * @brief Helper function to POST a carve to the graph endpoint.
    *
    * Once all of the files have been carved and the tgz has been
    * created, we POST the carved file to an endpoint specified by the
-   * carver_start_endpoint and carver_continue_endpoint
+   * carver_start_endpoint and carver_continue_endpoint.
    */
   virtual Status postCarve(const boost::filesystem::path& path);
 
-  // Getter for the carver status
-  Status getStatus() {
-    return status_;
-  }
-
-  // Helper function to return the carve directory
+  /// Helper function to return the carve directory.
   boost::filesystem::path getCarveDir() {
     return carveDir_;
   }
 
- private:
-  /*
-   * @brief a variable to keep track of the temp fs used in carving
+ protected:
+  /**
+   * @brief a variable to keep track of the temp path used in carving.
    *
    * This variable represents the location in which we store all of our carved
    * files. When a carve has completed all of the desired files, as well
-   * as the tar archive should reside in this directory
+   * as the tar archive should reside in this directory.
    */
   boost::filesystem::path carveDir_;
 
-  /*
-   * @brief a variable tracking all of the paths we attempt to carve
+  /**
+   * @brief a variable tracking all of the paths we attempt to carve.
    *
    * This is a globbed set of file paths that we're expecting will be
    * carved.
    */
   std::set<boost::filesystem::path> carvePaths_;
 
-  /*
+  /**
    * @brief a helper variable for keeping track of the posix tar archive.
    *
    * This variable is the absolute location of the tar archive created from
@@ -109,7 +162,7 @@ class Carver : public InternalRunnable {
    */
   boost::filesystem::path archivePath_;
 
-  /*
+  /**
    * @brief a helper variable for keeping track of the compressed tar.
    *
    * This variable is the absolute location of the tar archive created from
@@ -117,31 +170,29 @@ class Carver : public InternalRunnable {
    */
   boost::filesystem::path compressPath_;
 
-  /*
-   * @brief a unique ID identifying the 'carve'
+  /**
+   * @brief a unique ID identifying the 'carve'.
    *
    * This unique generated GUID is used to identify the carve session from
    * other carves. It is also used by our backend service to derive a
-   * session key for exfiltration.
+   * session key for sending results.
    */
   std::string carveGuid_;
 
   /**
-   * @brief the distributed work ID of a carve
+   * @brief the distributed work ID of a carve.
    *
    * This value should be used by the TLS endpoints where carve data is
-   * aggregated, to tie together a distributed query with the carve data
+   * aggregated, to tie together a distributed query with the carve data.
    */
   std::string requestId_;
-
-  // Running status of the carver
-  Status status_;
 };
 
 /**
- * @brief Start a file carve of the given paths
+ * @brief A basic entry point for executing carve requests.
  *
- * @return A status returning if the carves were started successfully
+ * This will dispatch the CarverRunner if it is not already running.
+ * Expect the scheduler to periodically call this method.
  */
-Status carvePaths(const std::set<std::string>& paths);
+void scheduleCarves();
 } // namespace osquery

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -57,7 +57,6 @@ void updateCarveValue(const std::string& guid,
 }
 
 Status carvePaths(const std::set<std::string>& paths) {
-  Status s;
   auto guid = generateNewUUID();
 
   JSON tree;
@@ -74,7 +73,7 @@ Status carvePaths(const std::set<std::string>& paths) {
   }
 
   std::string out;
-  s = tree.toString(out);
+  auto s = tree.toString(out);
   if (!s.ok()) {
     VLOG(1) << "Failed to serialize carve paths: " << s.what();
     return s;

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/flags.h>
+#include <osquery/core/system.h>
+#include <osquery/database/database.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/join.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/system/time.h>
+
+#include <osquery/carver/carver_utils.h>
+
+namespace osquery {
+
+CLI_FLAG(bool,
+         disable_carver,
+         true,
+         "Disable the osquery file carver (default true)");
+
+/// Helper function to update values related to a carve
+void updateCarveValue(const std::string& guid,
+                      const std::string& key,
+                      const std::string& value) {
+  std::string carve;
+  auto s = getDatabaseValue(kCarves, kCarverDBPrefix + guid, carve);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to update status of carve in database " << guid;
+    return;
+  }
+
+  JSON tree;
+  s = tree.fromString(carve);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to parse carve entries: " << s.what();
+    return;
+  }
+
+  tree.add(key, value);
+
+  std::string out;
+  s = tree.toString(out);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to serialize carve entries: " << s.what();
+  }
+
+  s = setDatabaseValue(kCarves, kCarverDBPrefix + guid, out);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to update status of carve in database " << guid;
+  }
+}
+
+Status carvePaths(const std::set<std::string>& paths) {
+  Status s;
+  auto guid = generateNewUUID();
+
+  JSON tree;
+  tree.add("carve_guid", guid);
+  tree.add("time", getUnixTime());
+  tree.add("status", kCarverStatusScheduled);
+  tree.add("sha256", "");
+  tree.add("size", -1);
+
+  if (paths.size() > 1) {
+    tree.add("path", osquery::join(paths, ","));
+  } else {
+    tree.add("path", *(paths.begin()));
+  }
+
+  std::string out;
+  s = tree.toString(out);
+  if (!s.ok()) {
+    VLOG(1) << "Failed to serialize carve paths: " << s.what();
+    return s;
+  }
+
+  return setDatabaseValue(kCarves, kCarverDBPrefix + guid, out);
+}
+} // namespace osquery

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -24,6 +24,8 @@ CLI_FLAG(bool,
          true,
          "Disable the osquery file carver (default true)");
 
+std::atomic<bool> kCarverPendingCarves{true};
+
 /// Helper function to update values related to a carve
 void updateCarveValue(const std::string& guid,
                       const std::string& key,
@@ -79,6 +81,7 @@ Status carvePaths(const std::set<std::string>& paths) {
     return s;
   }
 
+  kCarverPendingCarves = true;
   return setDatabaseValue(kCarves, kCarverDBPrefix + guid, out);
 }
 } // namespace osquery

--- a/osquery/carver/carver_utils.h
+++ b/osquery/carver/carver_utils.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <set>
+#include <string>
+
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+
+/// Prefix used for the temp FS where carved files are stored.
+const std::string kCarvePathPrefix = "osquery_carve_";
+
+/// Prefix applied to the file carve tar archive.
+const std::string kCarveNamePrefix = "carve_";
+
+/// Database prefix used to directly access and manipulate our carver entries.
+const std::string kCarverDBPrefix = "carves.";
+
+/// Internal carver 'status' indicating a completed carve.
+const std::string kCarverStatusSuccess = "SUCCESS";
+
+/// Internal carver 'status' indicating a carve request scheduled.
+const std::string kCarverStatusScheduled = "SCHEDULED";
+
+/// Update an attribute for a given carve GUID.
+void updateCarveValue(const std::string& guid,
+                      const std::string& key,
+                      const std::string& value);
+
+/**
+ * @brief Request a file carve of the given paths.
+ *
+ * The actual carving is deferred until the scheduler dispatches the request.
+ * This is to prevent several carves happening in parallel and to prevent carves
+ * from unexpectedly blocking query execution. We do not want to wait for remote
+ * servies to return before a query completes in this case.
+ *
+ * @return A status returning if the carves were scheduled successfully.
+ */
+Status carvePaths(const std::set<std::string>& paths);
+} // namespace osquery

--- a/osquery/carver/carver_utils.h
+++ b/osquery/carver/carver_utils.h
@@ -9,10 +9,11 @@
 
 #pragma once
 
+#include <osquery/utils/status/status.h>
+
+#include <atomic>
 #include <set>
 #include <string>
-
-#include <osquery/utils/status/status.h>
 
 namespace osquery {
 
@@ -30,6 +31,19 @@ const std::string kCarverStatusSuccess = "SUCCESS";
 
 /// Internal carver 'status' indicating a carve request scheduled.
 const std::string kCarverStatusScheduled = "SCHEDULED";
+
+/**
+ * @brief This flag is an optimization attempt used by the CarverRunner.
+ *
+ * When osquery starts, if the carver is enabled, the CarverRunner will scan
+ * for pending carves. After all are started, it will set this pending flag to
+ * false. Any carve requests will set it to true.
+ *
+ * CarverRunner threads start every 60 seconds. It is wasteful to start and stop
+ * the thread if there are no pending carves. This flag allows us to skip
+ * starting the thread.
+ */
+extern std::atomic<bool> kCarverPendingCarves;
 
 /// Update an attribute for a given carve GUID.
 void updateCarveValue(const std::string& guid,

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -158,6 +158,16 @@ TEST_F(CarverTests, test_schedule_carves) {
 
     EXPECT_EQ(runner.carves(), 1);
   }
+
+  {
+    FakeCarverRunner runner;
+    ASSERT_TRUE(FakeCarverRunner::running());
+    runner.start();
+
+    // All carves were previously completed.
+    EXPECT_EQ(runner.carves(), 0);
+  }
+
   ASSERT_FALSE(FakeCarverRunner::running());
 }
 

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <osquery/carver/carver.h>
+#include <osquery/carver/carver_utils.h>
 #include <osquery/config/tests/test_utils.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
@@ -40,6 +41,7 @@ class FakeCarver : public Carver {
 
  protected:
   Status postCarve(const boost::filesystem::path&) override {
+    updateCarveValue(carveGuid_, "status", kCarverStatusSuccess);
     return Status::success();
   }
 
@@ -48,6 +50,11 @@ class FakeCarver : public Carver {
   FRIEND_TEST(CarverTests, test_carve_files_locally);
   FRIEND_TEST(CarverTests, test_carve_start);
   FRIEND_TEST(CarverTests, test_carve_files_not_exists);
+};
+
+class FakeCarverRunner : public CarverRunner<FakeCarver> {
+ public:
+  FakeCarverRunner() : CarverRunner() {}
 };
 
 std::string genGuid() {
@@ -115,8 +122,8 @@ TEST_F(CarverTests, test_carve_files_locally) {
   auto guid = genGuid();
   std::string requestId = "";
   FakeCarver carve(getCarvePaths(), guid, requestId);
-  ASSERT_TRUE(carve.getStatus().ok());
 
+  ASSERT_TRUE(carve.createPaths());
   const auto carves = carve.carveAll();
   EXPECT_EQ(carves.size(), 3U);
 
@@ -130,14 +137,107 @@ TEST_F(CarverTests, test_carve_files_locally) {
   EXPECT_GT(tar.size(), 0U);
 }
 
-TEST_F(CarverTests, test_carve_start) {
+TEST_F(CarverTests, test_carve) {
   auto guid = genGuid();
   std::string requestId = "";
   FakeCarver carve(getCarvePaths(), guid, requestId);
-  ASSERT_TRUE(carve.getStatus().ok());
+  auto s = carve.carve();
+  ASSERT_TRUE(s.ok());
+}
 
-  carve.start();
-  ASSERT_TRUE(carve.getStatus().ok());
+TEST_F(CarverTests, test_schedule_carves) {
+  // Request paths for carving.
+  auto s = osquery::carvePaths(getCarvePaths());
+  ASSERT_TRUE(s.ok());
+
+  ASSERT_FALSE(FakeCarverRunner::running());
+  {
+    FakeCarverRunner runner;
+    ASSERT_TRUE(FakeCarverRunner::running());
+    runner.start();
+
+    EXPECT_EQ(runner.carves(), 1);
+  }
+  ASSERT_FALSE(FakeCarverRunner::running());
+}
+
+TEST_F(CarverTests, test_expiration) {
+  {
+    // Reset the carves.
+    std::vector<std::string> carves;
+    scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
+    for (const auto& key : carves) {
+      deleteDatabaseValue(kCarves, key);
+    }
+  }
+
+  // Create 2 carve requests.
+  auto s = osquery::carvePaths(getCarvePaths());
+  ASSERT_TRUE(s.ok());
+  s = osquery::carvePaths(getCarvePaths());
+  ASSERT_TRUE(s.ok());
+
+  {
+    // Set one request to an expired time.
+    std::vector<std::string> carves;
+    scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
+    EXPECT_EQ(carves.size(), 2);
+
+    std::string carve;
+    s = getDatabaseValue(kCarves, carves[0], carve);
+    ASSERT_TRUE(s.ok());
+
+    JSON tree;
+    s = tree.fromString(carve);
+    ASSERT_TRUE(s.ok());
+    std::string guid(tree.doc()["carve_guid"].GetString());
+
+    tree.add("time", 0);
+    tree.add("status", kCarverStatusSuccess);
+    s = tree.toString(carve);
+    ASSERT_TRUE(s.ok());
+    s = setDatabaseValue(kCarves, carves[0], carve);
+    ASSERT_TRUE(s.ok());
+  }
+
+  {
+    // Schedule the carves and expect the expired successful carve to be
+    // deleted.
+    FakeCarverRunner runner;
+    runner.start();
+    EXPECT_EQ(runner.carves(), 1);
+
+    std::vector<std::string> carves;
+    scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
+    EXPECT_EQ(carves.size(), 1);
+
+    std::string carve;
+    s = getDatabaseValue(kCarves, carves[0], carve);
+    ASSERT_TRUE(s.ok());
+
+    JSON tree;
+    s = tree.fromString(carve);
+    ASSERT_TRUE(s.ok());
+    std::string guid(tree.doc()["carve_guid"].GetString());
+
+    // This time only update the time.
+    // Expect the carve to have been successful.
+    tree.add("time", 0);
+    s = tree.toString(carve);
+    ASSERT_TRUE(s.ok());
+    s = setDatabaseValue(kCarves, carves[0], carve);
+    ASSERT_TRUE(s.ok());
+  }
+
+  {
+    FakeCarverRunner runner;
+    runner.start();
+    EXPECT_EQ(runner.carves(), 0);
+
+    std::vector<std::string> carves;
+    scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
+    EXPECT_TRUE(carves.empty());
+  }
 }
 
 TEST_F(CarverTests, test_carve_files_not_exists) {
@@ -146,8 +246,6 @@ TEST_F(CarverTests, test_carve_files_not_exists) {
   const std::set<std::string> notExistsCarvePaths = {
       (getFilesToCarveDir() / "not_exists").string()};
   FakeCarver carve(notExistsCarvePaths, guid, requestId);
-  ASSERT_TRUE(carve.getStatus().ok());
-
   const auto carves = carve.carveAll();
   EXPECT_TRUE(carves.empty());
 }

--- a/osquery/dispatcher/CMakeLists.txt
+++ b/osquery/dispatcher/CMakeLists.txt
@@ -46,6 +46,7 @@ function(generateOsqueryDistributedAndScheduler)
 
   target_link_libraries(osquery_dispatcher_scheduler PUBLIC
     osquery_cxx_settings
+    osquery_carver
     osquery_core
     osquery_database
     osquery_logger_datalogger

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -195,7 +195,7 @@ void SchedulerRunner::maybeRunDecorators(uint64_t time_step) {
 }
 
 void SchedulerRunner::maybeScheduleCarves(uint64_t time_step) {
-  if ((time_step & 60) == 0) {
+  if ((time_step % 60) == 0) {
     scheduleCarves();
   }
 }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -13,6 +13,7 @@
 #include <boost/format.hpp>
 #include <boost/io/detail/quoted_manip.hpp>
 
+#include <osquery/carver/carver.h>
 #include <osquery/config/config.h>
 #include <osquery/core/core.h>
 #include <osquery/core/flags.h>
@@ -193,6 +194,12 @@ void SchedulerRunner::maybeRunDecorators(uint64_t time_step) {
   }
 }
 
+void SchedulerRunner::maybeScheduleCarves(uint64_t time_step) {
+  if ((time_step & 60) == 0) {
+    scheduleCarves();
+  }
+}
+
 void SchedulerRunner::maybeReloadSchedule(uint64_t time_step) {
   if (FLAGS_schedule_reload > 0 && (time_step % FLAGS_schedule_reload) == 0) {
     if (FLAGS_schedule_reload_sql) {
@@ -236,6 +243,7 @@ void SchedulerRunner::start() {
     maybeRunDecorators(i);
     maybeReloadSchedule(i);
     maybeFlushLogs(i);
+    maybeScheduleCarves(i);
 
     auto loop_step_duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -54,6 +54,9 @@ class SchedulerRunner : public InternalRunnable {
   /// Check if buffered status logs should be flushed.
   void maybeFlushLogs(uint64_t time_step);
 
+  /// Check if carve requests should be scheduled.
+  void maybeScheduleCarves(uint64_t time_step);
+
  private:
   /// Interval in seconds between schedule steps.
   const std::chrono::milliseconds interval_;

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -10,7 +10,7 @@
 #include <set>
 #include <string>
 
-#include <osquery/carver/carver.h>
+#include <osquery/carver/carver_utils.h>
 #include <osquery/core/flags.h>
 #include <osquery/logger/logger.h>
 #include <osquery/utils/conversions/split.h>
@@ -20,13 +20,16 @@
 
 namespace osquery {
 
+CLI_FLAG(bool,
+         carver_disable_function,
+         true,
+         "Disable the osquery file carver function (default true)");
+
 /// Global set of requested carve paths.
 static std::set<std::string> kFunctionCarvePaths;
 
 /// Mutex to protect access to carve paths.
 Mutex kFunctionCarveMutex;
-
-DECLARE_bool(carver_disable_function);
 
 static void addCarveFile(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
   if (argc == 0) {

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -7,10 +7,12 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/carver/carver.h>
+#include <osquery/carver/carver_utils.h>
 #include <osquery/core/flags.h>
+#include <osquery/core/system.h>
 #include <osquery/core/tables.h>
 #include <osquery/database/database.h>
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/utils/json/json.h>
 


### PR DESCRIPTION
This change refactors the carver code and functionality.

From a functionality perspective, carving is now implemented using a request and handler model. Carving can be requested via the SQLite `carve` function or using the predicate `WHERE carve=1` on the `osquery_carves` table. Previously when a carve was requested, the carving and posting to a remote endpoint would occur during query execution. Now carve requests are buffered and the scheduler thread periodically "wakes up" a carving thread that handles the requests. Additionally, carving is now unique to `osqueryd` and the metadata from successful carve requests will be removed from osquery's internal database after 24hours.

From a code point of view the implementation is split into a "carver utilities" set that can be widely used/included. This allows components within osquery to request paths to be carved, as well as a minor amount of inspection into carver statuses. The new "carver" set implements the actual carving and a new "runner" thread to handle carver requests serially. This code should NOT be widely used as it has extensive linkage requirements.
