### PR TITLE
Update cmake_minum_required to 3.17.5 and pin version in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
+cmake_minimum_required(VERSION 3.17.5)
 
 cmake_policy(SET CMP0083 NEW)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
       vmImage: 'Ubuntu-16.04'
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v8
+      image: trailofbits/osquery:ubuntu-18.04-toolchain-v9
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     timeoutInMinutes: 120
@@ -46,17 +46,16 @@ jobs:
         path: $(Build.SourcesDirectory)/.git/modules
       displayName: Submodule cache
 
-    - task: CMake@1
+    - script: |
+        cmake --version
+        cmake -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+              -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain \
+              -DOSQUERY_BUILD_TESTS=ON \
+              -DOSQUERY_BUILD_ROOT_TESTS=ON \
+              $(EXTRA_CMAKE_ARGS) \
+              $(Build.SourcesDirectory)
       displayName: "Configure osquery"
-      inputs:
-        workingDirectory: $(BUILD_DIR)
-        cmakeArgs:
-          -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
-          -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain
-          -DOSQUERY_BUILD_TESTS=ON
-          -DOSQUERY_BUILD_ROOT_TESTS=ON
-          $(EXTRA_CMAKE_ARGS)
-          $(Build.SourcesDirectory)
+      workingDirectory: $(BUILD_DIR)
 
     - script: |
         ./tools/formatting/format-test.sh --build $(BUILD_DIR)
@@ -174,15 +173,18 @@ jobs:
 
     steps:
     - script: |
-        cmake --version
         brew upgrade
         brew install ccache flex bison
         pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
         sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
+        wget https://cmake.org/files/v3.17/cmake-3.17.5-Darwin-x86_64.tar.gz -O /tmp/cmake-3.17.5-Darwin-x86_64.tar.gz
+        tar xf /tmp/cmake-3.17.5-Darwin-x86_64.tar.gz -C $HOME
+        echo "##vso[task.prependpath]$HOME/cmake-3.17.5-Darwin-x86_64/CMake.app/Contents/bin"
       displayName: "Install Homebrew and prerequisites"
       timeoutInMinutes: 20
 
-    - script: mkdir $(Build.BinariesDirectory)/build
+    - script: |
+        mkdir $(Build.BinariesDirectory)/build
       displayName: "Create build folder"
 
     - task: CacheBeta@2
@@ -192,11 +194,15 @@ jobs:
         path: $(Build.SourcesDirectory)/.git/modules
       displayName: Submodule cache
 
-    - task: CMake@1
+    - script: |
+        cmake --version
+        cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
+              -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+              -DOSQUERY_BUILD_TESTS=ON \
+              $(EXTRA_CMAKE_ARGS) \
+              $(Build.SourcesDirectory)
       displayName: "Configure osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DOSQUERY_BUILD_TESTS=ON $(EXTRA_CMAKE_ARGS) $(Build.SourcesDirectory)
+      workingDirectory: $(Build.BinariesDirectory)/build
 
     - task: CacheBeta@2
       inputs:
@@ -205,22 +211,20 @@ jobs:
         path: $(CCACHE_DIR)
       displayName: ccache
 
-    - task: CMake@1
+    - script: |
+        cmake --build . -j 3
       displayName: "Build osquery"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: --build . -j 3
+      workingDirectory: $(Build.BinariesDirectory)/build
 
     - script: |
         ctest --build-nocmake -V
       displayName: "Run tests"
       workingDirectory: $(Build.BinariesDirectory)/build
 
-    - task: CMake@1
+    - script: |
+        cmake --build . --target package -j 3
       displayName: "Run productbuild packaging"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: --build . --target package -j 3
+      workingDirectory: $(Build.BinariesDirectory)/build
 
     - script: |
         cmake -DPACKAGING_SYSTEM=TGZ $(Build.SourcesDirectory)
