### PR TITLE
CMake: Disable BPF support if the LLVM libs are not compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,15 @@ function(importLibraries)
     "Linux,Darwin,Windows:openssl"
     "Linux,Darwin,Windows:aws-sdk-cpp"
     "Linux,Darwin,Windows:icu"
-    "Linux:ebpfpub"
     "Linux:expat"
     "Linux:dbus"
   )
+
+  if(OSQUERY_BUILD_BPF)
+    list(APPEND library_descriptor_list
+      "Linux:ebpfpub"
+    )
+  endif()
 
   foreach(library_descriptor ${library_descriptor_list})
     # Expand the library descriptor
@@ -179,7 +184,14 @@ function(importLibraries)
       endif()
 
     else()
-      message(FATAL_ERROR "The '${library}' library was found but it couldn't be imported correctly")
+      # In case we were trying to import ebpfpub, check whether the build option
+      # has been turned OFF automatically because the installed LLVM libraries
+      # were broken/not compatible
+      if(NOT OSQUERY_BUILD_BPF AND "${library}" STREQUAL "ebpfpub")
+        message(WARNING "ebpfpub could not correctly import the LLVM libraries. BPF support has been disabled")
+      else()
+        message(FATAL_ERROR "The '${library}' library was found but it couldn't be imported correctly")
+      endif()
     endif()
   endforeach()
 endfunction()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -77,6 +77,8 @@ option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
 option(OSQUERY_ENABLE_CLANG_TIDY "Enables clang-tidy support")
 set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,portability-*,readability-*,modernize-*,bugprone-*" CACHE STRING "List of checks performed by clang-tidy")
 
+option(OSQUERY_BUILD_BPF "Whether to enable and build BPF support" true)
+
 # Unfortunately, due glog always enabling BUILD_TESTING, we have to force it off, so that tests won't be built
 overwrite_cache_variable("BUILD_TESTING" "BOOL" "OFF")
 

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -22,14 +22,19 @@ function(generateOsqueryEvents)
       linux/auditdnetlink.cpp
       linux/auditeventpublisher.cpp
       linux/inotify.cpp
-      linux/bpf/bpfeventpublisher.cpp
-      linux/bpf/filesystem.cpp
-      linux/bpf/processcontextfactory.cpp
-      linux/bpf/setrlimit.cpp
-      linux/bpf/systemstatetracker.cpp
       linux/syslog.cpp
       linux/udev.cpp
     )
+
+    if(OSQUERY_BUILD_BPF)
+      list(APPEND source_files
+        linux/bpf/bpfeventpublisher.cpp
+        linux/bpf/filesystem.cpp
+        linux/bpf/processcontextfactory.cpp
+        linux/bpf/setrlimit.cpp
+        linux/bpf/systemstatetracker.cpp
+      )
+    endif()
 
   elseif(DEFINED PLATFORM_MACOS)
     list(APPEND source_files
@@ -77,8 +82,14 @@ function(generateOsqueryEvents)
       thirdparty_libaudit
       thirdparty_libudev
       thirdparty_util-linux
-      thirdparty_ebpfpub
     )
+
+    if(OSQUERY_BUILD_BPF)
+      target_link_libraries(osquery_events PUBLIC
+        thirdparty_ebpfpub
+      )
+    endif()
+
   elseif(DEFINED PLATFORM_WINDOWS)
     target_link_libraries(osquery_events PUBLIC
       plugins_config_parsers
@@ -98,21 +109,26 @@ function(generateOsqueryEvents)
       linux/inotify.h
       linux/process_events.h
       linux/process_file_events.h
-      linux/bpf/bpfeventpublisher.h
-      linux/bpf/filesystem.h
-      linux/bpf/ifilesystem.h
-      linux/bpf/iprocesscontextfactory.h
-      linux/bpf/isystemstatetracker.h
-      linux/bpf/processcontextfactory.h
-      linux/bpf/setrlimit.h
-      linux/bpf/systemstatetracker.h
-      linux/bpf/uniquedir.h
       linux/selinux_events.h
       linux/apparmor_events.h
       linux/socket_events.h
       linux/syslog.h
       linux/udev.h
     )
