### PR TITLE
Do not ignore mountpoints that have the same mount path

### DIFF
--- a/osquery/filesystem/linux/mounts.cpp
+++ b/osquery/filesystem/linux/mounts.cpp
@@ -44,7 +44,7 @@ Status getMountData(MountData& obj) {
 }
 } // namespace
 
-Status getMountedFilesystemMap(MountedFilesystemMap& mounted_fs_info) {
+Status getMountedFilesystems(MountedFilesystems& mounted_fs_info) {
   mounted_fs_info = {};
 
   MountData mount_data;
@@ -106,7 +106,7 @@ Status getMountedFilesystemMap(MountedFilesystemMap& mounted_fs_info) {
       }
     }
 
-    mounted_fs_info.insert({mount_info.path, std::move(mount_info)});
+    mounted_fs_info.emplace_back(std::move(mount_info));
   }
 
   return Status::success();

--- a/osquery/filesystem/linux/mounts.h
+++ b/osquery/filesystem/linux/mounts.h
@@ -57,7 +57,7 @@ struct MountInformation final {
 };
 
 // Information about all mounted filesystems
-using MountedFilesystemMap = std::unordered_map<std::string, MountInformation>;
+using MountedFilesystems = std::vector<MountInformation>;
 
-Status getMountedFilesystemMap(MountedFilesystemMap& mounted_fs_info);
+Status getMountedFilesystems(MountedFilesystems& mounted_fs_info);
 } // namespace osquery

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -14,8 +14,8 @@
 namespace osquery {
 namespace tables {
 QueryData genMounts(QueryContext& context) {
-  MountedFilesystemMap mounted_fs_map{};
-  auto status = getMountedFilesystemMap(mounted_fs_map);
+  MountedFilesystems mounted_fs{};
+  auto status = getMountedFilesystems(mounted_fs);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to list the system mounts: " << status.getMessage();
     return {};
@@ -23,10 +23,8 @@ QueryData genMounts(QueryContext& context) {
 
   QueryData results;
 
-  for (const auto& p : mounted_fs_map) {
+  for (const auto& mount_info : mounted_fs) {
     Row r = {};
-
-    const auto& mount_info = p.second;
 
     r["type"] = mount_info.type;
     r["device"] = mount_info.device;

--- a/osquery/tables/system/linux/selinux_settings.cpp
+++ b/osquery/tables/system/linux/selinux_settings.cpp
@@ -28,26 +28,25 @@ namespace {
 Status getSelinuxfsMountPath(std::string& path) {
   path = {};
 
-  MountedFilesystemMap mounted_fs_map{};
-  auto status = getMountedFilesystemMap(mounted_fs_map);
+  MountedFilesystems mounted_fs{};
+  auto status = getMountedFilesystems(mounted_fs);
   if (!status.ok()) {
     return status;
   }
 
   // clang-format off
   auto selinuxfs_info_it = std::find_if(
-    mounted_fs_map.begin(),
-    mounted_fs_map.end(),
+    mounted_fs.begin(),
+    mounted_fs.end(),
 
-    [](const std::pair<std::string, MountInformation> &p) -> bool {
-      const auto &fs_type = p.second.type;
-      return (fs_type == "selinuxfs");
+    [](const MountInformation &mount_info) -> bool {
+      return (mount_info.type == "selinuxfs");
     }
   );
   // clang-format on
 
-  if (selinuxfs_info_it != mounted_fs_map.end()) {
-    path = selinuxfs_info_it->second.path;
+  if (selinuxfs_info_it != mounted_fs.end()) {
+    path = selinuxfs_info_it->path;
   }
 
   return Status::success();


### PR DESCRIPTION
Use a vector instead of an unordered_map keyed on the mount path,
since we can have multiple mount points on the same mount path
and since all the other use cases do not need such data layout.
Although multiple mount points on the same mount path will override
each other, we still want to be faithful to the information
that /proc/mounts gives us.

Moreover with autofs mounted filesystems, we will always have two
mount lines when the target filesystem is mounted, one for autofs
and one for the target filesytem.

Fixes #6865
