### PR TITLE
Fix a leak in libdpkg when querying the deb_packages table

### DIFF
--- a/libraries/cmake/source/libdpkg/CMakeLists.txt
+++ b/libraries/cmake/source/libdpkg/CMakeLists.txt
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(libdpkgMain)
-  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set(library_root "${OSQUERY_libdpkg_ROOT_DIR}")
 
   add_library(thirdparty_libdpkg
     "${library_root}/lib/dpkg/pkg-format.c"

--- a/libraries/cmake/source/libdpkg/patches/src/fix-memory-leak.patch
+++ b/libraries/cmake/source/libdpkg/patches/src/fix-memory-leak.patch
@@ -1,0 +1,34 @@
+diff --git a/lib/dpkg/trigdeferred.c b/lib/dpkg/trigdeferred.c
+index e5bb2c3..d40d995 100644
+--- a/lib/dpkg/trigdeferred.c
++++ b/lib/dpkg/trigdeferred.c
+@@ -74,6 +74,7 @@ constructfn(struct varbuf *vb, const char *dir, const char *tail)
+ enum trigdef_update_status
+ trigdef_update_start(enum trigdef_update_flags uf)
+ {
++	free(triggersdir);
+ 	triggersdir = dpkg_db_get_path(TRIGGERSDIR);
+ 
+ 	if (uf & TDUF_WRITE) {
+diff --git a/lib/dpkg/triglib.c b/lib/dpkg/triglib.c
+index 57bd2a6..365de7a 100644
+--- a/lib/dpkg/triglib.c
++++ b/lib/dpkg/triglib.c
+@@ -791,11 +791,16 @@ trig_incorporate(enum modstatdb_rw cstatus)
+ 	}
+ 	switch (ur) {
+ 	case TDUS_ERROR_EMPTY_DEFERRED:
++		free(triggersdir);
++		triggersdir = NULL;
+ 		return;
+ 	case TDUS_ERROR_NO_DIR:
+ 	case TDUS_ERROR_NO_DEFERRED:
+-		if (!trigh.transitional_activate)
++		if (!trigh.transitional_activate) {
++			free(triggersdir);
++			triggersdir = NULL;
+ 			return;
++		}
+ 	/* Fall through. */
+ 	case TDUS_NO_DEFERRED:
+ 		trigh.transitional_activate(cstatus);

--- a/libraries/cmake/source/modules/Findlibdpkg.cmake
+++ b/libraries/cmake/source/modules/Findlibdpkg.cmake
@@ -12,4 +12,7 @@ importSourceSubmodule(
 
   SHALLOW_SUBMODULES
     "src"
+
+  PATCH
+    "src"
 )


### PR DESCRIPTION
libdpkg is leaking memory on every initialization.
Initialization happens everytime deb_packages gets queried.

The memory leaked is allocated for the "triggersdir"
global variable by "dpkg_db_get_path" called in "trigdef_update_start".
"trigdef_update_start" is called by "trig_incorporate" just after
the memory for "triggersdir" has been allocated.
In some occasions "trigdef_update_start" is also called two times in a
row. In all these cases the memory do not get deallocated in between calls,
so the old memory is lost.

Since the result of "dpkg_db_get_path" depends on the database dir that
has been set, and in the "trigdef_update_start" function it's not possible
to know if it has changed from the previous allocation or not,
it's necessary to always deallocate vs just avoid to call "dpkg_db_get_path".

Fix also a couple of other leaks on error.

Fixes: #6327

This was often hit by oss-fuzz too, though the stack trace would only contain 2 frames, `vasprintf` and the memory allocation.