### PR TITLE
CMake: Fix platformtablecontaineripc include namespace generation

### DIFF
--- a/osquery/worker/ipc/CMakeLists.txt
+++ b/osquery/worker/ipc/CMakeLists.txt
@@ -66,9 +66,9 @@ function(generateOsqueryWorkerIpcPlatformTableContainerIpc)
       osquery_core_sql
       osquery_worker_logging_glog_logger
     )
-  endif()
 
-  generateIncludeNamespace(osquery_worker_ipc_platformtablecontaineripc "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+    generateIncludeNamespace(osquery_worker_ipc_platformtablecontaineripc "osquery/worker/ipc" FILE_ONLY ${public_header_files})
+  endif()
 endfunction()
 
 function(generateOsqueryWorkerIpcTableChannel)


### PR DESCRIPTION
The public header is only present on non Linux platforms.
