### PR TITLE
Fix UB and dangerous casting in the pubsub framework

### DIFF
--- a/osquery/events/eventfactory.h
+++ b/osquery/events/eventfactory.h
@@ -15,6 +15,7 @@
 
 #include <osquery/events/eventer.h>
 #include <osquery/events/eventpublisherplugin.h>
+#include <osquery/events/eventsubscriberplugin.h>
 #include <osquery/events/subscription.h>
 #include <osquery/events/types.h>
 

--- a/osquery/events/eventpublisherplugin.h
+++ b/osquery/events/eventpublisherplugin.h
@@ -174,5 +174,4 @@ class EventPublisherPlugin : public Plugin,
   FRIEND_TEST(EventsTests, test_event_publisher);
   FRIEND_TEST(EventsTests, test_fire_event);
 };
-
 } // namespace osquery

--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -11,7 +11,6 @@
 #include <osquery/core/flags.h>
 #include <osquery/database/database.h>
 #include <osquery/events/eventfactory.h>
-#include <osquery/events/eventpublisher.h>
 #include <osquery/events/eventsubscriberplugin.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry_factory.h>
@@ -88,6 +87,9 @@ FLAG(uint64,
      "Maximum number of event batches per type to buffer");
 
 CREATE_REGISTRY(EventSubscriberPlugin, "event_subscriber");
+
+EventSubscriberPlugin::EventSubscriberPlugin(bool enabled)
+    : disabled(!enabled) {}
 
 Status EventSubscriberPlugin::init() {
   return Status::success();

--- a/osquery/events/types.h
+++ b/osquery/events/types.h
@@ -34,6 +34,8 @@ using EventIndex = std::map<EventTime, EventIDList>;
  * passed an EventContext.
  */
 struct EventContext : private boost::noncopyable {
+  virtual ~EventContext() {}
+
   /// An unique counting ID specific to the EventPublisher%'s fired events.
   EventContextID id{0};
 
@@ -57,21 +59,15 @@ using EventContextRef = std::shared_ptr<EventContext>;
  * networking protocols at various stacks. Process creation may subscribe on
  * process name, parent pid, etc.
  */
-struct SubscriptionContext : private boost::noncopyable {};
+struct SubscriptionContext : private boost::noncopyable {
+  virtual ~SubscriptionContext(){};
+};
 
 using SubscriptionContextRef = std::shared_ptr<SubscriptionContext>;
 
-template <class SC, class EC>
-class EventPublisher;
+class EventPublisherPlugin;
+using EventPublisherRef = std::shared_ptr<EventPublisherPlugin>;
 
-using BaseEventPublisher = EventPublisher<SubscriptionContext, EventContext>;
-
-using EventPublisherRef = std::shared_ptr<BaseEventPublisher>;
-
-template <class PUB>
-class EventSubscriber;
-
-using EventSubscriberRef = std::shared_ptr<EventSubscriber<BaseEventPublisher>>;
-using BaseEventSubscriber = EventSubscriber<BaseEventPublisher>;
-
+class EventSubscriberPlugin;
+using EventSubscriberRef = std::shared_ptr<EventSubscriberPlugin>;
 } // namespace osquery


### PR DESCRIPTION
- Downcasting a shared_ptr to a type T2 that's not a derived class or a base class of T1,
  even if they share the same base class B, it's undefined behaviour.
  For instance BPFEventPublisher inherits from EventPublisher<BPFEventSC,BPFEventEC>,
  which is a template that inherits from EventPublisherPlugin, which
  further inherits from Plugin.
  The register function was called passing an instance of std::shared_ptr<BPFEventPublisher>
  which was implicitly upcasted to std::shared_ptr<Plugin> as the
  function parameter.
  Then such parameter was downcasted to std::shared_ptr<EventPublisherPlugin>
  (which was fine), then further downcasted to std::shared_ptr<BaseEventPlugin>
  which actually was std::shared_ptr<EventPublisher<SubscriptionContext, EventContext>>.
  Although the two EventPublisher template parameters are base classes
  of BPFEventSC and BPFEventEC, the resulting concrete EventPublisher
  class is not related to BPFEventPublisher, so this is UB.
  This was done in an attempt to have a common type for all publishers
  to be used to store them into a std::map. Instead of using such type,
  use EventPublisherPlugin.
  A very similar thing happens with subcribers.

- Fix an incorrect success when a std::shared_ptr<Plugin>
  fails to be downcasted to a std::shared_ptr<EventPublisherPlugin>,
  in EventFactory::registerEventPublisher.

- Substitute dangerous reinterpret_cast on a pointer to a member function
  callback in EventSubscriber<PUB>::subscribe with a safer approach
  which uses a lambda that captures the object it has to call the callback on
  and properly converts the arguments, downcasting them to the appropriate type.
  Also remove a redundant template parameter.

- Add a virtual destructor to SubscriptionContext and EventContext
  structs since they are inherited from
  and used in a polymorphic context as pointers.