@@ -294,11 +298,16 @@ jobs:
     - checkout: self
 
     - powershell: |
-        cmake --version
         $python3_path = ((Get-Item C:\hostedtoolcache\windows\Python\3*\$(PYTHON_FOLDER)) | Sort-Object -Descending)[0].FullName
         & $python3_path\python -m pip install --upgrade pip --no-warn-script-location
         & $python3_path\python -m pip install setuptools psutil timeout_decorator thrift==0.11.0 osquery pywin32
       displayName: Install tests prerequisites
+
+    - powershell: |
+        (New-Object System.Net.WebClient).DownloadFile("https://cmake.org/files/v3.17/cmake-3.17.5-win64-x64.zip", "$env:TEMP\cmake-3.17.5-win64-x64.zip")
+        7z x -oC:\ -y "$env:TEMP\cmake-3.17.5-win64-x64.zip"
+        Write-Host "##vso[task.prependpath]C:\cmake-3.17.5-win64-x64\bin"
+      displayName: Install CMake
 
     - powershell: |
         mkdir $(Build.BinariesDirectory)\build
@@ -337,6 +346,7 @@ jobs:
       displayName: "Install Ninja"
 
     - script: |
+        cmake --version
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\$(VC_VARS_FILE)"
         cmake -G Ninja ^
         -DCMAKE_C_COMPILER=cl.exe ^
@@ -364,16 +374,15 @@ jobs:
       displayName: "Build osquery"
       workingDirectory: $(Build.BinariesDirectory)\build
 
-    - powershell: |
+    - script: |
         ctest --build-nocmake -C Release -V
       displayName: "Run tests"
       workingDirectory: $(Build.BinariesDirectory)/build
 
-    - task: CMake@1
+    - script: |
+        cmake --build . --target package --config Release -j 3
       displayName: "Run WIX packaging"
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)/build
-        cmakeArgs: --build . --target package --config Release -j 3
+      workingDirectory: $(Build.BinariesDirectory)/build
 
     - powershell: |
         # .artifactignore has to be copied in the cached folder, otherwise the CacheBeta task won't see it

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -76,3 +76,7 @@ endif()
 if(DEFINED PLATFORM_WINDOWS)
   enable_language(ASM_MASM)
 endif()
+
+if(DEFINED PLATFORM_MACOS)
+  enable_language(OBJCXX)
+endif()

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -8,7 +8,7 @@ The supported compilers are: the osquery toolchain (LLVM/Clang 9.0.1) on Linux, 
 
 ## Prerequisites
 
-Git (>= 2.14.0), CMake (>= 3.14.6), Python 3 are required to build. The rest of the dependencies are downloaded by CMake.
+Git (>= 2.14.0), CMake (>= 3.17.5), Python 3 are required to build. The rest of the dependencies are downloaded by CMake.
 
 The default build type is `RelWithDebInfo` (optimizations active + debug symbols) and can be changed in the CMake configure phase by setting the `CMAKE_BUILD_TYPE` flag to `Release` or `Debug`.
 
@@ -36,8 +36,8 @@ wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquer
 sudo tar xvf osquery-toolchain-1.1.0-x86_64.tar.xz -C /usr/local
 
 # Download and install a newer CMake
-wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
-sudo tar xvf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1
+wget https://cmake.org/files/v3.17/cmake-3.17.5-Linux-x86_64.tar.gz
+sudo tar xvf cmake-3.17.5-Linux-x86_64.tar.gz -C /usr/local --strip 1
 # Verify that `/usr/local/bin` is in the `PATH` and comes before `/usr/bin`
 
 # Download source
