### PR TITLE
[macOS][Tests] Fix tests on Catalina

### DIFF
--- a/osquery/tables/system/tests/darwin/startup_items_tests.cpp
+++ b/osquery/tables/system/tests/darwin/startup_items_tests.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
 
 #include <osquery/config/tests/test_utils.h>
@@ -31,11 +32,13 @@ TEST_F(StartupItemsTests, test_parse_startup_items) {
   genLoginItems(si_path, results);
   ASSERT_EQ(results.size(), 2U);
 
-  EXPECT_EQ("/Applications/iTunes.app/Contents/MacOS/iTunesHelper.app/",
-            results[0]["path"]);
+  EXPECT_TRUE(boost::starts_with(
+      results[0]["path"],
+      "/Applications/iTunes.app/Contents/MacOS/iTunesHelper.app"));
 
   // The second entry cannot be parsed with bookmark resolution.
-  EXPECT_EQ("/private/tmp/this_does_not_exist", results[1]["path"]);
+  EXPECT_TRUE(boost::starts_with(results[1]["path"],
+                                 "/private/tmp/this_does_not_exist"));
 }
 } // namespace tables
 } // namespace osquery

--- a/tests/integration/tables/apps.cpp
+++ b/tests/integration/tables/apps.cpp
@@ -50,8 +50,8 @@ TEST_F(apps, test_sanity) {
   validate_rows(data, row_map);
 
   // Not totally sure what apps we expect on the VMs used by CI.
-  auto const data1 = execute_query(
-      "select * from apps where name = 'Preview.app'");
+  auto const data1 =
+      execute_query("select * from apps where name = 'Preview.app'");
   ASSERT_EQ(data1.size(), 1ul);
   validate_rows(data1, row_map);
 }

--- a/tests/integration/tables/apps.cpp
+++ b/tests/integration/tables/apps.cpp
@@ -51,7 +51,8 @@ TEST_F(apps, test_sanity) {
 
   // Not totally sure what apps we expect on the VMs used by CI.
   auto const data1 = execute_query(
-      "select * from apps where path = '/Applications/Preview.app'");
+      "select * from apps where path = '/Applications/Preview.app' or path = "
+      "'/System//Applications/Preview.app'");
   ASSERT_EQ(data1.size(), 1ul);
   validate_rows(data1, row_map);
 }

--- a/tests/integration/tables/apps.cpp
+++ b/tests/integration/tables/apps.cpp
@@ -51,8 +51,7 @@ TEST_F(apps, test_sanity) {
 
   // Not totally sure what apps we expect on the VMs used by CI.
   auto const data1 = execute_query(
-      "select * from apps where path = '/Applications/Preview.app' or path = "
-      "'/System//Applications/Preview.app'");
+      "select * from apps where name = 'Preview.app'");
   ASSERT_EQ(data1.size(), 1ul);
   validate_rows(data1, row_map);
 }


### PR DESCRIPTION
Fixes couple of unit tests that are failing on Catalina because of minor differences between Mojave and Catalina. 

Uncovered these when I moved the Azure worker to Catalina for EndpointSecurity related PR.
