### PR TITLE
Fix SystemControlsTest adding sunrpc as an expected subsystem

### DIFF
--- a/tests/integration/tables/system_controls.cpp
+++ b/tests/integration/tables/system_controls.cpp
@@ -40,6 +40,7 @@ TEST_F(SystemControlsTest, test_sanity) {
                            "kernel",
                            "machdep",
                            "net",
+                           "sunrpc",
                            "user",
                            "vfs",
                            "vm"}},


### PR DESCRIPTION
Fixes #6868 