### PR TITLE
Change urls for submodules gpg-error, libgcrypt, libcap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,10 +75,10 @@
 	url = https://github.com/aclements/libelfin
 [submodule "libraries/cmake/source/libgcrypt/src"]
 	path = libraries/cmake/source/libgcrypt/src
-	url = https://dev.gnupg.org/source/libgcrypt.git
+	url = https://github.com/osquery/third-party-libgcrypt.git
 [submodule "libraries/cmake/source/libgpg-error/src"]
 	path = libraries/cmake/source/libgpg-error/src
-	url = https://dev.gnupg.org/source/libgpg-error.git
+	url = https://github.com/osquery/third-party-libgpg-error.git
 [submodule "libraries/cmake/source/libcryptsetup/src"]
 	path = libraries/cmake/source/libcryptsetup/src
 	url = https://gitlab.com/cryptsetup/cryptsetup.git
@@ -135,4 +135,4 @@
 	url = https://github.com/libexpat/libexpat
 [submodule "libraries/cmake/source/libcap/src"]
 	path = libraries/cmake/source/libcap/src
-	url = https://git.kernel.org/pub/scm/libs/libcap/libcap.git
+	url = https://kernel.googlesource.com/pub/scm/libs/libcap/libcap.git


### PR DESCRIPTION
The gpg-error and libgcrypt repositories often fail cloning.
We use our mirrored version on Github instead.

libcap repository does not support shallow cloning,
change the url to another official mirror which supports it.
