### PR TITLE
tests: Reduce flakiness of test_osqueryi

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -406,7 +406,9 @@ class ProcessGenerator(object):
             config["options"][option] = options_only[option]
         for key in overwrite:
             config[key] = overwrite[key]
-        utils.write_config(config)
+        if len(options_only.keys()) > 0:
+            # Write the temporary config.
+            utils.write_config(config)
         binary = getLatestOsqueryBinary('osqueryd')
 
         daemon = ProcRunner("daemon", binary, flags, silent=silent)

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -162,7 +162,8 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
                 "logger_path": logger_path,
                 "logger_mode": test_mode,
                 "verbose": True,
-            })
+            },
+        )
 
         self.assertTrue(daemon.isAlive())
 
@@ -243,28 +244,38 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         daemon.kill()
 
     def test_config_check_exits(self):
-        daemon = self._run_daemon({
-            "config_check": True,
-            "disable_extensions": True,
-            "disable_logging": False,
-            "disable_database": True,
-            "logger_plugin": "stdout",
-            "verbose": True,
-        })
+        daemon = self._run_daemon(
+            {
+                "config_check": True,
+                "disable_extensions": True,
+                "disable_logging": False,
+                "disable_database": True,
+                "logger_plugin": "stdout",
+                "verbose": True,
+            },
+            options_only={
+                "verbose": True,
+            },
+        )
 
         self.assertTrue(daemon.isDead(daemon.pid, 10))
         if os.name != "nt":
             self.assertEqual(daemon.retcode, 0)
 
     def test_config_dump_exits(self):
-        daemon = self._run_daemon({
-            "config_dump": True,
-            "disable_extensions": True,
-            "disable_logging": False,
-            "disable_database": True,
-            "logger_plugin": "stdout",
-            "verbose": True,
-        })
+        daemon = self._run_daemon(
+            {
+                "config_dump": True,
+                "disable_extensions": True,
+                "disable_logging": False,
+                "disable_database": True,
+                "logger_plugin": "stdout",
+                "verbose": True,
+            },
+            options_only={
+                "verbose": True,
+            },
+        )
 
         self.assertTrue(daemon.isDead(daemon.pid, 10))
         if os.name != "nt":

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -28,9 +28,6 @@ class OsqueryiTest(unittest.TestCase):
     def setUp(self):
         self.binary = test_base.getLatestOsqueryBinary('osqueryi')
         self.osqueryi = test_base.OsqueryWrapper(command=self.binary)
-        self.dbpath = "%s%s" % (
-            test_base.CONFIG["options"]["database_path"],
-            str(random.randint(1000, 9999)))
 
     @unittest.skipIf(os.name == "nt", "stderr tests not supported on Windows.")
     def test_error(self):
@@ -39,14 +36,13 @@ class OsqueryiTest(unittest.TestCase):
         self.assertRaises(test_base.OsqueryException,
                           self.osqueryi.run_query, 'foo')
 
+    @test_base.flaky
     def test_config_check_success(self):
         '''Test that a 0-config passes'''
         proc = test_base.TimeoutRunner([
             self.binary,
             "--config_check",
-            "--database_path=%s" % (self.dbpath),
             "--config_path=%s" % configFile("test.config"),
-            "--extensions_autoload=",
             "--verbose",
         ],
             SHELL_TIMEOUT)
@@ -55,6 +51,7 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    @test_base.flaky
     def test_config_dump(self):
         '''Test that config raw output is dumped when requested'''
         config = configFile("test_noninline_packs.conf")
@@ -62,7 +59,6 @@ class OsqueryiTest(unittest.TestCase):
                 self.binary,
                 "--config_dump",
                 "--config_path=%s" % config,
-                "--extensions_autoload=",
                 "--verbose",
             ],
             SHELL_TIMEOUT)
@@ -84,8 +80,6 @@ class OsqueryiTest(unittest.TestCase):
         proc = test_base.TimeoutRunner([
             self.binary,
             "--config_check",
-            "--database_path=%s" % (self.dbpath),
-            "--disable_extensions",
             "--verbose",
             "--config_path=/this/path/does/not/exist"
         ],
@@ -95,27 +89,25 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 1)
 
+    @test_base.flaky
     def test_config_check_failure_valid_path(self):
         # Now with a valid path, but invalid content.
         proc = test_base.TimeoutRunner([
             self.binary,
             "--config_check",
-            "--extensions_autoload=",
             "--verbose",
-            "--database_path=%s" % (self.dbpath),
             "--config_path=%s" % configFile("test.badconfig"),
         ],
             SHELL_TIMEOUT)
         self.assertEqual(proc.proc.poll(), 1)
         self.assertNotEqual(proc.stderr, "")
 
