### PR TITLE
Fix shadow table to detect empty passwords

### DIFF
--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -41,7 +41,7 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
     } else if (password[0] == '!' || password[0] == '*' || password[0] == 'x') {
       r["password_status"] = "locked";
     } else if (password == "") {
-        r["password_status"] = "empty";
+      r["password_status"] = "empty";
       }
     else {
       r["password_status"] = "active";

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -40,7 +40,7 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
       r["password_status"] = "not_set";
     } else if (password[0] == '!' || password[0] == '*' || password[0] == 'x') {
       r["password_status"] = "locked";
-    } else if (password == "") {
+    } else if (password.empty()) {
       r["password_status"] = "empty";
     } else {
       r["password_status"] = "active";

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -40,7 +40,7 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
       r["password_status"] = "not_set";
     } else if (password[0] == '!' || password[0] == '*' || password[0] == 'x') {
       r["password_status"] = "locked";
-    } else if password == "") {
+    } else if (password == "") {
         r["password_status"] = "empty";
       }
     else {

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -40,7 +40,10 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
       r["password_status"] = "not_set";
     } else if (password[0] == '!' || password[0] == '*' || password[0] == 'x') {
       r["password_status"] = "locked";
-    } else {
+    } else if password == "") {
+        r["password_status"] = "empty";
+      }
+    else {
       r["password_status"] = "active";
     }
     if (std::regex_search(password, matches, kPasswordHashAlgRegex)) {

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -42,8 +42,7 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
       r["password_status"] = "locked";
     } else if (password == "") {
       r["password_status"] = "empty";
-      }
-    else {
+    } else {
       r["password_status"] = "active";
     }
     if (std::regex_search(password, matches, kPasswordHashAlgRegex)) {


### PR DESCRIPTION
Add branch to if statement to detect empty, but not null, passwords.

I don't see how to easily add test cases here, and can't readily test this

Fixes: #5465
