### PR TITLE
CI: Add a RelWithDebInfo Linux job to generate packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,15 @@ jobs:
         Release:
           BUILD_TYPE: Release
           EXTRA_CMAKE_ARGS:
+          BUILD_TESTS: ON
+        RelWithDebInfo:
+          BUILD_TYPE: RelWithDebInfo
+          EXTRA_CMAKE_ARGS:
+          BUILD_TESTS: OFF
         Debug:
           BUILD_TYPE: Debug
           EXTRA_CMAKE_ARGS: -DOSQUERY_NO_DEBUG_SYMBOLS=ON
+          BUILD_TESTS: ON
 
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -41,6 +47,7 @@ jobs:
 
     - task: CMake@1
       displayName: "Configure osquery for formatting"
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       inputs:
         workingDirectory: $(BUILD_DIR)
         cmakeArgs:
@@ -51,10 +58,12 @@ jobs:
     - script: |
         ./tools/formatting/format-test.sh --build $(BUILD_DIR)
       displayName: "format_check.py test"
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       workingDirectory: $(Build.SourcesDirectory)
 
     - task: CMake@1
       displayName: "Check code formatting"
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       inputs:
         workingDirectory: $(BUILD_DIR)
         cmakeArgs: --build . --target format_check
@@ -70,8 +79,8 @@ jobs:
         cmake --version
         cmake -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
               -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain \
-              -DOSQUERY_BUILD_TESTS=ON \
-              -DOSQUERY_BUILD_ROOT_TESTS=ON \
+              -DOSQUERY_BUILD_TESTS=$(BUILD_TESTS) \
+              -DOSQUERY_BUILD_ROOT_TESTS=$(BUILD_TESTS) \
               -UOSQUERY_ENABLE_FORMAT_ONLY \
               $(EXTRA_CMAKE_ARGS) \
               $(Build.SourcesDirectory)
@@ -92,6 +101,7 @@ jobs:
         cmakeArgs: --build . -j 3
 
     - task: CMake@1
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       displayName: "Run cppcheck"
       inputs:
         workingDirectory: $(BUILD_DIR)
@@ -99,11 +109,13 @@ jobs:
 
     - script: |
         ctest --build-nocmake -LE "root-required" -V
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       displayName: "Run tests with a normal user"
       workingDirectory: $(BUILD_DIR)
 
     - script: |
         sudo ctest --build-nocmake -L "root-required" -V
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux RelWithDebInfo'))
       displayName: "Run tests which requires root"
       workingDirectory: $(BUILD_DIR)
 
@@ -112,6 +124,7 @@ jobs:
         cmake --build . --target package -j 3
         cp *.deb $(Build.ArtifactStagingDirectory)
         cp *.ddeb $(Build.ArtifactStagingDirectory)
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux Release'))
       displayName: "Run DEB packaging"
       workingDirectory: $(BUILD_DIR)
 
@@ -119,6 +132,7 @@ jobs:
         cmake -DPACKAGING_SYSTEM=RPM $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
         cp *.rpm $(Build.ArtifactStagingDirectory)
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux Release'))
       displayName: "Run RPM packaging"
       workingDirectory: $(BUILD_DIR)
 
@@ -126,10 +140,12 @@ jobs:
         cmake -DPACKAGING_SYSTEM=TGZ $(Build.SourcesDirectory)
         cmake --build . --target package -j 3
         cp *.tar.gz $(Build.ArtifactStagingDirectory)
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux Release'))
       displayName: "Run TGZ packaging"
       workingDirectory: $(BUILD_DIR)
 
     - task: PublishBuildArtifacts@1
+      condition: and(succeeded(), ne(variables['Agent.JobName'], 'Linux Release'))
       inputs:
         pathToPublish: "$(Build.ArtifactStagingDirectory)"
         artifactName: "Linux $(BUILD_TYPE) Packages"
@@ -156,13 +172,14 @@ jobs:
 
     variables:
       LinuxReleaseStatus: $[ dependencies.LinuxBuild.outputs['Release.JobResult.Status'] ]
+      LinuxRelWithDebInfoStatus: $[ dependencies.LinuxBuild.outputs['RelWithDebInfo.JobResult.Status'] ]
       LinuxDebugStatus: $[ dependencies.LinuxBuild.outputs['Debug.JobResult.Status'] ]
 
     steps:
     - checkout: none
 
     - script: |
-        if [ -z "$(LinuxReleaseStatus)" ] || [ -z "$(LinuxDebugStatus)" ]; then
+        if [ -z "$(LinuxReleaseStatus)" ] || [ -z "$(LinuxDebugStatus)" ] || [ -z "$(LinuxRelWithDebInfoStatus)" ]; then
           exit 1
         fi
       displayName: "Detect Linux jobs build statuses"


### PR DESCRIPTION
The job will output packages that will be used for the release.
We skip formatting checks and building tests,
so that more disk space is left for debug symbols.
