### PR TITLE
CI: Remove incorrect 2to3 symlink breaking Python brew upgrade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,6 +183,7 @@ jobs:
 
     steps:
     - script: |
+        rm -f /usr/local/bin/2to3
         brew update
         brew upgrade
         brew install ccache flex bison


### PR DESCRIPTION
Even if the macOS image have Python homebrew already installed,
there's the symlink /usr/local/bin/2to3 which points to the
system installed Python.
Normally that file is placed by homebrew Python,
but since it's not, upgrading the homebrew Python version
makes it soft fail because it cannot overwrite such symlink.
Later the CMake step fails to detect the correct Python version on the
system and the CI fails.

Since we are not interested in the Python 2 to 3 conversion,
delete the link and let homebrew place its own.
