### PR TITLE
Remove boost workaround introduced in #5591 for string_view

### DIFF
--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -20,11 +20,6 @@
 #define OPENSSL_NO_MD5 1
 #define OPENSSL_NO_DEPRECATED 1
 
-// TODO(5591) Remove this when addressed by Boost's ASIO config.
-// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
-// Standard library support for std::string_view.
-#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
-
 #ifdef WIN32
 // For std:call_once, used below
 #include <mutex>

--- a/osquery/sql/sqlite_hashing.cpp
+++ b/osquery/sql/sqlite_hashing.cpp
@@ -15,11 +15,6 @@
 #include <osquery/hashing/hashing.h>
 #include <osquery/logger/logger.h>
 
-// TODO(5591) Remove this when addressed by Boost's ASIO config.
-// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
-// Standard library support for std::string_view.
-#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
-
 #include <boost/asio/ip/address.hpp>
 #include <boost/endian/buffers.hpp>
 #include <sqlite3.h>

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -16,12 +16,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/json_parser.hpp>
-
-// TODO(5591) Remove this when addressed by Boost's ASIO config.
-// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
-// Standard library support for std::string_view.
-#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
-
 #include <boost/asio.hpp>
 #include <boost/foreach.hpp>
 

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -18,12 +18,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/algorithm/string.hpp>
-
-// TODO(5591) Remove this when addressed by Boost's ASIO config.
-// https://www.boost.org/doc/libs/1_67_0/boost/asio/detail/config.hpp
-// Standard library support for std::string_view.
-#define BOOST_ASIO_DISABLE_STD_STRING_VIEW 1
-
 #include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/io/detail/quoted_manip.hpp>


### PR DESCRIPTION
All the platforms now build correctly,
even with boost 1.70.
