### PR TITLE
Fix data type macro used for 64-bit timestamp variables

### DIFF
--- a/osquery/tables/applications/windows/office_mru.cpp
+++ b/osquery/tables/applications/windows/office_mru.cpp
@@ -74,7 +74,7 @@ void parseOfficeData(QueryData& results,
   file_time.dwLowDateTime = large_time.LowPart;
   auto open_time = filetimeToUnixtime(file_time);
 
-  r["last_opened_time"] = INTEGER(open_time);
+  r["last_opened_time"] = BIGINT(open_time);
   r["sid"] = sid;
   results.push_back(r);
 }

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -464,10 +464,10 @@ void addCertRow(PCCERT_CONTEXT certContext,
           : INTEGER(0);
 
   r["not_valid_before"] =
-      INTEGER(filetimeToUnixtime(certContext->pCertInfo->NotBefore));
+      BIGINT(filetimeToUnixtime(certContext->pCertInfo->NotBefore));
 
   r["not_valid_after"] =
-      INTEGER(filetimeToUnixtime(certContext->pCertInfo->NotAfter));
+      BIGINT(filetimeToUnixtime(certContext->pCertInfo->NotAfter));
 
   r["signing_algorithm"] =
       cryptOIDToString(certContext->pCertInfo->SignatureAlgorithm.pszObjId);

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -90,7 +90,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
     if (utcTime.dwLowDateTime != 0 || utcTime.dwHighDateTime != 0) {
       unixTime = filetimeToUnixtime(utcTime);
     }
-    r["time"] = INTEGER(unixTime);
+    r["time"] = BIGINT(unixTime);
 
     LPWSTR clientInfo = nullptr;
     bytesRet = 0;

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -127,13 +127,13 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
     VariantTimeToSystemTime(dRunTime, &st);
     SystemTimeToFileTime(&st, &ft);
     LocalFileTimeToFileTime(&ft, &locFt);
-    r["last_run_time"] = INTEGER(filetimeToUnixtime(locFt));
+    r["last_run_time"] = BIGINT(filetimeToUnixtime(locFt));
 
     pRegisteredTask->get_NextRunTime(&dRunTime);
     VariantTimeToSystemTime(dRunTime, &st);
     SystemTimeToFileTime(&st, &ft);
     LocalFileTimeToFileTime(&ft, &locFt);
-    r["next_run_time"] = INTEGER(filetimeToUnixtime(locFt));
+    r["next_run_time"] = BIGINT(filetimeToUnixtime(locFt));
 
     ITaskDefinition* taskDef = nullptr;
     IActionCollection* tActionCollection = nullptr;

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -5,7 +5,7 @@ schema([
     Column("user", TEXT, "User login name"),
     Column("tty", TEXT, "Device name"),
     Column("host", TEXT, "Remote hostname"),
-    Column("time", INTEGER, "Time entry was made"),
+    Column("time", BIGINT, "Time entry was made"),
     Column("pid", INTEGER, "Process (or thread) ID"),
 ])
 extended_schema(WINDOWS, [

--- a/specs/windows/office_mru.table
+++ b/specs/windows/office_mru.table
@@ -4,7 +4,7 @@ schema([
 	Column("application", TEXT, "Associated Office application"),
 	Column("version", TEXT, "Office application version number"),
 	Column("path", TEXT, "File path"),
-	Column("last_opened_time", INTEGER, "Most recent opened time file was opened"),
+	Column("last_opened_time", BIGINT, "Most recent opened time file was opened"),
 	Column("sid", TEXT, "User SID"),
 ])
 implementation("office_mru@genOfficeMru")

--- a/specs/windows/scheduled_tasks.table
+++ b/specs/windows/scheduled_tasks.table
@@ -7,8 +7,8 @@ schema([
   Column("enabled", INTEGER, "Whether or not the scheduled task is enabled"),
   Column("state", TEXT, "State of the scheduled task"),
   Column("hidden", INTEGER, "Whether or not the task is visible in the UI"),
-  Column("last_run_time", INTEGER, "Timestamp the task last ran"),
-  Column("next_run_time", INTEGER, "Timestamp the task is scheduled to run next"),
+  Column("last_run_time", BIGINT, "Timestamp the task last ran"),
+  Column("next_run_time", BIGINT, "Timestamp the task is scheduled to run next"),
   Column("last_run_message", TEXT, "Exit status message of the last task run"),
   Column("last_run_code", TEXT, "Exit status code of the last task run"),
 ])


### PR DESCRIPTION
Closes #6890 

As described in the issue, sometimes 64-bit (`long long`) variables used for timestamps were being put through the `INTEGER()` macro which would fail in the `tryto()` routine. This PR changes the fields that need to hold these timestamps to be `BIGINT`.