### PR TITLE
build: Fix windows build on newer MSVC

### DIFF
--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -95,9 +95,15 @@ function(thriftMain)
 
   # C++17 dropped support for random_shuffle. Add it back with a
   # custom header
-  target_compile_options(thirdparty_thrift PRIVATE
-    "${forced_include_file_flag}" "${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
-  )
+  if(DEFINED PLATFORM_WINDOWS)
+    target_compile_options(thirdparty_thrift PRIVATE
+      "${forced_include_file_flag} ${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
+    )
+  else()
+    target_compile_options(thirdparty_thrift PRIVATE
+      "${forced_include_file_flag}" "${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
+    )
+  endif()
 
   target_compile_definitions(thirdparty_thrift PRIVATE
     THRIFT_STATIC_DEFINE

--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -90,20 +90,14 @@ function(thriftMain)
   if(PLATFORM_WINDOWS)
     set(forced_include_file_flag "/FI")
   else()
-    set(forced_include_file_flag "-include")
+    set(forced_include_file_flag "--include")
   endif()
 
   # C++17 dropped support for random_shuffle. Add it back with a
   # custom header
-  if(DEFINED PLATFORM_WINDOWS)
-    target_compile_options(thirdparty_thrift PRIVATE
-      "${forced_include_file_flag}${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
-    )
-  else()
-    target_compile_options(thirdparty_thrift PRIVATE
-      "${forced_include_file_flag}" "${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
-    )
-  endif()
+  target_compile_options(thirdparty_thrift PRIVATE
+    "${forced_include_file_flag}${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
+  )
 
   target_compile_definitions(thirdparty_thrift PRIVATE
     THRIFT_STATIC_DEFINE

--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -97,7 +97,7 @@ function(thriftMain)
   # custom header
   if(DEFINED PLATFORM_WINDOWS)
     target_compile_options(thirdparty_thrift PRIVATE
-      "${forced_include_file_flag} ${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
+      "${forced_include_file_flag}${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
     )
   else()
     target_compile_options(thirdparty_thrift PRIVATE


### PR DESCRIPTION
Windows build was broken on newer MSVC:
It couldn't find the random_shuffle identifier:

```
TSocketPool.cpp(191): error C3861: 'random_shuffle': identifier not found 
```

Supersedes #6725  