### PR TITLE
Change libdpkg submodule url to our own github mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,7 @@
 	url = https://github.com/osquery/third-party-popt
 [submodule "libraries/cmake/source/libdpkg/src"]
 	path = libraries/cmake/source/libdpkg/src
-	url = https://git.dpkg.org/cgit/dpkg/dpkg.git
+	url = https://github.com/osquery/third-party-libdpkg
 [submodule "libraries/cmake/source/libaudit/src"]
 	path = libraries/cmake/source/libaudit/src
 	url = https://github.com/linux-audit/audit-userspace


### PR DESCRIPTION
The upstream repository was failing to do shallow clones.

Also oss-fuzz keeps failing to build due to that.