### PR TITLE
Add column for system extensions managed by configuration policy (system_extensions table)

### DIFF
--- a/osquery/tables/system/darwin/system_extensions.mm
+++ b/osquery/tables/system/darwin/system_extensions.mm
@@ -36,6 +36,70 @@ std::string getExtensionCategory(const pt::ptree& ptree) {
   return boost::algorithm::join(categories, ", ");
 }
 
+// com.apple.system-extension-policy payload defines the policy for
+// the system extensions. The function looks for team identifier or
+// extension bundle identifiers in the allowed list.
+// https://developer.apple.com/documentation/devicemanagement/systemextensions?language=objc
+uint32_t getPolicyFlag(const pt::ptree& ptree,
+                       const std::string& teamid,
+                       const std::string& identifier) {
+  enum : uint32_t {
+    POLICY_NONE = 0,
+    POLICY_MANAGED = 1,
+  };
+  const auto& policies_attr_opt = ptree.get_child_optional("extensionPolicies");
+  if (!policies_attr_opt.has_value()) {
+    return POLICY_NONE;
+  }
+
+  const auto& policies_attr = policies_attr_opt.value();
+  for (const auto& policy : policies_attr) {
+    // Get the list of AllowedTeamIdentifiers that are valid and system
+    // extensions signed by them are allowed to load.
+    //
+    // All system extensions signed with any of the specified team identifiers
+    // will be considered to be approved
+    const auto& policy_item = policy.second;
+
+    // get the list of allowed team id's in extension policy tree and
+    // look for the teamid in them
+    const auto& allowed_team_opt =
+        policy_item.get_child_optional("allowedTeamIDs");
+    if (allowed_team_opt.has_value()) {
+      const auto& allowed_team = allowed_team_opt.value();
+      for (const auto& team : allowed_team) {
+        if (team.second.get("", "") == teamid) {
+          return POLICY_MANAGED;
+        }
+      }
+    }
+
+    // if the teamid is not in the allowedTeamID's list check for the
+    // allowed system extensions.
+    const auto& allowed_extensions_opt =
+        policy_item.get_child_optional("allowedExtensions");
+    // allowed system extension is empty
+    if (!allowed_extensions_opt.has_value()) {
+      return POLICY_NONE;
+    }
+
+    // Get the list of allowed extensions which is a dictionary of
+    // extension list mapped with teamid
+    const auto& allowed_extensions = allowed_extensions_opt.value();
+    const auto& extensions_opt = allowed_extensions.get_child_optional(teamid);
+    if (extensions_opt.has_value()) {
+      const auto& extensions = extensions_opt.value();
+      for (const auto& extension : extensions) {
+        if (extension.second.get("", "") == identifier) {
+          return POLICY_MANAGED;
+        }
+      }
+    }
+  }
+
+  return POLICY_NONE;
+}
+
 void getExtensionRow(const pt::ptree& extension, Row& r) {
   r["path"] = extension.get("originPath", "");
   r["UUID"] = extension.get("uniqueID", "");
@@ -48,6 +112,7 @@ void getExtensionRow(const pt::ptree& extension, Row& r) {
   const auto category = extension.get_child("categories");
   r["category"] = getExtensionCategory(category);
   r["bundle_path"] = extension.get("container.bundlePath", "");
+  r["mdm_managed"] = INTEGER(0);
 }
 
 QueryData genExtensionsFromPtree(const pt::ptree& ptree) {
@@ -60,26 +125,47 @@ QueryData genExtensionsFromPtree(const pt::ptree& ptree) {
   const auto& extensions_attr = extensions_attr_opt.value();
   for (const auto& array_entry : extensions_attr) {
     const auto& extension_value = array_entry.second;
-    Row r;
-    getExtensionRow(extension_value, r);
-    results.push_back(r);
+    Row row;
+    getExtensionRow(extension_value, row);
+
+    // get row teamid and identifier and lookup for them in the
+    // extension policy
+    auto row_teamid = row["team"];
+
+    // teamid is required for the extension policy lookup. If teamid
+    // is empty the policy flag will be set to default(`0`)
+    if (!row_teamid.empty()) {
+      auto row_identifier = row["identifier"];
+      row["mdm_managed"] =
+          INTEGER(getPolicyFlag(ptree, row_teamid, row_identifier));
+    }
+
+    // add row to the results
+    results.push_back(row);
   }
   return results;
 }
 
 QueryData genSystemExtensions(QueryContext& context) {
-  if (!osquery::pathExists(kSysExtDBPath)) {
-    VLOG(1) << "System extension database does not exist: " << kSysExtDBPath;
+  if (@available(macOS 10.15, *)) {
+    if (!osquery::pathExists(kSysExtDBPath)) {
+      LOG(WARNING) << "System extension database does not exist: "
+                   << kSysExtDBPath;
+      return {};
+    }
+
+    pt::ptree ptree;
+    if (!osquery::parsePlist(kSysExtDBPath, ptree).ok()) {
+      LOG(ERROR) << "Failed to parse: " << kSysExtDBPath;
+      return {};
+    }
+
+    return genExtensionsFromPtree(ptree);
+  } else {
+    LOG(WARNING)
+        << "System Extensions are not supported (requires macOS (>= 10.15))";
     return {};
   }
-
-  pt::ptree ptree;
-  if (!osquery::parsePlist(kSysExtDBPath, ptree).ok()) {
-    LOG(ERROR) << "Failed to parse: " << kSysExtDBPath;
-    return {};
-  }
-
-  return genExtensionsFromPtree(ptree);
 }
 }
 }

--- a/osquery/tables/system/tests/darwin/system_extensions_test.cpp
+++ b/osquery/tables/system/tests/darwin/system_extensions_test.cpp
@@ -93,6 +93,7 @@ TEST_F(SystemExtensionTests, test_parse_ptree) {
             "/Applications/LuLu.app/Contents/Library/SystemExtensions/"
             "com.objective-see.lulu.extension.systemextension");
   EXPECT_EQ(results[0]["bundle_path"], "/Applications/LuLu.app");
+  EXPECT_EQ(results[0]["mdm_managed"], "0");
 }
 
 TEST_F(SystemExtensionTests, test_parse_plist) {
@@ -120,6 +121,7 @@ TEST_F(SystemExtensionTests, test_parse_plist) {
             "/Applications/LuLu.app/Contents/Library/SystemExtensions/"
             "com.objective-see.lulu.extension.systemextension");
   EXPECT_EQ(results[0]["bundle_path"], "/Applications/LuLu.app");
+  EXPECT_EQ(results[0]["mdm_managed"], "0");
 }
 
 } // namespace tables

