### PR TITLE
CMake: Add -pthread compile option on posix platforms

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -62,6 +62,7 @@ function(setupBuildFlags)
       -fno-limit-debug-info
       -pipe
       -pedantic
+      -pthread
     )
 
     if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")


### PR DESCRIPTION
osquery was already linking with -pthread and so linking
to libpthread on Linux, but it wasn't always defining
the _REENTRANT macro which is done by the -pthread option
given at compile time.
Although in the third party libraries that need it,
it should've been defined in other ways (directly or via a config.h),
always add -pthread for correctness and consistency.

Note: macOS doesn't need -pthread at link time because
pthreads are already implemented inside the libc library.