### PR TITLE
CMake: Detect missing headers during include namespace generation

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -45,6 +45,16 @@ function(generateIncludeNamespace target_name namespace_path mode)
   endif()
 
   foreach(relative_source_file_path ${ARGN})
+    set(source_base_path "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(absolute_source_file_path "${source_base_path}/${relative_source_file_path}")
+
+    if(NOT EXISTS "${absolute_source_file_path}")
+      message(FATAL_ERROR
+        "Error while creating include namespace of target ${target_name}: the header at ${absolute_source_file_path} does not exists, "
+        "please correct the path or remove it from the list."
+      )
+    endif()
+
     get_filename_component(source_name "${relative_source_file_path}" NAME)
 
     set(target_namespace_root_directory "${CMAKE_BINARY_DIR}/ns_${target_name}")
@@ -56,8 +66,6 @@ function(generateIncludeNamespace target_name namespace_path mode)
     endif()
 
     get_filename_component(parent_folder_path "${output_source_file_path}" DIRECTORY)
-    set(source_base_path "${CMAKE_CURRENT_SOURCE_DIR}")
-    set(absolute_source_file_path "${source_base_path}/${relative_source_file_path}")
 
     add_custom_command(
       OUTPUT "${output_source_file_path}"

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -349,7 +349,6 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/registry.h
       windows/certificates.h
       windows/users.h
-      windows/userassist.h
       windows/windows_eventlog.h
     )
   endif()


### PR DESCRIPTION
When a header specified to be added in a generated include namespace
does not exists because its path is wrong or it shoudn't be added,
issue a fatal error, so that it gets noticed and fixed.

Remove windows/userassist.h as a header to be added in an include
namespace, since it doesn't exists.