--- a/specs/darwin/system_extensions.table
+++ b/specs/darwin/system_extensions.table
@@ -8,7 +8,8 @@ schema([
     Column("version", TEXT, "System extension version"),
     Column("category", TEXT, "System extension category"),
     Column("bundle_path", TEXT, "System extension bundle path"),
-    Column("team", TEXT, "Signing team ID")
+    Column("team", TEXT, "Signing team ID"),
+    Column("mdm_managed", INTEGER, "1 if managed by MDM system extension payload configuration, 0 otherwise")
 ])
 implementation("system_extensions@genSystemExtensions")
 examples([

--- a/tests/integration/tables/system_extensions.cpp
+++ b/tests/integration/tables/system_extensions.cpp
@@ -31,7 +31,8 @@ TEST_F(SystemExtension, test_sanity) {
                            {"version", NormalType},
                            {"category", NormalType},
                            {"bundle_path", NormalType},
-                           {"team", NormalType}};
+                           {"team", NormalType},
+                           {"mdm_managed", NonNegativeInt}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

System extensions deployed on a managed environment can be configured through a device management profile.  The changes add a new column (`is_managed`) having information if the extension is managed by a payload policy. It scans through the extension payload policies and checks the allowed team identifiers & allowed extensions dictionary.

It will be great to get feedback from the community both on the changes and uses of having the information in the table. 

Refs: [com.apple.system-extension-policy](https://developer.apple.com/documentation/devicemanagement/systemextensions?language=objc)