+
+    if(OSQUERY_BUILD_BPF)
+      list(APPEND platform_public_header_files
+        linux/bpf/bpfeventpublisher.h
+        linux/bpf/filesystem.h
+        linux/bpf/ifilesystem.h
+        linux/bpf/iprocesscontextfactory.h
+        linux/bpf/isystemstatetracker.h
+        linux/bpf/processcontextfactory.h
+        linux/bpf/setrlimit.h
+        linux/bpf/systemstatetracker.h
+        linux/bpf/uniquedir.h
+      )
+    endif()
 
   elseif(DEFINED PLATFORM_MACOS)
     set(platform_public_header_files

--- a/osquery/events/tests/CMakeLists.txt
+++ b/osquery/events/tests/CMakeLists.txt
@@ -14,7 +14,10 @@ function(osqueryEventsTestsMain)
     generateOsqueryEventsTestsAudittestsTest()
     generateOsqueryEventsTestsProcessfileeventstestsTest()
     generateOsqueryEventsTestsInotifytestsTest()
-    generateOsqueryEventsTestsBpftestsTest()
+
+    if(OSQUERY_BUILD_BPF)
+      generateOsqueryEventsTestsBpftestsTest()
+    endif()
   endif()
 
   if(DEFINED PLATFORM_MACOS)

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -25,14 +25,19 @@ function(generateOsqueryTablesEventsEventstable)
       linux/hardware_events.cpp
       linux/process_events.cpp
       linux/process_file_events.cpp
-      linux/bpf_process_events.cpp
-      linux/bpf_socket_events.cpp
       linux/selinux_events.cpp
       linux/socket_events.cpp
       linux/syslog_events.cpp
       linux/user_events.cpp
       linux/apparmor_events.cpp
     )
+
+    if(OSQUERY_BUILD_BPF)
+      list(APPEND source_files
+        linux/bpf_process_events.cpp
+        linux/bpf_socket_events.cpp
+      )
+    endif()
 
   elseif(DEFINED PLATFORM_MACOS)
     list(APPEND source_files

--- a/osquery/tables/events/tests/CMakeLists.txt
+++ b/osquery/tables/events/tests/CMakeLists.txt
@@ -11,7 +11,10 @@ function(osqueryTablesEventsTestsMain)
   if(DEFINED PLATFORM_LINUX)
     generateOsqueryTablesEventsTestsSelinuxeventstestsTest()
     generateOsqueryTablesEventsTestsProcesseventstestsTest()
-    generateOsqueryTablesEventsTestsBPFtestsTest()
+
+    if(OSQUERY_BUILD_BPF)
+      generateOsqueryTablesEventsTestsBPFtestsTest()
+    endif()
 
   elseif(DEFINED PLATFORM_WINDOWS)
     generateOsqueryTablesEventsTestsPowershelleventstestsTest()

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -157,8 +157,6 @@ function(generateNativeTables)
     "linux/elf_segments.table:linux"
     "linux/md_devices.table:linux"
     "linux/process_namespaces.table:linux"
-    "linux/bpf_process_events.table:linux"
-    "linux/bpf_socket_events.table:linux"
     "linux/syslog_events.table:linux"
     "linux/rpm_packages.table:linux"
     "linux/portage_packages.table:linux"
@@ -303,6 +301,13 @@ function(generateNativeTables)
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,freebsd,windows"
   )
+
+  if(OSQUERY_BUILD_BPF)
+    list(APPEND platform_dependent_spec_files
+      "linux/bpf_process_events.table:linux"
+      "linux/bpf_socket_events.table:linux"
+    )
+  endif()
 
   foreach(spec_descriptor ${platform_dependent_spec_files})
     string(REPLACE ":" ";" spec_descriptor "${spec_descriptor}")


### PR DESCRIPTION
This fixes oss-fuzz support