### PR TITLE
bugfix-6560: free memory allocated by ConvertStringSidToSid

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -223,7 +223,7 @@ std::string getUsernameFromSid(const std::string& sidString) {
                           domName.data(),
                           &domNameSize,
                           &eUse);
-
+  LocalFree(sid);
   if (ret == 0) {
     VLOG(1) << "LookupAccountSid failed with " << GetLastError()
             << " for sid: " << sidString;

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -191,13 +191,10 @@ Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
     DWORD accntNameLen = UNLEN + 1;
     DWORD domNameLen = DNLEN + 1;
     SID_NAME_USE eUse;
-    if (!LookupAccountSidW(nullptr,
-                           sid,
-                           accntName,
-                           &accntNameLen,
-                           domName,
-                           &domNameLen,
-                           &eUse)) {
+    BOOL result = LookupAccountSidW(
+        nullptr, sid, accntName, &accntNameLen, domName, &domNameLen, &eUse);
+    LocalFree(sid);
+    if (!result) {
       return Status(GetLastError(), "Could not find sid");
     } else {
       rUsername = std::move(wstringToString(accntName));

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -110,6 +110,8 @@ void processRoamingProfiles(const std::set<std::string>& processedSids,
     ret = LookupAccountSidW(
         nullptr, sid, accntName, &accntNameLen, domName, &domNameLen, &eUse);
     r["username"] = ret != 0 ? wstringToString(accntName) : "";
+    LocalFree(sid);
+
     results.push_back(r);
   }
 }


### PR DESCRIPTION
Free up memory allocated by ConvertStringSidToSid with calls to LocalFree (as described under Sid parameter in [here](https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertstringsidtosida)) as per bug ticket #6560. 