### PR TITLE
CI: Make the built packages available to be downloaded

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,20 +100,30 @@ jobs:
     - script: |
         cmake -DPACKAGING_SYSTEM=DEB $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
+        cp *.deb $(Build.ArtifactStagingDirectory)
+        cp *.ddeb $(Build.ArtifactStagingDirectory)
       displayName: "Run DEB packaging"
       workingDirectory: $(BUILD_DIR)
 
     - script: |
         cmake -DPACKAGING_SYSTEM=RPM $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
+        cp *.rpm $(Build.ArtifactStagingDirectory)
       displayName: "Run RPM packaging"
       workingDirectory: $(BUILD_DIR)
 
     - script: |
         cmake -DPACKAGING_SYSTEM=TGZ $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
+        cp *.tar.gz $(Build.ArtifactStagingDirectory)
       displayName: "Run TGZ packaging"
       workingDirectory: $(BUILD_DIR)
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: "$(Build.ArtifactStagingDirectory)"
+        artifactName: "Linux $(BUILD_TYPE) Packages"
+      displayName: Publish Linux packages
 
     - script: |
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
@@ -223,14 +233,22 @@ jobs:
 
     - script: |
         cmake --build . --target package -j 3
+        cp *.pkg $(Build.ArtifactStagingDirectory)
       displayName: "Run productbuild packaging"
       workingDirectory: $(Build.BinariesDirectory)/build
 
     - script: |
         cmake -DPACKAGING_SYSTEM=TGZ $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
+        cp *.tar.gz $(Build.ArtifactStagingDirectory)
       displayName: "Run TGZ packaging"
       workingDirectory: $(Build.BinariesDirectory)/build
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: "$(Build.ArtifactStagingDirectory)"
+        artifactName: "macOS $(BUILD_TYPE) Packages"
+      displayName: Publish macOS packages
 
     - script: |
         echo "##vso[task.setvariable variable=Status;isOutput=true]1"
@@ -381,8 +399,15 @@ jobs:
 
     - script: |
         cmake --build . --target package --config Release -j 3
+        cp *.msi $(Build.ArtifactStagingDirectory)
       displayName: "Run WIX packaging"
       workingDirectory: $(Build.BinariesDirectory)/build
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: "$(Build.ArtifactStagingDirectory)"
+        artifactName: "Windows-$(System.JobName) Packages"
+      displayName: Publish Windows packages
 
     - powershell: |
         # .artifactignore has to be copied in the cached folder, otherwise the CacheBeta task won't see it

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -18,6 +18,7 @@ set(windows_supported_packaging_system
 
 set(macos_supported_packaging_system
   productbuild
+  TGZ
   # Bundle
 )
 


### PR DESCRIPTION
Also add TGZ as a supported package format on macOS,
since it's already used on the CI.

NOTE, to download them:
1. You need to open the CI page which points to a specific build; you can reach that for instance from a PR build results in the `Checks` tab or on the bottom of the `Conversation` tab where all the checks results are shown.
2. You want to follow the `Details` link of the `osquery` check, then `View more details on Azure Pipelines`.
3. On the Azure Pipelines website, you should see the summary of the PR CI build, with all the platforms. On the top right you want to find the following area:
![image](https://user-images.githubusercontent.com/148902/100476438-db4f8d80-30e5-11eb-82f2-11b336c8065d.png)
Instead of a `0 artifacts` there's should be written something like `6 published`, click on it.
4. A list of packages grouped by platform and build type should be shown now. You can download all the packages for a specific platform build type, or you can expand the platform build and select which package you want to download.

These are not meant to be used in production, but could be useful to test some features or debug issues that the CI build highlights.
The artifacts will remain available as long as the build run is available on the CI, which is 30 days.
