### PR TITLE
Don't mark scope and key columns as index in selinux_settings table

### DIFF
--- a/osquery/tables/system/linux/selinux_settings.cpp
+++ b/osquery/tables/system/linux/selinux_settings.cpp
@@ -266,7 +266,7 @@ QueryData genSELinuxSettings(QueryContext& context) {
 
   status = generateClasses(row_list, selinuxfs_path);
   if (!status.ok()) {
-    LOG(ERROR) << "failed to bla bla";
+    LOG(ERROR) << "Failed to generate SELinux class: " << status.getMessage();
   }
 
   return row_list;

--- a/specs/linux/selinux_settings.table
+++ b/specs/linux/selinux_settings.table
@@ -1,8 +1,8 @@
 table_name("selinux_settings")
 description("Track active SELinux settings.")
 schema([
-    Column("scope", TEXT, "Where the key is located inside the SELinuxFS mount point.", index=True),
-    Column("key", TEXT, "Key or class name.", index=True),
+    Column("scope", TEXT, "Where the key is located inside the SELinuxFS mount point."),
+    Column("key", TEXT, "Key or class name."),
     Column("value", TEXT, "Active value."),
 ])
 implementation("system/selinux_settings@genSELinuxSettings")


### PR DESCRIPTION
There's no logic to implement such constraints,
moreover the columns values are not unique,
so they shouldn't be exclusively part of the primary key.

Use a slightly more meaningful error message
when reading SELinux classes fails.
