### PR TITLE
Fix incorrect stat return checking within process_events

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -69,7 +69,7 @@ Status AuditProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   for (auto& row : emitted_row_list) {
     struct stat file_stat;
-    if (stat(row.at("path").c_str(), &file_stat)) {
+    if (!stat(row.at("path").c_str(), &file_stat)) {
       if (row["mode"].empty()) {
         row["mode"] = lsperms(file_stat.st_mode);
       }


### PR DESCRIPTION
`stat` returns `0` on success.