### PR TITLE
[macOS][CI] Update XCode to 12.3 and Update min macOS version to 10.12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,7 +214,7 @@ jobs:
         brew update
         brew upgrade
         brew install ccache flex bison
-        sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_12.3.app/Contents/Developer
       displayName: "Upgrade Homebrew and install build prerequisites"
       timeoutInMinutes: 20
 
@@ -240,7 +240,7 @@ jobs:
 
     - script: |
         cmake --version
-        cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
+        cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 \
               -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
               -DOSQUERY_BUILD_TESTS=ON \
               $(EXTRA_CMAKE_ARGS) \

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -69,7 +69,7 @@ pip3 install --user setuptools pexpect==3.3 psutil timeout_decorator six thrift=
 
 ### Step 2: Download and build source on macOS
 
-In the following example, the use of the additional CMake argument `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11` specifies macOS 10.11 as the minimum compatible macOS version to which you can deploy osquery (this affects the version of the macOS SDK used at build time).
+In the following example, the use of the additional CMake argument `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12` specifies macOS 10.12 as the minimum compatible macOS version to which you can deploy osquery (this affects the version of the macOS SDK used at build time).
 
 ```bash
 # Download source
@@ -78,7 +78,7 @@ cd osquery
 
 # Configure
 mkdir build; cd build
-cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..
+cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 ..
 
 # Build
 cmake --build . -j $(sysctl -n hw.ncpu)
@@ -343,7 +343,7 @@ On macOS you can choose between a TGZ or a PKG, which is the default.
 You may override this with the CMake `PACKAGING_SYSTEM` variable as seen in the example below.
 
 ```sh
-cmake -DPACKAGING_SYSTEM=TGZ -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..
+cmake -DPACKAGING_SYSTEM=TGZ -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 ..
 cmake --build . --target package
 ```
 

--- a/docs/wiki/installation/install-macos.md
+++ b/docs/wiki/installation/install-macos.md
@@ -1,6 +1,6 @@
 # Installing on macOS
 
-Continuous Integration currently tests stable release versions of osquery against macOS 10.14 (see the `vmImage: macos-10.14` line in the [CI configuration](https://github.com/osquery/osquery/blob/master/azure-pipelines.yml). There are no reported issues which block expected core functionality on 10.11 and greater, however 10.9 and previous macOS versions are not supported.
+Continuous Integration currently tests stable release versions of osquery against macOS 10.15 (see the `vmImage: macos-10.15` line in the [CI configuration](https://github.com/osquery/osquery/blob/master/azure-pipelines.yml). There are no reported issues which block expected core functionality on 10.12 and greater, however 10.11 and previous macOS versions are not supported.
 
 ## Package Installation
 


### PR DESCRIPTION
This updates:

* `CMAKE_OSX_DEPLOYMENT_TARGET` to 10.12. This in turn sets `mmacosx-version-min` CFLAG to 10.12
* Updates to the latest XCode. CMake uses the XCode path to build against the latest 11.1 SDK (Note: this CI image is still on 10.15 Catalina)

The benefit of this is, that we still support older macOS versions, while incorporating newer changes.

```
➜  vtool -show ./osqueryi
./osqueryi:
Load command 9
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.12
      sdk 11.1
Load command 10
      cmd LC_SOURCE_VERSION
  cmdsize 16
  version 0.0

➜  ./osqueryi -A os_version;
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| name  | version | major | minor | patch | build | platform | platform_like | codename | arch   |
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| macOS | 11.1    | 11    | 1     | 0     | 20C69 | darwin   | darwin        |          | x86_64 |
+-------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+

➜  SYSTEM_VERSION_COMPAT=1 ./osqueryi -A os_version;
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| name     | version | major | minor | patch | build | platform | platform_like | codename | arch   |
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
| Mac OS X | 10.16   | 10    | 16    | 0     | 20C69 | darwin   | darwin        |          | x86_64 |
+----------+---------+-------+-------+-------+-------+----------+---------------+----------+--------+
```

Closes #6840 