### PR TITLE
Add a table for the unified log on darwin

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -180,6 +180,7 @@ function(setupBuildFlags)
         "-framework Security"
         "-framework ServiceManagement"
         "-framework SystemConfiguration"
+        "-framework OSLog"
       )
 
       set(osquery_macos_common_defines

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -180,7 +180,7 @@ function(setupBuildFlags)
         "-framework Security"
         "-framework ServiceManagement"
         "-framework SystemConfiguration"
-        "-framework OSLog"
+        "-weak_framework OSLog"
       )
 
       set(osquery_macos_common_defines

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -157,6 +157,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/system_extensions.mm
       darwin/system_info.cpp
       darwin/time_machine.cpp
+      darwin/unified_log.mm
       darwin/usb_devices.cpp
       darwin/user_groups.mm
       darwin/virtual_memory_info.cpp

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, The osquery authors
+ * Copyright (c) 2014-present, The osquery authors
  *
  * This source code is licensed as defined by the LICENSE file found in the
  * root directory of this source tree.

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -98,116 +98,113 @@ void addQueryOp(NSMutableArray* preds,
   }
 }
 
-void genUnifiedLog(QueryContext& queryContext, QueryData& results) {
+QueryData genUnifiedLog(QueryContext& queryContext) {
+  QueryData results;
   if (@available(macOS 10.15, *)) {
-    NSError* error = nil;
-    OSLogStore* logstore = [OSLogStore localStoreAndReturnError:&error];
-    if (error != nil) {
-      TLOG << "error getting handle to log store: "
-           << [[error localizedDescription] UTF8String];
-      return;
-    }
-
-    OSLogPosition* position = nil;
-
-    // the timestamp column can be used to aggressively filter
-    // results returned from the log store
-    if (queryContext.hasConstraint("timestamp", GREATER_THAN) ||
-        queryContext.hasConstraint("timestamp", GREATER_THAN_OR_EQUALS)) {
-      std::string start_time;
-      if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
-        start_time =
-            *queryContext.constraints["timestamp"].getAll(GREATER_THAN).begin();
-      } else {
-        start_time = *queryContext.constraints["timestamp"]
-                          .getAll(GREATER_THAN_OR_EQUALS)
-                          .begin();
+    @autoreleasepool {
+      NSError* error = nil;
+      OSLogStore* logstore = [OSLogStore localStoreAndReturnError:&error];
+      if (error != nil) {
+        TLOG << "error getting handle to log store: "
+             << [[error localizedDescription] UTF8String];
+        return QueryData();
       }
 
-      double provided_timestamp =
-          [[NSString stringWithUTF8String:start_time.c_str()] doubleValue];
-      NSDate* provided_date =
-          [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
+      OSLogPosition* position = nil;
 
-      position = [logstore positionWithDate:provided_date];
-    }
-
-    // grab all the supported columns used in simple constraints and make a
-    // compound predicate out of them.
-    NSMutableArray* subpredicates = [[NSMutableArray alloc] init];
-    for (const auto& it : queryContext.constraints) {
-      const std::string& key = it.first;
-      for (const auto& constraint : it.second.getAll()) {
-        addQueryOp(subpredicates,
-                   key,
-                   constraint.expr,
-                   static_cast<ConstraintOperator>(constraint.op));
-      }
-    }
-
-    NSPredicate* predicate =
-        [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
-
-    // enumerate the entries in ascending order by timestamp
-    OSLogEnumeratorOptions option = 0;
-
-    OSLogEnumerator* enumerator =
-        [logstore entriesEnumeratorWithOptions:option
-                                      position:position
-                                     predicate:predicate
-                                         error:&error];
-    if (error != nil) {
-      TLOG << "error enumerating entries in system log: "
-           << [[error localizedDescription] UTF8String];
-      return;
-    }
-    for (OSLogEntryLog* entry in enumerator) {
-      Row r;
-      r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
-      r["message"] = TEXT([[entry composedMessage] UTF8String]);
-      r["storage"] = INTEGER([entry storeCategory]);
-
-      if ([entry respondsToSelector:@selector(activityIdentifier)]) {
-        r["activity"] = INTEGER([entry activityIdentifier]);
-        r["process"] = TEXT([[entry process] UTF8String]);
-        r["pid"] = INTEGER([entry processIdentifier]);
-        r["sender"] = TEXT([[entry sender] UTF8String]);
-        r["tid"] = INTEGER([entry threadIdentifier]);
-      }
-
-      if ([entry respondsToSelector:@selector(subsystem)]) {
-        NSString* subsystem = [entry subsystem];
-        if (subsystem != nil) {
-          r["subsystem"] = TEXT([subsystem UTF8String]);
+      // the timestamp column can be used to aggressively filter
+      // results returned from the log store
+      if (queryContext.hasConstraint("timestamp", GREATER_THAN) ||
+          queryContext.hasConstraint("timestamp", GREATER_THAN_OR_EQUALS)) {
+        std::string start_time;
+        if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
+          start_time = *queryContext.constraints["timestamp"]
+                            .getAll(GREATER_THAN)
+                            .begin();
+        } else {
+          start_time = *queryContext.constraints["timestamp"]
+                            .getAll(GREATER_THAN_OR_EQUALS)
+                            .begin();
         }
-        NSString* category = [entry category];
-        if (category != nil) {
-          r["category"] = TEXT([category UTF8String]);
+
+        double provided_timestamp =
+            [[NSString stringWithUTF8String:start_time.c_str()] doubleValue];
+        NSDate* provided_date =
+            [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
+
+        position = [logstore positionWithDate:provided_date];
+      }
+
+      // grab all the supported columns used in simple constraints and make a
+      // compound predicate out of them.
+      NSMutableArray* subpredicates = [[NSMutableArray alloc] init];
+      for (const auto& it : queryContext.constraints) {
+        const std::string& key = it.first;
+        for (const auto& constraint : it.second.getAll()) {
+          addQueryOp(subpredicates,
+                     key,
+                     constraint.expr,
+                     static_cast<ConstraintOperator>(constraint.op));
         }
       }
-      if ([entry respondsToSelector:@selector(level)]) {
-        const char* logLevelNames[] = {
-            [OSLogEntryLogLevelUndefined] = "undefined",
-            [OSLogEntryLogLevelDebug] = "debug",
-            [OSLogEntryLogLevelInfo] = "info",
-            [OSLogEntryLogLevelNotice] = "default",
-            [OSLogEntryLogLevelError] = "error",
-            [OSLogEntryLogLevelFault] = "fault",
-        };
 
-        r["level"] = TEXT(logLevelNames[[entry level]]);
+      NSPredicate* predicate =
+          [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+
+      // enumerate the entries in ascending order by timestamp
+      OSLogEnumeratorOptions option = 0;
+
+      OSLogEnumerator* enumerator =
+          [logstore entriesEnumeratorWithOptions:option
+                                        position:position
+                                       predicate:predicate
+                                           error:&error];
+      if (error != nil) {
+        TLOG << "error enumerating entries in system log: "
+             << [[error localizedDescription] UTF8String];
+        return QueryData();
       }
-      results.push_back(r);
+      for (OSLogEntryLog* entry in enumerator) {
+        Row r;
+        r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
+        r["message"] = TEXT([[entry composedMessage] UTF8String]);
+        r["storage"] = INTEGER([entry storeCategory]);
+
+        if ([entry respondsToSelector:@selector(activityIdentifier)]) {
+          r["activity"] = INTEGER([entry activityIdentifier]);
+          r["process"] = TEXT([[entry process] UTF8String]);
+          r["pid"] = INTEGER([entry processIdentifier]);
+          r["sender"] = TEXT([[entry sender] UTF8String]);
+          r["tid"] = INTEGER([entry threadIdentifier]);
+        }
+
+        if ([entry respondsToSelector:@selector(subsystem)]) {
+          NSString* subsystem = [entry subsystem];
+          if (subsystem != nil) {
+            r["subsystem"] = TEXT([subsystem UTF8String]);
+          }
+          NSString* category = [entry category];
+          if (category != nil) {
+            r["category"] = TEXT([category UTF8String]);
+          }
+        }
+        if ([entry respondsToSelector:@selector(level)]) {
+          const char* logLevelNames[] = {
+              [OSLogEntryLogLevelUndefined] = "undefined",
+              [OSLogEntryLogLevelDebug] = "debug",
+              [OSLogEntryLogLevelInfo] = "info",
+              [OSLogEntryLogLevelNotice] = "default",
+              [OSLogEntryLogLevelError] = "error",
+              [OSLogEntryLogLevelFault] = "fault",
+          };
+
+          r["level"] = TEXT(logLevelNames[[entry level]]);
+        }
+        results.push_back(r);
+      }
     }
   } else {
     VLOG(1) << "OSLog framework is not available";
-  }
-}
-
-QueryData genUnifiedLog(QueryContext& context) {
-  QueryData results;
-  @autoreleasepool {
-    genUnifiedLog(context, results);
   }
   return results;
 }

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -112,12 +112,20 @@ void genUnifiedLog(QueryContext& queryContext, QueryData& results) {
 
     // the timestamp column can be used to aggressively filter
     // results returned from the log store
-    if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
-      auto start_time =
-          queryContext.constraints["timestamp"].getAll(GREATER_THAN);
+    if (queryContext.hasConstraint("timestamp", GREATER_THAN) ||
+        queryContext.hasConstraint("timestamp", GREATER_THAN_OR_EQUALS)) {
+      std::string start_time;
+      if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
+        start_time =
+            *queryContext.constraints["timestamp"].getAll(GREATER_THAN).begin();
+      } else {
+        start_time = *queryContext.constraints["timestamp"]
+                          .getAll(GREATER_THAN_OR_EQUALS)
+                          .begin();
+      }
 
-      double provided_timestamp = [[NSString
-          stringWithUTF8String:start_time.begin()->c_str()] doubleValue];
+      double provided_timestamp =
+          [[NSString stringWithUTF8String:start_time.c_str()] doubleValue];
       NSDate* provided_date =
           [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
 

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -21,7 +21,7 @@ namespace ba = boost::algorithm;
 namespace osquery {
 namespace tables {
 
-const std::map<ConstraintOperator, NSPredicateOperatorType> supportedOps = {
+const std::map<ConstraintOperator, NSPredicateOperatorType> kSupportedOps = {
     {EQUALS, NSEqualToPredicateOperatorType},
     {GREATER_THAN, NSGreaterThanPredicateOperatorType},
     {GREATER_THAN_OR_EQUALS, NSGreaterThanOrEqualToPredicateOperatorType},
@@ -29,7 +29,7 @@ const std::map<ConstraintOperator, NSPredicateOperatorType> supportedOps = {
     {LESS_THAN_OR_EQUALS, NSLessThanOrEqualToPredicateOperatorType},
     {LIKE, NSLikePredicateOperatorType}};
 
-const std::map<std::string, std::string> columnToOSLogEntryProp = {
+const std::map<std::string, std::string> kColumnToOSLogEntryProp = {
     {"timestamp", "date"},
     {"message", "composedMessage"},
     {"storage", "storeCategory"},
@@ -41,7 +41,7 @@ const std::map<std::string, std::string> columnToOSLogEntryProp = {
     {"subsystem", "subsystem"},
     {"category", "category"}};
 
-const std::map<std::string, bool> columnIsNumeric = {{"timestamp", false},
+const std::map<std::string, bool> kColumnIsNumeric = {{"timestamp", false},
                                                      {"message", false},
                                                      {"storage", true},
                                                      {"activity", true},
@@ -64,9 +64,9 @@ void addQueryOp(NSMutableArray* preds,
                 const std::string& key,
                 const std::string& value,
                 ConstraintOperator op) {
-  if (supportedOps.count(op) > 0 && columnToOSLogEntryProp.count(key) > 0) {
+  if (kSupportedOps.count(op) > 0 && kColumnToOSLogEntryProp.count(key) > 0) {
     std::string modified_val = value;
-    std::string modified_key = columnToOSLogEntryProp.at(key);
+    std::string modified_key = kColumnToOSLogEntryProp.at(key);
     if (op == LIKE) {
       modified_val = convertLikeExpr(value);
     }
@@ -81,7 +81,7 @@ void addQueryOp(NSMutableArray* preds,
       valExp = [NSExpression
           expressionForConstantValue:
               [NSDate dateWithTimeIntervalSince1970:provided_timestamp]];
-    } else if (columnIsNumeric.at(key)) {
+    } else if (kColumnIsNumeric.at(key)) {
       valExp =
           [NSExpression expressionWithFormat:@"%lld", [valStr longLongValue]];
     } else {
@@ -92,7 +92,7 @@ void addQueryOp(NSMutableArray* preds,
         predicateWithLeftExpression:keyExp
                     rightExpression:valExp
                            modifier:NSDirectPredicateModifier
-                               type:supportedOps.at(op)
+                               type:kSupportedOps.at(op)
                             options:0];
     [preds addObject:pred];
   }

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -199,17 +199,15 @@ void genUnifiedLog(QueryContext& queryContext, QueryData& results) {
       }
       results.push_back(r);
     }
+  } else {
+    VLOG(1) << "OSLog framework is not available";
   }
 }
 
 QueryData genUnifiedLog(QueryContext& context) {
   QueryData results;
-  if (@available(macOS 10.15, *)) {
-    @autoreleasepool {
-      genUnifiedLog(context, results);
-    }
-  } else {
-    VLOG(1) << "OSLog framework is not available";
+  @autoreleasepool {
+    genUnifiedLog(context, results);
   }
   return results;
 }

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -186,7 +186,16 @@ void genUnifiedLog(QueryContext& queryContext, QueryData& results) {
         }
       }
       if ([entry respondsToSelector:@selector(level)]) {
-        r["level"] = INTEGER([entry level]);
+        const char* logLevelNames[] = {
+            [OSLogEntryLogLevelUndefined] = "undefined",
+            [OSLogEntryLogLevelDebug] = "debug",
+            [OSLogEntryLogLevelInfo] = "info",
+            [OSLogEntryLogLevelNotice] = "default",
+            [OSLogEntryLogLevelError] = "error",
+            [OSLogEntryLogLevelFault] = "fault",
+        };
+
+        r["level"] = TEXT(logLevelNames[[entry level]]);
       }
       results.push_back(r);
     }

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -107,7 +107,7 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
       if (error != nil) {
         TLOG << "error getting handle to log store: "
              << [[error localizedDescription] UTF8String];
-        return QueryData();
+        return {};
       }
 
       OSLogPosition* position = nil;
@@ -162,7 +162,7 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
       if (error != nil) {
         TLOG << "error enumerating entries in system log: "
              << [[error localizedDescription] UTF8String];
-        return QueryData();
+        return {};
       }
       for (OSLogEntryLog* entry in enumerator) {
         Row r;

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -27,10 +27,9 @@ const std::map<ConstraintOperator, NSPredicateOperatorType> supportedOps = {
     {GREATER_THAN_OR_EQUALS, NSGreaterThanOrEqualToPredicateOperatorType},
     {LESS_THAN, NSLessThanPredicateOperatorType},
     {LESS_THAN_OR_EQUALS, NSLessThanOrEqualToPredicateOperatorType},
-    {LIKE, NSLikePredicateOperatorType}
-};
+    {LIKE, NSLikePredicateOperatorType}};
 
-const std::map<std::string, std::string>  columnToOSLogEntryProp {
+const std::map<std::string, std::string> columnToOSLogEntryProp = {
     {"timestamp", "date"},
     {"message", "composedMessage"},
     {"storage", "storeCategory"},
@@ -40,144 +39,151 @@ const std::map<std::string, std::string>  columnToOSLogEntryProp {
     {"sender", "sender"},
     {"tid", "threadIdentifier"},
     {"subsystem", "subsystem"},
-    {"category", "category"}
-};
+    {"category", "category"}};
 
-const std::map<std::string, bool>  columnIsNumeric {
-    {"timestamp", false},
-    {"message", false},
-    {"storage", true},
-    {"activity", true},
-    {"process", false},
-    {"pid", true},
-    {"sender", false},
-    {"tid", true},
-    {"subsystem", false},
-    {"category", false}
-};
+const std::map<std::string, bool> columnIsNumeric = {{"timestamp", false},
+                                                     {"message", false},
+                                                     {"storage", true},
+                                                     {"activity", true},
+                                                     {"process", false},
+                                                     {"pid", true},
+                                                     {"sender", false},
+                                                     {"tid", true},
+                                                     {"subsystem", false},
+                                                     {"category", false}};
 
-std::string convertLikeExpr(const std::string &value) {
-    // for the LIKE operator in NSPredicates, '*' matches 0 or more characters
-    //   and '?' matches a single character
-    std::string res = ba::replace_all_copy(value, "%", "*");
-    ba::replace_all(res, "_", "?");
-    return res;
+std::string convertLikeExpr(const std::string& value) {
+  // for the LIKE operator in NSPredicates, '*' matches 0 or more characters
+  //   and '?' matches a single character
+  std::string res = ba::replace_all_copy(value, "%", "*");
+  ba::replace_all(res, "_", "?");
+  return res;
 }
 
-void addQueryOp(NSMutableArray *preds,
-                const std::string &key,
-                const std::string &value,
+void addQueryOp(NSMutableArray* preds,
+                const std::string& key,
+                const std::string& value,
                 ConstraintOperator op) {
-    if (supportedOps.count(op) > 0) {
-        std::string modified_val = value;
-        std::string modified_key = columnToOSLogEntryProp.at(key);
-        if (op == LIKE) {
-            modified_val = convertLikeExpr(value);
-        }
-        NSExpression *keyExp = [NSExpression expressionForKeyPath:[NSString stringWithUTF8String:modified_key.c_str()]];
-        NSString *valStr = [NSString stringWithUTF8String:modified_val.c_str()];
-
-        NSExpression *valExp = nil;
-        if (key == "timestamp") {
-            double provided_timestamp = [valStr doubleValue];
-            valExp = [NSExpression expressionForConstantValue:[NSDate dateWithTimeIntervalSince1970: provided_timestamp]];
-        } else if (columnIsNumeric.at(key)) {
-            valExp = [NSExpression expressionWithFormat:@"%lld", [valStr longLongValue]];
-        } else {
-            valExp = [NSExpression expressionForConstantValue:valStr];
-        }
-
-        NSPredicate *pred = [NSComparisonPredicate
-            predicateWithLeftExpression:keyExp
-            rightExpression:valExp
-            modifier:NSDirectPredicateModifier
-            type:supportedOps.at(op)
-            options:0];
-        [preds addObject:pred];
+  if (supportedOps.count(op) > 0) {
+    std::string modified_val = value;
+    std::string modified_key = columnToOSLogEntryProp.at(key);
+    if (op == LIKE) {
+      modified_val = convertLikeExpr(value);
     }
+    NSExpression* keyExp = [NSExpression
+        expressionForKeyPath:[NSString
+                                 stringWithUTF8String:modified_key.c_str()]];
+    NSString* valStr = [NSString stringWithUTF8String:modified_val.c_str()];
+
+    NSExpression* valExp = nil;
+    if (key == "timestamp") {
+      double provided_timestamp = [valStr doubleValue];
+      valExp = [NSExpression
+          expressionForConstantValue:
+              [NSDate dateWithTimeIntervalSince1970:provided_timestamp]];
+    } else if (columnIsNumeric.at(key)) {
+      valExp =
+          [NSExpression expressionWithFormat:@"%lld", [valStr longLongValue]];
+    } else {
+      valExp = [NSExpression expressionForConstantValue:valStr];
+    }
+
+    NSPredicate* pred = [NSComparisonPredicate
+        predicateWithLeftExpression:keyExp
+                    rightExpression:valExp
+                           modifier:NSDirectPredicateModifier
+                               type:supportedOps.at(op)
+                            options:0];
+    [preds addObject:pred];
+  }
 }
 
-
-void genUnifiedLog(QueryContext& queryContext, QueryData &results) {
-
-    if (@available(macOS 10.15, *)) {
-    NSError *error = nil;
-    OSLogStore *logstore = [OSLogStore localStoreAndReturnError:&error];
+void genUnifiedLog(QueryContext& queryContext, QueryData& results) {
+  if (@available(macOS 10.15, *)) {
+    NSError* error = nil;
+    OSLogStore* logstore = [OSLogStore localStoreAndReturnError:&error];
     if (error != nil) {
-        VLOG(1) << "error getting handle to log store: " << [[error localizedDescription] UTF8String];
-        return;
+      VLOG(1) << "error getting handle to log store: "
+              << [[error localizedDescription] UTF8String];
+      return;
     }
 
-    OSLogPosition *position = nil;
+    OSLogPosition* position = nil;
 
-    NSMutableArray *subpredicates = [[NSMutableArray alloc] init];
+    NSMutableArray* subpredicates = [[NSMutableArray alloc] init];
     if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
-        auto start_time = queryContext.constraints["timestamp"].getAll(GREATER_THAN);
+      auto start_time =
+          queryContext.constraints["timestamp"].getAll(GREATER_THAN);
 
-        double provided_timestamp = [[NSString stringWithUTF8String:start_time.begin()->c_str()] doubleValue];
-        NSDate *provided_date = [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
+      double provided_timestamp = [[NSString
+          stringWithUTF8String:start_time.begin()->c_str()] doubleValue];
+      NSDate* provided_date =
+          [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
 
-        position = [logstore positionWithDate:provided_date];
+      position = [logstore positionWithDate:provided_date];
     }
 
-    for (const auto &it : queryContext.constraints) {
-        const std::string &key = it.first;
-        for (const auto &constraint : it.second.getAll()) {
-            addQueryOp(subpredicates, key, constraint.expr,
-                       static_cast<ConstraintOperator>(constraint.op));
-        }
+    for (const auto& it : queryContext.constraints) {
+      const std::string& key = it.first;
+      for (const auto& constraint : it.second.getAll()) {
+        addQueryOp(subpredicates,
+                   key,
+                   constraint.expr,
+                   static_cast<ConstraintOperator>(constraint.op));
+      }
     }
 
-    // QueryContext.constraints doesn't list how the constraints interact with each other,
-    // so we assume they're all ANDed together.
-    NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+    NSPredicate* predicate =
+        [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
 
     // enumerate the entries in ascending order by timestamp
     OSLogEnumeratorOptions option = 0;
 
-    OSLogEnumerator *enumerator = [logstore entriesEnumeratorWithOptions:option
-                                                                position:position
-                                                               predicate:predicate
-                                                                   error:&error];
+    OSLogEnumerator* enumerator =
+        [logstore entriesEnumeratorWithOptions:option
+                                      position:position
+                                     predicate:predicate
+                                         error:&error];
     if (error != nil) {
-        VLOG(1) << "error enumerating entries in system log: " <<  [[error localizedDescription] UTF8String];
-        return;
+      VLOG(1) << "error enumerating entries in system log: "
+              << [[error localizedDescription] UTF8String];
+      return;
     }
-    for (OSLogEntryLog *entry in enumerator) {
-        Row r;
-        r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
-        r["message"] = TEXT([[entry composedMessage] UTF8String]);
-        r["storage"] = INTEGER([entry storeCategory]);
+    for (OSLogEntryLog* entry in enumerator) {
+      Row r;
+      r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
+      r["message"] = TEXT([[entry composedMessage] UTF8String]);
+      r["storage"] = INTEGER([entry storeCategory]);
 
-        if ([entry respondsToSelector:@selector(activityIdentifier)]) {
-          r["activity"] = INTEGER([entry activityIdentifier]);
-          r["process"] = TEXT([[entry process] UTF8String]);
-          r["pid"] = INTEGER([entry processIdentifier]);
-          r["sender"] = TEXT([[entry sender] UTF8String]);
-          r["tid"] = INTEGER([entry threadIdentifier]);
-        }
+      if ([entry respondsToSelector:@selector(activityIdentifier)]) {
+        r["activity"] = INTEGER([entry activityIdentifier]);
+        r["process"] = TEXT([[entry process] UTF8String]);
+        r["pid"] = INTEGER([entry processIdentifier]);
+        r["sender"] = TEXT([[entry sender] UTF8String]);
+        r["tid"] = INTEGER([entry threadIdentifier]);
+      }
 
-        if ([entry respondsToSelector:@selector(subsystem)]) {
-          NSString *subsystem = [entry subsystem];
-          if (subsystem != nil) {
-            r["subsystem"] = TEXT([subsystem UTF8String]);
-          }
-          NSString *category = [entry category];
-          if (category != nil) {
-            r["category"] = TEXT([category UTF8String]);
-          }
+      if ([entry respondsToSelector:@selector(subsystem)]) {
+        NSString* subsystem = [entry subsystem];
+        if (subsystem != nil) {
+          r["subsystem"] = TEXT([subsystem UTF8String]);
         }
-        results.push_back(r);
+        NSString* category = [entry category];
+        if (category != nil) {
+          r["category"] = TEXT([category UTF8String]);
+        }
+      }
+      results.push_back(r);
     }
-    }
+  }
 }
 
 QueryData genUnifiedLog(QueryContext& context) {
   QueryData results;
   if (@available(macOS 10.15, *)) {
-  @autoreleasepool {
-    genUnifiedLog(context, results);
-  }
+    @autoreleasepool {
+      genUnifiedLog(context, results);
+    }
   } else {
     VLOG(1) << "OSLog framework is not available";
   }

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -42,15 +42,15 @@ const std::map<std::string, std::string> kColumnToOSLogEntryProp = {
     {"category", "category"}};
 
 const std::map<std::string, bool> kColumnIsNumeric = {{"timestamp", false},
-                                                     {"message", false},
-                                                     {"storage", true},
-                                                     {"activity", true},
-                                                     {"process", false},
-                                                     {"pid", true},
-                                                     {"sender", false},
-                                                     {"tid", true},
-                                                     {"subsystem", false},
-                                                     {"category", false}};
+                                                      {"message", false},
+                                                      {"storage", true},
+                                                      {"activity", true},
+                                                      {"process", false},
+                                                      {"pid", true},
+                                                      {"sender", false},
+                                                      {"tid", true},
+                                                      {"subsystem", false},
+                                                      {"category", false}};
 
 std::string convertLikeExpr(const std::string& value) {
   // for the LIKE operator in NSPredicates, '*' matches 0 or more characters
@@ -100,112 +100,113 @@ void addQueryOp(NSMutableArray* preds,
 
 QueryData genUnifiedLog(QueryContext& queryContext) {
   QueryData results;
-  if (@available(macOS 10.15, *)) {
-    @autoreleasepool {
-      NSError* error = nil;
-      OSLogStore* logstore = [OSLogStore localStoreAndReturnError:&error];
-      if (error != nil) {
-        TLOG << "error getting handle to log store: "
-             << [[error localizedDescription] UTF8String];
-        return {};
+  if (!@available(macOS 10.15, *)) {
+    VLOG(1) << "OSLog framework is not available";
+    return {};
+  }
+
+  @autoreleasepool {
+    NSError* error = nil;
+    OSLogStore* logstore = [OSLogStore localStoreAndReturnError:&error];
+    if (error != nil) {
+      TLOG << "error getting handle to log store: "
+           << [[error localizedDescription] UTF8String];
+      return {};
+    }
+
+    OSLogPosition* position = nil;
+
+    // the timestamp column can be used to aggressively filter
+    // results returned from the log store
+    if (queryContext.hasConstraint("timestamp", GREATER_THAN) ||
+        queryContext.hasConstraint("timestamp", GREATER_THAN_OR_EQUALS)) {
+      std::string start_time;
+      if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
+        start_time =
+            *queryContext.constraints["timestamp"].getAll(GREATER_THAN).begin();
+      } else {
+        start_time = *queryContext.constraints["timestamp"]
+                          .getAll(GREATER_THAN_OR_EQUALS)
+                          .begin();
       }
 
-      OSLogPosition* position = nil;
+      double provided_timestamp =
+          [[NSString stringWithUTF8String:start_time.c_str()] doubleValue];
+      NSDate* provided_date =
+          [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
 
-      // the timestamp column can be used to aggressively filter
-      // results returned from the log store
-      if (queryContext.hasConstraint("timestamp", GREATER_THAN) ||
-          queryContext.hasConstraint("timestamp", GREATER_THAN_OR_EQUALS)) {
-        std::string start_time;
-        if (queryContext.hasConstraint("timestamp", GREATER_THAN)) {
-          start_time = *queryContext.constraints["timestamp"]
-                            .getAll(GREATER_THAN)
-                            .begin();
-        } else {
-          start_time = *queryContext.constraints["timestamp"]
-                            .getAll(GREATER_THAN_OR_EQUALS)
-                            .begin();
-        }
+      position = [logstore positionWithDate:provided_date];
+    }
 
-        double provided_timestamp =
-            [[NSString stringWithUTF8String:start_time.c_str()] doubleValue];
-        NSDate* provided_date =
-            [NSDate dateWithTimeIntervalSince1970:provided_timestamp];
-
-        position = [logstore positionWithDate:provided_date];
-      }
-
-      // grab all the supported columns used in simple constraints and make a
-      // compound predicate out of them.
-      NSMutableArray* subpredicates = [[NSMutableArray alloc] init];
-      for (const auto& it : queryContext.constraints) {
-        const std::string& key = it.first;
-        for (const auto& constraint : it.second.getAll()) {
-          addQueryOp(subpredicates,
-                     key,
-                     constraint.expr,
-                     static_cast<ConstraintOperator>(constraint.op));
-        }
-      }
-
-      NSPredicate* predicate =
-          [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
-
-      // enumerate the entries in ascending order by timestamp
-      OSLogEnumeratorOptions option = 0;
-
-      OSLogEnumerator* enumerator =
-          [logstore entriesEnumeratorWithOptions:option
-                                        position:position
-                                       predicate:predicate
-                                           error:&error];
-      if (error != nil) {
-        TLOG << "error enumerating entries in system log: "
-             << [[error localizedDescription] UTF8String];
-        return {};
-      }
-      for (OSLogEntryLog* entry in enumerator) {
-        Row r;
-        r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
-        r["message"] = TEXT([[entry composedMessage] UTF8String]);
-        r["storage"] = INTEGER([entry storeCategory]);
-
-        if ([entry respondsToSelector:@selector(activityIdentifier)]) {
-          r["activity"] = INTEGER([entry activityIdentifier]);
-          r["process"] = TEXT([[entry process] UTF8String]);
-          r["pid"] = INTEGER([entry processIdentifier]);
-          r["sender"] = TEXT([[entry sender] UTF8String]);
-          r["tid"] = INTEGER([entry threadIdentifier]);
-        }
-
-        if ([entry respondsToSelector:@selector(subsystem)]) {
-          NSString* subsystem = [entry subsystem];
-          if (subsystem != nil) {
-            r["subsystem"] = TEXT([subsystem UTF8String]);
-          }
-          NSString* category = [entry category];
-          if (category != nil) {
-            r["category"] = TEXT([category UTF8String]);
-          }
-        }
-        if ([entry respondsToSelector:@selector(level)]) {
-          const char* logLevelNames[] = {
-              [OSLogEntryLogLevelUndefined] = "undefined",
-              [OSLogEntryLogLevelDebug] = "debug",
-              [OSLogEntryLogLevelInfo] = "info",
-              [OSLogEntryLogLevelNotice] = "default",
-              [OSLogEntryLogLevelError] = "error",
-              [OSLogEntryLogLevelFault] = "fault",
-          };
-
-          r["level"] = TEXT(logLevelNames[[entry level]]);
-        }
-        results.push_back(r);
+    // grab all the supported columns used in simple constraints and make a
+    // compound predicate out of them.
+    NSMutableArray* subpredicates = [[NSMutableArray alloc] init];
+    for (const auto& it : queryContext.constraints) {
+      const std::string& key = it.first;
+      for (const auto& constraint : it.second.getAll()) {
+        addQueryOp(subpredicates,
+                   key,
+                   constraint.expr,
+                   static_cast<ConstraintOperator>(constraint.op));
       }
     }
-  } else {
-    VLOG(1) << "OSLog framework is not available";
+
+    NSPredicate* predicate =
+        [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+
+    // enumerate the entries in ascending order by timestamp
+    OSLogEnumeratorOptions option = 0;
+
+    OSLogEnumerator* enumerator =
+        [logstore entriesEnumeratorWithOptions:option
+                                      position:position
+                                     predicate:predicate
+                                         error:&error];
+    if (error != nil) {
+      TLOG << "error enumerating entries in system log: "
+           << [[error localizedDescription] UTF8String];
+      return {};
+    }
+    for (OSLogEntryLog* entry in enumerator) {
+      Row r;
+      r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
+      r["message"] = TEXT([[entry composedMessage] UTF8String]);
+      r["storage"] = INTEGER([entry storeCategory]);
+
+      if ([entry respondsToSelector:@selector(activityIdentifier)]) {
+        r["activity"] = INTEGER([entry activityIdentifier]);
+        r["process"] = TEXT([[entry process] UTF8String]);
+        r["pid"] = INTEGER([entry processIdentifier]);
+        r["sender"] = TEXT([[entry sender] UTF8String]);
+        r["tid"] = INTEGER([entry threadIdentifier]);
+      }
+
+      if ([entry respondsToSelector:@selector(subsystem)]) {
+        NSString* subsystem = [entry subsystem];
+        if (subsystem != nil) {
+          r["subsystem"] = TEXT([subsystem UTF8String]);
+        }
+        NSString* category = [entry category];
+        if (category != nil) {
+          r["category"] = TEXT([category UTF8String]);
+        }
+      }
+      if ([entry respondsToSelector:@selector(level)]) {
+        const char* logLevelNames[] = {
+            [OSLogEntryLogLevelUndefined] = "undefined",
+            [OSLogEntryLogLevelDebug] = "debug",
+            [OSLogEntryLogLevelInfo] = "info",
+            [OSLogEntryLogLevelNotice] = "default",
+            [OSLogEntryLogLevelError] = "error",
+            [OSLogEntryLogLevelFault] = "fault",
+        };
+
+        r["level"] = TEXT(logLevelNames[[entry level]]);
+      }
+      results.push_back(r);
+    }
   }
+
   return results;
 }
 

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -104,7 +104,7 @@ void genUnifiedLog(QueryContext& queryContext, QueryData &results) {
     NSError *error = nil;
     OSLogStore *logstore = [OSLogStore localStoreAndReturnError:&error];
     if (error != nil) {
-        NSLog(@"error getting handle to log store: %@", error);
+        VLOG(1) << "error getting handle to log store: " << [[error localizedDescription] UTF8String];
         return;
     }
 
@@ -140,7 +140,7 @@ void genUnifiedLog(QueryContext& queryContext, QueryData &results) {
                                                                predicate:predicate
                                                                    error:&error];
     if (error != nil) {
-        NSLog(@"error enumerating entries in system log: %@", error);
+        VLOG(1) << "error enumerating entries in system log: " <<  [[error localizedDescription] UTF8String];
         return;
     }
     for (OSLogEntryLog *entry in enumerator) {

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2021-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <OSLog/OSLog.h>
+
+#include <osquery/core/tables.h>
+
+namespace osquery {
+namespace tables {
+    
+void genUnifiedLog(QueryData &results) {
+    if (@available(macOS 10.15, *)) {
+    NSError *error = nil;
+    OSLogStore *logstore = [OSLogStore localStoreAndReturnError:&error];
+    if (error != nil) {
+        NSLog(@"error getting handle to log store: %@", error);
+        return;
+    }
+
+    NSDate *interval = [NSDate dateWithTimeIntervalSinceNow:-10];
+    OSLogEnumeratorOptions option = 0;
+    OSLogPosition *position = [logstore positionWithDate:interval];
+    OSLogEnumerator *enumerator = [logstore entriesEnumeratorWithOptions:option
+                                                                position:position
+                                                               predicate:nil 
+                                                                   error:&error];
+    if (error != nil) {
+        NSLog(@"error getting handle to log store: %@", error);
+        return;
+    }
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"dd-MM-yyyy"];
+
+    for (OSLogEntry *entry in enumerator) {
+        Row r;
+        NSString *dateString = [dateFormatter stringFromDate:[entry date]];
+        r["date"] = TEXT([dateString UTF8String]);
+        r["message"] = TEXT([[entry composedMessage] UTF8String]);
+        r["category"] = INTEGER([entry storeCategory]);
+        results.push_back(r);
+    }
+    }
+}
+
+QueryData genUnifiedLog(QueryContext& context) {
+  QueryData results;
+  Row row;
+  @autoreleasepool {
+    genUnifiedLog(results);
+  }
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -137,6 +137,7 @@ function(generateNativeTables)
     "darwin/temperature_sensors.table:macos"
     "darwin/time_machine_backups.table:macos"
     "darwin/time_machine_destinations.table:macos"
+    "darwin/unified_log.table:macos"
     "darwin/user_interaction_events.table:macos"
     "darwin/virtual_memory_info.table:macos"
     "darwin/wifi_networks.table:macos"

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -12,6 +12,6 @@ schema([
   Column("tid", BIGINT, "the tid of the thread that made the entry", additional=True),
   Column("category", TEXT, "the category of the os_log_t used", additional=True),
   Column("subsystem", TEXT, "the subsystem of the os_log_t used", additional=True),
-  Column("level", INTEGER, "the severity level of the entry")
+  Column("level", TEXT, "the severity level of the entry")
 ])
 implementation("unified_log@genUnifiedLog")

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -3,14 +3,14 @@ description("Queries the OSLog framework for entries in the system log.")
 
 schema([
   Column("timestamp", BIGINT, "unix timestamp associated with the entry", additional=True),
-  Column("storage", INTEGER, "the storage category for the entry"),
-  Column("message", TEXT, "composed message"),
-  Column("activity", INTEGER, "the activity ID associate with the entry"),
-  Column("process", TEXT, "the name of the process that made the entry"),
-  Column("pid", BIGINT, "the pid of the process that made the entry"),
-  Column("sender", TEXT, "the name of the binary image that made the entry"),
-  Column("tid", BIGINT, "the tid of the thread that made the entry"),
-  Column("category", TEXT, "the category of the os_log_t used"),
+  Column("storage", INTEGER, "the storage category for the entry", additional=True),
+  Column("message", TEXT, "composed message", additional=True),
+  Column("activity", INTEGER, "the activity ID associate with the entry", additional=True),
+  Column("process", TEXT, "the name of the process that made the entry", additional=True),
+  Column("pid", BIGINT, "the pid of the process that made the entry", additional=True),
+  Column("sender", TEXT, "the name of the binary image that made the entry", additional=True),
+  Column("tid", BIGINT, "the tid of the thread that made the entry", additional=True),
+  Column("category", TEXT, "the category of the os_log_t used", additional=True),
   Column("subsystem", TEXT, "the subsystem of the os_log_t used", additional=True)
 ])
 implementation("unified_log@genUnifiedLog")

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -3,7 +3,14 @@ description("Queries the OSLog framework for entries in the system log.")
 
 schema([
   Column("date",  TEXT, "timestamp associated with the entry"),
+  Column("storage", INTEGER, "the storage category for the entry"),
   Column("message", TEXT, "composed message"),
-  Column("category", INTEGER, "the storage category for the entry"),
+  Column("activity", INTEGER, "the activity ID associate with the entry"),
+  Column("process", TEXT, "the name of the process that made the entry"),
+  Column("pid", BIGINT, "the pid of the process that made the entry"),
+  Column("sender", TEXT, "the name of the binary image that made the entry"),
+  Column("tid", BIGINT, "the tid of the thread that made the entry"),
+  Column("category", TEXT, "the category of the os_log_t used"),
+  Column("subsystem", TEXT, "the subsystem of the os_log_t used")
 ])
 implementation("unified_log@genUnifiedLog")

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -2,7 +2,7 @@ table_name("unified_log")
 description("Queries the OSLog framework for entries in the system log.")
 
 schema([
-  Column("date",  TEXT, "timestamp associated with the entry"),
+  Column("timestamp", BIGINT, "unix timestamp associated with the entry", additional=True),
   Column("storage", INTEGER, "the storage category for the entry"),
   Column("message", TEXT, "composed message"),
   Column("activity", INTEGER, "the activity ID associate with the entry"),
@@ -11,6 +11,6 @@ schema([
   Column("sender", TEXT, "the name of the binary image that made the entry"),
   Column("tid", BIGINT, "the tid of the thread that made the entry"),
   Column("category", TEXT, "the category of the os_log_t used"),
-  Column("subsystem", TEXT, "the subsystem of the os_log_t used")
+  Column("subsystem", TEXT, "the subsystem of the os_log_t used", additional=True)
 ])
 implementation("unified_log@genUnifiedLog")

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -11,6 +11,7 @@ schema([
   Column("sender", TEXT, "the name of the binary image that made the entry", additional=True),
   Column("tid", BIGINT, "the tid of the thread that made the entry", additional=True),
   Column("category", TEXT, "the category of the os_log_t used", additional=True),
-  Column("subsystem", TEXT, "the subsystem of the os_log_t used", additional=True)
+  Column("subsystem", TEXT, "the subsystem of the os_log_t used", additional=True),
+  Column("level", INTEGER, "the severity level of the entry")
 ])
 implementation("unified_log@genUnifiedLog")

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -1,0 +1,9 @@
+table_name("unified_log")
+description("Queries the OSLog framework for entries in the system log.")
+
+schema([
+  Column("date",  TEXT, "timestamp associated with the entry"),
+  Column("message", TEXT, "composed message"),
+  Column("category", INTEGER, "the storage category for the entry"),
+])
+implementation("unified_log@genUnifiedLog")


### PR DESCRIPTION
This code implements a virtual table for darwin that uses the OSLog framework to read and return entries from the unified system log. Prior versions of macOS did not have an api to access this data, necessitating an extension that invoked the `log` utility. macOS 10.15 makes this no longer necessary.

At the moment I've tested these changes only on a 10.15 vm. I'd be grateful to the community for feedback regarding building on earlier versions of macOS.

Closes https://github.com/osquery/osquery/issues/5760