### PR TITLE
Add indexed column support to Windows users table

### DIFF
--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -161,7 +161,7 @@ void processRoamingProfiles(const std::set<std::string>& selectedUids,
 void processLocalAccounts(const std::set<std::string>& selectedUids,
                           std::set<std::string>& processedSids,
                           QueryData& results) {
-  unsigned long dwUserInfoLevel = 1; // retrieve username with NetUserEnum()
+  unsigned long dwUserInfoLevel = 0; // retrieve username with NetUserEnum()
   unsigned long dwDetailedUserInfoLevel = 4; // get SID with NetUserGetInfo()
   unsigned long dwNumUsersRead = 0;
   unsigned long dwTotalUsers = 0;
@@ -180,11 +180,11 @@ void processLocalAccounts(const std::set<std::string>& selectedUids,
 
     if ((ret == NERR_Success || ret == ERROR_MORE_DATA) &&
         userBuffer != nullptr) {
-      auto iterBuff = LPUSER_INFO_1(userBuffer);
+      auto iterBuff = LPUSER_INFO_0(userBuffer);
       for (size_t i = 0; i < dwNumUsersRead; i++) {
         LPBYTE userLvl4Buff = nullptr;
         ret = NetUserGetInfo(nullptr,
-                             iterBuff->usri1_name,
+                             iterBuff->usri0_name,
                              dwDetailedUserInfoLevel,
                              &userLvl4Buff);
 
@@ -193,7 +193,7 @@ void processLocalAccounts(const std::set<std::string>& selectedUids,
             NetApiBufferFree(userLvl4Buff);
           }
           VLOG(1) << "Failed to get SID for "
-                  << wstringToString(iterBuff->usri1_name)
+                  << wstringToString(iterBuff->usri0_name)
                   << " with error code " << ret;
           iterBuff++;
           continue;
@@ -209,7 +209,7 @@ void processLocalAccounts(const std::set<std::string>& selectedUids,
         if (sidMatchesAnyDesiredUids(selectedUids, sidString)) {
           Row r;
           r["uuid"] = sidString;
-          r["username"] = wstringToString(iterBuff->usri1_name);
+          r["username"] = wstringToString(iterBuff->usri0_name);
           r["uid"] = BIGINT(uid);
           r["gid"] = BIGINT(gid);
           r["uid_signed"] = INTEGER(uid);

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -54,6 +54,13 @@ const std::set<std::string> kWellKnownSids = {
 
 namespace tables {
 
+std::string getUserShell(const std::string& sid) {
+  // TODO: This column exists for cross-platform consistency, but
+  // the answer on Windows is arbitrary. %COMSPEC% env variable may
+  // be the best answer. Currently, hard-coded.
+  return "C:\\Windows\\system32\\cmd.exe";
+}
+
 std::string getUserHomeDir(const std::string& sid) {
   QueryData res;
   queryKey(kRegProfilePath + kRegSep + sid, res);
@@ -71,7 +78,8 @@ void genUser(const std::string& sidString, QueryData& results) {
 
   r["uuid"] = sidString;
   r["directory"] = getUserHomeDir(sidString);
-
+  r["shell"] = getUserShell(sidString);
+  
   PSID sid;
   auto ret = ConvertStringSidToSidA(sidString.c_str(), &sid);
   if (ret == 0) {
@@ -87,8 +95,6 @@ void genUser(const std::string& sidString, QueryData& results) {
                   ? "roaming"
                   : "special";
 
-  // TODO
-  r["shell"] = "C:\\Windows\\system32\\cmd.exe";
   r["description"] = "";
 
   wchar_t accntName[UNLEN] = {0};
@@ -184,7 +190,7 @@ void processLocalAccounts(std::set<std::string>& processedSids,
         r["description"] =
             wstringToString(LPUSER_INFO_4(userLvl4Buff)->usri4_comment);
         r["directory"] = getUserHomeDir(sidString);
-        r["shell"] = "C:\\Windows\\System32\\cmd.exe";
+        r["shell"] = getUserShell(sidString);
         r["type"] = "local";
         if (userLvl4Buff != nullptr) {
           NetApiBufferFree(userLvl4Buff);

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -125,9 +125,9 @@ void genUser(const std::string& sidString, QueryData& results) {
     ret = LookupAccountSidW(
         nullptr, sid, accntName, &accntNameLen, domName, &domNameLen, &eUse);
     r["username"] = ret != 0 ? wstringToString(accntName) : "";
-  }
 
-  results.push_back(r);
+    results.push_back(r);
+  }
 }
 
 // Enumerate the users from the profiles key in the Registry, matching only

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -75,13 +75,14 @@ std::string getUserHomeDir(const std::string& sid) {
 
 // If given a list of UIDs to constrain the results, check if a particular SID
 // has a RID that matches any of those UIDs.
-bool sidMatchesAnyDesiredUids(const std::set<std::string>& uidStrings, const std::string& sidString) {
+bool sidMatchesAnyDesiredUids(const std::set<std::string>& uidStrings,
+                              const std::string& sidString) {
   // If there is no constraint of UIDs given, results will not be filtered
   if (uidStrings.empty()) {
     return true;
   }
 
-  auto toks =  osquery::split(sidString, "-");
+  auto toks = osquery::split(sidString, "-");
   auto uid = toks.at(toks.size() - 1);
   for (auto desiredUid : uidStrings) {
     if (uid.compare(desiredUid) == 0) {
@@ -103,7 +104,7 @@ void genUser(const std::string& sidString, QueryData& results) {
                   ? "roaming"
                   : "special";
   r["description"] = "";
-  
+
   PSID sid;
   auto ret = ConvertStringSidToSidA(sidString.c_str(), &sid);
   if (ret == 0) {
@@ -125,12 +126,12 @@ void genUser(const std::string& sidString, QueryData& results) {
         nullptr, sid, accntName, &accntNameLen, domName, &domNameLen, &eUse);
     r["username"] = ret != 0 ? wstringToString(accntName) : "";
   }
-  
+
   results.push_back(r);
 }
 
 // Enumerate the users from the profiles key in the Registry, matching only
-// the UIDs/RIDs (if any) and skipping any SIDs of local-only users that 
+// the UIDs/RIDs (if any) and skipping any SIDs of local-only users that
 // were already processed in the earlier API-based enumeration.
 void processRoamingProfiles(const std::set<std::string>& selectedUids,
                             const std::set<std::string>& processedSids,
@@ -145,7 +146,7 @@ void processRoamingProfiles(const std::set<std::string>& selectedUids,
     }
 
     auto sidString = profile.at("name");
-    
+
     if (sidMatchesAnyDesiredUids(selectedUids, sidString)) {
       // Skip this user if already processed
       if (processedSids.find(sidString) == processedSids.end()) {
@@ -222,12 +223,12 @@ void processLocalAccounts(const std::set<std::string>& selectedUids,
 
           results.push_back(r);
         }
-        
+
         // Free the buffer allocated by NetUserGetInfo()
         if (userLvl4Buff != nullptr) {
           NetApiBufferFree(userLvl4Buff);
         }
-        iterBuff++;  //index to the next record returned by NetUserEnum()
+        iterBuff++; // index to the next record returned by NetUserEnum()
       }
     } else {
       // If there are no local users something may be amiss.
@@ -247,7 +248,7 @@ QueryData genUsers(QueryContext& context) {
   std::set<std::string> processedSids;
   std::set<std::string> selectedUids;
 
-  // implement index on UUID (SID on Windows) column by returning only the 
+  // implement index on UUID (SID on Windows) column by returning only the
   // users in the constraint, bypassing the enumeration step entirely:
   if (context.constraints["uuid"].exists(EQUALS)) {
     auto sidStrings = context.constraints["uuid"].getAll(EQUALS);

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -109,6 +109,7 @@ void genUser(const std::string& sidString, QueryData& results) {
   auto ret = ConvertStringSidToSidA(sidString.c_str(), &sid);
   if (ret == 0) {
     VLOG(1) << "Converting SIDstring to SID failed with " << GetLastError();
+    return;
   } else {
     auto uid = getUidFromSid(sid);
     auto gid = getGidFromSid(sid);
@@ -162,8 +163,10 @@ void processRoamingProfiles(const std::set<std::string>& selectedUids,
 void processLocalAccounts(const std::set<std::string>& selectedUids,
                           std::set<std::string>& processedSids,
                           QueryData& results) {
-  unsigned long dwUserInfoLevel = 0; // retrieve username with NetUserEnum()
-  unsigned long dwDetailedUserInfoLevel = 4; // get SID with NetUserGetInfo()
+  // Enumerate the users by only the usernames (level 0 struct) and then
+  // get the desired level of info for each (level 4 struct includes SIDs).
+  unsigned long dwUserInfoLevel = 0;
+  unsigned long dwDetailedUserInfoLevel = 4;
   unsigned long dwNumUsersRead = 0;
   unsigned long dwTotalUsers = 0;
   unsigned long resumeHandle = 0;

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -134,7 +134,8 @@ void processRoamingProfiles(const std::set<std::string>& processedSids,
 // Enumerate all local users
 void processLocalAccounts(std::set<std::string>& processedSids,
                           QueryData& results) {
-  unsigned long dwUserInfoLevel = 3;
+  unsigned long dwUserInfoLevel = 3; // 3 is valid for NetUserEnum(); 4 is not
+  unsigned long dwDetailedUserInfoLevel = 4; // level 4 returns the SID value
   unsigned long dwNumUsersRead = 0;
   unsigned long dwTotalUsers = 0;
   unsigned long resumeHandle = 0;
@@ -154,8 +155,6 @@ void processLocalAccounts(std::set<std::string>& processedSids,
         userBuffer != nullptr) {
       auto iterBuff = LPUSER_INFO_3(userBuffer);
       for (size_t i = 0; i < dwNumUsersRead; i++) {
-        // User level 4 contains the SID value
-        unsigned long dwDetailedUserInfoLevel = 4;
         LPBYTE userLvl4Buff = nullptr;
         ret = NetUserGetInfo(nullptr,
                              iterBuff->usri3_name,

--- a/specs/users.table
+++ b/specs/users.table
@@ -9,7 +9,7 @@ schema([
     Column("description", TEXT, "Optional user description"),
     Column("directory", TEXT, "User's home directory"),
     Column("shell", TEXT, "User's configured default shell"),
-    Column("uuid", TEXT, "User's UUID (Apple) or SID (Windows)"),
+    Column("uuid", TEXT, "User's UUID (Apple) or SID (Windows)", index=True),
 ])
 extended_schema(WINDOWS, [
     Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),


### PR DESCRIPTION
Fixes #6411 by advertising and implementing an index on the `uuid` column of the `users` table on Windows, allowing for `JOIN` operations with linear performance instead of exponential.

Although `uid` is the indexed column on POSIX systems, I went with the `uuid` column since it holds SIDs, the preferred (?) unique identifier for Windows users.

- [x] Should the `uid` column also implement an index?

The following output shows that the table only generates the required rows in a `JOIN`, rather than all of them.

```
PS C:\Projects\osquery\build> .\osquery\RelWithDebInfo\osqueryi.exe --verbose --planner
I1130 21:31:01.193373  3708 init.cpp:340] osquery initialized [version=4.5.1-50-gc75fd9e3]
I1130 21:31:01.196367  3708 extensions.cpp:453] Could not autoload extensions: Cannot open file for reading: \Program Files\osquery\extensions.load
I1130 21:31:01.211212  3708 dispatcher.cpp:78] Adding new service: ExtensionWatcher (0000029B5A9DB620) to thread: 9032 (0000029B5AA4DE80) in process 9584
I1130 21:31:01.211212  3708 dispatcher.cpp:78] Adding new service: ExtensionRunnerCore (0000029B5A9DB760) to thread: 1340 (0000029B5AA4EB20) in process 9584
I1130 21:31:01.212294  3708 auto_constructed_tables.cpp:97] Removing stale ATC entries
I1130 21:31:01.212294  3708 init.cpp:589] Error reading config: config file does not exist: \Program Files\osquery\osquery.conf
I1130 21:31:01.255307  1340 interface.cpp:270] Extension manager service starting: \\.\pipe\shell.em
Using a [1mvirtual database[0m. Need help, type '.help'
osquery> select registry.name, users.username
    ...> from registry
    ...> left join users
    ...> ON registry.name=users.uuid
    ...> where registry.path like 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\%'
    ...> AND registry.name like 'S-%';
osquery planner: xBestIndex Evaluating constraints for table: registry [index=0 column=2 term=4 usable=1]
osquery planner: xBestIndex Evaluating constraints for table: registry [index=1 column=2 term=5 usable=1]
osquery planner: xBestIndex Evaluating constraints for table: registry [index=2 column=2 term=6 usable=1]
osquery planner: xBestIndex Evaluating constraints for table: registry [index=3 column=1 term=7 usable=1]
osquery planner: xBestIndex Evaluating constraints for table: registry [index=4 column=1 term=8 usable=1]
osquery planner: xBestIndex Evaluating constraints for table: registry [index=5 column=1 term=9 usable=1]
osquery planner: xBestIndex Adding index constraint for table: registry [column=path arg_index=1 op=65]
osquery planner: xBestIndex Recording constraint set for table: registry [cost=1.000000 size=1 idx=0]
osquery planner: xBestIndex Evaluating constraints for table: users [index=0 column=8 term=3 usable=1]
osquery planner: xBestIndex Adding index constraint for table: users [column=uuid arg_index=1 op=2]
osquery planner: xBestIndex Recording constraint set for table: users [cost=1.000000 size=1 idx=1]
osquery planner: xOpen Opening cursor (0) for table: registry
osquery planner: xOpen Opening cursor (1) for table: users
osquery planner: xFilter Filtering called for table: registry [constraint_count=1 argc=1 idx=0]
osquery planner: xFilter Adding constraint to cursor (0): path LIKE HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\%
osquery planner: Scanning rows for cursor (0)
osquery planner: xFilter registry generate returned row count:8
osquery planner: xFilter Filtering called for table: users [constraint_count=1 argc=1 idx=1]
osquery planner: xFilter Adding constraint to cursor (1): uuid = S-1-5-18
osquery planner: Scanning rows for cursor (1)
osquery planner: xFilter users generate returned row count:1
osquery planner: xFilter Filtering called for table: users [constraint_count=1 argc=1 idx=1]
osquery planner: xFilter Adding constraint to cursor (1): uuid = S-1-5-19
osquery planner: Scanning rows for cursor (1)
osquery planner: xFilter users generate returned row count:1
osquery planner: xFilter Filtering called for table: users [constraint_count=1 argc=1 idx=1]
osquery planner: xFilter Adding constraint to cursor (1): uuid = S-1-5-20
osquery planner: Scanning rows for cursor (1)
osquery planner: xFilter users generate returned row count:1
osquery planner: xFilter Filtering called for table: users [constraint_count=1 argc=1 idx=1]
osquery planner: xFilter Adding constraint to cursor (1): uuid = S-1-5-21-1834681238-529199191-1868829719-1002
osquery planner: Scanning rows for cursor (1)
osquery planner: xFilter users generate returned row count:1
osquery planner: Closing cursor (0)
osquery planner: Closing cursor (1)
+-----------------------------------------------+-----------------+
| name                                          | username        |
+-----------------------------------------------+-----------------+
| S-1-5-18                                      | SYSTEM          |
| S-1-5-19                                      | LOCAL SERVICE   |
| S-1-5-20                                      | NETWORK SERVICE |
| S-1-5-21-1834681238-529199191-1868829719-1002 |                 |
+-----------------------------------------------+-----------------+
```