### PR TITLE
CI: Update brew scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ jobs:
 
     steps:
     - script: |
+        brew update
         brew upgrade
         brew install ccache flex bison
         sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer


### PR DESCRIPTION
Small change: runs `brew update` before `brew upgrade`. This fixes things, even though `upgrade` is expected to run `update` automatically it apparently doesn't.