### PR TITLE
Permit running formatting earlier in the CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,15 @@ if(OSQUERY_ENABLE_CLANG_TIDY)
 endif()
 
 function(main)
+
+  findClangFormat()
+  findPythonExecutablePath()
+  generateSpecialTargets()
+
+  if(OSQUERY_ENABLE_FORMAT_ONLY)
+    return()
+  endif()
+
   message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
   message(STATUS "Shared libraries: ${BUILD_SHARED_LIBS}")
 
@@ -75,9 +84,6 @@ function(main)
       message(STATUS "Warning: the selected C or C++ compiler is not clang/clang++. Compilation may fail")
     endif()
   endif()
-
-  findPythonExecutablePath()
-  generateSpecialTargets()
 
   add_subdirectory("libraries")
   importLibraries()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,26 @@ jobs:
     - script: mkdir -p $(BUILD_DIR)
       displayName: "Create build folder"
 
+    - task: CMake@1
+      displayName: "Configure osquery for formatting"
+      inputs:
+        workingDirectory: $(BUILD_DIR)
+        cmakeArgs:
+          -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain
+          -DOSQUERY_ENABLE_FORMAT_ONLY=ON
+          $(Build.SourcesDirectory)
+
+    - script: |
+        ./tools/formatting/format-test.sh --build $(BUILD_DIR)
+      displayName: "format_check.py test"
+      workingDirectory: $(Build.SourcesDirectory)
+
+    - task: CMake@1
+      displayName: "Check code formatting"
+      inputs:
+        workingDirectory: $(BUILD_DIR)
+        cmakeArgs: --build . --target format_check
+
     - task: CacheBeta@2
       inputs:
         key: submodules | Linux | $(SubmoduleCacheVersion) | $(Build.SourceVersion)
@@ -52,21 +72,11 @@ jobs:
               -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain \
               -DOSQUERY_BUILD_TESTS=ON \
               -DOSQUERY_BUILD_ROOT_TESTS=ON \
+              -UOSQUERY_ENABLE_FORMAT_ONLY \
               $(EXTRA_CMAKE_ARGS) \
               $(Build.SourcesDirectory)
       displayName: "Configure osquery"
       workingDirectory: $(BUILD_DIR)
-
-    - script: |
-        ./tools/formatting/format-test.sh --build $(BUILD_DIR)
-      displayName: "format_check.py test"
-      workingDirectory: $(Build.SourcesDirectory)
-
-    - task: CMake@1
-      displayName: "Check code formatting"
-      inputs:
-        workingDirectory: $(BUILD_DIR)
-        cmakeArgs: --build . --target format_check
 
     - task: CacheBeta@2
       inputs:

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -84,6 +84,8 @@ option(OSQUERY_BUILD_BPF "Whether to enable and build BPF support" true)
 # This is a temporary option to ignore the version check if there's no intention to generate RPM packages
 option(OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK "Ignore the maximum cmake version check introduced due to CPack generating incorrect RPM packages")
 
+option(OSQUERY_ENABLE_FORMAT_ONLY "Configure CMake to format only, not build")
+
 # Unfortunately, due glog always enabling BUILD_TESTING, we have to force it off, so that tests won't be built
 overwrite_cache_variable("BUILD_TESTING" "BOOL" "OFF")
 

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -266,18 +266,17 @@ function(generateSpecialTargets)
     "libraries"
   )
 
-  set(command_prefix)
-  if(OSQUERY_TOOLCHAIN_SYSROOT)
-    set(command_prefix "${CMAKE_COMMAND}" -E env "PATH=${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin:$ENV{PATH}")
-  endif()
-
   add_custom_target(format_check
-    COMMAND ${command_prefix} "${OSQUERY_PYTHON_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py --exclude-folders ${excluded_folders} origin/master
+    COMMAND "${OSQUERY_PYTHON_EXECUTABLE}"
+            "${CMAKE_SOURCE_DIR}/tools/formatting/format-check.py"
+            --exclude-folders "${excluded_folders}" --binary "${OSQUERY_CLANG_FORMAT}" origin/master
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     VERBATIM
   )
   add_custom_target(format
-    COMMAND ${command_prefix} "${OSQUERY_PYTHON_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py --exclude-folders ${excluded_folders} -f --style=file
+    COMMAND "${OSQUERY_PYTHON_EXECUTABLE}"
+            "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
+            --exclude-folders "${excluded_folders}" --binary "${OSQUERY_CLANG_FORMAT}" -f --style=file
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     VERBATIM
   )
