### PR TITLE
docker_image_history table

### DIFF
--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -197,6 +197,7 @@ function(generateNativeTables)
     "posix/docker_container_fs_changes.table:linux,macos,freebsd"
     "posix/docker_container_stats.table:linux,macos,freebsd"
     "posix/docker_containers.table:linux,macos,freebsd"
+    "posix/docker_image_history.table:linux,macos,freebsd"
     "posix/docker_image_labels.table:linux,macos,freebsd"
     "posix/docker_image_layers.table:linux,macos,freebsd"
     "posix/docker_images.table:linux,macos,freebsd"

--- a/specs/posix/docker_image_history.table
+++ b/specs/posix/docker_image_history.table
@@ -1,0 +1,16 @@
+table_name("docker_image_history")
+description("Docker image history information.")
+schema([
+    Column("id", TEXT, "Image ID", index=True),
+    Column("created", BIGINT, "Time of creation as UNIX time"),
+    Column("size", BIGINT, "Size of instruction in bytes"),
+    Column("created_by", TEXT, "Created by instruction"),
+    Column("tags", TEXT, "Comma-separated list of tags"),
+    Column("comment", TEXT, "Instruction comment")
+])
+implementation("applications/docker@genImageHistory")
+examples([
+  "select * from docker_image_history",
+  "select * from docker_image_history where id = '6a2f32de169d'",
+  "select * from docker_image_history where id = '6a2f32de169d14e6f8a84538eaa28f2629872d7d4f580a303b296c60db36fbd7'"
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -96,6 +96,7 @@ function(generateTestsIntegrationTablesTestsTest)
       docker_container_processes.cpp
       docker_container_stats.cpp
       docker_containers.cpp
+      docker_image_history.cpp
       docker_image_labels.cpp
       docker_image_layers.cpp
       docker_images.cpp

--- a/tests/integration/tables/docker_image_history.cpp
+++ b/tests/integration/tables/docker_image_history.cpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for docker_image_history
+// Spec file: specs/posix/docker_image_history.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class dockerImageHistoryTest : public testing::Test {
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(dockerImageHistoryTest, test_sanity) {
+  QueryData data = execute_query("select * from docker_images");
+  if (data.size() <= 0) { // docker not installed, or issues talking to dockerd,
+                          // or no images present
+    return;
+  }
+
+  data = execute_query("select * from docker_image_history");
+  ASSERT_GT(data.size(), 0ul);
+  ValidationMap row_map = {
+      {"id", NonEmptyString},
+      {"created", NonNegativeInt},
+      {"size", NonNegativeInt},
+      {"created_by", NormalType},
+      {"tags", NormalType},
+      {"comment", NormalType},
+  };
+  validate_rows(data, row_map);
+}
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
This table provides output similar to "docker history" command.
See: https://docs.docker.com/engine/reference/commandline/history/
created_by column has useful information related to the command history

Sample output:
```
osquery> select * from docker_image_history where id = '9499db781771';
+--------------+------------+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------+
| id           | created    | size      | created_by                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | tags         | comment |
+--------------+------------+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------+
| 9499db781771 | 1606343174 | 0         | /bin/sh -c #(nop)  CMD ["/bin/bash"]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ubuntu:16.04 |         |
| 9499db781771 | 1606343174 | 7         | /bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |              |         |
| 9499db781771 | 1606343173 | 0         | /bin/sh -c rm -rf /var/lib/apt/lists/*                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |              |         |
| 9499db781771 | 1606343172 | 745       | /bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests |              |         |
| 9499db781771 | 1606343171 | 130659802 | /bin/sh -c #(nop) ADD file:8eef54430e581236e6d529a7d09df648f43c840e889d9ae132e5ed25d7bd2b88 in /                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |              |         |
+--------------+------------+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------+
```