### PR TITLE
Reduce linkage requirements for tests

### DIFF
--- a/osquery/carver/tests/CMakeLists.txt
+++ b/osquery/carver/tests/CMakeLists.txt
@@ -14,18 +14,14 @@ function(generateOsqueryCarverTestsTest)
 
   target_link_libraries(osquery_carver_tests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_carver
     osquery_database
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_hashing
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -16,13 +16,11 @@
 
 #include <osquery/carver/carver.h>
 #include <osquery/carver/carver_utils.h>
-#include <osquery/config/tests/test_utils.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/filesystem/fileops.h>
 #include <osquery/hashing/hashing.h>
 #include <osquery/registry/registry.h>
-#include <osquery/sql/sql.h>
 #include <osquery/utils/json/json.h>
 
 namespace osquery {

--- a/osquery/config/tests/CMakeLists.txt
+++ b/osquery/config/tests/CMakeLists.txt
@@ -34,18 +34,15 @@ function(generateOsqueryConfigTestsTest)
   target_link_libraries(osquery_config_tests-test PRIVATE
     osquery_cxx_settings
     osquery_config
+    osquery_config_tests_testutils
     osquery_database
     osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_filesystem_mockfilestructure
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_system_time
-    plugins_config_tlsconfig
-    specs_tables
-    osquery_config_tests_testutils
+    tests_helper
     thirdparty_googletest
   )
 
@@ -57,18 +54,15 @@ function(generateOsqueryConfigTestsPacksTest)
   target_link_libraries(osquery_config_tests_packs-test PRIVATE
     osquery_cxx_settings
     osquery_config
+    osquery_config_tests_testutils
     osquery_database
     osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_filesystem_mockfilestructure
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_system_time
-    plugins_config_tlsconfig
-    specs_tables
-    osquery_config_tests_testutils
+    tests_helper
     thirdparty_googletest
   )
 

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -33,6 +33,7 @@ function(generateOsqueryCoreInit)
     osquery_core
     osquery_numericmonitoring
     osquery_extensions
+    osquery_distributed
   )
 
   target_link_libraries(osquery_core_init PUBLIC

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -23,20 +23,12 @@ function(generateOsqueryCoreTestsFlagstestsTest)
 
   target_link_libraries(osquery_core_tests_flagstests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    tests_helper
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -46,20 +38,12 @@ function(generateOsqueryCoreTestsSystemtestsTest)
 
   target_link_libraries(osquery_core_tests_systemtests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    tests_helper
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -69,20 +53,12 @@ function(generateOsqueryCoreTestsTablestestsTest)
 
   target_link_libraries(osquery_core_tests_tablestests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     tests_helper
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
     thirdparty_googletest
   )
 endfunction()
@@ -101,21 +77,13 @@ function(generateOsqueryCoreTestsWatcherpermissionstestsTest)
 
   target_link_libraries(osquery_core_tests_watcherpermissionstests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_process
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     tests_helper
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
     thirdparty_googletest
   )
 endfunction()
@@ -125,21 +93,13 @@ function(generateOsqueryCoreTestsQuerytestsTest)
 
   target_link_libraries(osquery_core_tests_querytests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql_tests_sqltestutils
     tests_helper
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
     thirdparty_googletest
   )
 endfunction()
@@ -150,8 +110,6 @@ function(generateOsqueryCoreTestsWmitestsTest)
   target_link_libraries(osquery_core_tests_wmitests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config_tests_testutils
-    osquery_remote_enroll_tlsenroll
     osquery_sql_tests_sqltestutils
     osquery_utils_info
     tests_helper

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ function(generateOsqueryCoreTestsWmitestsTest)
 
   target_link_libraries(osquery_core_tests_wmitests-test PRIVATE
     osquery_cxx_settings
+    osquery_config_tests_testutils
     osquery_core
     osquery_sql_tests_sqltestutils
     osquery_utils_info

--- a/osquery/database/tests/CMakeLists.txt
+++ b/osquery/database/tests/CMakeLists.txt
@@ -18,15 +18,11 @@ function(generateOsqueryDatabaseTestsTest)
     osquery_cxx_settings
     osquery_core
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_json
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -39,16 +35,12 @@ function(generateOsqueryDatabaseTestsResultsTest)
     osquery_core_sql
     osquery_core
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_json
     osquery_sql_tests_sqltestutils
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/dispatcher/CMakeLists.txt
+++ b/osquery/dispatcher/CMakeLists.txt
@@ -49,6 +49,7 @@ function(generateOsqueryDistributedAndScheduler)
     osquery_carver
     osquery_core
     osquery_database
+    osquery_distributed
     osquery_logger_datalogger
     osquery_process
     osquery_profiler

--- a/osquery/dispatcher/tests/CMakeLists.txt
+++ b/osquery/dispatcher/tests/CMakeLists.txt
@@ -17,14 +17,10 @@ function(generateOsqueryDispatcherTestsTest)
     osquery_cxx_settings
     osquery_database
     osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -36,15 +32,11 @@ function(generateOsqueryDispatcherTestsSchedulerTest)
     osquery_cxx_settings
     osquery_database
     osquery_dispatcher_scheduler
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
     osquery_utils_system_time
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/events/tests/CMakeLists.txt
+++ b/osquery/events/tests/CMakeLists.txt
@@ -36,12 +36,13 @@ function(generateOsqueryEventsTestsTest)
     osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -51,13 +52,13 @@ function(generateOsqueryEventsTestsEventsdatabasetestsTest)
 
   target_link_libraries(osquery_events_tests_eventsdatabasetests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
@@ -71,17 +72,15 @@ function(generateOsqueryEventsTestsSyslogtestsTest)
 
   target_link_libraries(osquery_events_tests_syslogtests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
-    osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -91,17 +90,18 @@ function(generateOsqueryEventsTestsAudittestsTest)
 
   target_link_libraries(osquery_events_tests_audittests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
     specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -111,13 +111,13 @@ function(generateOsqueryEventsTestsProcessfileeventstestsTest)
 
   target_link_libraries(osquery_events_tests_processfileeventstests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
@@ -131,17 +131,15 @@ function(generateOsqueryEventsTestsInotifytestsTest)
 
   target_link_libraries(osquery_events_tests_inotifytests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
-    osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -151,19 +149,16 @@ function(generateOsqueryEventsTestsFseventstestsTest)
 
   target_link_libraries(osquery_events_tests_fseventstests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
     osquery_database
     osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
-    osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
     specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -172,18 +167,17 @@ function(generateOsqueryEventsTestsWindowsusnjournalreadertestsTest)
   add_osquery_executable(osquery_events_tests_usnjournalreadertests-test windows/usn_journal_reader_tests.cpp)
 
   target_link_libraries(osquery_events_tests_usnjournalreadertests-test PRIVATE
-    osquery_tables_system_systemtable
+    osquery_cxx_settings
     osquery_core
     osquery_database
     osquery_events
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
     osquery_utils
     osquery_utils_conversions
-    osquery_config_tests_testutils
-    osquery_remote_tests_remotetestutils
-    osquery_database
-    osquery_core_sql
     specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -121,21 +121,14 @@ function(generateOsqueryFilesystemTest)
 
   target_link_libraries(osquery_filesystem_filesystemtests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_process
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
     osquery_filesystem_mockfilestructure
     osquery_filesystem
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -121,6 +121,7 @@ function(generateOsqueryFilesystemTest)
 
   target_link_libraries(osquery_filesystem_filesystemtests-test PRIVATE
     osquery_cxx_settings
+    osquery_config_tests_testutils
     osquery_core
     osquery_extensions
     osquery_extensions_implthrift

--- a/osquery/logger/tests/CMakeLists.txt
+++ b/osquery/logger/tests/CMakeLists.txt
@@ -17,16 +17,13 @@ function(generateOsqueryLoggerTestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/numeric_monitoring/tests/CMakeLists.txt
+++ b/osquery/numeric_monitoring/tests/CMakeLists.txt
@@ -16,14 +16,11 @@ function(osqueryNumericmonitoringTestsTest)
   target_link_libraries(osquery_numericmonitoring_tests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_numericmonitoring
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -34,16 +31,11 @@ function(osqueryNumericmonitoringTestsPreaggregationcacheTest)
   target_link_libraries(osquery_numericmonitoring_tests_preaggregationcache-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_numericmonitoring
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/registry/tests/CMakeLists.txt
+++ b/osquery/registry/tests/CMakeLists.txt
@@ -15,14 +15,11 @@ function(osqueryRegistryTestsTest)
   target_link_libraries(osquery_registry_tests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
     osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -42,7 +42,7 @@ function(generateOsquerySql)
 
   target_link_libraries(osquery_sql PUBLIC
     osquery_cxx_settings
-    osquery_carver
+    osquery_carver_utils
     osquery_core
     osquery_core_plugins
     osquery_hashing

--- a/osquery/sql/tests/CMakeLists.txt
+++ b/osquery/sql/tests/CMakeLists.txt
@@ -25,14 +25,11 @@ function(generateOsquerySqlTestsSqltestutils)
   target_link_libraries(osquery_sql_tests_sqltestutils PUBLIC
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
-    plugins_config_tlsconfig
+    tests_helper
     specs_tables
   )
 endfunction()
@@ -43,16 +40,12 @@ function(generateOsquerySqlTestsTest)
   target_link_libraries(osquery_sql_tests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
     osquery_sql_tests_sqltestutils
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -63,15 +56,11 @@ function(generateOsquerySqlTestsVirtualtableTestsTest)
   target_link_libraries(osquery_sql_tests_virtualtabletests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -82,16 +71,12 @@ function(generateOsquerySqlTestsSqliteutiltestsTest)
   target_link_libraries(osquery_sql_tests_sqliteutilstests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
     osquery_sql_tests_sqltestutils
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -105,7 +90,7 @@ function(generateOsquerySqlTestsSqlitehashingtestsTest)
     osquery_sql
     osquery_sql_tests_sqltestutils
     thirdparty_googletest
-    )
+  )
 endfunction()
 
 osquerySqlMain()

--- a/osquery/system/network/tests/CMakeLists.txt
+++ b/osquery/system/network/tests/CMakeLists.txt
@@ -14,23 +14,15 @@ function(generateOsquerySystemNetworkTestsHostnamehostidentitytestsTest)
 
   target_link_libraries(osquery_system_network_tests_hostnamehostidentitytests-test PRIVATE
     osquery_cxx_settings
-    osquery_system_network_hostname
-    thirdparty_boost
-    osquery_config_tests_testutils
     osquery_core
-    osquery_core_sql
-    osquery_dispatcher
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
+    osquery_system_network_hostname
     osquery_utils_info
-    plugins_config_tlsconfig
     tests_helper
-    specs_tables
     thirdparty_googletest
+    thirdparty_boost
   )
 endfunction()
 

--- a/osquery/tables/applications/CMakeLists.txt
+++ b/osquery/tables/applications/CMakeLists.txt
@@ -67,6 +67,10 @@ function(generateOsqueryTablesApplications)
     list(APPEND public_header_files
       posix/prometheus_metrics.h
     )
+
+    target_link_libraries(osquery_tables_applications PUBLIC
+      osquery_remote_utility
+    )
   endif()
 
   generateIncludeNamespace(osquery_tables_applications "osquery/tables/applications" "FULL_PATH" ${public_header_files})

--- a/osquery/tables/applications/posix/tests/CMakeLists.txt
+++ b/osquery/tables/applications/posix/tests/CMakeLists.txt
@@ -17,17 +17,11 @@ function(generateOsqueryTablesApplicationsPosixTestsPrometheusmetricstestsTest)
   target_link_libraries(osquery_tables_applications_posix_tests_prometheusmetricstests-test PRIVATE
     osquery_cxx_settings
     osquery_database
-    osquery_distributed
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    osquery_sql
-    osquery_sql_tests_sqltestutils
     osquery_tables_applications
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/tables/events/tests/CMakeLists.txt
+++ b/osquery/tables/events/tests/CMakeLists.txt
@@ -30,11 +30,8 @@ function(generateOsqueryTablesEventsTestsFileeventstestsTest)
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -45,18 +42,13 @@ function(generateOsqueryTablesEventsTestsSelinuxeventstestsTest)
   target_link_libraries(osquery_tables_events_tests_selinuxeventstests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config
-    osquery_config_tests_testutils
     osquery_database
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -67,18 +59,13 @@ function(generateOsqueryTablesEventsTestsProcesseventstestsTest)
   target_link_libraries(osquery_tables_events_tests_processeventstests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config
-    osquery_config_tests_testutils
     osquery_database
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -89,18 +76,13 @@ function(generateOsqueryTablesEventsTestsPowershelleventstestsTest)
   target_link_libraries(osquery_tables_events_tests_powershelleventstests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config
-    osquery_config_tests_testutils
     osquery_database
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -116,18 +98,13 @@ function(generateOsqueryTablesEventsTestsWindowseventstestsTest)
   target_link_libraries(osquery_tables_events_tests_windowseventstests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config
-    osquery_config_tests_testutils
     osquery_database
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/tables/forensic/CMakeLists.txt
+++ b/osquery/tables/forensic/CMakeLists.txt
@@ -16,7 +16,7 @@ function(generateOsqueryTablesForensic)
 
   target_link_libraries(osquery_tables_forensic PUBLIC
     osquery_cxx_settings
-    osquery_carver
+    osquery_carver_utils
     osquery_core
     osquery_database
     osquery_logger

--- a/osquery/tables/networking/CMakeLists.txt
+++ b/osquery/tables/networking/CMakeLists.txt
@@ -77,7 +77,7 @@ function(generateOsqueryTablesNetworking)
     osquery_cxx_settings
     osquery_core
     osquery_filesystem
-    osquery_remote_httpclient
+    osquery_remote_utility
     osquery_utils
     osquery_utils_conversions
     osquery_tables_system_systemtable

--- a/osquery/tables/smart/tests/CMakeLists.txt
+++ b/osquery/tables/smart/tests/CMakeLists.txt
@@ -17,18 +17,12 @@ function(generateOsqueryTablesSmartTestsSmartdrivestestsTest)
   target_link_libraries(osquery_tables_smart_tests_smartdrivestests-test PRIVATE
     osquery_cxx_settings
     osquery_core
-    osquery_config
-    osquery_config_tests_testutils
     osquery_database
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    osquery_tables_events_eventstable
-    plugins_config_tlsconfig
-    plugins_config_parsers
-    specs_tables
+    tests_helper
     thirdparty_smartmontools
     thirdparty_googletest
   )

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -38,15 +38,16 @@ function(generateOsqueryTablesSystemLinuxTests)
 
   target_link_libraries(osquery_tables_system_linux_tests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -63,15 +64,16 @@ function(generateOsqueryTablesSystemPosixTests)
 
   target_link_libraries(osquery_tables_system_posix_tests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -83,15 +85,16 @@ function(generateOsqueryTablesSystemTestsSystemtablestestsTest)
 
   target_link_libraries(osquery_tables_system_tests_systemtablestests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -114,15 +117,16 @@ function(generateOsqueryTablesSystemDarwinTests)
 
   target_link_libraries(osquery_tables_system_darwin_tests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -137,15 +141,16 @@ function(generateOsqueryTablesSystemWindowsTests)
 
   target_link_libraries(osquery_tables_system_windows_tests-test PRIVATE
     osquery_cxx_settings
-    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
     osquery_filesystem
-    osquery_remote_tests_remotetestutils
     osquery_tables_system_systemtable
     osquery_utils
     osquery_utils_conversions
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -159,15 +164,11 @@ function(generateOsqueryTablesSystemTestsAugeasTestsTest)
     osquery_cxx_settings
     osquery_config_tests_testutils
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
-    osquery_tables_events_eventstable
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ function(generateOsqueryTablesSystemDarwinTests)
 
   target_link_libraries(osquery_tables_system_darwin_tests-test PRIVATE
     osquery_cxx_settings
+    osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
     osquery_database

--- a/osquery/tables/yara/CMakeLists.txt
+++ b/osquery/tables/yara/CMakeLists.txt
@@ -45,6 +45,7 @@ function(generateOsqueryTablesYaraYaratable)
     osquery_events
     osquery_logger
     osquery_registry
+    osquery_remote_utility
     osquery_utils_config
     thirdparty_boost
     thirdparty_yara

--- a/osquery/utils/aws/tests/CMakeLists.txt
+++ b/osquery/utils/aws/tests/CMakeLists.txt
@@ -16,16 +16,12 @@ function(generateOsqueryUtilsAwsTestsTest)
     osquery_cxx_settings
     osquery_config_tests_testutils
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_process
-    osquery_remote_enroll_tlsenroll
     osquery_utils_aws
     osquery_utils_info
-    plugins_config_tlsconfig
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/worker/ipc/linux/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/linux/tests/CMakeLists.txt
@@ -20,20 +20,14 @@ function(generateOsqueryWorkerIpcLinuxTestsTableContainerTest)
 
   target_link_libraries(osquery_worker_ipc_linux_tests_tablecontainer-test PRIVATE
     osquery_cxx_settings
-    osquery_cxx_settings
     osquery_core
-    osquery_core_sql
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    osquery_tables_events_eventstable
     osquery_utils_status
-    specs_tables
     osquery_worker_ipc_linux_tablecontaineripc
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/worker/ipc/posix/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/posix/tests/CMakeLists.txt
@@ -19,18 +19,14 @@ function(generateOsqueryWorkerIpcPosixTestsIpcPipeChannelTest)
 
   target_link_libraries(osquery_worker_ipc_posix_tests_pipechannel-test PRIVATE
     osquery_cxx_settings
-    osquery_events
-    osquery_tables_events_eventstable
     osquery_dispatcher
     osquery_extensions
     osquery_extensions_implthrift
     osquery_filesystem
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_sql
-    osquery_sdk_pluginsdk
-    osquery_events
     osquery_worker_ipc_posix_pipechannel
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/worker/ipc/tests/CMakeLists.txt
+++ b/osquery/worker/ipc/tests/CMakeLists.txt
@@ -21,17 +21,13 @@ function(generateOsqueryWorkerIpcTestsJsonConversionsTest)
     osquery_core
     osquery_core_sql
     osquery_database
-    osquery_dispatcher
-    osquery_events
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
-    osquery_tables_events_eventstable
     osquery_utils_status
     osquery_worker_ipc_tableipc
     osquery_worker_ipc_tableipcjsonconverter
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/plugins/database/tests/CMakeLists.txt
+++ b/plugins/database/tests/CMakeLists.txt
@@ -17,17 +17,13 @@ function(generatePluginsDatabaseTestsSqliteplugintestsTest)
     osquery_cxx_settings
     osquery_core
     osquery_database
-    osquery_dispatcher
-    osquery_events
+    osquery_database_tests_databasetestutils
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_json
-    plugins_config_tlsconfig
     plugins_database_sqliteplugin
-    specs_tables
-    osquery_database_tests_databasetestutils
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -39,17 +35,13 @@ function(generatePluginsDatabaseTestsRocksdbtestsTest)
     osquery_cxx_settings
     osquery_core
     osquery_database
-    osquery_dispatcher
-    osquery_events
+    osquery_database_tests_databasetestutils
     osquery_extensions
     osquery_extensions_implthrift
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_json
-    plugins_config_tlsconfig
     plugins_database_rocksdbplugin
-    specs_tables
-    osquery_database_tests_databasetestutils
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/plugins/distributed/CMakeLists.txt
+++ b/plugins/distributed/CMakeLists.txt
@@ -21,6 +21,7 @@ function(generatePluginsDistributedTls)
     osquery_core
     osquery_core_plugins
     osquery_database
+    osquery_distributed
     osquery_logger
     osquery_remote_utility
     osquery_remote_serializers_serializerjson

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -155,6 +155,7 @@ function(generatePluginsLoggerKafkaproducer)
     osquery_cxx_settings
     osquery_config
     osquery_dispatcher
+    osquery_remote_utility
     osquery_utils_config
     plugins_config_parsers
     plugins_logger_commondeps

--- a/plugins/logger/tests/CMakeLists.txt
+++ b/plugins/logger/tests/CMakeLists.txt
@@ -25,18 +25,15 @@ function(generatePluginsLoggerTestsFilesystemloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_filesystemlogger
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -49,18 +46,15 @@ function(generatePluginsLoggerTestsBufferedloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_buffered
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
@@ -73,18 +67,15 @@ function(generatePluginsLoggerTestsKafkaproducerloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_kafkaproducer
-    specs_tables
+    tests_helper
     thirdparty_googletest
     thirdparty_gflags
   )
@@ -98,19 +89,16 @@ function(generatePluginsLoggerTestsAwskinesisloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_awskinesis
     plugins_logger_buffered
-    specs_tables
+    tests_helper
     thirdparty_googletest
     thirdparty_gflags
   )
@@ -124,7 +112,6 @@ function(generatePluginsLoggerTestsTlsloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
@@ -134,9 +121,8 @@ function(generatePluginsLoggerTestsTlsloggertestsTest)
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_tlslogger
-    specs_tables
+    tests_helper
     thirdparty_googletest
     thirdparty_gflags
   )
@@ -150,21 +136,17 @@ function(generatePluginsLoggerTestsSyslogloggertestsTest)
     osquery_core
     osquery_core_plugins
     osquery_database
-    osquery_distributed
     osquery_extensions
     osquery_extensions_implthrift
     osquery_logger_datalogger
     osquery_registry
-    osquery_remote_enroll_tlsenroll
     osquery_utils_conversions
     osquery_utils_info
     osquery_utils_system_time
-    plugins_config_tlsconfig
     plugins_logger_syslog
-    specs_tables
+    tests_helper
     thirdparty_googletest
     thirdparty_gflags
-    osquery_remote_tests_remotetestutils
   )
 endfunction()
 

--- a/plugins/numeric_monitoring/tests/CMakeLists.txt
+++ b/plugins/numeric_monitoring/tests/CMakeLists.txt
@@ -19,10 +19,8 @@ function(pluginsNumericmonitoringTestsFilesystemtestsTest)
     osquery_extensions
     osquery_extensions_implthrift
     osquery_numericmonitoring
-    osquery_remote_enroll_tlsenroll
-    plugins_config_tlsconfig
     plugins_numericmonitoring_filesystem
-    specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,10 +26,10 @@ function(generateTestsHelper)
   target_link_libraries(tests_helper PUBLIC
     osquery_cxx_settings
     osquery_core
+    osquery_config
     osquery_database
     osquery_filesystem
     osquery_process
-    osquery_remote_serializers_serializerjson
     osquery_sql
     osquery_utils
     osquery_utils_conversions


### PR DESCRIPTION
We should be able to "relax" linkage requirements for tests after the recent carver refactors. These changes need to be tested on macOS and Windows.

The goal is to only link what we use. This might not be 100% accurate but it should at least be "better". :)