@@ -418,4 +417,39 @@ function(getCleanedOsqueryVersionComponents major minor patch)
   set("${major}" "${${major}}" PARENT_SCOPE)
   set("${minor}" "${${minor}}" PARENT_SCOPE)
   set("${patch}" "${${patch}}" PARENT_SCOPE)
+endfunction()
+
+function(findClangFormat)
+  set(clang_format_doc "Path to the clang-format binary")
+
+  if(OSQUERY_TOOLCHAIN_SYSROOT)
+    if(NOT EXISTS "${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin/clang-format")
+        set(error_message "Could not find clang-format in the custom toolchain sysroot, please try to install the toolchain again.")
+        if(OSQUERY_ENABLE_FORMAT_ONLY)
+          message(FATAL_ERROR "${error_message}")
+        else()
+          message(WARNING "${error_message}")
+        endif()
+    else()
+      set(OSQUERY_CLANG_FORMAT "${OSQUERY_TOOLCHAIN_SYSROOT}/usr/bin/clang-format" CACHE FILEPATH "${clang_format_doc}")
+    endif()
+  else()
+    find_program(OSQUERY_CLANG_FORMAT clang-format DOC "${clang_format_doc}")
+
+    set(error_message "Could not find clang-format in the system, please install it and be sure that it can be found via the PATH env var. "
+      "Otherwise provide its location by passing -DOSQUERY_CLANG_FORMAT=<clang-format-path>"
+    )
+
+    if("${OSQUERY_CLANG_FORMAT}" STREQUAL "OSQUERY_CLANG_FORMAT-NOTFOUND")
+      if(OSQUERY_ENABLE_FORMAT_ONLY)
+        message(FATAL_ERROR "${error_message}")
+      else()
+        message(WARNING "${error_message}")
+      endif()
+    endif()
+  endif()
+
+  if(NOT "${OSQUERY_CLANG_FORMAT}" STREQUAL "OSQUERY_CLANG_FORMAT-NOTFOUND")
+    message(STATUS "Found clang-format: ${OSQUERY_CLANG_FORMAT}")
+  endif()
 endfunction()

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 
 
-def check(base_commit, exclude_folders):
+def check(base_commit, exclude_folders, clang_binary):
     try:
         cmd = [
           sys.executable,
@@ -26,6 +26,9 @@ def check(base_commit, exclude_folders):
 
         if exclude_folders:
             cmd += ["--exclude-folders", exclude_folders]
+
+        if clang_binary:
+            cmd += ["--binary", clang_binary]
 
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,
@@ -69,26 +72,34 @@ def get_base_commit(base_branch):
 def main():
     parser = argparse.ArgumentParser(description="Check code changes formatting.")
     parser.add_argument(
-            "--exclude-folders",
-            metavar="excluded_folders",
-            type=str,
-            default="",
-            help="comma-separated list of relative paths to folders to exclude from formatting"
+        "--exclude-folders",
+        metavar="excluded_folders",
+        type=str,
+        default="",
+        help="comma-separated list of relative paths to folders to exclude from formatting"
     )
     parser.add_argument(
-            "base_branch",
-            metavar="base_branch",
-            type=str,
-            nargs="?",
-            default="master",
-            help="The base branch to compare to.",
-            )
+        "--binary",
+        metavar="clang_binary",
+        dest="clang_binary",
+        type=str,
+        default="",
+        help="Path to the clang-format binary"
+    )
+    parser.add_argument(
+        "base_branch",
+        metavar="base_branch",
+        type=str,
+        nargs="?",
+        default="master",
+        help="The base branch to compare to.",
+    )
 
     args = parser.parse_args()
 
     base_commit = get_base_commit(args.base_branch)
 
-    return check(base_commit, args.exclude_folders) if base_commit is not None else False
+    return check(base_commit, args.exclude_folders, args.clang_binary) if base_commit is not None else False
 
 if __name__ == "__main__":
     sys.exit(not main())


### PR DESCRIPTION
Also find the clang-format binary using find_program and
permit to give a path if it doesn't find it,
unless the Linux osquery toolchain is used.

Although caching the submodules has made the formatting checks come considerably sooner, this makes it slightly faster and a bit more consistent.