### PR TITLE
Disable incremental linking to reduce build size on Windows

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -273,6 +273,7 @@ function(setupBuildFlags)
 
     set(windows_common_link_options
       /SUBSYSTEM:CONSOLE
+      /INCREMENTAL:NO
       ntdll.lib
       ole32.lib
       oleaut32.lib


### PR DESCRIPTION
A previous PR removed the unused /LTCG linker flag,
which was also disabling incremental linking,
permitting the build to stay under a certain size.
Now that the incremental linking is enabled again,
the size of a full build with RelWithDebInfo increased by 29GB,
for a total of almost 50GB.

This is too big, so disable incremental linking to reduce build size.
