### PR TITLE
Add Yandex Browser support for chrome_extensions

### DIFF
--- a/osquery/tables/applications/browser_chrome.cpp
+++ b/osquery/tables/applications/browser_chrome.cpp
@@ -54,6 +54,16 @@ static std::vector<fs::path> getChromePaths() {
     chromePaths.push_back("/.config/chromium/%/Extensions/");
   }
 
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    chromePaths.push_back(
+        "\\AppData\\Local\\Yandex\\YandexBrowser\\User Data\\%\\Extensions\\");
+  } else if (isPlatform(PlatformType::TYPE_OSX)) {
+    chromePaths.push_back(
+        "/Library/Application Support/Yandex/YandexBrowser/%/Extensions/");
+  } else {
+    chromePaths.push_back("/.config/yandex-browser%/%/Extensions/");
+  }
+
   return chromePaths;
 }
 


### PR DESCRIPTION
Yandex Browser (https://browser.yandex.com/) is a popular Chromium-based browser on Windows, macOS and Linux. However, chrome_extensions table doesn't check its extensions.
This PR adds default paths for Yandex Browser extensions.
For Linux systems the default path `/.config/yandex-browser%/%/Extensions/` has the first `%`-sign because currently it's `yandex-browser-beta`. Thus, in case of future changes we don't need to fix the code one more time.

The PR was successfully tested on Ubuntu 18.04 x64 (5.3.0-28-generic) and Windows 10 1809 17763.1217.  Unfortunately, I experience difficulties building osquery for macOS Catalina (10.15.7) which aren't connected with the PR. 