### PR TITLE
Updated unwanted-chrome-extensions

### DIFF
--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -50,6 +50,21 @@
       "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='hinehnlkkmckjblijjpbpamhljokoohh';",
       "interval": 3600,
       "description": "(https://www.virustotal.com/#/file/5cab0821f597100dc1170bfef704d8cebaf67743e9d509e83b0b208eb630d992/detection)"
+    },
+    "User-Agent Switcher": {
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='clddifkhlkcojbojppdojfeeikdkgiae';",
+      "interval": 3600,
+      "description": "(https://chris.partridge.tech/2020/extensions-the-next-generation-of-malware/help-for-users/)"
+    },
+    "Nano Adblocker": {
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='gabbbocakeomblphkmmnoamkioajlkfo';",
+      "interval": 3600,
+      "description": "(https://chris.partridge.tech/2020/extensions-the-next-generation-of-malware/help-for-users/)"
+    },
+    "Nano Defender ": {
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid) WHERE identifier='ggolfgbegefeeoocgjbmkembbncoadlb';",
+      "interval": 3600,
+      "description": "(https://chris.partridge.tech/2020/extensions-the-next-generation-of-malware/help-for-users/)"
     }
   }
 }


### PR DESCRIPTION
Updating the unwanted-chrome-extensions query pack with three new extensions that were recently compromised and made tech news sites. Extensions have been removed by Google from Chrome Web Store. Since removal from the Chrome Web Store does not remove already installed extensions, this query will allow users of osquery to monitor their endpoints for these malicious extensions.

References:
https://chris.partridge.tech/2020/extensions-the-next-generation-of-malware/help-for-users/
https://arstechnica.com/information-technology/2020/10/popular-chromium-ad-blockers-caught-stealing-user-data-and-accessing-accounts/
