### PR TITLE
libs: Port the RocksDB Win7 compatibility patch to the MSBuild generator

### DIFF
--- a/libraries/cmake/source/rocksdb/CMakeLists.txt
+++ b/libraries/cmake/source/rocksdb/CMakeLists.txt
@@ -281,15 +281,6 @@ function(rocksdbMain)
     PROPERTIES INCLUDE_DIRECTORIES "${library_root}/util"
   )
 
-  # By defining this, we'll cause the WinEnvIO::AreFilesSame method to return
-  # Status::NotSupported(), so that the caller can use a different way to
-  # determine whether the files are matching. This lets us keep the project-wide
-  # _WIN32_WINNT definition set to Windows 7 under cmake/flags.cmake.
-  set_source_files_properties(
-    "${library_root}/port/win/env_win.cc"
-    PROPERTIES COMPILE_DEFINITIONS "_WIN32_WINNT=_WIN32_WINNT_VISTA"
-  )
-
   if(DEFINED PLATFORM_WINDOWS)
     target_sources(thirdparty_rocksdb PRIVATE
       "${library_root}/port/win/env_default.cc"
@@ -299,6 +290,15 @@ function(rocksdbMain)
       "${library_root}/port/win/win_logger.cc"
       "${library_root}/port/win/win_thread.cc"
       "${library_root}/port/win/xpress_win.cc"
+    )
+
+    # By defining this, we'll cause the WinEnvIO::AreFilesSame method to return
+    # Status::NotSupported(), so that the caller can use a different way to
+    # determine whether the files are matching. This lets us keep the project-wide
+    # _WIN32_WINNT definition set to Windows 7 under cmake/flags.cmake.
+    set_source_files_properties(
+      "${library_root}/port/win/env_win.cc"
+      PROPERTIES COMPILE_OPTIONS "/FI${CMAKE_CURRENT_SOURCE_DIR}/patches/env_win.h"
     )
 
   else()

--- a/libraries/cmake/source/rocksdb/patches/env_win.h
+++ b/libraries/cmake/source/rocksdb/patches/env_win.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+
+#define _WIN32_WINNT _WIN32_WINNT_VISTA


### PR DESCRIPTION
This PR updates the Windows 7 compatibility patch for RocksDB so that it works with both the Ninja and MSBuild generators