### PR TITLE
[CI] Update macOS agent to 10.15 Catalina

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -186,7 +186,7 @@ jobs:
         brew update
         brew upgrade
         brew install ccache flex bison
-        sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer
       displayName: "Upgrade Homebrew and install build prerequisites"
       timeoutInMinutes: 20
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ jobs:
           EXTRA_CMAKE_ARGS: -DOSQUERY_NO_DEBUG_SYMBOLS=ON
 
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
 
     timeoutInMinutes: 120
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -4,7 +4,7 @@ osquery supports many flavors of Linux, macOS, and Windows.
 
 While osquery runs on a large number of operating systems, we only provide build instructions for a select few.
 
-The supported compilers are: the osquery toolchain (LLVM/Clang 9.0.1) on Linux, MSVC v142 on Windows, and AppleClang from Xcode Command Line Tools 10.2.1.
+The supported compilers are: the osquery toolchain (LLVM/Clang 9.0.1) on Linux, MSVC v142 on Windows, and AppleClang from Xcode Command Line Tools 11.7.
 
 ## Prerequisites
 

--- a/tests/integration/tables/browser_plugins.cpp
+++ b/tests/integration/tables/browser_plugins.cpp
@@ -36,14 +36,24 @@ TEST_F(browserPlugins, test_sanity) {
       {"disabled", IntType},
   };
 
-  auto const data = execute_query("select * from browser_plugins");
-  ASSERT_FALSE(data.empty());
-  validate_rows(data, row_map);
+  auto os_data = execute_query("select * from os_version");
+  ASSERT_EQ(os_data.size(), 1U);
 
+  auto const data = execute_query("select * from browser_plugins");
   auto const datauser =
       execute_query("select * from browser_plugins where uid = 0");
-  ASSERT_FALSE(datauser.empty());
-  validate_rows(datauser, row_map);
+
+  if (os_data.front().at("major") == "10" &&
+      std::stoi(os_data.front().at("minor")) < 15) {
+    ASSERT_FALSE(data.empty());
+    validate_rows(data, row_map);
+
+    ASSERT_FALSE(datauser.empty());
+    validate_rows(datauser, row_map);
+  } else {
+    ASSERT_TRUE(data.empty());
+    ASSERT_TRUE(datauser.empty());
+  }
 }
 
 } // namespace table_tests


### PR DESCRIPTION
Updating the Azure Pipelines agent to use 10.15 Catalina image. This will also help with the EndpointSecurity work.

Here is the agent info: https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.15-Readme.md

Closes #6707


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
