### PR TITLE
Remove the last usage of sqlite3 from sleuthkit

### DIFF
--- a/libraries/cmake/source/sleuthkit/CMakeLists.txt
+++ b/libraries/cmake/source/sleuthkit/CMakeLists.txt
@@ -12,8 +12,6 @@ function(sleuthkitMain)
 
   add_library(thirdparty_sleuthkit_cpp
     "${library_root}/tsk/auto/auto.cpp"
-    "${library_root}/tsk/auto/auto_db.cpp"
-    "${library_root}/tsk/auto/case_db.cpp"
     "${library_root}/tsk/auto/guid.cpp"
     "${library_root}/tsk/auto/is_image_supported.cpp"
     "${library_root}/tsk/auto/tsk_db.cpp"


### PR DESCRIPTION
To completely remove sqlite3 as a dependency of sleuthkit,
case_db.cpp and auto_db.cpp should not be compiled,
because both depend on the header tsk_case_db.h,
which in turn include tsk_db_sqlite.h
which then depends on the sqlite3.h header.

NOTE: The library was using the sqlite3.h header embedded in sleuthkit instead of the one provided by our version of sqlite, not only because we were not linking sleuthkit against sqlite anymore, but because we had not defined the `HAVE_LIBSQLITE3` define, that would change header inclusion type from `""` to `<>`.
Nonetheless this should not be necessary anymore, since we're removing all the sqlite3 uses.
