### PR TITLE
Make the usb_devices pack query available only on posix

### DIFF
--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -149,6 +149,7 @@
     "usb_devices": {
       "query" : "select * from usb_devices;",
       "interval" : "86400",
+      "platform" : "posix",
       "version" : "1.4.5",
       "description" : "Retrieves the current list of USB devices in the target system.",
       "value" : "General security posture."


### PR DESCRIPTION
The usb_devices table and respective query in the packs/it-compliance.conf pack is posix only.
