### PR TITLE
Fix typos across source code

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -614,12 +614,12 @@ void Initializer::start() const {
 }
 
 /**
- * This is a small interruptable thread implementation.
+ * This is a small interruptible thread implementation.
  *
  * The goal is to wait until interrupted or an alarm timeout. If the timeout
  * occurs then osquery is stuck shutting down and we force-terminate.
  */
-class AlarmRunnable : public InterruptableRunnable {
+class AlarmRunnable : public interruptibleRunnable {
  public:
   /// Thread entry point.
   void run() {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -619,7 +619,7 @@ void Initializer::start() const {
  * The goal is to wait until interrupted or an alarm timeout. If the timeout
  * occurs then osquery is stuck shutting down and we force-terminate.
  */
-class AlarmRunnable : public interruptibleRunnable {
+class AlarmRunnable : public InterruptibleRunnable {
  public:
   /// Thread entry point.
   void run() {

--- a/osquery/core/plugins/sql.cpp
+++ b/osquery/core/plugins/sql.cpp
@@ -17,7 +17,7 @@
  *
  * Abstracting the SQL implementation behind the osquery registry allows
  * the SDK (libosquery) to describe how the SQL implementation is used without
- * having dependencies on the thrird-party code.
+ * having dependencies on the third-party code.
  *
  * When osqueryd/osqueryi are built libosquery_additional, the library which
  * provides the core plugins and core virtual tables, includes SQLite as

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -18,7 +18,7 @@
  *
  * Abstracting the SQL implementation behind the osquery registry
  * allows the SDK (libosquery) to describe how the SQL implementation
- * is used without having dependencies on the thrird-party code.
+ * is used without having dependencies on the third-party code.
  *
  * When osqueryd/osqueryi are built libosquery_additional, the library
  * which provides the core plugins and core virtual tables, includes

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -208,7 +208,7 @@ inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
   doc.add("epoch", static_cast<size_t>(item.epoch), obj);
   doc.add("counter", static_cast<size_t>(item.counter), obj);
 
-  // Apply field indicatiting if numerics are serialized as numbers
+  // Apply field indicating if numerics are serialized as numbers
   doc.add("numerics", FLAGS_logger_numerics, obj);
 
   // Append the decorations.

--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -128,7 +128,7 @@ class Query {
    * which can be accessed via the getColumnFamilyName getter method.
    *
    * @param name The query name.
-   * @param q a SheduledQuery struct.
+   * @param q a ScheduledQuery struct.
    */
   explicit Query(std::string name, const ScheduledQuery& q)
       : query_(q.query), name_(std::move(name)) {}

--- a/osquery/core/sql/column.h
+++ b/osquery/core/sql/column.h
@@ -20,7 +20,7 @@ namespace osquery {
  * @brief Column options allow for more-complicated modeling of concepts.
  *
  * To accommodate the oddities of operating system concepts we make use of
- * simple SQLite abstractions like indexs/keys and foreign keys, we also
+ * simple SQLite abstractions like indexes/keys and foreign keys, we also
  * allow for optimizing based on query constraints (WHERE).
  *
  * There are several 'complications' where the default table filter (SELECT)

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -74,7 +74,7 @@ Mutex kDatabaseReset;
  */
 const size_t kDatabaseMaxRetryCount{25};
 
-/// Number of millisecons to pause between database initialize retries.
+/// Number of milliseconds to pause between database initialize retries.
 const size_t kDatabaseRetryDelay{200};
 
 Status DatabasePlugin::reset() {
@@ -479,7 +479,7 @@ Status initDatabasePlugin() {
     }
 
     if (FLAGS_disable_database) {
-      // Do not try multiple times to initialize the emphemeral plugin.
+      // Do not try multiple times to initialize the ephemeral plugin.
       break;
     }
     sleepFor(kDatabaseRetryDelay);

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -88,7 +88,7 @@ class DatabasePlugin : public Plugin {
    * Database value access indexing is abstracted into domains and keys.
    * Both are string values but exist separately for simple indexing without
    * API-enforcing tokenization. In some cases we do add a component-specific
-   * tokeninzation to keys.
+   * tokenization to keys.
    *
    * @param domain A string value representing abstract storage indexing.
    * @param key A string value representing the lookup/retrieval key.

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -17,7 +17,7 @@ namespace osquery {
 /// The worker_threads define the default thread pool size.
 FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
 
-void interruptibleRunnable::interrupt() {
+void InterruptibleRunnable::interrupt() {
   // Set the service as interrupted.
   if (!interrupted_.exchange(true)) {
     // Tear down the service's resources such that exiting the expected run
@@ -29,11 +29,11 @@ void interruptibleRunnable::interrupt() {
   }
 }
 
-bool interruptibleRunnable::interrupted() {
+bool InterruptibleRunnable::interrupted() {
   return interrupted_;
 }
 
-void interruptibleRunnable::pause(std::chrono::milliseconds milli) {
+void InterruptibleRunnable::pause(std::chrono::milliseconds milli) {
   std::unique_lock<std::mutex> lock(condition_lock);
   if (!interrupted_) {
     condition_.wait_for(lock, milli);

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -17,7 +17,7 @@ namespace osquery {
 /// The worker_threads define the default thread pool size.
 FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
 
-void InterruptableRunnable::interrupt() {
+void interruptibleRunnable::interrupt() {
   // Set the service as interrupted.
   if (!interrupted_.exchange(true)) {
     // Tear down the service's resources such that exiting the expected run
@@ -29,11 +29,11 @@ void InterruptableRunnable::interrupt() {
   }
 }
 
-bool InterruptableRunnable::interrupted() {
+bool interruptibleRunnable::interrupted() {
   return interrupted_;
 }
 
-void InterruptableRunnable::pause(std::chrono::milliseconds milli) {
+void interruptibleRunnable::pause(std::chrono::milliseconds milli) {
   std::unique_lock<std::mutex> lock(condition_lock);
   if (!interrupted_) {
     condition_.wait_for(lock, milli);

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -28,9 +28,9 @@ namespace osquery {
 class Status;
 class Dispatcher;
 
-class interruptibleRunnable {
+class InterruptibleRunnable {
  public:
-  virtual ~interruptibleRunnable() = default;
+  virtual ~InterruptibleRunnable() = default;
 
   /**
    * @brief The std::thread's interruption point.
@@ -52,7 +52,7 @@ class interruptibleRunnable {
   /// Put the runnable into an interruptible sleep.
   void pause(std::chrono::milliseconds milli);
 
-  /// Name of the interruptibleRunnable which is also the thread name
+  /// Name of the InterruptibleRunnable which is also the thread name
   std::string runnable_name_;
 
  private:
@@ -75,7 +75,7 @@ class interruptibleRunnable {
 };
 
 class InternalRunnable : private boost::noncopyable,
-                         public interruptibleRunnable {
+                         public InterruptibleRunnable {
  public:
   InternalRunnable(const std::string& name) : run_(false) {
     runnable_name_ = name;

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -28,9 +28,9 @@ namespace osquery {
 class Status;
 class Dispatcher;
 
-class InterruptableRunnable {
+class interruptibleRunnable {
  public:
-  virtual ~InterruptableRunnable() = default;
+  virtual ~interruptibleRunnable() = default;
 
   /**
    * @brief The std::thread's interruption point.
@@ -52,7 +52,7 @@ class InterruptableRunnable {
   /// Put the runnable into an interruptible sleep.
   void pause(std::chrono::milliseconds milli);
 
-  /// Name of the InterruptableRunnable which is also the thread name
+  /// Name of the interruptibleRunnable which is also the thread name
   std::string runnable_name_;
 
  private:
@@ -75,7 +75,7 @@ class InterruptableRunnable {
 };
 
 class InternalRunnable : private boost::noncopyable,
-                         public InterruptableRunnable {
+                         public interruptibleRunnable {
  public:
   InternalRunnable(const std::string& name) : run_(false) {
     runnable_name_ = name;

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -231,7 +231,7 @@ Status Distributed::acceptWork(const std::string& work) {
                        "distributed_accelerate_checkins_expire",
                        std::to_string(getUnixTime() + duration));
     } else {
-      VLOG(1) << "Falied to Accelerate: Timeframe is not an integer";
+      VLOG(1) << "Failed to Accelerate: Timeframe is not an integer";
     }
   }
   return Status::success();

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -143,7 +143,7 @@ class FSEventsEventPublisher
   std::set<std::string> transformSubscription(
       FSEventsSubscriptionContextRef& sc) const;
 
-  /// Build the set of excluded paths for which events are not to be propogated.
+  /// Build the set of excluded paths for which events are not to be propagated.
   void buildExcludePathsSet();
 
  private:

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -64,7 +64,7 @@ Status OpenBSMEventPublisher::configureAuditPipe() {
   }
 
   if (true == FLAGS_audit_allow_user_events) {
-    // capture user (login, autherization etc...) events
+    // capture user (login, authorization, etc.) events
     ev_classes.insert("lo");
     ev_classes.insert("aa");
   }

--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -400,7 +400,7 @@ Status EventFactory::run(const std::string& type_id) {
       break;
     }
     publisher->restart_count_++;
-    // This is a 'default' cool-off implemented in InterruptableRunnable.
+    // This is a 'default' cool-off implemented in interruptibleRunnable.
     // If a publisher fails to perform some sort of interruption point, this
     // prevents the thread from thrashing through exiting checks.
     publisher->pause(std::chrono::milliseconds(200));

--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -400,7 +400,7 @@ Status EventFactory::run(const std::string& type_id) {
       break;
     }
     publisher->restart_count_++;
-    // This is a 'default' cool-off implemented in interruptibleRunnable.
+    // This is a 'default' cool-off implemented in InterruptibleRunnable.
     // If a publisher fails to perform some sort of interruption point, this
     // prevents the thread from thrashing through exiting checks.
     publisher->pause(std::chrono::milliseconds(200));

--- a/osquery/events/eventpublisherplugin.h
+++ b/osquery/events/eventpublisherplugin.h
@@ -18,7 +18,7 @@
 namespace osquery {
 
 class EventPublisherPlugin : public Plugin,
-                             public InterruptableRunnable,
+                             public interruptibleRunnable,
                              public Eventer {
  public:
   /**

--- a/osquery/events/eventpublisherplugin.h
+++ b/osquery/events/eventpublisherplugin.h
@@ -18,7 +18,7 @@
 namespace osquery {
 
 class EventPublisherPlugin : public Plugin,
-                             public interruptibleRunnable,
+                             public InterruptibleRunnable,
                              public Eventer {
  public:
   /**

--- a/osquery/events/linux/bpf/bpfeventpublisher.cpp
+++ b/osquery/events/linux/bpf/bpfeventpublisher.cpp
@@ -167,7 +167,7 @@ Status BPFEventPublisher::setUp() {
 
       if (tracer_allocator.syscall_name == "openat2") {
         verbose_message << ". This syscall may not be available on this "
-                           "system, continuining despite the error";
+                           "system, continuing despite the error";
       }
 
       VLOG(1) << verbose_message.str();

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -222,7 +222,7 @@ class INotifyEventPublisher
   bool monitorSubscription(INotifySubscriptionContextRef& sc,
                            bool add_watch = true);
 
-  /// Build the set of excluded paths for which events are not to be propogated.
+  /// Build the set of excluded paths for which events are not to be propagated.
   void buildExcludePathsSet();
 
   /// Remove an INotify watch (monitor) from our tracking.

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -229,7 +229,7 @@ void SyslogEventPublisher::unlockPipe() {
 
 Status SyslogEventPublisher::run() {
   // This run function will be called by the event factory with ~100ms pause
-  // (see interruptibleRunnable::pause()) between runs. In case something goes
+  // (see InterruptibleRunnable::pause()) between runs. In case something goes
   // weird and there is a huge amount of input, we limit how many logs we
   // take in per run to avoid pegging the CPU.
 

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -229,7 +229,7 @@ void SyslogEventPublisher::unlockPipe() {
 
 Status SyslogEventPublisher::run() {
   // This run function will be called by the event factory with ~100ms pause
-  // (see InterruptableRunnable::pause()) between runs. In case something goes
+  // (see interruptibleRunnable::pause()) between runs. In case something goes
   // weird and there is a huge amount of input, we limit how many logs we
   // take in per run to avoid pegging the CPU.
 

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -87,7 +87,7 @@ class NonBlockingFStream : public boost::noncopyable {
    * a complete line was dequeued from the managed stream. If too much data is
    * written and our internal buffer overflows then no data will be output.
    *
-   * Overflowing the internal buffer does not break the reading. If this occures
+   * Overflowing the internal buffer does not break the reading. If this occurs
    * then expect a line to be truncated and only yield the max bytes.
    */
   Status getline(std::string& output);

--- a/osquery/events/pathset.h
+++ b/osquery/events/pathset.h
@@ -25,7 +25,7 @@ namespace osquery {
 /**
  * @brief multiset based implementation for path search.
  *
- * 'multiset' is used because with patterns we can serach for equivalent keys.
+ * 'multiset' is used because with patterns we can search for equivalent keys.
  * Since  '/This/Path/is' ~= '/This/Path/%' ~= '/This/Path/%%' (equivalent).
  *
  * multiset is protected by lock. It is threadsafe.

--- a/osquery/events/tests/linux/bpf/systemstatetracker.cpp
+++ b/osquery/events/tests/linux/bpf/systemstatetracker.cpp
@@ -1316,7 +1316,7 @@ TEST_F(SystemStateTrackerTests, saveFileHandle) {
   EXPECT_EQ(context.file_handle_struct_map.count(index), 1U);
   EXPECT_EQ(context.file_handle_struct_index.size(), 1U);
 
-  // Make sure that the handle was saved correcly
+  // Make sure that the handle was saved correctly
   auto first_item_it = context.file_handle_struct_map.begin();
   const auto& file_handle_struct = first_item_it->second;
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -659,7 +659,7 @@ Status getExtensions(const std::string& manager_path,
   // Add the extension manager to the list called (core).
   extensions[0] = {"core", kVersion, "0.0.0", kSDKVersion};
 
-  // Convert from Thrift-internal list type to RouteUUID/ExtenionInfo type.
+  // Convert from Thrift-internal list type to RouteUUID/ExtensionInfo type.
   for (const auto& ext : ext_list) {
     extensions[ext.first] = {ext.second.name,
                              ext.second.version,

--- a/osquery/extensions/extensions.h
+++ b/osquery/extensions/extensions.h
@@ -58,7 +58,7 @@ class ExternalSQLPlugin : public SQLPlugin {
                          TableColumns& columns) const override;
 };
 
-/// Status get a list of active extenions.
+/// Status get a list of active extensions.
 Status getExtensions(ExtensionList& extensions);
 
 /// Internal getExtensions using a UNIX domain socket path.

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -226,9 +226,9 @@ Status procGetSocketList(int family,
   switch (family) {
   case AF_INET:
     if (kLinuxProtocolNames.count(protocol) == 0) {
-      return Status(1,
-                    "Invalid family " + std::to_string(protocol) +
-                        " for AF_INET family");
+      return Status(
+          1,
+          "Invalid family " + std::to_string(protocol) + " for AF_INET family");
     } else {
       path += kLinuxProtocolNames.at(protocol);
     }

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -228,7 +228,7 @@ Status procGetSocketList(int family,
     if (kLinuxProtocolNames.count(protocol) == 0) {
       return Status(1,
                     "Invalid family " + std::to_string(protocol) +
-                        " for AF_INET familiy");
+                        " for AF_INET family");
     } else {
       path += kLinuxProtocolNames.at(protocol);
     }
@@ -238,7 +238,7 @@ Status procGetSocketList(int family,
     if (kLinuxProtocolNames.count(protocol) == 0) {
       return Status(1,
                     "Invalid protocol " + std::to_string(protocol) +
-                        " for AF_INET6 familiy");
+                        " for AF_INET6 family");
     } else {
       path += kLinuxProtocolNames.at(protocol) + "6";
     }
@@ -248,7 +248,7 @@ Status procGetSocketList(int family,
     if (protocol != IPPROTO_IP) {
       return Status(1,
                     "Invalid protocol " + std::to_string(protocol) +
-                        " for AF_UNIX familiy");
+                        " for AF_UNIX family");
     } else {
       path += "unix";
     }

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -324,7 +324,7 @@ Status platformIsTmpDir(const fs::path& dir) {
 Status platformIsFileAccessible(const fs::path& path) {
   struct stat link_stat;
   if (::lstat(path.c_str(), &link_stat) < 0) {
-    return Status(1, "File is not acccessible");
+    return Status(1, "File is not accessible");
   }
   return Status::success();
 }

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1716,7 +1716,7 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
          << std::setw(sizeof(unsigned long long) * 2) << std::hex << file_index;
   std::string file_id(stream.str());
 
-  // Windows has fileid's that are displayed in hex using:
+  // Windows has file IDs that are displayed in hex using:
   // fsutil file queryfileid <filename>
   wfile_stat->file_id = file_id;
 

--- a/osquery/logger/data_logger.h
+++ b/osquery/logger/data_logger.h
@@ -35,7 +35,7 @@ void initStatusLogger(const std::string& name, bool init_glog = true);
 
 /**
  * @brief Initialize the osquery Logger facility by dumping the buffered status
- * logs and configurating status log forwarding.
+ * logs and configuring status log forwarding.
  *
  * initLogger will disable the `BufferedLogSink` facility, dump any status logs
  * emitted between process start and this init call, then configure the new

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -122,7 +122,7 @@ class BufferedLogSink : public google::LogSink, private boost::noncopyable {
             const char* message,
             size_t message_len) override;
 
-  /// Pop from the aync sender queue and wait for one send to complete.
+  /// Pop from the async sender queue and wait for one send to complete.
   void WaitTillSent() override;
 
  public:

--- a/osquery/main/main.h
+++ b/osquery/main/main.h
@@ -19,7 +19,7 @@ namespace osquery {
  * @brief Install osqueryd as a service for the platform.
  *
  * Currently, this is only used by Windows. POSIX platforms use a companion
- * script called osquerycrl to move files and install launch daemons or init
+ * script called osquerycrtl to move files and install launch daemons or init
  * scripts/systemd units.
  *
  * This disconnect of install flows is a limitation. The POSIX install flows

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -34,7 +34,7 @@ FLAG(string,
 FLAG(uint64,
      numeric_monitoring_pre_aggregation_time,
      60,
-     "Time period in seconds for numeric monitoring pre-aggreagation buffer.");
+     "Time period in seconds for numeric monitoring pre-aggregation buffer.");
 
 namespace {
 using monitoring::PreAggregationType;

--- a/osquery/registry/registry_factory.h
+++ b/osquery/registry/registry_factory.h
@@ -111,7 +111,7 @@ class RegistryFactory : private boost::noncopyable {
                    const std::string& item_name);
 
   /// Get a registry's active plugin.
-  std::string getActive(const std::string& registry_nane) const;
+  std::string getActive(const std::string& registry_name) const;
 
   bool exists(const std::string& registry_name) const {
     return (registries_.count(registry_name) > 0);

--- a/osquery/remote/serializers/json.h
+++ b/osquery/remote/serializers/json.h
@@ -24,7 +24,7 @@ class JSONSerializer : public Serializer {
   Status serialize(const JSON& json, std::string& serialized);
 
   /**
-   * @brief See Serializer::desiralize
+   * @brief See Serializer::deserialize
    */
   Status deserialize(const std::string& serialized, JSON& json);
 

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -91,7 +91,7 @@ class TLSTransport : public Transport {
    * This returns basic/generial options.
    *
    * Use these options if you are communicating with AWS or generic Internet
-   * infrastrucutre.
+   * infrastructure.
    */
   http::Client::Options getOptions();
 

--- a/osquery/tables/events/windows/ntfs_journal_events.cpp
+++ b/osquery/tables/events/windows/ntfs_journal_events.cpp
@@ -320,14 +320,14 @@ void processConfiguration(const NTFSEventSubscriptionContextRef context,
     // resolveFilePattern should filter out any nonexistent files,
     // so this should never be the case (except for TOCTOU).
     if (file_hnd == INVALID_HANDLE_VALUE) {
-      TLOG << "Couldn't open " << path << " while buiding FRN set";
+      TLOG << "Couldn't open " << path << " while building FRN set";
       continue;
     }
 
     // NOTE(woodruffw): This shouldn't fail once we have a valid handle, but
     // there's another TOCTOU here: another process could delete the file before
     // we get its information. We don't want to lock the file, though, since it
-    // could be something imporant used by another process.
+    // could be something important used by another process.
     USNFileReferenceNumber frn{};
 
 #if _WIN32_WINNT > _WIN32_WINNT_WIN7

--- a/osquery/tables/system/tests/linux/extended_attributes_tests.cpp
+++ b/osquery/tables/system/tests/linux/extended_attributes_tests.cpp
@@ -82,7 +82,7 @@ class ExtendedAttributesTableTests : public testing::Test {
     for (const auto& p : kTestAttributeList) {
       const auto& attribute_name = p.first;
       if (attribute_name.find("user.") != 0U) {
-        throw std::logic_error("Invalud test attribute name");
+        throw std::logic_error("Invalid test attribute name");
       }
 
       const auto& desc = p.second;

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -275,7 +275,7 @@ QueryData genYara(QueryContext& context) {
   YaraScanContext scanContext;
 
   // Initialize yara library
-  auto init_status = yaraInitilize();
+  auto init_status = yaraInitialize();
   if (!init_status.ok()) {
     LOG(WARNING) << init_status.toString();
     return results;

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -55,7 +55,7 @@ void YARACompilerCallback(int error_level,
 
 // yr_initialize maintains a reference count and avoid
 // re-initialization
-Status yaraInitilize(void) {
+Status yaraInitialize(void) {
   auto result = yr_initialize();
   if (result != ERROR_SUCCESS) {
     return Status::failure("Failed to initialize YARA " +

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -34,7 +34,7 @@ void YARACompilerCallback(int error_level,
                           const char* message,
                           void* user_data);
 
-Status yaraInitilize(void);
+Status yaraInitialize(void);
 
 Status yaraFinalize(void);
 

--- a/osquery/utils/caches/lru.h
+++ b/osquery/utils/caches/lru.h
@@ -44,7 +44,7 @@ class LRU {
   /**
    * @brief Insert new key and value to the cache.
    *
-   * @details Key and value are taked by const reference, that means they will
+   * @details Key and value are taken by const reference, that means they will
    * be copied to cache. If value with the same kay is exists in the cache it
    * will be replaced with new one.
    *

--- a/osquery/utils/debug/debug_only.h
+++ b/osquery/utils/debug/debug_only.h
@@ -59,10 +59,10 @@ inline void verifyTrue(bool expected_true, const char* msg) {
 }
 
 /**
- * Class for debug variables and verifys regarding to it.
- * It is designed to contain a value of given type and perform some verifys and
- * updates to it in debug build.
- * In release build objects are empty and verifys and updates do nothing.
+ * Class for debug variables and verifications regarding to it.
+ * It is designed to contain a value of given type and perform some
+ * verifications and updates to it in debug build.
+ * In release build objects are empty; verifications and updates do nothing.
  *
  * See examples of usage in tests osquery/debug/tests/debug_only_tests.cpp
  */

--- a/osquery/utils/error/tests/error.cpp
+++ b/osquery/utils/error/tests/error.cpp
@@ -34,10 +34,10 @@ GTEST_TEST(ErrorTest, initialization) {
 }
 
 GTEST_TEST(ErrorTest, recursive) {
-  auto orignalError = std::make_unique<osquery::Error<TestError>>(
+  auto originalError = std::make_unique<osquery::Error<TestError>>(
       TestError::SomeError, "SuperTestMessage");
   auto error = osquery::Error<TestError>(
-      TestError::AnotherError, "TestMessage", std::move(orignalError));
+      TestError::AnotherError, "TestMessage", std::move(originalError));
   EXPECT_TRUE(error.hasUnderlyingError());
 
   auto shortMsg = error.getNonRecursiveMessage();

--- a/osquery/utils/expected/expected.h
+++ b/osquery/utils/expected/expected.h
@@ -61,7 +61,7 @@
  *        break;
  *   }
  * }
- * @see osquery/utils/exptected/tests/expected.cpp for more examples.
+ * @see osquery/utils/expected/tests/expected.cpp for more examples.
  *
  * Rvalue ref-qualified methods of unconditional access value or error are
  * explicitly deleted. As far as `osquery` does not have an exceptions we

--- a/osquery/utils/expected/tests/expected.cpp
+++ b/osquery/utils/expected/tests/expected.cpp
@@ -287,8 +287,8 @@ GTEST_TEST(ExpectedTest, error__takeOr) {
 GTEST_TEST(ExpectedTest, error__takeOr_with_user_defined_class) {
   class SomeTestClass {
    public:
-    explicit SomeTestClass(const std::string& prefix, const std::string& sufix)
-        : text{prefix + " - " + sufix} {}
+    explicit SomeTestClass(const std::string& prefix, const std::string& suffix)
+        : text{prefix + " - " + suffix} {}
 
     std::string text;
   };

--- a/osquery/utils/system/posix/system.h
+++ b/osquery/utils/system/posix/system.h
@@ -41,7 +41,7 @@ class DropPrivileges : private boost::noncopyable {
    */
   bool dropToParent(const boost::filesystem::path& path);
 
-  /// See DropPrivileges::dropToParent but explicitiy set the UID and GID.
+  /// See DropPrivileges::dropToParent but explicitly set the UID and GID.
   bool dropTo(const std::string& uid, const std::string& gid);
 
   /// See DropPrivileges::dropToParent but explicitly set the UID and GID.

--- a/specs/posix/docker_container_processes.table
+++ b/specs/posix/docker_container_processes.table
@@ -12,7 +12,7 @@ schema([
     Column("egid", BIGINT, "Effective group ID"),
     Column("suid", BIGINT, "Saved user ID"),
     Column("sgid", BIGINT, "Saved group ID"),
-    Column("wired_size", BIGINT, "Bytes of unpagable memory used by process"),
+    Column("wired_size", BIGINT, "Bytes of unpageable memory used by process"),
     Column("resident_size", BIGINT, "Bytes of private memory used by process"),
     Column("total_size", BIGINT, "Total virtual memory size",
         aliases=["phys_footprint"]),

--- a/specs/posix/lxd_storage_pools.table
+++ b/specs/posix/lxd_storage_pools.table
@@ -5,7 +5,7 @@ schema([
     Column("driver", TEXT, "Storage driver"),
     Column("source", TEXT, "Storage pool source"),
     Column("size", TEXT, "Size of the storage pool"),
-    Column("space_used", BIGINT, "Storgae space used in bytes"),
+    Column("space_used", BIGINT, "Storage space used in bytes"),
     Column("space_total", BIGINT, "Total available storage space in bytes for this storage pool"),
     Column("inodes_used", BIGINT, "Number of inodes used"),
     Column("inodes_total", BIGINT, "Total number of inodes available in this storage pool")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -16,7 +16,7 @@ schema([
     Column("sgid", BIGINT, "Unsigned saved group ID"),
     Column("on_disk", INTEGER,
         "The process path exists yes=1, no=0, unknown=-1"),
-    Column("wired_size", BIGINT, "Bytes of unpagable memory used by process"),
+    Column("wired_size", BIGINT, "Bytes of unpageable memory used by process"),
     Column("resident_size", BIGINT, "Bytes of private memory used by process"),
     Column("total_size", BIGINT, "Total virtual memory size",
         aliases=["phys_footprint"]),

--- a/specs/utility/osquery_extensions.table
+++ b/specs/utility/osquery_extensions.table
@@ -5,7 +5,7 @@ schema([
     Column("name", TEXT, "Extension's name"),
     Column("version", TEXT, "Extension's version"),
     Column("sdk_version", TEXT, "osquery SDK version used to build the extension"),
-    Column("path", TEXT, "Path of the extenion's domain socket or library path"),
+    Column("path", TEXT, "Path of the extension's Thrift connection or library path"),
     Column("type", TEXT, "SDK extension type: extension or module")
 ])
 attributes(utility=True)

--- a/specs/windows/video_info.table
+++ b/specs/windows/video_info.table
@@ -5,7 +5,7 @@ schema([
     Column("driver", TEXT, "The driver of the device."),
     Column("driver_date", BIGINT, "The date listed on the installed driver."),
     Column("driver_version", TEXT, "The version of the installed driver."),
-    Column("manufacturer", TEXT, "The manufaturer of the gpu."),
+    Column("manufacturer", TEXT, "The manufacturer of the gpu."),
     Column("model", TEXT, "The model of the gpu."),
     Column("series", TEXT, "The series of the gpu."),
     Column("video_mode", TEXT, "The current resolution of the display."),

--- a/tests/integration/tables/account_policy_data.cpp
+++ b/tests/integration/tables/account_policy_data.cpp
@@ -30,7 +30,7 @@ TEST_F(accountPolicyData, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/acpi_tables.cpp
+++ b/tests/integration/tables/acpi_tables.cpp
@@ -30,7 +30,7 @@ TEST_F(acpiTables, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/ad_config.cpp
+++ b/tests/integration/tables/ad_config.cpp
@@ -30,7 +30,7 @@ TEST_F(adConfig, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/alf.cpp
+++ b/tests/integration/tables/alf.cpp
@@ -30,7 +30,7 @@ TEST_F(alf, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"allow_signed_enabled", IntType}

--- a/tests/integration/tables/alf_explicit_auths.cpp
+++ b/tests/integration/tables/alf_explicit_auths.cpp
@@ -30,7 +30,7 @@ TEST_F(alfExplicitAuths, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"process", NormalType}

--- a/tests/integration/tables/app_schemes.cpp
+++ b/tests/integration/tables/app_schemes.cpp
@@ -30,7 +30,7 @@ TEST_F(appSchemes, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"scheme", NormalType}

--- a/tests/integration/tables/appcompat_shims.cpp
+++ b/tests/integration/tables/appcompat_shims.cpp
@@ -30,7 +30,7 @@ TEST_F(appcompatShims, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"executable", NormalType}

--- a/tests/integration/tables/augeas.cpp
+++ b/tests/integration/tables/augeas.cpp
@@ -30,7 +30,7 @@ TEST_F(augeas, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"node", NormalType}

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -30,7 +30,7 @@ TEST_F(authenticode, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/authorization_mechanisms.cpp
+++ b/tests/integration/tables/authorization_mechanisms.cpp
@@ -30,7 +30,7 @@ TEST_F(authorizationMechanisms, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"label", NormalType}

--- a/tests/integration/tables/authorizations.cpp
+++ b/tests/integration/tables/authorizations.cpp
@@ -30,7 +30,7 @@ TEST_F(authorizations, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"label", NormalType}

--- a/tests/integration/tables/authorized_keys.cpp
+++ b/tests/integration/tables/authorized_keys.cpp
@@ -30,7 +30,7 @@ TEST_F(authorizedKeys, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/autoexec.cpp
+++ b/tests/integration/tables/autoexec.cpp
@@ -30,7 +30,7 @@ TEST_F(autoexec, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/battery.cpp
+++ b/tests/integration/tables/battery.cpp
@@ -30,7 +30,7 @@ TEST_F(battery, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"manufacturer", NormalType}

--- a/tests/integration/tables/bitlocker_info.cpp
+++ b/tests/integration/tables/bitlocker_info.cpp
@@ -30,7 +30,7 @@ TEST_F(bitlockerInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device_id", NormalType}

--- a/tests/integration/tables/block_devices.cpp
+++ b/tests/integration/tables/block_devices.cpp
@@ -30,7 +30,7 @@ TEST_F(blockDevices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/carbon_black_info.cpp
+++ b/tests/integration/tables/carbon_black_info.cpp
@@ -30,7 +30,7 @@ TEST_F(carbonBlackInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"sensor_id", IntType}

--- a/tests/integration/tables/carves.cpp
+++ b/tests/integration/tables/carves.cpp
@@ -30,7 +30,7 @@ TEST_F(carves, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"time", IntType}

--- a/tests/integration/tables/cpu_time.cpp
+++ b/tests/integration/tables/cpu_time.cpp
@@ -30,7 +30,7 @@ TEST_F(cpuTime, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"core", IntType}

--- a/tests/integration/tables/cups_destinations.cpp
+++ b/tests/integration/tables/cups_destinations.cpp
@@ -30,7 +30,7 @@ TEST_F(cupsDestinations, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/cups_jobs.cpp
+++ b/tests/integration/tables/cups_jobs.cpp
@@ -30,7 +30,7 @@ TEST_F(cupsJobs, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"title", NormalType}

--- a/tests/integration/tables/curl.cpp
+++ b/tests/integration/tables/curl.cpp
@@ -30,7 +30,7 @@ TEST_F(curl, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"url", NormalType}

--- a/tests/integration/tables/device_file.cpp
+++ b/tests/integration/tables/device_file.cpp
@@ -31,7 +31,7 @@ TEST_F(deviceFile, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device", NormalType}

--- a/tests/integration/tables/device_firmware.cpp
+++ b/tests/integration/tables/device_firmware.cpp
@@ -30,7 +30,7 @@ TEST_F(deviceFirmware, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"type", NormalType}

--- a/tests/integration/tables/device_hash.cpp
+++ b/tests/integration/tables/device_hash.cpp
@@ -32,7 +32,7 @@ TEST_F(deviceHash, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device", NormalType}

--- a/tests/integration/tables/device_partitions.cpp
+++ b/tests/integration/tables/device_partitions.cpp
@@ -31,7 +31,7 @@ TEST_F(devicePartitions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device", NormalType}

--- a/tests/integration/tables/disk_encryption.cpp
+++ b/tests/integration/tables/disk_encryption.cpp
@@ -30,7 +30,7 @@ TEST_F(diskEncryption, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/disk_events.cpp
+++ b/tests/integration/tables/disk_events.cpp
@@ -30,7 +30,7 @@ TEST_F(diskEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"action", NormalType}

--- a/tests/integration/tables/dns_resolvers.cpp
+++ b/tests/integration/tables/dns_resolvers.cpp
@@ -30,7 +30,7 @@ TEST_F(dnsResolvers, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", IntType}

--- a/tests/integration/tables/docker_container_labels.cpp
+++ b/tests/integration/tables/docker_container_labels.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerContainerLabels, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_container_mounts.cpp
+++ b/tests/integration/tables/docker_container_mounts.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerContainerMounts, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_container_networks.cpp
+++ b/tests/integration/tables/docker_container_networks.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerContainerNetworks, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_container_ports.cpp
+++ b/tests/integration/tables/docker_container_ports.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerContainerPorts, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_container_processes.cpp
+++ b/tests/integration/tables/docker_container_processes.cpp
@@ -31,7 +31,7 @@ TEST_F(dockerContainerProcesses, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_container_stats.cpp
+++ b/tests/integration/tables/docker_container_stats.cpp
@@ -31,7 +31,7 @@ TEST_F(dockerContainerStats, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_containers.cpp
+++ b/tests/integration/tables/docker_containers.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerContainers, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_image_labels.cpp
+++ b/tests/integration/tables/docker_image_labels.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerImageLabels, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_images.cpp
+++ b/tests/integration/tables/docker_images.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerImages, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_info.cpp
+++ b/tests/integration/tables/docker_info.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_network_labels.cpp
+++ b/tests/integration/tables/docker_network_labels.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerNetworkLabels, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_networks.cpp
+++ b/tests/integration/tables/docker_networks.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerNetworks, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"id", NormalType}

--- a/tests/integration/tables/docker_version.cpp
+++ b/tests/integration/tables/docker_version.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerVersion, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"version", NormalType}

--- a/tests/integration/tables/docker_volume_labels.cpp
+++ b/tests/integration/tables/docker_volume_labels.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerVolumeLabels, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/docker_volumes.cpp
+++ b/tests/integration/tables/docker_volumes.cpp
@@ -30,7 +30,7 @@ TEST_F(dockerVolumes, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/drivers.cpp
+++ b/tests/integration/tables/drivers.cpp
@@ -30,7 +30,7 @@ TEST_F(drivers, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device_id", NormalType}

--- a/tests/integration/tables/ec2_instance_metadata.cpp
+++ b/tests/integration/tables/ec2_instance_metadata.cpp
@@ -30,7 +30,7 @@ TEST_F(ec2InstanceMetadata, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"instance_id", NormalType}

--- a/tests/integration/tables/ec2_instance_tags.cpp
+++ b/tests/integration/tables/ec2_instance_tags.cpp
@@ -30,7 +30,7 @@ TEST_F(ec2InstanceTags, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"instance_id", NormalType}

--- a/tests/integration/tables/elf_dynamic.cpp
+++ b/tests/integration/tables/elf_dynamic.cpp
@@ -30,7 +30,7 @@ TEST_F(elfDynamic, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"tag", IntType}

--- a/tests/integration/tables/elf_info.cpp
+++ b/tests/integration/tables/elf_info.cpp
@@ -30,7 +30,7 @@ TEST_F(elfInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"class", NormalType}

--- a/tests/integration/tables/elf_sections.cpp
+++ b/tests/integration/tables/elf_sections.cpp
@@ -30,7 +30,7 @@ TEST_F(elfSections, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/elf_segments.cpp
+++ b/tests/integration/tables/elf_segments.cpp
@@ -30,7 +30,7 @@ TEST_F(elfSegments, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/elf_symbols.cpp
+++ b/tests/integration/tables/elf_symbols.cpp
@@ -30,7 +30,7 @@ TEST_F(elfSymbols, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/etc_hosts.cpp
+++ b/tests/integration/tables/etc_hosts.cpp
@@ -30,7 +30,7 @@ TEST_F(etcHosts, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"address", NormalType}

--- a/tests/integration/tables/etc_services.cpp
+++ b/tests/integration/tables/etc_services.cpp
@@ -30,7 +30,7 @@ TEST_F(etcServices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/event_taps.cpp
+++ b/tests/integration/tables/event_taps.cpp
@@ -30,7 +30,7 @@ TEST_F(eventTaps, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"enabled", IntType}

--- a/tests/integration/tables/example.cpp
+++ b/tests/integration/tables/example.cpp
@@ -30,7 +30,7 @@ TEST_F(example, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/extended_attributes.cpp
+++ b/tests/integration/tables/extended_attributes.cpp
@@ -31,7 +31,7 @@ TEST_F(extendedAttributes, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/fan_speed_sensors.cpp
+++ b/tests/integration/tables/fan_speed_sensors.cpp
@@ -30,7 +30,7 @@ TEST_F(fanSpeedSensors, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"fan", NormalType}

--- a/tests/integration/tables/fbsd_kmods.cpp
+++ b/tests/integration/tables/fbsd_kmods.cpp
@@ -30,7 +30,7 @@ TEST_F(fbsdKmods, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/file_events.cpp
+++ b/tests/integration/tables/file_events.cpp
@@ -30,7 +30,7 @@ TEST_F(fileEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"target_path", NormalType}

--- a/tests/integration/tables/firefox_addons.cpp
+++ b/tests/integration/tables/firefox_addons.cpp
@@ -30,7 +30,7 @@ TEST_F(firefoxAddons, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/gatekeeper.cpp
+++ b/tests/integration/tables/gatekeeper.cpp
@@ -30,7 +30,7 @@ TEST_F(gatekeeper, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"assessments_enabled", IntType}

--- a/tests/integration/tables/gatekeeper_approved_apps.cpp
+++ b/tests/integration/tables/gatekeeper_approved_apps.cpp
@@ -30,7 +30,7 @@ TEST_F(gatekeeperApprovedApps, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -27,7 +27,7 @@ class groups : public testing::Test {
 
 TEST_F(groups, test_sanity) {
   // Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   ValidationMap row_map = {
       {"gid", IntType},

--- a/tests/integration/tables/hardware_events.cpp
+++ b/tests/integration/tables/hardware_events.cpp
@@ -30,7 +30,7 @@ TEST_F(hardwareEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"action", NormalType}

--- a/tests/integration/tables/homebrew_packages.cpp
+++ b/tests/integration/tables/homebrew_packages.cpp
@@ -30,7 +30,7 @@ TEST_F(homebrewPackages, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/ie_extensions.cpp
+++ b/tests/integration/tables/ie_extensions.cpp
@@ -30,7 +30,7 @@ TEST_F(ieExtensions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/intel_me_info.cpp
+++ b/tests/integration/tables/intel_me_info.cpp
@@ -30,7 +30,7 @@ TEST_F(intelMeInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"version", NormalType}

--- a/tests/integration/tables/iokit_devicetree.cpp
+++ b/tests/integration/tables/iokit_devicetree.cpp
@@ -30,7 +30,7 @@ TEST_F(iokitDevicetree, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/iokit_registry.cpp
+++ b/tests/integration/tables/iokit_registry.cpp
@@ -30,7 +30,7 @@ TEST_F(iokitRegistry, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/kernel_extensions.cpp
+++ b/tests/integration/tables/kernel_extensions.cpp
@@ -30,7 +30,7 @@ TEST_F(kernelExtensions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"idx", IntType}

--- a/tests/integration/tables/kernel_panics.cpp
+++ b/tests/integration/tables/kernel_panics.cpp
@@ -30,7 +30,7 @@ TEST_F(kernelPanics, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/keychain_acls.cpp
+++ b/tests/integration/tables/keychain_acls.cpp
@@ -33,7 +33,7 @@ TEST_F(keychainAcls, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"keychain_path", NormalType}

--- a/tests/integration/tables/kva_speculative_info.cpp
+++ b/tests/integration/tables/kva_speculative_info.cpp
@@ -30,7 +30,7 @@ TEST_F(kvaSpeculativeInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"kva_shadow_enabled", IntType}

--- a/tests/integration/tables/launchd.cpp
+++ b/tests/integration/tables/launchd.cpp
@@ -30,7 +30,7 @@ TEST_F(launchd, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/launchd_overrides.cpp
+++ b/tests/integration/tables/launchd_overrides.cpp
@@ -30,7 +30,7 @@ TEST_F(launchdOverrides, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"label", NormalType}

--- a/tests/integration/tables/listening_ports.cpp
+++ b/tests/integration/tables/listening_ports.cpp
@@ -30,7 +30,7 @@ TEST_F(listeningPorts, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/lldp_neighbors.cpp
+++ b/tests/integration/tables/lldp_neighbors.cpp
@@ -30,7 +30,7 @@ TEST_F(lldpNeighbors, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"interface", NormalType}

--- a/tests/integration/tables/load_average.cpp
+++ b/tests/integration/tables/load_average.cpp
@@ -30,7 +30,7 @@ TEST_F(loadAverage, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"period", NormalType}

--- a/tests/integration/tables/logon_sessions.cpp
+++ b/tests/integration/tables/logon_sessions.cpp
@@ -30,7 +30,7 @@ TEST_F(logonSessions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"logon_id", IntType}

--- a/tests/integration/tables/magic.cpp
+++ b/tests/integration/tables/magic.cpp
@@ -30,7 +30,7 @@ TEST_F(magic, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/managed_policies.cpp
+++ b/tests/integration/tables/managed_policies.cpp
@@ -30,7 +30,7 @@ TEST_F(managedPolicies, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"domain", NormalType}

--- a/tests/integration/tables/md_devices.cpp
+++ b/tests/integration/tables/md_devices.cpp
@@ -30,7 +30,7 @@ TEST_F(mdDevices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device_name", NormalType}

--- a/tests/integration/tables/md_drives.cpp
+++ b/tests/integration/tables/md_drives.cpp
@@ -30,7 +30,7 @@ TEST_F(mdDrives, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"md_device_name", NormalType}

--- a/tests/integration/tables/md_personalities.cpp
+++ b/tests/integration/tables/md_personalities.cpp
@@ -30,7 +30,7 @@ TEST_F(mdPersonalities, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/memory_array_mapped_addresses.cpp
+++ b/tests/integration/tables/memory_array_mapped_addresses.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryArrayMappedAddresses, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/memory_arrays.cpp
+++ b/tests/integration/tables/memory_arrays.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryArrays, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/memory_device_mapped_addresses.cpp
+++ b/tests/integration/tables/memory_device_mapped_addresses.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryDeviceMappedAddresses, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/memory_devices.cpp
+++ b/tests/integration/tables/memory_devices.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryDevices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/memory_error_info.cpp
+++ b/tests/integration/tables/memory_error_info.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryErrorInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/memory_info.cpp
+++ b/tests/integration/tables/memory_info.cpp
@@ -30,7 +30,7 @@ TEST_F(memoryInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"memory_total", IntType}

--- a/tests/integration/tables/msr.cpp
+++ b/tests/integration/tables/msr.cpp
@@ -30,7 +30,7 @@ TEST_F(msr, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"processor_number", IntType}

--- a/tests/integration/tables/nfs_shares.cpp
+++ b/tests/integration/tables/nfs_shares.cpp
@@ -30,7 +30,7 @@ TEST_F(nfsShares, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"share", NormalType}

--- a/tests/integration/tables/oem_strings.cpp
+++ b/tests/integration/tables/oem_strings.cpp
@@ -30,7 +30,7 @@ TEST_F(oemStrings, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"handle", NormalType}

--- a/tests/integration/tables/opera_extensions.cpp
+++ b/tests/integration/tables/opera_extensions.cpp
@@ -30,7 +30,7 @@ TEST_F(operaExtensions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/osquery_events.cpp
+++ b/tests/integration/tables/osquery_events.cpp
@@ -30,7 +30,7 @@ TEST_F(osqueryEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/osquery_extensions.cpp
+++ b/tests/integration/tables/osquery_extensions.cpp
@@ -30,7 +30,7 @@ TEST_F(osqueryExtensions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uuid", IntType}

--- a/tests/integration/tables/osquery_flags.cpp
+++ b/tests/integration/tables/osquery_flags.cpp
@@ -31,7 +31,7 @@ TEST_F(osqueryFlags, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/osquery_info.cpp
+++ b/tests/integration/tables/osquery_info.cpp
@@ -30,7 +30,7 @@ TEST_F(osqueryInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/osquery_packs.cpp
+++ b/tests/integration/tables/osquery_packs.cpp
@@ -30,7 +30,7 @@ TEST_F(osqueryPacks, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/osquery_registry.cpp
+++ b/tests/integration/tables/osquery_registry.cpp
@@ -30,7 +30,7 @@ TEST_F(osqueryRegistry, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"registry", NormalType}

--- a/tests/integration/tables/osquery_schedule.cpp
+++ b/tests/integration/tables/osquery_schedule.cpp
@@ -30,7 +30,7 @@ TEST_F(osquerySchedule, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/package_bom.cpp
+++ b/tests/integration/tables/package_bom.cpp
@@ -30,7 +30,7 @@ TEST_F(packageBom, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"filepath", NormalType}

--- a/tests/integration/tables/package_install_history.cpp
+++ b/tests/integration/tables/package_install_history.cpp
@@ -30,7 +30,7 @@ TEST_F(packageInstallHistory, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package_id", NormalType}

--- a/tests/integration/tables/package_receipts.cpp
+++ b/tests/integration/tables/package_receipts.cpp
@@ -30,7 +30,7 @@ TEST_F(packageReceipts, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package_id", NormalType}

--- a/tests/integration/tables/patches.cpp
+++ b/tests/integration/tables/patches.cpp
@@ -30,7 +30,7 @@ TEST_F(patches, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"csname", NormalType}

--- a/tests/integration/tables/pci_devices.cpp
+++ b/tests/integration/tables/pci_devices.cpp
@@ -30,7 +30,7 @@ TEST_F(pciDevices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pci_slot", NormalType}

--- a/tests/integration/tables/physical_disk_performance.cpp
+++ b/tests/integration/tables/physical_disk_performance.cpp
@@ -30,7 +30,7 @@ TEST_F(physicalDiskPerformance, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/pipes.cpp
+++ b/tests/integration/tables/pipes.cpp
@@ -30,7 +30,7 @@ TEST_F(pipes, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/pkg_packages.cpp
+++ b/tests/integration/tables/pkg_packages.cpp
@@ -30,7 +30,7 @@ TEST_F(pkgPackages, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/platform_info.cpp
+++ b/tests/integration/tables/platform_info.cpp
@@ -30,7 +30,7 @@ TEST_F(platformInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"vendor", NormalType}

--- a/tests/integration/tables/plist.cpp
+++ b/tests/integration/tables/plist.cpp
@@ -30,7 +30,7 @@ TEST_F(plist, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"key", NormalType}

--- a/tests/integration/tables/portage_keywords.cpp
+++ b/tests/integration/tables/portage_keywords.cpp
@@ -30,7 +30,7 @@ TEST_F(portageKeywords, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package", NormalType}

--- a/tests/integration/tables/portage_packages.cpp
+++ b/tests/integration/tables/portage_packages.cpp
@@ -30,7 +30,7 @@ TEST_F(portagePackages, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package", NormalType}

--- a/tests/integration/tables/portage_use.cpp
+++ b/tests/integration/tables/portage_use.cpp
@@ -30,7 +30,7 @@ TEST_F(portageUse, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package", NormalType}

--- a/tests/integration/tables/power_sensors.cpp
+++ b/tests/integration/tables/power_sensors.cpp
@@ -30,7 +30,7 @@ TEST_F(powerSensors, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"key", NormalType}

--- a/tests/integration/tables/powershell_events.cpp
+++ b/tests/integration/tables/powershell_events.cpp
@@ -30,7 +30,7 @@ TEST_F(powershellEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"time", IntType}

--- a/tests/integration/tables/process_events.cpp
+++ b/tests/integration/tables/process_events.cpp
@@ -30,7 +30,7 @@ TEST_F(processEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/process_file_events.cpp
+++ b/tests/integration/tables/process_file_events.cpp
@@ -30,7 +30,7 @@ TEST_F(processFileEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"operation", NormalType}

--- a/tests/integration/tables/process_memory_map.cpp
+++ b/tests/integration/tables/process_memory_map.cpp
@@ -30,7 +30,7 @@ TEST_F(processMemoryMap, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/process_namespaces.cpp
+++ b/tests/integration/tables/process_namespaces.cpp
@@ -30,7 +30,7 @@ TEST_F(processNamespaces, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"pid", IntType}

--- a/tests/integration/tables/prometheus_metrics.cpp
+++ b/tests/integration/tables/prometheus_metrics.cpp
@@ -30,7 +30,7 @@ TEST_F(prometheusMetrics, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"target_name", NormalType}

--- a/tests/integration/tables/quicklook_cache.cpp
+++ b/tests/integration/tables/quicklook_cache.cpp
@@ -30,7 +30,7 @@ TEST_F(quicklookCache, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/rpm_package_files.cpp
+++ b/tests/integration/tables/rpm_package_files.cpp
@@ -30,7 +30,7 @@ TEST_F(rpmPackageFiles, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"package", NormalType}

--- a/tests/integration/tables/safari_extensions.cpp
+++ b/tests/integration/tables/safari_extensions.cpp
@@ -30,7 +30,7 @@ TEST_F(safariExtensions, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/scheduled_tasks.cpp
+++ b/tests/integration/tables/scheduled_tasks.cpp
@@ -30,7 +30,7 @@ TEST_F(scheduledTasks, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/selinux_events.cpp
+++ b/tests/integration/tables/selinux_events.cpp
@@ -30,7 +30,7 @@ TEST_F(selinuxEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"type", NormalType}

--- a/tests/integration/tables/services.cpp
+++ b/tests/integration/tables/services.cpp
@@ -30,7 +30,7 @@ TEST_F(services, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/shadow.cpp
+++ b/tests/integration/tables/shadow.cpp
@@ -30,7 +30,7 @@ TEST_F(shadow, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"password_status", NormalType}

--- a/tests/integration/tables/shared_folders.cpp
+++ b/tests/integration/tables/shared_folders.cpp
@@ -30,7 +30,7 @@ TEST_F(sharedFolders, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/shared_memory.cpp
+++ b/tests/integration/tables/shared_memory.cpp
@@ -30,7 +30,7 @@ TEST_F(sharedMemory, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"shmid", IntType}

--- a/tests/integration/tables/shared_resources.cpp
+++ b/tests/integration/tables/shared_resources.cpp
@@ -30,7 +30,7 @@ TEST_F(sharedResources, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"description", NormalType}

--- a/tests/integration/tables/shell_history.cpp
+++ b/tests/integration/tables/shell_history.cpp
@@ -30,7 +30,7 @@ TEST_F(shellHistory, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/signature.cpp
+++ b/tests/integration/tables/signature.cpp
@@ -30,7 +30,7 @@ TEST_F(signature, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/sip_config.cpp
+++ b/tests/integration/tables/sip_config.cpp
@@ -30,7 +30,7 @@ TEST_F(sipConfig, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"config_flag", NormalType}

--- a/tests/integration/tables/smart_drive_info.cpp
+++ b/tests/integration/tables/smart_drive_info.cpp
@@ -30,7 +30,7 @@ TEST_F(smartDriveInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"device_name", NormalType}

--- a/tests/integration/tables/smbios_tables.cpp
+++ b/tests/integration/tables/smbios_tables.cpp
@@ -30,7 +30,7 @@ TEST_F(smbiosTables, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"number", IntType}

--- a/tests/integration/tables/smc_keys.cpp
+++ b/tests/integration/tables/smc_keys.cpp
@@ -30,7 +30,7 @@ TEST_F(smcKeys, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"key", NormalType}

--- a/tests/integration/tables/socket_events.cpp
+++ b/tests/integration/tables/socket_events.cpp
@@ -30,7 +30,7 @@ TEST_F(socketEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"action", NormalType}

--- a/tests/integration/tables/ssh_configs.cpp
+++ b/tests/integration/tables/ssh_configs.cpp
@@ -30,7 +30,7 @@ TEST_F(sshConfigs, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/syslog_events.cpp
+++ b/tests/integration/tables/syslog_events.cpp
@@ -30,7 +30,7 @@ TEST_F(syslogEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"time", IntType}

--- a/tests/integration/tables/temperature_sensors.cpp
+++ b/tests/integration/tables/temperature_sensors.cpp
@@ -30,7 +30,7 @@ TEST_F(temperatureSensors, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"key", NormalType}

--- a/tests/integration/tables/time_machine_backups.cpp
+++ b/tests/integration/tables/time_machine_backups.cpp
@@ -30,7 +30,7 @@ TEST_F(timeMachineBackups, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"destination_id", NormalType}

--- a/tests/integration/tables/time_machine_destinations.cpp
+++ b/tests/integration/tables/time_machine_destinations.cpp
@@ -30,7 +30,7 @@ TEST_F(timeMachineDestinations, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"alias", NormalType}

--- a/tests/integration/tables/ulimit_info.cpp
+++ b/tests/integration/tables/ulimit_info.cpp
@@ -30,7 +30,7 @@ TEST_F(ulimitInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"type", NormalType}

--- a/tests/integration/tables/usb_devices.cpp
+++ b/tests/integration/tables/usb_devices.cpp
@@ -30,7 +30,7 @@ TEST_F(usbDevices, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"usb_address", IntType}

--- a/tests/integration/tables/user_events.cpp
+++ b/tests/integration/tables/user_events.cpp
@@ -30,7 +30,7 @@ TEST_F(userEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/user_interaction_events.cpp
+++ b/tests/integration/tables/user_interaction_events.cpp
@@ -30,7 +30,7 @@ TEST_F(userInteractionEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"time", IntType}

--- a/tests/integration/tables/user_ssh_keys.cpp
+++ b/tests/integration/tables/user_ssh_keys.cpp
@@ -30,7 +30,7 @@ TEST_F(userSshKeys, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"uid", IntType}

--- a/tests/integration/tables/video_info.cpp
+++ b/tests/integration/tables/video_info.cpp
@@ -30,7 +30,7 @@ TEST_F(videoInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"color_depth", IntType}

--- a/tests/integration/tables/virtual_memory_info.cpp
+++ b/tests/integration/tables/virtual_memory_info.cpp
@@ -30,7 +30,7 @@ TEST_F(virtualMemoryInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"free", IntType}

--- a/tests/integration/tables/wifi_networks.cpp
+++ b/tests/integration/tables/wifi_networks.cpp
@@ -30,7 +30,7 @@ TEST_F(wifiNetworks, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"ssid", NormalType}

--- a/tests/integration/tables/wifi_status.cpp
+++ b/tests/integration/tables/wifi_status.cpp
@@ -30,7 +30,7 @@ TEST_F(wifiStatus, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"interface", NormalType}

--- a/tests/integration/tables/wifi_survey.cpp
+++ b/tests/integration/tables/wifi_survey.cpp
@@ -30,7 +30,7 @@ TEST_F(wifiSurvey, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"interface", NormalType}

--- a/tests/integration/tables/winbaseobj.cpp
+++ b/tests/integration/tables/winbaseobj.cpp
@@ -30,7 +30,7 @@ TEST_F(winbaseobj, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"session_id", IntType}

--- a/tests/integration/tables/windows_crashes.cpp
+++ b/tests/integration/tables/windows_crashes.cpp
@@ -30,7 +30,7 @@ TEST_F(windowsCrashes, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"datetime", NormalType}

--- a/tests/integration/tables/windows_events.cpp
+++ b/tests/integration/tables/windows_events.cpp
@@ -30,7 +30,7 @@ TEST_F(windowsEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"time", IntType}

--- a/tests/integration/tables/wmi_bios_info.cpp
+++ b/tests/integration/tables/wmi_bios_info.cpp
@@ -30,7 +30,7 @@ TEST_F(wmiBiosInfo, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/wmi_cli_event_consumers.cpp
+++ b/tests/integration/tables/wmi_cli_event_consumers.cpp
@@ -30,7 +30,7 @@ TEST_F(wmiCliEventConsumers, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/wmi_event_filters.cpp
+++ b/tests/integration/tables/wmi_event_filters.cpp
@@ -30,7 +30,7 @@ TEST_F(wmiEventFilters, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/wmi_filter_consumer_binding.cpp
+++ b/tests/integration/tables/wmi_filter_consumer_binding.cpp
@@ -30,7 +30,7 @@ TEST_F(wmiFilterConsumerBinding, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"consumer", NormalType}

--- a/tests/integration/tables/wmi_script_event_consumers.cpp
+++ b/tests/integration/tables/wmi_script_event_consumers.cpp
@@ -30,7 +30,7 @@ TEST_F(wmiScriptEventConsumers, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/xprotect_entries.cpp
+++ b/tests/integration/tables/xprotect_entries.cpp
@@ -30,7 +30,7 @@ TEST_F(xprotectEntries, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/xprotect_meta.cpp
+++ b/tests/integration/tables/xprotect_meta.cpp
@@ -30,7 +30,7 @@ TEST_F(xprotectMeta, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"identifier", NormalType}

--- a/tests/integration/tables/xprotect_reports.cpp
+++ b/tests/integration/tables/xprotect_reports.cpp
@@ -30,7 +30,7 @@ TEST_F(xprotectReports, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -30,7 +30,7 @@ TEST_F(yara, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"path", NormalType}

--- a/tests/integration/tables/yara_events.cpp
+++ b/tests/integration/tables/yara_events.cpp
@@ -30,7 +30,7 @@ TEST_F(yaraEvents, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"target_path", NormalType}

--- a/tests/integration/tables/yum_sources.cpp
+++ b/tests/integration/tables/yum_sources.cpp
@@ -30,7 +30,7 @@ TEST_F(yumSources, test_sanity) {
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
-  // See helper.h for avaialbe flags
+  // See helper.h for available flags
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"name", NormalType}

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -28,7 +28,7 @@ CANONICAL_PLATFORMS = {
     "darwin": "Darwin (Apple OS X)",
     "linux": "Ubuntu, CentOS",
     "freebsd": "FreeBSD",
-    "posix": "POSIX-compatible Plaforms",
+    "posix": "POSIX-compatible Platforms",
     "windows": "Microsoft Windows",
     "utility": "Utility",
     "yara": "YARA",

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -62,7 +62,7 @@ def get_base_commit(base_branch):
                 ["git", "merge-base", "HEAD", base_branch]
                 ).decode().strip()
     except OSError as e:
-        print("{}\n\n{}".format("Failed to execut git", str(e)))
+        print("{}\n\n{}".format("Failed to execute git", str(e)))
     except subprocess.CalledProcessError as e:
         print("{}\n\n{}".format("Failed to determine merge-base", str(e)))
 


### PR DESCRIPTION
This PR fixes misspellings throughout the code, although almost all of them are in comments. In a couple of places I also fixed the spelling of what was clearly a typo in a code symbol.

Although this touches many files, it's because a single typo was copy/pasted in a comment across many files.

Reasons to merge this:

- searching across files for anything is better when everything is spelled correctly
- user experience (in error strings or user-facing output)
- improves the perceived quality of our code to anyone reading it