### PR TITLE
Add cppcheck support to macOS

### DIFF
--- a/cmake/modules/Findcppcheck.cmake
+++ b/cmake/modules/Findcppcheck.cmake
@@ -19,7 +19,12 @@ function(FindCppcheck)
         PATHS "${OSQUERY_TOOLCHAIN_SYSROOT}"
       )
     endif()
-
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(executable_name "cppcheck")
+    
+    set(optional_path_suffix_list 
+      PATH_SUFFIXES usr/local/bin
+    )
   else()
     set(executable_name "cppcheck.exe")
   endif()


### PR DESCRIPTION
This PR adds a clause to the CMake that finds the `cppcheck` executable, that also finds it on macOS. Tested with `brew install cppcheck` which is the instruction step that I recently added to the build documentation.

To test:

```
cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..
cmake --build . --target cppcheck
```