### PR TITLE
Disable deprecated TLS versions 1.0, 1.1

### DIFF
--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -153,7 +153,8 @@ http::Client::Options TLSTransport::getInternalOptions() {
   }
 
   options.openssl_ciphers(kTLSCiphers);
-  options.openssl_options(SSL_OP_NO_SSLv3 | SSL_OP_NO_SSLv2 | SSL_OP_ALL);
+  options.openssl_options(SSL_OP_NO_SSLv3 | SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 |
+                          SSL_OP_NO_TLSv1_1 | SSL_OP_ALL);
 
   if (client_certificate_file_.size() > 0) {
     if (!osquery::isReadable(client_certificate_file_).ok()) {


### PR DESCRIPTION
> The PCI Council suggested that organizations migrate from TLS 1.0 to TLS 1.1 or higher before June 30, 2018. In October 2018, Apple, Google, Microsoft, and Mozilla jointly announced they would deprecate TLS 1.0 and 1.1 in March 2020.

https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.0

TLS 1.2 is the recommended minimum version of the TLS protocol to allow. Support in OpenSSL was introduced in 2012, from OpenSSL version 1.0.1. TLS 1.0 and 1.1 have been deprecated throughout the web, and osquery should drop its use of them too.

According to Zach, Fleet has supported TLS 1.2 and 1.3 for a long time (years).