### PR TITLE
Add Reptile rootkit to ossec-rootkit pack

### DIFF
--- a/packs/ossec-rootkit.conf
+++ b/packs/ossec-rootkit.conf
@@ -408,5 +408,12 @@
       "value": "Artifacts used by this malware", 
       "platform": "linux"
     }
+    "reptile_rootkit": {
+      "query": "select * from file where path in ('/reptile/reptile_cmd ', '/lib/udev/reptile');", 
+      "interval": "3600", 
+      "description": "reptile_rootkit", 
+      "value": "Artifacts used by this malware", 
+      "platform": "linux"
+    }
   }
 }

--- a/packs/ossec-rootkit.conf
+++ b/packs/ossec-rootkit.conf
@@ -409,7 +409,7 @@
       "platform": "linux"
     },
     "reptile_rootkit": {
-      "query": "select * from file where path in ('/reptile/reptile_cmd ', '/lib/udev/reptile');", 
+      "query": "select * from file where path in ('/reptile/reptile_cmd', '/lib/udev/reptile');", 
       "interval": "3600", 
       "description": "reptile_rootkit", 
       "value": "Artifacts used by this malware", 

--- a/packs/ossec-rootkit.conf
+++ b/packs/ossec-rootkit.conf
@@ -407,7 +407,7 @@
       "description": "tuxkit_rootkit", 
       "value": "Artifacts used by this malware", 
       "platform": "linux"
-    }
+    },
     "reptile_rootkit": {
       "query": "select * from file where path in ('/reptile/reptile_cmd ', '/lib/udev/reptile');", 
       "interval": "3600", 


### PR DESCRIPTION
This PR adds Reptile rootkit inline with ossec: https://github.com/ossec/ossec-hids/blob/master/src/rootcheck/db/rootkit_files.txt#L409

Reptile rootkit files mentioned in their wiki: https://github.com/f0rb1dd3n/Reptile/wiki/Install#uninstalling

