### PR TITLE
Add new table location_services for darwin

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -170,6 +170,7 @@ function(setupBuildFlags)
         "-framework Foundation"
         "-framework CoreServices"
         "-framework CoreFoundation"
+        "-framework CoreLocation"
         "-framework CoreWLAN"
         "-framework CoreGraphics"
         "-framework DiskArbitration"

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -124,6 +124,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/keychain_items.cpp
       darwin/keychain_utils.cpp
       darwin/launchd.cpp
+      darwin/location_services.mm
       darwin/managed_policies.cpp
       darwin/mdfind.mm
       darwin/mdls.mm

--- a/osquery/tables/system/darwin/location_services.mm
+++ b/osquery/tables/system/darwin/location_services.mm
@@ -13,8 +13,6 @@
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
 
-namespace fs = boost::filesystem;
-
 namespace osquery {
 namespace tables {
 
@@ -25,9 +23,8 @@ QueryData genLocationServices(QueryContext& context) {
   @try {
     locationServicesEnabled = [CLLocationManager locationServicesEnabled];
   } @catch (NSException* exception) {
-    LOG(ERROR)
-        << "[CLLocationManager locationServicesEnabled]: threw exception "
-        << exception.name;
+    LOG(ERROR) << "CoreLocation API locationServicesEnabled threw exception: "
+               << exception.name;
     return {r};
   }
 

--- a/osquery/tables/system/darwin/location_services.mm
+++ b/osquery/tables/system/darwin/location_services.mm
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#import <CoreLocation/CoreLocation.h>
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+QueryData genLocationServices(QueryContext& context) {
+  Row r;
+  BOOL locationServicesEnabled;
+
+  @try {
+    locationServicesEnabled = [CLLocationManager locationServicesEnabled];
+  } @catch (NSException* exception) {
+    LOG(ERROR)
+        << "[CLLocationManager locationServicesEnabled]: threw exception "
+        << exception.name;
+    return {r};
+  }
+
+  r["enabled"] = INTEGER(locationServicesEnabled ? 1 : 0);
+  return {r};
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -112,6 +112,7 @@ function(generateNativeTables)
     "darwin/keychain_items.table:macos"
     "darwin/launchd.table:macos"
     "darwin/launchd_overrides.table:macos"
+    "darwin/location_services.table:macos"
     "darwin/managed_policies.table:macos"
     "darwin/mdfind.table:macos"
     "darwin/mdls.table:macos"

--- a/specs/darwin/location_services.table
+++ b/specs/darwin/location_services.table
@@ -1,0 +1,6 @@
+table_name("location_services")
+description("Reports the status of the Location Services feature of the OS.")
+schema([
+    Column("enabled", INTEGER, "1 if Location Services are enabled, else 0"),
+])
+implementation("location_services@genLocationServices")

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -47,7 +47,6 @@ function(generateTestsIntegrationTablesTestsTest)
     interface_addresses.cpp
     interface_details.cpp
     listening_ports.cpp
-    location_services.cpp
     logged_in_users.cpp
     os_version.cpp
     osquery_events.cpp
@@ -224,6 +223,7 @@ function(generateTestsIntegrationTablesTestsTest)
       keychain_items.cpp
       launchd.cpp
       launchd_overrides.cpp
+      location_services.cpp
       managed_policies.cpp
       mdfind.cpp
       nfs_shares.cpp

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -47,6 +47,7 @@ function(generateTestsIntegrationTablesTestsTest)
     interface_addresses.cpp
     interface_details.cpp
     listening_ports.cpp
+    location_services.cpp
     logged_in_users.cpp
     os_version.cpp
     osquery_events.cpp

--- a/tests/integration/tables/location_services.cpp
+++ b/tests/integration/tables/location_services.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for location_services
+// Spec file: specs/darwin/location_services.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class locationServices : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(locationServices, test_sanity) {
+  auto const data = execute_query("select * from location_services");
+  ASSERT_EQ(data.size(), 1ul);
+  ValidationMap row_map = {
+      {"enabled", IntType},
+  } validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/location_services.cpp
+++ b/tests/integration/tables/location_services.cpp
@@ -27,7 +27,8 @@ TEST_F(locationServices, test_sanity) {
   ASSERT_EQ(data.size(), 1ul);
   ValidationMap row_map = {
       {"enabled", IntType},
-  } validate_rows(data, row_map);
+  };
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
### What does this new table do?
This table consists of only one column that reports the enabled/disabled status of the Location Services feature of macOS. See screenshots below.

#### Location Services Enabled
<img width="1063" alt="Screen Shot 2020-12-20 at 12 33 23 PM" src="https://user-images.githubusercontent.com/315873/102720052-dc787280-42bf-11eb-81ff-3c20ccca1c68.png">

#### Location Services Disabled
<img width="1059" alt="Screen Shot 2020-12-20 at 12 33 57 PM" src="https://user-images.githubusercontent.com/315873/102720056-dedacc80-42bf-11eb-979c-b5fc54bc707e.png">

### Why is this useful?
There are many people for compliance and privacy reasons who need to understand the current state of Location Services.

### Other Notes

1. I added a new framework to get this data (Corelocation), the framework has been around since 10.6 so we should be safe, but we might want to verify older macOS compatibility just to be sure the API hasn't changed.

1. I kept the table simple as I imagine this would be something we could extend to Windows.

1. This API does not pass any errors by reference so I just threw it in a Try/Catch block just in case we have issues, not sure if that is an acceptable pattern for such a simple class method API.
