### PR TITLE
CMake: Refactor and rename fuzzers build flag

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -71,8 +71,10 @@ option(OSQUERY_NO_DEBUG_SYMBOLS "Whether to build without debug symbols or not, 
 option(OSQUERY_BUILD_TESTS "Whether to enable and build tests or not")
 option(OSQUERY_BUILD_ROOT_TESTS "Whether to enable and build tests that require root access")
 
-option(OSQUERY_ENABLE_FUZZER_SANITIZERS "Whether to build fuzzing harnesses")
-option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
+if(DEFINED PLATFORM_LINUX)
+  option(OSQUERY_BUILD_FUZZERS "Whether to build fuzzing harnesses")
+  option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
+endif()
 
 option(OSQUERY_ENABLE_CLANG_TIDY "Enables clang-tidy support")
 set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,portability-*,readability-*,modernize-*,bugprone-*" CACHE STRING "List of checks performed by clang-tidy")

--- a/osquery/main/CMakeLists.txt
+++ b/osquery/main/CMakeLists.txt
@@ -8,7 +8,7 @@
 function(osqueryMainMain)
   generateOsqueryMain()
 
-  if(OSQUERY_ENABLE_FUZZER_SANITIZERS AND OSQUERY_BUILD_TESTS AND PLATFORM_LINUX)
+  if(OSQUERY_BUILD_FUZZERS)
     add_subdirectory("harnesses")
   endif()
 endfunction()

--- a/osquery/main/harnesses/CMakeLists.txt
+++ b/osquery/main/harnesses/CMakeLists.txt
@@ -6,11 +6,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(osqueryMainHarnesses)
-  if(OSQUERY_ENABLE_FUZZER_SANITIZERS AND NOT OSQUERY_ENABLE_ADDRESS_SANITIZER)
+  if(OSQUERY_BUILD_FUZZERS AND NOT OSQUERY_ENABLE_ADDRESS_SANITIZER)
     message( FATAL_ERROR "If fuzzing is enabled, a sanitizer must be chosen. (Currently only OSQUERY_ENABLE_ADDRESS_SANITIZER is available.)" )
   endif()
 
-  if(OSQUERY_ENABLE_FUZZER_SANITIZERS AND
+  if(OSQUERY_BUILD_FUZZERS AND
       (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
     message( FATAL_ERROR "If fuzzing is enabled, it must be built in Release or RelWithDebInfo" )
   endif()


### PR DESCRIPTION
The flag to build the fuzzers is now OSQUERY_BUILD_FUZZERS
and it is independent from OSQUERY_BUILD_TESTS.

Now it's possible to build with the address sanitizer
but without any feature required by the fuzzers.

The fuzzers and the sanitizer flags are presented only on Linux.

NOTE: This is also eventually needed to fix the current oss-fuzz build failure, since we connected the build of the fuzzers with the build of the tests, without changing the oss-fuzz build script.