### PR TITLE
Force osquery to use the modern macOS version scheme

### DIFF
--- a/osquery/tables/system/darwin/os_version.cpp
+++ b/osquery/tables/system/darwin/os_version.cpp
@@ -16,6 +16,7 @@
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
 #include <osquery/utils/conversions/split.h>
+#include <osquery/utils/system/env.h>
 
 namespace osquery {
 namespace tables {
@@ -37,6 +38,9 @@ QueryData genOSVersion(QueryContext& context) {
   }
 
   // The version path plist is parsed by the OS X tool: sw_vers.
+  // We set a special ENV to ensure despite the fact Osquery is built against
+  // an pre Big Sur SDK, we want the modern numbering scheme for macOS.
+  setEnvVar("SYSTEM_VERSION_COMPAT", "1");
   auto sw_vers = SQL::selectAllFrom("plist", "path", EQUALS, kVersionPath);
   if (sw_vers.empty()) {
     return {r};


### PR DESCRIPTION
### Before This PR (on macOS Big Sur)

```
☁  osquery [jem_fix_os_versioning_big_sur] echo "select * from os_version;" | osqueryi
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| name     | version | major | minor | patch | build | platform | platform_like | codename | arch   |
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| Mac OS X | 10.16   | 10    | 16    | 0     | 20C69 | darwin   | darwin        |          | x86_64 |
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
```

### After This PR 

```
☁  osquery [jem_fix_os_versioning_big_sur] echo "select * from os_version;" | ~/code/facebook/osquery/build/osquery/osqueryi
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| name  | version | major | minor | patch | build | platform | platform_like | codename | arch   |
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| macOS | 11.1    | 11    | 1     | 0     | 20C69 | darwin   | darwin        |          | x86_64 |
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
```

### How?

For compatibility reasons macOS will actually return the contents of a different PLIST containing the deprecated macOS version (10.16) on Big Sur if your app is not built on the 11.0 SDK or doesn't pass a special ENV flag. Since using the modern SDK is not possible, we set the magic ENV var instead.

See https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/

### Why?

Using the correct macOS version is important because their compatibility version scheme actually hides the fact that I am on a new minor version of the OS. Notice in my example above I am actually on 11.1 but osquery still reports me on 10.16.0 since it really doesn't care about accurately converting the minor portion of the version in the new scheme into a patch portion in the compatibility scheme. 