### PR TITLE
CMake: Do not attempt to dllimport Thrift symbols

### DIFF
--- a/libraries/cmake/source/thrift/CMakeLists.txt
+++ b/libraries/cmake/source/thrift/CMakeLists.txt
@@ -88,7 +88,7 @@ function(thriftMain)
     "${forced_include_file_flag}${CMAKE_CURRENT_SOURCE_DIR}/patches/random_shuffle.h"
   )
 
-  target_compile_definitions(thirdparty_thrift PRIVATE
+  target_compile_definitions(thirdparty_thrift PUBLIC
     THRIFT_STATIC_DEFINE
   )
 


### PR DESCRIPTION
The THRIFT_STATIC_DEFINE define should be publicly used,
because it's used in a header that will be included by osquery.
