### PR TITLE
CMake: Add Valgrind support

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -222,13 +222,6 @@ function(setupBuildFlags)
           -fsanitize-coverage=edge,indirect-calls
         )
 
-        # Support ASAN within coroutines2.
-        # Note that __ucontext__ is orders of magnitude slower than __fcontext__.
-        target_compile_definitions(cxx_settings INTERFACE
-          BOOST_USE_UCONTEXT
-          BOOST_USE_ASAN
-        )
-
         # Require at least address (may be refactored out)
         target_link_options(cxx_settings INTERFACE
           -fsanitize=address
@@ -245,20 +238,13 @@ function(setupBuildFlags)
         -fsanitize=address
       )
 
-      # Support ASAN within coroutines2.
-      # Note that __ucontext__ is orders of magnitude slower than __fcontext__.
-      target_compile_definitions(cxx_settings INTERFACE
-        BOOST_USE_UCONTEXT
-        BOOST_USE_ASAN
-      )
-
       # Require at least address (may be refactored out)
       target_link_options(cxx_settings INTERFACE
         -fsanitize=address
       )
       target_link_options(c_settings INTERFACE
-          -fsanitize=address
-        )
+        -fsanitize=address
+      )
     endif()
   elseif(DEFINED PLATFORM_WINDOWS)
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -74,6 +74,12 @@ option(OSQUERY_BUILD_ROOT_TESTS "Whether to enable and build tests that require 
 if(DEFINED PLATFORM_LINUX)
   option(OSQUERY_BUILD_FUZZERS "Whether to build fuzzing harnesses")
   option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
+  # This is required for Boost coroutines/context to be built in a way that are compatible to Valgrind
+  option(OSQUERY_ENABLE_VALGRIND_SUPPORT "Whether to enable support for osquery to be run under Valgrind")
+
+  if(OSQUERY_ENABLE_VALGRIND_SUPPORT AND OSQUERY_ENABLE_ADDRESS_SANITIZER)
+    message(FATAL_ERROR "Cannot mix Vagrind and ASAN sanitizers, please choose only one.")
+  endif()
 endif()
 
 option(OSQUERY_ENABLE_CLANG_TIDY "Enables clang-tidy support")

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -29,6 +29,74 @@ function(boostMain)
   generateBoostWinapi()
   generateBoostEndian()
 
+  if(OSQUERY_ENABLE_VALGRIND_SUPPORT)
+    set(valgrind_header_possible_paths
+      /usr/include/valgrind
+      /usr/local/include/valgrind
+    )
+
+    find_file(VALGRIND_HEADER_PATH valgrind.h HINTS ${valgrind_header_possible_paths})
+
+    if("${VALGRIND_HEADER_PATH}" STREQUAL "VALGRIND_HEADER_PATH-NOTFOUND")
+      message(FATAL_ERROR "Could not find valgrind.h. Please install Valgrind and provide the path to its header.")
+    else()
+      message(STATUS "Found valgrind header: ${VALGRIND_HEADER_PATH}")
+    endif()
+
+    # We copy the header into the build folder, so that if it's installed in the system
+    # we are not forced to include a folder which can contain other headers we don't want.
+    set(valgrind_header_dest "${CMAKE_CURRENT_BINARY_DIR}/external_headers/valgrind/valgrind.h")
+
+    add_custom_target(provide_valgrind_header DEPENDS "${valgrind_header_dest}")
+
+    add_custom_command(OUTPUT "${valgrind_header_dest}"
+      COMMAND "${CMAKE_COMMAND}" -E copy "${VALGRIND_HEADER_PATH}" "${valgrind_header_dest}"
+      DEPENDS "${VALGRIND_HEADER_PATH}"
+    )
+
+    add_dependencies(thirdparty_boost_coroutine provide_valgrind_header)
+    add_dependencies(thirdparty_boost_coroutine2 provide_valgrind_header)
+    add_dependencies(thirdparty_boost_context provide_valgrind_header)
+
+    target_compile_definitions(thirdparty_boost_coroutine PUBLIC
+      BOOST_USE_VALGRIND
+    )
+    target_include_directories(thirdparty_boost_coroutine SYSTEM PUBLIC
+      "${CMAKE_CURRENT_BINARY_DIR}/external_headers"
+    )
+
+    target_compile_definitions(thirdparty_boost_coroutine2 INTERFACE
+      BOOST_USE_VALGRIND
+    )
+    target_include_directories(thirdparty_boost_coroutine2 SYSTEM INTERFACE
+      "${CMAKE_CURRENT_BINARY_DIR}/external_headers"
+    )
+
+    target_compile_definitions(thirdparty_boost_context PUBLIC
+      BOOST_USE_VALGRIND
+    )
+    target_include_directories(thirdparty_boost_context SYSTEM PUBLIC
+      "${CMAKE_CURRENT_BINARY_DIR}/external_headers"
+    )
+  endif()
+
+  if(OSQUERY_ENABLE_ADDRESS_SANITIZER)
+    # Support ASAN within coroutine, context and coroutines2.
+    # Note that __ucontext__ is orders of magnitude slower than __fcontext__.
+    target_compile_definitions(thirdparty_boost_coroutine PUBLIC
+      BOOST_USE_UCONTEXT
+      BOOST_USE_ASAN
+    )
+    target_compile_definitions(thirdparty_boost_coroutine2 INTERFACE
+      BOOST_USE_UCONTEXT
+      BOOST_USE_ASAN
+    )
+    target_compile_definitions(thirdparty_boost_context PUBLIC
+      BOOST_USE_UCONTEXT
+      BOOST_USE_ASAN
+    )
+  endif()
+
   add_library(thirdparty_boost INTERFACE)
 
   target_link_libraries(thirdparty_boost INTERFACE

--- a/osquery/main/harnesses/CMakeLists.txt
+++ b/osquery/main/harnesses/CMakeLists.txt
@@ -6,12 +6,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(osqueryMainHarnesses)
-  if(OSQUERY_BUILD_FUZZERS AND NOT OSQUERY_ENABLE_ADDRESS_SANITIZER)
-    message( FATAL_ERROR "If fuzzing is enabled, a sanitizer must be chosen. (Currently only OSQUERY_ENABLE_ADDRESS_SANITIZER is available.)" )
+  if(OSQUERY_BUILD_FUZZERS AND
+      NOT (OSQUERY_ENABLE_ADDRESS_SANITIZER OR OSQUERY_ENABLE_VALGRIND_SUPPORT))
+    message(FATAL_ERROR "If fuzzing is enabled, a sanitizer must be chosen. "
+      "Please choose between OSQUERY_ENABLE_ADDRESS_SANITIZER and OSQUERY_ENABLE_VALGRIND_SUPPORT.")
   endif()
 
   if(OSQUERY_BUILD_FUZZERS AND
-      (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
+      NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Release" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
     message( FATAL_ERROR "If fuzzing is enabled, it must be built in Release or RelWithDebInfo" )
   endif()
 


### PR DESCRIPTION
Add OSQUERY_ENABLE_VALGRIND_SUPPORT so that it's possible
to run osquery under Valgrind.
This is specifically required by the boost library
that needs to be compiled with a special define
and it also requires the valgrind.h header.

Also move the defines for the ASAN usage to the boost
library CMakeLists.txt instead of being in flags.cmake.
This way we reduce the unnecessary recompilation of code that
doesn't depend on boost, when switching options.