+    @test_base.flaky
     def test_config_check_failure_missing_plugin(self):
         # Finally with a missing config plugin
         proc = test_base.TimeoutRunner([
             self.binary,
             "--config_check",
-            "--database_path=%s" % (self.dbpath),
-            "--extensions_autoload=",
             "--verbose",
             "--config_plugin=does_not_exist"
         ],
@@ -125,13 +117,13 @@ class OsqueryiTest(unittest.TestCase):
         # Also do not accept a SIGSEG
         self.assertEqual(proc.proc.poll(), EXIT_CATASTROPHIC)
 
+    @test_base.flaky
     def test_config_check_example(self):
         '''Test that the example config passes'''
         proc = test_base.TimeoutRunner([
                 self.binary,
                 "--config_check",
                 "--config_path=%s" % configFile("osquery.example.conf"),
-                "--extensions_autoload=",
                 "--verbose",
             ],
             SHELL_TIMEOUT)
@@ -140,6 +132,7 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    @test_base.flaky
     def test_meta_commands(self):
         '''Test the supported meta shell/help/info commands'''
         commands = [
@@ -185,12 +178,12 @@ class OsqueryiTest(unittest.TestCase):
             result = self.osqueryi.run_command(command)
         pass
 
+    @test_base.flaky
     def test_json_output(self):
         '''Test that the output of --json is valid json'''
         proc = test_base.TimeoutRunner([
             self.binary,
             "select 0",
-            "--disable_extensions",
             "--json",
             ],
             SHELL_TIMEOUT

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -36,7 +36,6 @@ class OsqueryiTest(unittest.TestCase):
         self.assertRaises(test_base.OsqueryException,
                           self.osqueryi.run_query, 'foo')
 
-    @test_base.flaky
     def test_config_check_success(self):
         '''Test that a 0-config passes'''
         proc = test_base.TimeoutRunner([
@@ -51,7 +50,6 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
-    @test_base.flaky
     def test_config_dump(self):
         '''Test that config raw output is dumped when requested'''
         config = configFile("test_noninline_packs.conf")
@@ -74,7 +72,6 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
-    @test_base.flaky
     def test_config_check_failure_invalid_path(self):
         '''Test that a missing config fails'''
         proc = test_base.TimeoutRunner([
@@ -89,7 +86,6 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 1)
 
-    @test_base.flaky
     def test_config_check_failure_valid_path(self):
         # Now with a valid path, but invalid content.
         proc = test_base.TimeoutRunner([
@@ -102,7 +98,6 @@ class OsqueryiTest(unittest.TestCase):
         self.assertEqual(proc.proc.poll(), 1)
         self.assertNotEqual(proc.stderr, "")
 
-    @test_base.flaky
     def test_config_check_failure_missing_plugin(self):
         # Finally with a missing config plugin
         proc = test_base.TimeoutRunner([
@@ -117,7 +112,6 @@ class OsqueryiTest(unittest.TestCase):
         # Also do not accept a SIGSEG
         self.assertEqual(proc.proc.poll(), EXIT_CATASTROPHIC)
 
-    @test_base.flaky
     def test_config_check_example(self):
         '''Test that the example config passes'''
         proc = test_base.TimeoutRunner([
@@ -132,7 +126,6 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
-    @test_base.flaky
     def test_meta_commands(self):
         '''Test the supported meta shell/help/info commands'''
         commands = [
@@ -178,7 +171,6 @@ class OsqueryiTest(unittest.TestCase):
             result = self.osqueryi.run_command(command)
         pass
 
-    @test_base.flaky
     def test_json_output(self):
         '''Test that the output of --json is valid json'''
         proc = test_base.TimeoutRunner([
@@ -196,7 +188,6 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
-    @test_base.flaky
     def test_time(self):
         '''Demonstrating basic usage of OsqueryWrapper with the time table'''
         self.osqueryi.run_command(' ')  # flush error output
@@ -209,7 +200,6 @@ class OsqueryiTest(unittest.TestCase):
         self.assertTrue(0 <= int(row['seconds']) <= 60)
 
     # TODO: Running foreign table tests as non-priv user fails
-    @test_base.flaky
     @unittest.skipIf(os.name == "nt", "foreign table tests not supported on Windows.")
     def test_foreign_tables(self):
         '''Requires the --enable_foreign flag to add at least one table.'''
@@ -227,20 +217,17 @@ class OsqueryiTest(unittest.TestCase):
         after = int(result[0]['c'])
         self.assertGreater(after, before)
 
-    @test_base.flaky
     def test_time_using_all(self):
         self.osqueryi.run_command(' ')
         result = self.osqueryi.run_command('.all time')
         self.assertNotEqual(result.rstrip(), "Error querying table: time")
 
-    @test_base.flaky
     def test_config_bad_json(self):
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
                                                  args={"config_path": "/"})
         result = self.osqueryi.run_query('SELECT * FROM time;')
         self.assertEqual(len(result), 1)
 
-    @test_base.flaky
     def test_atc(self):
         local_osquery_instance = test_base.OsqueryWrapper(self.binary,
                                                  args={"config_path": "test.config"})

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -198,4 +198,3 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
     if stats.get("fds") is not None:
         rval["fds"] = stats["fds"]
     return rval
-    


### PR DESCRIPTION
This PR aims to reduce the flakiness of `test_osqueryi` by reducing the complexity of flag usage. It also adds the 'default flags' to `TimeoutRunner`, preventing local state from impacting the tests.