### PR TITLE
Enable AWS Instance profile as credential provider on Windows

### DIFF
--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -304,12 +304,8 @@ OsqueryAWSCredentialsProviderChain::OsqueryAWSCredentialsProviderChain(bool sts)
   AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());
   AddProvider(
       std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());
-
-// This is disabled on Windows because it causes a crash
-#if !defined(WINDOWS)
   AddProvider(
       std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
-#endif
 }
 
 Status getAWSRegionFromProfile(std::string& region) {


### PR DESCRIPTION
Enables use of AWS Instance profile as a credential provider on Windows 

Depends on: #6749 
