### PR TITLE
Add additional file stat flags to darwin (bsd_flags)

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -544,7 +544,7 @@ void Initializer::start() const {
   auto s = osquery::startExtensionManager();
   if (!s.ok()) {
     auto error_message =
-        "An error occured during extension manager startup: " + s.getMessage();
+        "An error occurred during extension manager startup: " + s.getMessage();
     auto severity =
         (FLAGS_disable_extensions) ? google::GLOG_INFO : google::GLOG_ERROR;
     if (severity == google::GLOG_INFO) {

--- a/osquery/filesystem/darwin/bsd_file_flags.cpp
+++ b/osquery/filesystem/darwin/bsd_file_flags.cpp
@@ -19,15 +19,24 @@
 namespace osquery {
 namespace {
 /// The list of supported flags, as documented in `man 2 chflags`
+/// And in https://github.com/apple/darwin-xnu/blob/master/bsd/sys/stat.h
 const std::map<std::uint32_t, std::string> kBsdFlagMap = {
-    {UF_NODUMP, "NODUMP"},
-    {UF_IMMUTABLE, "UF_IMMUTABLE"},
-    {UF_APPEND, "UF_APPEND"},
-    {UF_OPAQUE, "OPAQUE"},
-    {UF_HIDDEN, "HIDDEN"},
-    {SF_ARCHIVED, "ARCHIVED"},
-    {SF_IMMUTABLE, "SF_IMMUTABLE"},
-    {SF_APPEND, "SF_APPEND"}};
+    {UF_APPEND, "UF_APPEND"}, // 0x00000004
+    {UF_COMPRESSED, "COMPRESSED"}, // 0x00000020
+    {UF_DATAVAULT, "DATAVAULT"}, // 0x00000080
+    {UF_HIDDEN, "HIDDEN"}, // 0x00008000
+    {UF_IMMUTABLE, "UF_IMMUTABLE"}, // 0x00000002
+    {UF_NODUMP, "NODUMP"}, // 0x00000001
+    {UF_OPAQUE, "OPAQUE"}, // 0x00000008
+    {UF_TRACKED, "TRACKED"}, // 0x00000040
+
+    {SF_APPEND, "SF_APPEND"}, // 0x00040000
+    {SF_ARCHIVED, "ARCHIVED"}, // 0x00010000
+    {SF_IMMUTABLE, "SF_IMMUTABLE"}, // 0x00020000
+    {SF_NOUNLINK, "SF_NOUNLINK"}, // 0x00100000
+    {SF_RESTRICTED, "SF_RESTRICTED"}, // 0x00080000
+    {SF_SUPPORTED, "SF_SUPPORTED"}, // 0x001f0000
+};
 
 std::uint32_t getBsdFlagMask() {
   std::uint32_t result = 0U;

--- a/osquery/filesystem/tests/darwin/bsd_file_flags_tests.cpp
+++ b/osquery/filesystem/tests/darwin/bsd_file_flags_tests.cpp
@@ -18,12 +18,15 @@ namespace {
 class DarwinBsdFlags : public testing::Test {};
 
 TEST_F(DarwinBsdFlags, testAllFlags) {
-  auto flags = UF_NODUMP | UF_IMMUTABLE | UF_APPEND | UF_OPAQUE | UF_HIDDEN |
-               SF_ARCHIVED | SF_IMMUTABLE | SF_APPEND;
+  auto flags = UF_APPEND | UF_COMPRESSED | UF_DATAVAULT | UF_HIDDEN |
+               UF_IMMUTABLE | UF_NODUMP | UF_OPAQUE | UF_TRACKED | SF_APPEND |
+               SF_ARCHIVED | SF_IMMUTABLE | SF_NOUNLINK | SF_RESTRICTED |
+               SF_SUPPORTED;
 
   std::string expected_description =
-      "NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, "
-      "SF_IMMUTABLE, SF_APPEND";
+      "NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, COMPRESSED, TRACKED, "
+      "DATAVAULT, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND, "
+      "SF_RESTRICTED, SF_NOUNLINK, SF_SUPPORTED";
 
   // The function should return true when there are no undocumented bits
   // set inside the `flags` value


### PR DESCRIPTION
On macOS, there are several additional bsd_flags that may be set. These are not documented in the man page, but are documented in the header file.

(plus a tiny unrelated spelling fix)

```
osqueryd --verbose -S "select bsd_flags from file where path = '/private/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound'"
I1006 12:09:15.603936 82957760 init.cpp:343] osquery initialized [version=4.4.0]
I1006 12:09:15.627223 82957760 file.cpp:107] The following file had undocumented BSD file flags (chflags) set: "/private/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound"
+------------+
| bsd_flags  |
+------------+
| 0x00080000 |
+------------+
```

After patch:
```
dover:build seph$ ./osquery/osqueryd --verbose -S "select bsd_flags from file where path = '/private/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound'"
I1006 12:11:04.253655 275928512 init.cpp:340] osquery initialized [version=4.5.0-43-g335c01360-dirty]
+-----------------------------+
| bsd_flags                   |
+-----------------------------+
| SF_RESTRICTED, SF_SUPPORTED |
+-----------------------------+
```