### PR TITLE
CMake: Fix amalgamated tables generation on change

### DIFF
--- a/tools/codegen/CMakeLists.txt
+++ b/tools/codegen/CMakeLists.txt
@@ -202,7 +202,7 @@ function(generateTableCategoryAmalgamation category_name)
     OUTPUT "${amalgamation_file}"
     COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}" "${OSQUERY_PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/codegen/amalgamate.py" --templates "${CMAKE_SOURCE_DIR}/tools/codegen/templates" ${amalgamation_type} --sources "${generateTables_output}" --output "${amalgamation_file}"
     COMMENT "Generating amalgamation file for the ${category_name} tables..."
-    DEPENDS "${category_spec_files}" ${generateTables_targetList}
+    DEPENDS ${category_spec_files} ${generateTables_targetList}
   )
 
   # Build the library


### PR DESCRIPTION
The list of spec files, dependency of the amalgamated table generation,
was incorrectly specified.
When a list is used in a DEPENDS argument, all the components of
the argument should be a list.
Using double quotes breaks that.