### PR TITLE
Fix config validation oom with duplicated keys

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -630,7 +630,7 @@ Status Config::validateConfig(const JSON& document) {
         for (rapidjson::Value::ConstMemberIterator itr = node.MemberBegin();
              itr != node.MemberEnd();
              ++itr) {
-          nodes.push(node[itr->name]);
+          nodes.push(itr->value);
         }
       } else if (node.IsArray()) {
         for (size_t i = 0; i < node.Size(); ++i) {


### PR DESCRIPTION
This fixes a pathological case where the validation algorithm
is unable to verify if there's a deeply nested tree,
and it can end up into an oom situation.

Added a regression test to verify this case.


This has been found by oss-fuzz.
