### PR TITLE
Improve fuzzing speed and stack trace accuracy

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -230,6 +230,17 @@ function(setupBuildFlags)
           -fsanitize=address
         )
       endif()
+
+      list(APPEND osquery_defines
+        OSQUERY_IS_FUZZING
+      )
+
+      target_compile_options(cxx_settings INTERFACE
+        -fno-omit-frame-pointer
+      )
+      target_compile_options(c_settings INTERFACE
+        -fno-omit-frame-pointer
+      )
     elseif(OSQUERY_ENABLE_ADDRESS_SANITIZER)
       target_compile_options(cxx_settings INTERFACE
         -fsanitize=address

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -209,6 +209,10 @@ static void serializeIntermediateLog(const std::vector<StatusLogLine>& log,
 }
 
 void setVerboseLevel() {
+#ifdef OSQUERY_IS_FUZZING
+  return;
+#endif
+
   if (Flag::getValue("verbose") == "true") {
     // Turn verbosity up to 1.
     // Do log DEBUG, INFO, WARNING, ERROR to their log files.

--- a/plugins/config/parsers/decorators.cpp
+++ b/plugins/config/parsers/decorators.cpp
@@ -241,6 +241,10 @@ inline void addDecoration(const std::string& source,
 
 inline void runDecorators(const std::string& source,
                           const std::vector<std::string>& queries) {
+#ifdef OSQUERY_IS_FUZZING
+  return;
+#else
+
   for (const auto& query : queries) {
     SQL results(query);
     if (results.rows().size() > 0) {
@@ -257,6 +261,7 @@ inline void runDecorators(const std::string& source,
       LOG(WARNING) << "Multiple rows returned for decorator query: " << query;
     }
   }
+#endif
 }
 
 void clearDecorations(const std::string& source) {

--- a/plugins/config/parsers/file_paths.cpp
+++ b/plugins/config/parsers/file_paths.cpp
@@ -46,7 +46,7 @@ class FilePathsConfigParserPlugin : public ConfigParserPlugin {
 
  private:
   /// The access map binds source to category.
-  std::map<std::string, std::vector<std::string> > access_map_;
+  std::map<std::string, std::vector<std::string>> access_map_;
 };
 
 Status FilePathsConfigParserPlugin::setUp() {
@@ -117,6 +117,10 @@ void FilePathsConfigParserPlugin::updateFilePaths(const JSON& file_paths,
 
 void FilePathsConfigParserPlugin::updateFilePathsQuery(
     const JSON& file_paths_query, const std::string& source) {
+#ifdef OSQUERY_IS_FUZZING
+  return;
+#else
+
   if (!file_paths_query.doc().IsObject()) {
     return;
   }
@@ -152,6 +156,7 @@ void FilePathsConfigParserPlugin::updateFilePathsQuery(
       }
     }
   }
+#endif
 }
 
 void FilePathsConfigParserPlugin::updateExcludePaths(
@@ -220,4 +225,4 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
 }
 
 REGISTER_INTERNAL(FilePathsConfigParserPlugin, "config_parser", "file_paths");
-}
+} // namespace osquery


### PR DESCRIPTION
Add a special define when osquery is built for fuzzing.

With that is possible to enable code that ignores
changing log levels.
With the config fuzzer, even if the fuzzer code was settings
the minloglevel to 4, that was immediately changed by the osquery logic.

Do not run queries parsed from the config to improve
the config fuzzer performance and avoid oom issues.

When built for fuzzing, compile osquery and libraries
without optimizing the frame pointer away.
This in some cases improves the accuracy of the stack trace
presented when a bug is found.

\
The config fuzzer was getting stuck on queries that would take all the time available to run, or would consume more than 2.5GB of memory, which is the limit oss-fuzz uses.
With Valgrind in front, instead of ASAN, a simple one line query with a join on all columns would consume 16GB+ of memory.