### PR TITLE
Fixes #6752 - support TLS client cert chains

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -220,8 +220,7 @@ void Client::encryptConnection() {
   }
 
   if (client_options_.client_certificate_file_) {
-    ctx.use_certificate_file(*client_options_.client_certificate_file_,
-                             boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(*client_options_.client_certificate_file_);
   }
 
   if (client_options_.client_private_key_file_) {


### PR DESCRIPTION
This PR switches the OpenSSL call used to load the client cert file into the context to use one which allows specifying a PEM cert **chain** rather than just a single-cert PEM file.  This allows use of client certs that are issued from intermediate CAs (as are widely deployed in our infrastructure).  The existing code assumes that the client cert will chain directly up to the server's trusted root CA, which is incorrect as TLS allows for either peer to supply a cert chain and the root CA should be all that is necessary to verify the supplied chain.

This PR changes from calling `use_certificate_file` to `use_certificate_chain_file`, which is compatible with `use_certificate_file` **with the exception** that `use_certificate_file` allows the caller to specify that the file is in ASN.1 format rather than PEM.  However, **osquery** has the format argument hardcoded to PEM, which means that _as **osquery** uses it_, this call is a compatible replacement.
