### PR TITLE
Spellcheck and Markdown nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ osquery is a SQL powered operating system instrumentation, monitoring, and analy
 Available for Linux, macOS, Windows, and FreeBSD.
 </p>
 
-**Information and resources**
-- Homepage: https://osquery.io
-- Downloads: https://osquery.io/downloads
-- Documentation: https://osquery.readthedocs.org
-- Stack Overflow: https://stackoverflow.com/questions/tagged/osquery
-- Table Schema: https://osquery.io/schema
-- Query Packs: [https://osquery.io/packs](https://github.com/osquery/osquery/tree/master/packs)
+## Information and resources
+
+- Homepage: [osquery.io](https://osquery.io)
+- Downloads: [osquery.io/downloads](https://osquery.io/downloads)
+- Documentation: [ReadTheDocs](https://osquery.readthedocs.org)
+- Stack Overflow: [Stack Overflow questions](https://stackoverflow.com/questions/tagged/osquery)
+- Table Schema: [osquery.io/schema](https://osquery.io/schema)
+- Query Packs: [osquery.io/packs](https://github.com/osquery/osquery/tree/master/packs)
 - Slack: [Request an auto-invite!](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw)
 - Build Status: [![Build Status](https://dev.azure.com/trailofbits/osquery/_apis/build/status/osquery?branchName=master)](https://dev.azure.com/trailofbits/osquery/_build/latest?definitionId=6&branchName=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/13317/badge.svg)](https://scan.coverity.com/projects/osquery) [![Documentation Status](https://readthedocs.org/projects/osquery/badge/?version=latest)](https://osquery.readthedocs.io/en/latest/?badge=latest)
 - CII Best Practices: [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3125/badge)](https://bestpractices.coreinfrastructure.org/projects/3125)
-
 
 ## What is osquery?
 
@@ -36,16 +36,19 @@ understand the expressiveness that is afforded to you by osquery, consider the f
 queries:
 
 List the [`users`](https://osquery.io/schema/current#users):
+
 ```sql
 SELECT * FROM users;
 ```
 
 Check the [`processes`](https://osquery.io/schema/current#processes) that have a deleted executable:
+
 ```sql
 SELECT * FROM processes WHERE on_disk = 0;
 ```
 
 Get the process name, port, and PID, for processes listening on all interfaces:
+
 ```sql
 SELECT DISTINCT processes.name, listening_ports.port, processes.pid
   FROM listening_ports JOIN processes USING (pid)
@@ -53,6 +56,7 @@ SELECT DISTINCT processes.name, listening_ports.port, processes.pid
 ```
 
 Find every macOS LaunchDaemon that launches an executable and keeps it running:
+
 ```sql
 SELECT name, program || program_arguments AS executable
   FROM launchd
@@ -78,11 +82,12 @@ SELECT address, mac, mac_count
 ```
 
 These queries can be:
-* performed on an ad-hoc basis to explore operating system state using the
+
+- performed on an ad-hoc basis to explore operating system state using the
   [osqueryi](https://osquery.readthedocs.org/en/latest/introduction/using-osqueryi/) shell
-* executed via a [scheduler](https://osquery.readthedocs.org/en/latest/introduction/using-osqueryd/)
+- executed via a [scheduler](https://osquery.readthedocs.org/en/latest/introduction/using-osqueryd/)
   to monitor operating system state across a set of hosts
-* launched from custom applications using osquery Thrift APIs
+- launched from custom applications using osquery Thrift APIs
 
 ## Download & Install
 

--- a/docs/wiki/deployment/extensions.md
+++ b/docs/wiki/deployment/extensions.md
@@ -17,7 +17,7 @@ icacls .\Extensions /inheritance:r /t
 icacls .\Extensions /inheritance:d /t
 ```
 
-## Autoloading Extensions
+## Auto-loading Extensions
 
 The following [CLI flags](../installation/cli-flags.md) control extension auto-loading:
 
@@ -73,7 +73,7 @@ $ cat /etc/osquery/osquery.flags
 ## Retrieving Tables and Columns with SQL
 
 Aside from the `.tables` and `.schema` shell builtins, there is an alternative way to retrieve all available tables and columns: using SQL.
- 
+
 To retrieve all tables:
 
 ```sqlite

--- a/docs/wiki/deployment/log-aggregation.md
+++ b/docs/wiki/deployment/log-aggregation.md
@@ -2,8 +2,7 @@
 
 osquery is designed to work with any environment's existing data infrastructure. Since the problem space of forwarding logs is so well developed, osquery does not implement log forwarding internally, but rather via plugins.
 
-**Note**: Ulimately, the solution for forwarding and analyzing osquery logs depends on your particular environment and deployment needs. This page offers advice and some options for you to consider, but at the end of the day, you know your infrastructure best and you should make your decisions based on that knowledge.
-
+**Note**: Ultimately, the solution for forwarding and analyzing osquery logs depends on your particular environment and deployment needs. This page offers advice and some options for you to consider, but at the end of the day, you know your infrastructure best and you should make your decisions based on that knowledge.
 
 When it comes to aggregating the logs that `osqueryd` generates, you have several options. If you use the filesystem logger plugin (which is the default), then you're responsible for shipping the logs off somewhere. There are many open source and commercial products which excel in this area. This section will explore a few of those options.
 
@@ -82,13 +81,13 @@ Logstash will index logs into ElasticSearch using a default index format of logs
 
 An example Kibana log entry:
 
-![](https://i.imgur.com/thivGYc.png)
+![An example Kibana log entry in table view](https://i.imgur.com/thivGYc.png)
 
 ### Splunk
 
 Splunk will automatically extract the relevant fields for analytics, as shown below:
 
-![](https://i.imgur.com/tWCPx51.png)
+![Splunk, showing the interesting fields](https://i.imgur.com/tWCPx51.png)
 
 ## Rsyslog, Fluentd, Scribe, etc
 

--- a/docs/wiki/deployment/performance-safety.md
+++ b/docs/wiki/deployment/performance-safety.md
@@ -67,11 +67,11 @@ To estimate how often these should run, you should evaluate what a differential 
 
 ### Understanding the output from profile.py
 
-The osquery `profile.py` script uses `utils.py` in `tools/tests/` which uses python’s `psutil` library to collect process stats for osqueryi as its running given queries. 
+The osquery `profile.py` script uses `utils.py` in `tools/tests/` which uses python’s `psutil` library to collect process stats for osqueryi as its running given queries.
 
 The script returns 5 stats:
 
-**Utilization (U)**: Utilization is calculated by taking the average of non-0 results of the cpu_percent(interval=1) function in `psutils.Process()`. This value can be greater than 100% for processes with threads running across different CPUs. The script sets an interval of 1 meaning that the function compares process time to system CPU times elapsed before and after the 1 second interval. This is a blocking call. 
+**Utilization (U)**: Utilization is calculated by taking the average of non-0 results of the cpu_percent(interval=1) function in `psutils.Process()`. This value can be greater than 100% for processes with threads running across different CPUs. The script sets an interval of 1 meaning that the function compares process time to system CPU times elapsed before and after the 1 second interval. This is a blocking call.
 
 **CPU time (C)**: CPU time uses the `psutils.Process()`'s `cpu_times()` function. It returns a named tuple containing user, system, children_user, system_user, and iowait
 
@@ -81,11 +81,10 @@ The script returns 5 stats:
 - system_user: user time of all child processes (always 0 on Windows and macOS).
 - iowait: (Linux) time spent waiting for blocking I/O to complete. This value is excluded from user and system times count (because the CPU is not doing any work).
 
-The profile script adds user and system together for the CPU 
-Time output.
+The profile script adds user and system together for the CPU Time output.
 
 **Duration (D)**:
-Duration is calculated by taking the subtracting `start_time` - 2 from the current time. The start time is set before the script starts the `osqueryi` process to run the query. The `start_time` - 2 comes from the `--profile_delay` flag used by the profile.py script. This flag causes osquery to wait before and after running the code under test. The 2 is to make up for this wait time. 
+Duration is calculated by taking the subtracting `start_time` - 2 from the current time. The start time is set before the script starts the `osqueryi` process to run the query. The `start_time` - 2 comes from the `--profile_delay` flag used by the profile.py script. This flag causes osquery to wait before and after running the code under test. The 2 is to make up for this wait time.
 
 **fds (F)**: Uses the `num_fds()` function and returns the file descriptors used by the `osqueryi` process during query execution
 

--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -169,7 +169,7 @@ osqueryi --audit_allow_config=true --audit_allow_sockets=true --audit_persist=tr
 
 If you would like to debug the raw audit events as `osqueryd` sees them, use the hidden flag `--audit_debug`. This will print all of the RAW audit lines to osquery's `stdout`.
 
-> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`. 
+> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`.
 
 ## User event auditing with Audit
 
@@ -182,10 +182,12 @@ When osquery is running on a recent kernel (>= 4.18), the BPF eventing framework
 In order to start the publisher and enable the subscribers, the following flags must be passed: `--disable_events=false --enable_bpf_events=true`. The `--verbose` flag can also be extremely useful when setting up the configuration for the first time, since it emit more debug information when something fails.
 
 The BPF framework will make use of a perf event array and several per-cpu maps in order to receive events and correctly capture strings and buffers. These structures can be configured using the following command line flags:
- - **bpf_perf_event_array_exp**: size of the perf event array, as a power of two
- - **bpf_buffer_storage_size**: how many slots of 4096 bytes should be available in each memory pool
 
-Memory usage depends on both
+- **bpf_perf_event_array_exp**: size of the perf event array, as a power of two
+- **bpf_buffer_storage_size**: how many slots of 4096 bytes should be available in each memory pool
+
+Memory usage depends on both:
+
  1. How many processors are currently online
  2. How many processors can be added by hotswapping
 

--- a/docs/wiki/deployment/syslog.md
+++ b/docs/wiki/deployment/syslog.md
@@ -1,4 +1,4 @@
-# Reading syslogs with osquery
+# Reading syslog with osquery
 
 osquery 1.7.3 introduced support for consuming and querying the macOS system log via Apple System Log (ASL). osquery 1.7.4 introduced support for the Linux syslog via **rsyslog**. This document explains how to configure and use these syslog tables.
 

--- a/docs/wiki/development/creating-tables.md
+++ b/docs/wiki/development/creating-tables.md
@@ -204,7 +204,7 @@ Examples:
   }
 ```
 
-`processes` optionally uses a predicate. A syscall to list process pids requires few resources. Enumerating "/proc" information and parsing environment/argument uses MANY resources. The table implementation includes:
+`processes` optionally uses a predicate. A syscall to list process PIDs requires few resources. Enumerating "/proc" information and parsing environment/argument uses MANY resources. The table implementation includes:
 
 ```cpp
   for (auto &pid : pidlist) {

--- a/docs/wiki/development/osquery-sdk.md
+++ b/docs/wiki/development/osquery-sdk.md
@@ -107,7 +107,7 @@ osquery project page <https://osquery.io>.
 $ ./build/darwin/osquery/example_extension.ext --socket /Users/USERNAME/.osquery/shell.em &
 ```
 
-Before executing the extension we've inspected the potential CLI flags, which are a subset of the shell or daemon's [CLI flags](../installation/cli-flags.md). We executed the example extension in the background, so now we can resume the osqeury shell and use the 'example' table provided by the extension.
+Before executing the extension we've inspected the potential CLI flags, which are a subset of the shell or daemon's [CLI flags](../installation/cli-flags.md). We executed the example extension in the background, so now we can resume the osquery shell and use the 'example' table provided by the extension.
 
 ```sh
 [2] 98795

--- a/docs/wiki/development/pubsub-framework.md
+++ b/docs/wiki/development/pubsub-framework.md
@@ -22,7 +22,7 @@ When scheduling queries that include `_events` (subscriber-based) tables, additi
 
 An osquery event publisher is a combination of a threaded run loop and event storage abstraction. The publisher loops on some selected resource or uses operating system APIs to register callbacks. The loop or callback introspects on the event and sends it to every appropriate subscriber. An osquery event subscriber will send subscriptions to a publisher, save published data, and react to a query by returning appropriate data.
 
-The pubsub runflow is exposed as a publisher `setUp()`, a series of `addSubscription(const SubscriptionRef)` by subscribers, a publisher `configure()`, and finally a new thread scheduled with the publisher's `run()` static method as the entrypoint. For every event the publisher receives it will loop through every `Subscription` and call `fire(const EventContextRef, EventTime)` to send the event to the subscriber.
+The pubsub runflow is exposed as a publisher `setUp()`, a series of `addSubscription(const SubscriptionRef)` by subscribers, a publisher `configure()`, and finally a new thread scheduled with the publisher's `run()` static method as the entry point. For every event the publisher receives it will loop through every `Subscription` and call `fire(const EventContextRef, EventTime)` to send the event to the subscriber.
 
 ## Example: inotify
 

--- a/docs/wiki/development/unit-tests.md
+++ b/docs/wiki/development/unit-tests.md
@@ -1,6 +1,6 @@
 # Unit testing in osquery
 
-All commits to osquery should be well unit-tested. Having tests is useful for many reasons. In addition to the subtle advantage of being able to assert program correctness, tests are often the smallest possible executable which can run a given bit of code. This makes testing new features for memory leaks much easier. Using tools like valgrind in conjunction with compiled tests, we can directly analyze the desired code with minimal outside influence.
+All commits to osquery should be well unit-tested. Having tests is useful for many reasons. In addition to the subtle advantage of being able to assert program correctness, tests are often the smallest possible executable which can run a given bit of code. This makes testing new features for memory leaks much easier. Using tools like Valgrind in conjunction with compiled tests, we can directly analyze the desired code with minimal outside influence.
 
 ## Writing a test
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -92,7 +92,7 @@ CPU: default 25% (for 9 seconds), restrictive 18% (for 9 seconds)
 
 The normal level allows for 10 restarts if the limits are violated. The restrictive allows for only 4, then the service will be disabled. For both there is a linear backoff of 5 seconds, doubling each retry.
 
-It is better to set the level to disabled (`-1`) rather than disabling the watchdog outright, as the worker/watcher concept is used for extensions autoloading too. 
+It is better to set the level to disabled (`-1`) rather than disabling the watchdog outright, as the worker/watcher concept is used for extensions auto-loading too.
 
 The watchdog "profiles" can be overridden for Memory and CPU Utilization.
 
@@ -161,12 +161,12 @@ Path to the extensions UNIX domain socket.
 
 `--extensions_autoload=/etc/osquery/extensions.load`
 
-Optional path to a list of autoloaded and managed extensions.
-If using an extension to provide a proprietary config or logger plugin the extension process can be started by the daemon. Include line-delimited paths to extension executables. See the extensions [deployment](../deployment/extensions.md) page for more details on extension autoloading.
+Optional path to a list of auto-loaded and managed extensions.
+If using an extension to provide a proprietary config or logger plugin the extension process can be started by the daemon. Include line-delimited paths to extension executables. See the extensions [deployment](../deployment/extensions.md) page for more details on extension auto-loading.
 
 `--extensions_timeout=3`
 
-Seconds to wait for autoloaded extensions to register.
+Seconds to wait for auto-loaded extensions to register.
 osqueryd may depend on a config plugin from an extension. If the requested config plugin name is not registered within the timeout the daemon will exit with a failure.
 
 `--extensions_interval=3`
@@ -276,7 +276,7 @@ It is often not the intention of the schedule author to run these queries togeth
 
 Max time drift in seconds.
 The scheduler tries to compensate the splay drift until the delta exceeds this value.
-If the max drift is exceeded the splay will be reseted to zero and the compensation process will start from the beginning.
+If the max drift is exceeded the splay will be reset to zero and the compensation process will start from the beginning.
 This is needed to avoid the problem of endless compensation (which is CPU greedy) after a long SIGSTOP/SIGCONT pause or something similar. Set it to zero to disable drift compensation.
 
 `--pack_refresh_interval=3600`
@@ -429,7 +429,7 @@ Compression codec to use for compressing message sets. Valid options are ("none"
 
 `--buffered_log_max=1000000`
 
-There are multiple logger plugins that use a "buffered logging" implementation. The TLS and AWS loggers use this approach. This flag sets the maximum number of logs to buffer before dropping new logs. If the buffered logs have not been shuttled to the logger destintation they will be purged in order of their timestamp. The oldest logs are purged first.
+There are multiple logger plugins that use a "buffered logging" implementation. The TLS and AWS loggers use this approach. This flag sets the maximum number of logs to buffer before dropping new logs. If the buffered logs have not been shuttled to the logger destination they will be purged in order of their timestamp. The oldest logs are purged first.
 
 Setting this to value to `0` means unlimited logs will be buffered.
 

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -22,7 +22,7 @@ The default packages create the following structure:
 
 To install osquery, follow the instructions on the [Downloads](https://osquery.io/downloads/official) page according to your distro.
 
-> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`. 
+> NOTICE: Linux systems running `journald` will collect logging data originating from the kernel audit subsystem (something that osquery enables) from several sources, including audit records. To avoid performance problems on busy boxes (specially when osquery event tables are enabled), it is recommended to mask audit logs from entering the journal with the following command `systemctl mask --now systemd-journald-audit.socket`.
 
 ## Running osquery
 

--- a/docs/wiki/introduction/using-osqueryi.md
+++ b/docs/wiki/introduction/using-osqueryi.md
@@ -42,7 +42,7 @@ $ osqueryi --json "SELECT * FROM routes WHERE destination = '::1'"
 You may also pipe a query as *stdin*. The input will be executed on the `osqueryi` shell and must be well-formed SQL or `osqueryi` meta-commands. Note the added ';' to the query when using *stdin*:
 
 ```
-$ echo "SELECT * FROM routes WHERE destination = '::1';" | osqueryi --json
+echo "SELECT * FROM routes WHERE destination = '::1';" | osqueryi --json
 ```
 
 ## Getting help


### PR DESCRIPTION
Just a routine spellchecking and Markdown pass on our docs.

We gotta stop misspelling `osquery` 👀