### PR TITLE
Fix wifi_tests on macOS 10.15 and above

### DIFF
--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -105,6 +105,5 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
     EXPECT_EQ(results.back()[column.first], column.second);
   }
 }
-
 }
 }

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -15,6 +15,7 @@
 #include <osquery/core/sql/query_data.h>
 #include <osquery/core/system.h>
 #include <osquery/registry/registry_factory.h>
+#include <osquery/sql/sql.h>
 
 namespace osquery {
 namespace tables {
@@ -30,10 +31,20 @@ class WifiNetworksTest : public testing::Test {
 };
 
 TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
-  std::string path = (getTestConfigDirectory() / "test_airport.plist").string();
+  // the keys and values of the plist file have changed with new versions of
+  // macOS, so the version of the test input file has to be consistent
+  auto qd = SQL::selectAllFrom("os_version");
+  ASSERT_EQ(qd.size(), 1);
+
+  std::string file =
+      (qd.front().at("major") < "11" && qd.front().at("minor") < "15")
+          ? "test_airport_pre_macOS_10.15.plist"
+          : "test_airport.plist";
+  std::string path = (getTestConfigDirectory() / file).string();
 
   auto plist = (__bridge CFDictionaryRef)
       [NSDictionary dictionaryWithContentsOfFile:@(path.c_str())];
+  ASSERT_NE(plist, nullptr);
   ASSERT_GE((long)CFDictionaryGetCount(plist), 1);
   std::string key = "KnownNetworks";
   auto cfkey = CFStringCreateWithCString(
@@ -55,20 +66,6 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   ASSERT_GT(results.size(), 0);
 
   Row expected1 = {
-      {"ssid", "2890d228 3487"},
-      {"network_name", "High-Fi"},
-      {"security_type", "WPA2 Personal"},
-      {"last_connected", "1419843361"},
-      {"passpoint", "0"},
-      {"possibly_hidden", "0"},
-      {"roaming", "0"},
-      {"roaming_profile", "Single"},
-      {"captive_portal", "0"},
-      {"auto_login", "0"},
-      {"temporarily_disabled", "0"},
-      {"disabled", "0"},
-  };
-  Row expected2 = {
       {"ssid", "85e965a1 63ab"},
       {"network_name", "WhyFi"},
       {"security_type", "Open"},
@@ -78,45 +75,10 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
       {"roaming", "0"},
       {"roaming_profile", "None"},
       {"captive_portal", "1"},
-      {"auto_login", "0"},
       {"temporarily_disabled", "0"},
       {"disabled", "0"},
   };
-
-  for (const auto& column : expected1) {
-    EXPECT_EQ(results.front()[column.first], column.second);
-  }
-  for (const auto& column : expected2) {
-    EXPECT_EQ(results.back()[column.first], column.second);
-  }
-}
-
-TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {
-  std::string path =
-      (getTestConfigDirectory() / "test_airport_legacy.plist").string();
-
-  auto plist = (__bridge CFDictionaryRef)
-      [NSDictionary dictionaryWithContentsOfFile:@(path.c_str())];
-  ASSERT_GE((long)CFDictionaryGetCount(plist), 1);
-  std::string key = "RememberedNetworks";
-  auto cfkey = CFStringCreateWithCString(
-      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
-  auto networks = (CFArrayRef)CFDictionaryGetValue(plist, cfkey);
-
-  CFRelease(cfkey);
-
-  QueryData results;
-  auto count = CFArrayGetCount(networks);
-  ASSERT_EQ((long)count, 2);
-
-  for (CFIndex i = 0; i < count; i++) {
-    parseNetworks(
-        (CFDictionaryRef)CFArrayGetValueAtIndex((CFArrayRef)networks, i),
-        results);
-  }
-  ASSERT_GT(results.size(), 0);
-
-  Row expected1 = {
+  Row expected2 = {
       {"ssid", "2890d228 3487"},
       {"network_name", "High-Fi"},
       {"security_type", "WPA2 Personal"},
@@ -126,31 +88,24 @@ TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {
       {"roaming", "0"},
       {"roaming_profile", "Single"},
       {"captive_portal", "0"},
-      {"auto_login", "0"},
-      {"temporarily_disabled", "0"},
-      {"disabled", "0"},
-  };
-  Row expected2 = {
-      {"ssid", "85e965a1 63ab"},
-      {"network_name", "WhyFi"},
-      {"security_type", "Open"},
-      {"last_connected", "1437434883"},
-      {"passpoint", "0"},
-      {"possibly_hidden", "0"},
-      {"roaming", "0"},
-      {"roaming_profile", "None"},
-      {"captive_portal", "1"},
-      {"auto_login", "0"},
       {"temporarily_disabled", "0"},
       {"disabled", "0"},
   };
 
-  for (const auto& column : expected2) {
+  // Pre-macOS 10.15, there was also an auto_login field to read
+  if (qd.front().at("major") < "11" && qd.front().at("minor") < "15")
+  {
+    expected1.insert(std::pair<std::string, RowData>("auto_login", "0"));
+    expected2.insert(std::pair<std::string, RowData>("auto_login", "0"));
+  }
+
+  for (const auto& column : expected1) {
     EXPECT_EQ(results.front()[column.first], column.second);
   }
-  for (const auto& column : expected1) {
+  for (const auto& column : expected2) {
     EXPECT_EQ(results.back()[column.first], column.second);
   }
 }
+
 }
 }

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -93,8 +93,7 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   };
 
   // Pre-macOS 10.15, there was also an auto_login field to read
-  if (qd.front().at("major") < "11" && qd.front().at("minor") < "15")
-  {
+  if (qd.front().at("major") < "11" && qd.front().at("minor") < "15") {
     expected1.insert(std::pair<std::string, RowData>("auto_login", "0"));
     expected2.insert(std::pair<std::string, RowData>("auto_login", "0"));
   }

--- a/tools/tests/configs/test_airport.plist
+++ b/tools/tests/configs/test_airport.plist
@@ -8,10 +8,22 @@
 	<dict>
 		<key>wifi.ssid.&lt;47f70e38 5cd1d54b 69&gt;</key>
 		<dict>
-			<key>AutoLogin</key>
-			<false/>
+			<key>AddedBy</key>
+			<integer>2</integer>
+			<key>BSSIDList</key>
+			<array>
+				<dict>
+					<key>LEAKY_AP_BSSID</key>
+					<string>14:ed:bb:34:cd:32</string>
+					<key>LEAKY_AP_LEARNED_DATA</key>
+					<data>
+					</data>
+				</dict>
+			</array>
 			<key>Captive</key>
 			<true/>
+			<key>CaptiveBypass</key>
+			<false/>
 			<key>ChannelHistory</key>
 			<array>
 				<dict>
@@ -21,18 +33,19 @@
 					<date>2015-07-20T23:28:03Z</date>
 				</dict>
 			</array>
-			<key>Closed</key>
-			<false/>
 			<key>CollocatedGroup</key>
-			<array>
-				<string>foo</string>
-				<string>bar</string>
-			</array>
+			<array/>
 			<key>Disabled</key>
 			<false/>
-			<key>LastConnected</key>
+			<key>HiddenNetwork</key>
+			<false/>
+			<key>LastAutoJoinAt</key>
 			<date>2015-07-20T23:28:03Z</date>
+			<key>NetworkWasCaptive</key>
+			<false/>
 			<key>Passpoint</key>
+			<false/>
+			<key>PersonalHotspot</key>
 			<false/>
 			<key>PossiblyHiddenNetwork</key>
 			<false/>
@@ -48,16 +61,32 @@
 			<string>WhyFi</string>
 			<key>SecurityType</key>
 			<string>Open</string>
+			<key>ShareMode</key>
+			<integer>3</integer>
 			<key>SystemMode</key>
 			<true/>
 			<key>TemporarilyDisabled</key>
 			<false/>
+			<key>UserRole</key>
+			<integer>1</integer>
 		</dict>
 		<key>wifi.ssid.&lt;06fa78ca 7a47b05e b61d74cc 2e9e6622&gt;</key>
 		<dict>
-			<key>AutoLogin</key>
-			<false/>
+			<key>AddedBy</key>
+			<integer>2</integer>
+			<key>BSSIDList</key>
+			<array>
+				<dict>
+					<key>LEAKY_AP_BSSID</key>
+					<string>14:ed:bb:34:cd:32</string>
+					<key>LEAKY_AP_LEARNED_DATA</key>
+					<data>
+					</data>
+				</dict>
+			</array>
 			<key>Captive</key>
+			<false/>
+			<key>CaptiveBypass</key>
 			<false/>
 			<key>ChannelHistory</key>
 			<array>
@@ -68,15 +97,19 @@
 					<date>2014-12-29T08:56:02Z</date>
 				</dict>
 			</array>
-			<key>Closed</key>
-			<false/>
 			<key>CollocatedGroup</key>
 			<array/>
 			<key>Disabled</key>
 			<false/>
-			<key>LastConnected</key>
+			<key>HiddenNetwork</key>
+			<false/>
+			<key>LastAutoJoinAt</key>
 			<date>2014-12-29T08:56:01Z</date>
+			<key>NetworkWasCaptive</key>
+			<false/>
 			<key>Passpoint</key>
+			<false/>
+			<key>PersonalHotspot</key>
 			<false/>
 			<key>PossiblyHiddenNetwork</key>
 			<false/>
@@ -92,13 +125,17 @@
 			<string>High-Fi</string>
 			<key>SecurityType</key>
 			<string>WPA2 Personal</string>
+			<key>ShareMode</key>
+			<integer>3</integer>
 			<key>SystemMode</key>
 			<true/>
 			<key>TemporarilyDisabled</key>
 			<false/>
+			<key>UserRole</key>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>Version</key>
-	<integer>2200</integer>
+	<integer>2600</integer>
 </dict>
 </plist>

--- a/tools/tests/configs/test_airport_pre_macOS_10.15.plist
+++ b/tools/tests/configs/test_airport_pre_macOS_10.15.plist
@@ -2,8 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>RememberedNetworks</key>
-	<array>
+	<key>Counter</key>
+	<integer>2</integer>
+	<key>KnownNetworks</key>
+	<dict>
+		<key>wifi.ssid.&lt;47f70e38 5cd1d54b 69&gt;</key>
 		<dict>
 			<key>AutoLogin</key>
 			<false/>
@@ -50,6 +53,7 @@
 			<key>TemporarilyDisabled</key>
 			<false/>
 		</dict>
+		<key>wifi.ssid.&lt;06fa78ca 7a47b05e b61d74cc 2e9e6622&gt;</key>
 		<dict>
 			<key>AutoLogin</key>
 			<false/>
@@ -93,8 +97,8 @@
 			<key>TemporarilyDisabled</key>
 			<false/>
 		</dict>
-	</array>
+	</dict>
 	<key>Version</key>
-	<integer>14</integer>
+	<integer>2200</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Updates the test input plist file for the `wifi_networks` test, to reflect what the plist looks like on macOS 10.15
- Also removes the test and test input file for macOS 10.9, a way older version of macOS that is not supported by Apple or osquery anymore.

Closes #6722