### PR TITLE
macOS: Fix OpenDirectory attribute mismatch

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -37,9 +37,16 @@ void genODEntries(ODRecordType record_type,
     return;
   }
 
+  NSString* attribute = nullptr;
+  if ([record_type isEqualToString:(kODRecordTypeGroups)]) {
+    attribute = kODAttributeTypePrimaryGroupID;
+  } else {
+    attribute = kODAttributeTypeUniqueID;
+  }
+
   ODQuery* query = [ODQuery queryWithNode:root
                            forRecordTypes:record_type
-                                attribute:kODAttributeTypeUniqueID
+                                attribute:attribute
                                 matchType:kODMatchEqualTo
                               queryValues:record
                          returnAttributes:kODAttributeTypeAllTypes


### PR DESCRIPTION
Fixes #6320

Tested on macOS 10.14, 10.15 and 11.0.