### PR TITLE
Fix additional relative path check in Yara for Windows

### DIFF
--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -220,7 +220,9 @@ Status getYaraRules(YARAConfigParser parser,
     YR_RULES* tmp_rules = nullptr;
     switch (sign_type) {
     case YC_FILE: {
-      auto path = (sign[0] != '/') ? (kYARAHome + sign) : sign;
+      auto path = (boost::filesystem::path(sign).is_relative())
+                      ? (kYARAHome + sign)
+                      : sign;
       auto status = compileSingleFile(path, &tmp_rules);
       if (!status.ok()) {
         LOG(WARNING) << "YARA compile error: " << status.toString();


### PR DESCRIPTION
This is a follow-up to #6893 fixing an additional cross-platform
compatibility issue with the relative path check in Yara.