### PR TITLE
PackageIdentifiers are optional in InstallHistory.plist

### DIFF
--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -468,10 +468,17 @@ void genPkgInstallHistoryEntry(const pt::ptree& entry, QueryData& results) {
     r[it.second] = entry.get(it.first, "");
   }
 
-  for (const auto& package_identifier : entry.get_child("packageIdentifiers")) {
-    r["package_id"] = package_identifier.second.get<std::string>("");
-    results.push_back(r);
+  // some packages do not set packageIdentifiers, allow it to be
+  // empty. Empirically this seems to be os packages, but we can't
+  // assume that.
+  if (const auto& identifiers =
+          entry.get_child_optional("packageIdentifiers")) {
+    for (const auto& package_identifier : *identifiers) {
+      r["package_id"] = package_identifier.second.get<std::string>("");
+    }
   }
+
+  results.push_back(r);
 }
 
 QueryData genPackageInstallHistory(QueryContext& context) {

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -475,10 +475,12 @@ void genPkgInstallHistoryEntry(const pt::ptree& entry, QueryData& results) {
           entry.get_child_optional("packageIdentifiers")) {
     for (const auto& package_identifier : *identifiers) {
       r["package_id"] = package_identifier.second.get<std::string>("");
+      results.push_back(r);
     }
+  } else {
+    // push_back for the nil packageIdentifiers case
+    results.push_back(r);
   }
-
-  results.push_back(r);
 }
 
 QueryData genPackageInstallHistory(QueryContext& context) {


### PR DESCRIPTION
When parsing `/Library/Receipts/InstallHistory.plist` not all entries have a PackageIdentifiers. Allow them to remain unset.

This opts to leave them unset, preserving the underlying data, and does not make assumptions about it

Fixes: #6766