### PR TITLE
Journald Audit Logs Masking Documentation

### DIFF
--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -169,6 +169,8 @@ osqueryi --audit_allow_config=true --audit_allow_sockets=true --audit_persist=tr
 
 If you would like to debug the raw audit events as `osqueryd` sees them, use the hidden flag `--audit_debug`. This will print all of the RAW audit lines to osquery's `stdout`.
 
+> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`. 
+
 ## User event auditing with Audit
 
 On Linux, a companion table called `user_events` is included that provides several authentication-based events. If you are enabling process auditing it should be trivial to also include this table.

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -22,6 +22,8 @@ The default packages create the following structure:
 
 To install osquery, follow the instructions on the [Downloads](https://osquery.io/downloads/official) page according to your distro.
 
+> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`. 
+
 ## Running osquery
 
 To start a standalone osquery use: `osqueryi`. This does not need a server or service. All the table implementations are included!


### PR DESCRIPTION
This PR adds additional notices to the osquery documentation to warn users about the impact on journald audit logs and how to mask those logs from entering the systemd journald if needed.

This problem has been discussed on the following thread in the Osquery[ slack channel](https://osquery.slack.com/archives/C08V7KTJB/p1603126388324400) and @theopolis has recommended to add this to the documentation.

Idea is, by default, systemd journald will collect the audit logs generated by the kernel auditing (something that osquery enables). On busy boxes, we saw that the lack of mask on those logs can greatly affect the performance on the box - for example considerably increasing the disk write operations that can reach limits like the burst allowance ones enforced on AWS so it is really recommended to enable this masking on Linux installations specially when event tables are enabled.

Please let me know if there is any additional info required.