### PR TITLE
Document retrieval of available tables/columns via SQL

### DIFF
--- a/docs/wiki/deployment/extensions.md
+++ b/docs/wiki/deployment/extensions.md
@@ -70,6 +70,27 @@ $ cat /etc/osquery/osquery.flags
 --logger_plugin=scribe
 ```
 
+## Retrieving Tables and Columns with SQL
+
+Aside from the `.tables` and `.schema` shell builtins, there is an alternative way to retrieve all available tables and columns: using SQL.
+ 
+To retrieve all tables:
+
+```sqlite
+SELECT * FROM osquery_registry
+    WHERE active = true
+    AND internal = false
+    AND registry = 'table';
+```
+
+To retrieve all columns for a given table:
+
+```sqlite
+PRAGMA TABLE_INFO("table-name");
+```
+
+Note: [`PRAGMA`](https://www.sqlite.org/pragma.html) is unavailable in v4.6.0, but was added back in later versions.
+
 ## Troubleshooting
 
 - Ensure that your osquery config has `--disable_extensions=false`, which ought to be the default value.


### PR DESCRIPTION
The `.tables` and `.schema` shell builtins are useful, but in my use-case I need to retrieve the same data via SQL over the Thrift API.