### PR TITLE
build: Fix windows build on newer MSVC

### DIFF
--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -96,7 +96,7 @@ function(thriftMain)
   # C++17 dropped support for random_shuffle. Add it back with a
   # custom header
   target_compile_options(thirdparty_thrift PRIVATE
-    "${forced_include_file_flag}" "${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
+    "${forced_include_file_flag} ${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
   )
 
   target_compile_definitions(thirdparty_thrift PRIVATE


### PR DESCRIPTION
Windows build was broken on newer MSVC:
It couldn't find the `random_shuffle` identifier:

```
TSocketPool.cpp(191): error C3861: 'random_shuffle': identifier not found 
```

Turns out we weren't quoting things properly to include the `random_shuffle.h` patch. 
Hat tip to @Smjert for figuring that out.

cc: @muffins 