### PR TITLE
Fix heap-use-after-free in deregisterEventSubscriber

### DIFF
--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -187,7 +187,7 @@ Status EventFactory::deregisterEventSubscriber(const std::string& sub) {
     return Status::failure("Event subscriber is missing");
   }
 
-  auto& subscriber = subscriber_it->second;
+  auto subscriber = subscriber_it->second;
   ef.event_subs_.erase(subscriber_it);
 
   subscriber->tearDown();


### PR DESCRIPTION
Do not take a reference to a shared_ptr to be accessed
after being removed from the last persistent place
that was possibly keeping it alive.


This was only used by tests. Found with Asan.