### PR TITLE
Fix missing negations, duplicate rows in iptables table

### DIFF
--- a/osquery/tables/networking/linux/iptc_proxy.h
+++ b/osquery/tables/networking/linux/iptc_proxy.h
@@ -50,6 +50,16 @@ struct iptcproxy_rule {
 };
 typedef struct iptcproxy_rule iptcproxy_rule;
 
+/* Values for "invflags" field in struct ip_data. */
+#define IPTC_INV_VIA_IN 0x01 /* Invert the sense of IN IFACE. */
+#define IPTC_INV_VIA_OUT 0x02 /* Invert the sense of OUT IFACE */
+#define IPTC_INV_TOS 0x04 /* Invert the sense of TOS. */
+#define IPTC_INV_SRCIP 0x08 /* Invert the sense of SRC IP. */
+#define IPTC_INV_DSTIP 0x10 /* Invert the sense of DST OP. */
+#define IPTC_INV_FRAG 0x20 /* Invert the sense of FRAG. */
+#define IPTC_INV_PROTO 0x40 /* Invert the sense of PROTO. */
+#define IPTC_INV_MASK 0x7F /* All possible flag bits mask. */
+
 const iptcproxy_handle* iptcproxy_init(const char* filter);
 void iptcproxy_free(const iptcproxy_handle* handle);
 

--- a/osquery/tables/networking/tests/linux/iptables_tests.cpp
+++ b/osquery/tables/networking/tests/linux/iptables_tests.cpp
@@ -32,6 +32,7 @@ iptcproxy_rule getIpEntryContent() {
   strcpy(ip_rule.ip_data.outiface, "eth0");
   inet_aton("123.123.123.123", &ip_rule.ip_data.src);
   inet_aton("45.45.45.45", &ip_rule.ip_data.dst);
+  ip_rule.ip_data.invflags = IPTC_INV_DSTIP;
   inet_aton("250.251.252.253", &ip_rule.ip_data.smsk);
   inet_aton("253.252.251.250", &ip_rule.ip_data.dmsk);
   memset(ip_rule.ip_data.iniface_mask, 0xfe, IFNAMSIZ);
@@ -52,7 +53,7 @@ Row getIpEntryExpectedResults() {
   row["iniface"] = "all";
   row["outiface"] = "eth0";
   row["src_ip"] = "123.123.123.123";
-  row["dst_ip"] = "45.45.45.45";
+  row["dst_ip"] = "!45.45.45.45";
   row["src_mask"] = "250.251.252.253";
   row["dst_mask"] = "253.252.251.250";
   row["iniface_mask"] = "FEFEFEFEFEFEFEFEFEFEFEFEFEFEFE";


### PR DESCRIPTION
This isn't a formatted or tested PR, just wanted to throw this up so I could highlight the issues and how I'm thinking about fixing them to get feedback.

Our QA team identified two issues with the iptables table:

1. The chain default row is being stomped on by the last rule row being output, so it's outputting a duplicate row instead of the default policy for the chain. The fix is to create a copy of the chain row, update it with the rule data, and then move it into the result set. That leaves the chain rule alone.
2. There's a bitfield that specifies which match fields in the rule are logical negations. That information was not being included in the output. In this PR I prefix any negated fields with !.