### PR TITLE
type of size field in kernel_modules table should be BIGINT

### DIFF
--- a/specs/linux/kernel_modules.table
+++ b/specs/linux/kernel_modules.table
@@ -2,7 +2,7 @@ table_name("kernel_modules")
 description("Linux kernel modules both loaded and within the load search path.")
 schema([
     Column("name", TEXT, "Module name"),
-    Column("size", TEXT, "Size of module content"),
+    Column("size", BIGINT, "Size of module content"),
     Column("used_by", TEXT, "Module reverse dependencies"),
     Column("status", TEXT, "Kernel module status"),
     Column("address", TEXT, "Kernel module address"),


### PR DESCRIPTION
This fixes https://github.com/osquery/osquery/issues/6711

this makes size consistent with other size fields in the schema like deb_packages.