### PR TITLE
CMake: Do not compile Windows libraries with debug symbols

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -235,7 +235,7 @@ function(setupBuildFlags)
   elseif(DEFINED PLATFORM_WINDOWS)
 
     set(windows_common_compile_options
-      "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/Z7;/Gs;/GS>"
+      "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/Gs;/GS>"
       "$<$<CONFIG:Debug>:/Od;/UNDEBUG>$<$<NOT:$<CONFIG:Debug>>:/Ot>"
       /guard:cf
       /bigobj
@@ -243,6 +243,7 @@ function(setupBuildFlags)
 
     set(osquery_windows_compile_options
       /W3
+      "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/Z7>"
     )
 
     set(windows_common_link_options


### PR DESCRIPTION
When possible try to avoid generating debug symbols
for third party libraries, when compiling in Debug or
RelWithDebInfo mode, like for POSIX platforms.

This might not always possible because there's no way
to explicitly disable symbol generation on Windows,
but this should be an improvement.
