### PR TITLE
CMake: add max version limit to 3.18.0 on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-cmake_minimum_required(VERSION 3.17.5)
+cmake_minimum_required(VERSION 3.17.5 FATAL_ERROR)
 
 cmake_policy(SET CMP0083 NEW)
 
@@ -25,6 +25,20 @@ include(cmake/globals.cmake)
 include(cmake/options.cmake)
 include(cmake/flags.cmake)
 include(cmake/packaging.cmake)
+
+if(DEFINED PLATFORM_LINUX AND "${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.18.0")
+  if(OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK)
+    message(WARNING
+      "CPack contained in CMake version 3.18 and newer generates RPM packages that won't install correctly on some distributions. " 
+      "You are using version ${CMAKE_VERSION} which has the bug, remember to use version 3.17.5 if a RPM package has to be generated.")
+  else()
+    message(FATAL_ERROR
+      "CPack contained in CMake version 3.18 and newer generates RPM packages that won't install correctly on some distributions. "
+      "You are using version ${CMAKE_VERSION} which has the bug, please use version 3.17.5 or set OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK=TRUE "
+      "if you're not going to generate a RPM package."
+    )
+  endif()
+endif()
 
 if(OSQUERY_TOOLCHAIN_SYSROOT AND NOT DEFINED PLATFORM_LINUX)
   message(FATAL_ERROR "The custom toolchain can only be used with Linux, undefine OSQUERY_TOOLCHAIN_SYSROOT and specify a compiler to use")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -79,6 +79,9 @@ set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,
 
 option(OSQUERY_BUILD_BPF "Whether to enable and build BPF support" true)
 
+# This is a temporary option to ignore the version check if there's no intention to generate RPM packages
+option(OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK "Ignore the maximum cmake version check introduced due to CPack generating incorrect RPM packages")
+
 # Unfortunately, due glog always enabling BUILD_TESTING, we have to force it off, so that tests won't be built
 overwrite_cache_variable("BUILD_TESTING" "BOOL" "OFF")
 


### PR DESCRIPTION
Due to a bug present in CPack provided with CMake
version 3.18.0 and higher on RPM packages generation,
add a check which fails the configuration
if a version with the bug is found.
Provide a way to ignore the check by setting
OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK=TRUE.

This should prevent issue #6755 until a solution has been found on upstream.

NOTE: This shouldn't be merged immediately. When and if we are ok with the PR, we need to do one on the oss-fuzz project first, so that it doesn't fail configuring.
