### PR TITLE
feature 6401: authenticode table with catalog file info

### DIFF
--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -126,7 +126,7 @@ void generateRow(Row& row, const SignatureInformation& signature_info) {
   }
 }
 
-bool getCatalogPathForFilePath(const std::wstring path,
+bool getCatalogPathForFilePath(const std::wstring& path,
                                std::wstring& catalogFile) {
   bool status = false;
   HANDLE handle = CreateFile(path.c_str(),

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -136,7 +136,7 @@ bool getCatalogPathForFilePath(const std::wstring& path,
                              OPEN_EXISTING,
                              FILE_ATTRIBUTE_NORMAL,
                              NULL);
-  if (INVALID_HANDLE_VALUE != handle) {
+  if (handle != INVALID_HANDLE_VALUE) {
     HCATADMIN context;
     GUID subsystem = DRIVER_ACTION_VERIFY;
     HCATINFO catalog = NULL;

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -126,8 +126,8 @@ void generateRow(Row& row, const SignatureInformation& signature_info) {
   }
 }
 
-__checkReturn __success(return == true) bool getCatalogPathForFilePath(
-    __in const std::wstring path, __out std::wstring& catalogFile) {
+bool getCatalogPathForFilePath(const std::wstring path,
+                               std::wstring& catalogFile) {
   bool status = false;
   HANDLE handle = CreateFile(path.c_str(),
                              GENERIC_READ,


### PR DESCRIPTION
Fix for #6401. Authenticode table will now show signature information for files, which themselves are not signed, but whose hashes are in a signed system catalog file.