### PR TITLE
Fix leaks when a query fails from the shell

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -379,7 +379,6 @@ struct callback_data {
   char nullvalue[20]; /* The text to print when a NULL comes back from
                       ** the database */
   char outfile[FILENAME_MAX]; /* Filename for *out */
-  char* zFreeOnClose; /* Filename to free when closing */
   sqlite3_stmt* pStmt; /* Current statement if any. */
   FILE* pLog; /* Write log output here */
   int* aiIndent; /* Array of indents used in MODE_Explain */
@@ -1686,6 +1685,7 @@ int runQuery(struct callback_data* data, const char* query) {
   if (error != nullptr) {
     fprintf(stderr, "Error: %s\n", error);
     rc = (rc == 0) ? 1 : rc;
+    sqlite3_free(error);
   } else if (rc != 0) {
     fprintf(stderr, "Error: unable to process SQL \"%s\"\n", query);
   }
@@ -1771,6 +1771,9 @@ int launchIntoShell(int argc, char** argv) {
     } else {
       rc = runQuery(&data, query);
       if (rc != 0) {
+        if (data.prettyPrint != nullptr) {
+          delete data.prettyPrint;
+        }
         return rc;
       }
     }
@@ -1802,7 +1805,6 @@ int launchIntoShell(int argc, char** argv) {
   }
 
   set_table_name(&data, nullptr);
-  sqlite3_free(data.zFreeOnClose);
 
   if (data.prettyPrint != nullptr) {
     delete data.prettyPrint;


### PR DESCRIPTION
Reported by ASAN when querying a non existing table:
```
=================================================================
==18372==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x559d9969a93d in operator new(unsigned long) /opt/toolchain/llvm/compiler-rt/lib/asan/asan_new_delete.cpp:99:3
    #1 0x559d99b0e4d6 in main_init(callback_data*) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:1648:23
    #2 0x559d99b0e4d6 in osquery::launchIntoShell(int, char**) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:1725:3
    #3 0x559d99b0846e in osquery::startShell(osquery::Initializer&, int, char**) /home/smjert/Development/osquery/src/osquery/main/main.cpp:140:17
    #4 0x559d99b08d36 in osquery::startOsquery(int, char**) /home/smjert/Development/osquery/src/osquery/main/main.cpp:191:17
    #5 0x559d99b074a6 in main /home/smjert/Development/osquery/src/osquery/main/posix/main.cpp:31:10
    #6 0x7f5aa675ebf6 in __libc_start_main /build/glibc-S7xCS9/glibc-2.27/csu/../csu/libc-start.c:310

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x559d9966acad in __interceptor_malloc /opt/toolchain/llvm/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x559d9cfb0cb0 in sqlite3MemMalloc (/home/smjert/Development/osquery/build/ossfuzz/osquery/osqueryd+0x6d33cb0)
    #2 0x559d9cdc98a7 in sqlite3Malloc (/home/smjert/Development/osquery/build/ossfuzz/osquery/osqueryd+0x6b4c8a7)
    #3 0x559d9cdc968c in sqlite3_malloc (/home/smjert/Development/osquery/build/ossfuzz/osquery/osqueryd+0x6b4c68c)
    #4 0x559d99b12939 in save_err_msg(sqlite3*) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:795:43
    #5 0x559d99b0bd9c in shell_exec(char const*, int (*)(void*, int, char const**, char const**, int*), callback_data*, char**) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:839:21
    #6 0x559d99b0b927 in osquery::runQuery(callback_data*, char const*) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:1689:12
    #7 0x559d99b0f174 in osquery::launchIntoShell(int, char**) /home/smjert/Development/osquery/src/osquery/devtools/shell.cpp:1777:12
    #8 0x559d99b0846e in osquery::startShell(osquery::Initializer&, int, char**) /home/smjert/Development/osquery/src/osquery/main/main.cpp:140:17
    #9 0x559d99b08d36 in osquery::startOsquery(int, char**) /home/smjert/Development/osquery/src/osquery/main/main.cpp:191:17
    #10 0x559d99b074a6 in main /home/smjert/Development/osquery/src/osquery/main/posix/main.cpp:31:10
    #11 0x7f5aa675ebf6 in __libc_start_main /build/glibc-S7xCS9/glibc-2.27/csu/../csu/libc-start.c:310

SUMMARY: AddressSanitizer: 112 byte(s) leaked in 2 allocation(s).
```