@@ -94,7 +94,7 @@ The initial directory is assumed to be `C:\`
 
 Note: It may be easier to install these prerequisites using [Chocolatey](https://chocolatey.org/).
 
-- [CMake](https://cmake.org/) (>= 3.14.6): the MSI installer is recommended. During installation, select the option to add it to the system `PATH` for all users. If there is any older version of CMake installed (e.g., using Chocolatey), uninstall that version first!  Do not install CMake using the Visual Studio Installer, because it contains an older version than required.
+- [CMake](https://cmake.org/) (>= 3.17.5): the MSI installer is recommended. During installation, select the option to add it to the system `PATH` for all users. If there is any older version of CMake installed (e.g., using Chocolatey), uninstall that version first!  Do not install CMake using the Visual Studio Installer, because it contains an older version than required.
 - Visual Studio 2019 (2 options)
   1. [Visual Studio 2019 Build Tools Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16) (without Visual Studio): In the installer choose the "C++ build tools" workload, then on the right, under "Optional", select "MSVC v142 - VS 2019 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".
   2. [Visual Studio 2019 Community Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16): In the installer choose the "Desktop development with C++" workload, then on the right, under "Optional", select "MSVC v142 - VS 2019 C++", "Windows 10 SDK", and "C++ Clang tools for Windows".

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -5,8 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.13.3)
-
 function(librariesMain)
   if("${OSQUERY_THIRD_PARTY_SOURCE}" STREQUAL "")
     message(STATUS "Disabling local third-party sources. Using system libraries")

--- a/libraries/cmake/formula/modules/Findopenssl.cmake
+++ b/libraries/cmake/formula/modules/Findopenssl.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importFormula("openssl")

--- a/libraries/cmake/formula/modules/utils.cmake
+++ b/libraries/cmake/formula/modules/utils.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include(ExternalProject)
 
 set(OSQUERY_FORMULA_INSTALL_DIRECTORY "${CMAKE_BINARY_DIR}/installed_formulas")

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14.6)
 project(thirdparty_openssl)
 
 set(OPENSSL_VERSION "1.1.1g")

--- a/libraries/cmake/source/modules/Findaugeas.cmake
+++ b/libraries/cmake/source/modules/Findaugeas.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findaws-sdk-cpp.cmake
+++ b/libraries/cmake/source/modules/Findaws-sdk-cpp.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findberkeley-db.cmake
+++ b/libraries/cmake/source/modules/Findberkeley-db.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findboost.cmake
+++ b/libraries/cmake/source/modules/Findboost.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findbzip2.cmake
+++ b/libraries/cmake/source/modules/Findbzip2.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Finddbus.cmake
+++ b/libraries/cmake/source/modules/Finddbus.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findebpfpub.cmake
+++ b/libraries/cmake/source/modules/Findebpfpub.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 # The osquery-toolchain v1.0 shipped with a broken LLVM installation, so

--- a/libraries/cmake/source/modules/Findexpat.cmake
+++ b/libraries/cmake/source/modules/Findexpat.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findgflags.cmake
+++ b/libraries/cmake/source/modules/Findgflags.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findglog.cmake
+++ b/libraries/cmake/source/modules/Findglog.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findgoogletest.cmake
+++ b/libraries/cmake/source/modules/Findgoogletest.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findicu.cmake
+++ b/libraries/cmake/source/modules/Findicu.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibarchive.cmake
+++ b/libraries/cmake/source/modules/Findlibarchive.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibaudit.cmake
+++ b/libraries/cmake/source/modules/Findlibaudit.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibcap.cmake
+++ b/libraries/cmake/source/modules/Findlibcap.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibcryptsetup.cmake
+++ b/libraries/cmake/source/modules/Findlibcryptsetup.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibdevmapper.cmake
+++ b/libraries/cmake/source/modules/Findlibdevmapper.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibdpkg.cmake
+++ b/libraries/cmake/source/modules/Findlibdpkg.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibelfin.cmake
+++ b/libraries/cmake/source/modules/Findlibelfin.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibgcrypt.cmake
+++ b/libraries/cmake/source/modules/Findlibgcrypt.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibgpg-error.cmake
+++ b/libraries/cmake/source/modules/Findlibgpg-error.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibiptables.cmake
+++ b/libraries/cmake/source/modules/Findlibiptables.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibmagic.cmake
+++ b/libraries/cmake/source/modules/Findlibmagic.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibrdkafka.cmake
+++ b/libraries/cmake/source/modules/Findlibrdkafka.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibrpm.cmake
+++ b/libraries/cmake/source/modules/Findlibrpm.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibudev.cmake
+++ b/libraries/cmake/source/modules/Findlibudev.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlibxml2.cmake
+++ b/libraries/cmake/source/modules/Findlibxml2.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlinenoise-ng.cmake
+++ b/libraries/cmake/source/modules/Findlinenoise-ng.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlldpd.cmake
+++ b/libraries/cmake/source/modules/Findlldpd.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findlzma.cmake
+++ b/libraries/cmake/source/modules/Findlzma.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findpopt.cmake
+++ b/libraries/cmake/source/modules/Findpopt.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findrapidjson.cmake
+++ b/libraries/cmake/source/modules/Findrapidjson.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findrocksdb.cmake
+++ b/libraries/cmake/source/modules/Findrocksdb.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findsleuthkit.cmake
+++ b/libraries/cmake/source/modules/Findsleuthkit.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findsmartmontools.cmake
+++ b/libraries/cmake/source/modules/Findsmartmontools.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findsqlite.cmake
+++ b/libraries/cmake/source/modules/Findsqlite.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findssdeep-cpp.cmake
+++ b/libraries/cmake/source/modules/Findssdeep-cpp.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findthrift.cmake
+++ b/libraries/cmake/source/modules/Findthrift.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findutil-linux.cmake
+++ b/libraries/cmake/source/modules/Findutil-linux.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findyara.cmake
+++ b/libraries/cmake/source/modules/Findyara.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findzlib.cmake
+++ b/libraries/cmake/source/modules/Findzlib.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/Findzstd.cmake
+++ b/libraries/cmake/source/modules/Findzstd.cmake
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
 include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
 
 importSourceSubmodule(

--- a/libraries/cmake/source/modules/utils.cmake
+++ b/libraries/cmake/source/modules/utils.cmake
@@ -5,8 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.14.6)
-
 option(OSQUERY_THIRD_PARTY_SOURCE_MODULE_WARNINGS "This option can be enable to show all warnings in the source modules. Not recommended" OFF)
 
 function(initializeGitSubmodule submodule_path no_recursive shallow)

--- a/tests/cppcheck/CMakeLists.txt
+++ b/tests/cppcheck/CMakeLists.txt
@@ -5,8 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.13.3)
-
 include(ProcessorCount)
 
 function(cppcheckMain)

--- a/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
+++ b/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
@@ -28,8 +28,8 @@ RUN apt update -q -y && apt upgrade -q -y && apt install -q -y --no-install-reco
 && dpkg -i linux-base_1.0_all.deb linux-firmware_1.0_all.deb linux-generic_1.0_all.deb \
 && apt clean && rm -rf /var/lib/apt/lists/* \
 && sudo pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3 docker
-RUN cd ~ && wget https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz \
-&& sudo tar xvf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1 && rm cmake-3.14.6-Linux-x86_64.tar.gz \
+RUN cd ~ && wget https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.tar.gz \
+&& sudo tar xvf cmake-3.17.5-Linux-x86_64.tar.gz -C /usr/local --strip 1 && rm cmake-3.17.5-Linux-x86_64.tar.gz \
 && wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz \
 && sudo tar xvf osquery-toolchain-1.1.0-x86_64.tar.xz -C /usr/local && rm osquery-toolchain-1.1.0-x86_64.tar.xz
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Enable the objective-c++ language
which is now explicitly supported.

Update third-party-sqlite to tag 3.31.1-2,
which has the updated CMake.

Update the dockerfile and Docker image to v9.

Update the building docs.
