### PR TITLE
CMake: Add an option to disable building libdpkg tables and library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,6 @@ function(importLibraries)
     "Linux:libaudit"
     "Linux:libcryptsetup"
     "Linux:libdevmapper"
-    "Linux:libdpkg"
     "Linux:libelfin"
     "Linux:libgcrypt"
     "Linux:libgpg-error"
@@ -158,6 +157,12 @@ function(importLibraries)
   if(OSQUERY_BUILD_AWS)
     list(APPEND library_descriptor_list
       "Linux,Darwin,Windows:aws-sdk-cpp"
+    )
+  endif()
+
+  if(OSQUERY_BUILD_DPKG)
+    list(APPEND library_descriptor_list
+      "Linux:libdpkg"
     )
   endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -87,6 +87,7 @@ set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,
 
 option(OSQUERY_BUILD_BPF "Whether to enable and build BPF support" ON)
 option(OSQUERY_BUILD_AWS "Whether to build the aws tables and library, to decrease memory usage and increase speed during build." ON)
+option(OSQUERY_BUILD_DPKG "Whether to build the dpkg tables" ON)
 
 # This is a temporary option to ignore the version check if there's no intention to generate RPM packages
 option(OSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK "Ignore the maximum cmake version check introduced due to CPack generating incorrect RPM packages")

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -58,7 +58,6 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/dbus/uniquedbusmessage.cpp
       linux/acpi_tables.cpp
       linux/block_devices.cpp
-      linux/deb_packages.cpp
       linux/disk_encryption.cpp
       linux/elf_info.cpp
       linux/extended_attributes.cpp
@@ -92,6 +91,12 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/apparmor_profiles.cpp
       linux/systemd_units.cpp
     )
+
+    if(OSQUERY_BUILD_DPKG)
+      list(APPEND source_files
+        linux/deb_packages.cpp
+      )
+    endif()
 
   elseif(DEFINED PLATFORM_MACOS)
     list(APPEND source_files
@@ -266,7 +271,6 @@ function(generateOsqueryTablesSystemSystemtable)
   if(DEFINED PLATFORM_LINUX)
     target_link_libraries(osquery_tables_system_systemtable PUBLIC
       thirdparty_libdevmapper
-      thirdparty_libdpkg
       thirdparty_libelfin
       thirdparty_libcryptsetup
       thirdparty_librpm
@@ -274,6 +278,12 @@ function(generateOsqueryTablesSystemSystemtable)
       thirdparty_dbus
       thirdparty_libcap
     )
+
+    if(OSQUERY_BUILD_DPKG)
+      target_link_libraries(osquery_tables_system_systemtable PUBLIC
+        thirdparty_libdpkg
+      )
+    endif()
 
   elseif(DEFINED PLATFORM_MACOS)
     target_link_libraries(osquery_tables_system_systemtable PUBLIC

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -169,7 +169,6 @@ function(generateNativeTables)
     "linux/memory_info.table:linux"
     "linux/msr.table:linux"
     "linux/memory_map.table:linux"
-    "linux/deb_packages.table:linux"
     "linux/elf_dynamic.table:linux"
     "linux/elf_sections.table:linux"
     "linux/selinux_settings.table:linux"
@@ -313,6 +312,12 @@ function(generateNativeTables)
     list(APPEND platform_dependent_spec_files
       "linwin/ec2_instance_metadata.table:linux,windows"
       "linwin/ec2_instance_tags.table:linux,windows"
+    )
+  endif()
+
+  if(OSQUERY_BUILD_DPKG)
+    list(APPEND platform_dependent_spec_files
+      "linux/deb_packages.table:linux"
     )
   endif()
 

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -151,7 +151,6 @@ function(generateTestsIntegrationTablesTestsTest)
     set(platform_source_files
       arp_cache.cpp
       atom_packages.cpp
-      deb_packages.cpp
       elf_dynamic.cpp
       elf_info.cpp
       elf_sections.cpp
@@ -187,6 +186,12 @@ function(generateTestsIntegrationTablesTestsTest)
       yara_events.cpp
       yara.cpp
     )
+
+    if(OSQUERY_BUILD_DPKG)
+      list(APPEND platform_source_files
+        deb_packages.cpp
+      )
+    endif()
 
     list(APPEND source_files ${platform_source_files})
   elseif(DEFINED PLATFORM_MACOS)


### PR DESCRIPTION
The goal is to support distros (and their maintainers!) like Arch, which do not usually package support for deb/apt/etc. See: https://archlinux.org/packages/community/x86_64/osquery/ and the impact supporting has on downstream dependency management.