### PR TITLE
Move try/catch to all partial failure during /proc iteration

### DIFF
--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -143,8 +143,16 @@ Status procEnumerateProcesses(UserData& user_data,
                               bool (*callback)(const std::string&, UserData&)) {
   boost::filesystem::directory_iterator it(kLinuxProcPath), end;
 
-  try {
-    for (; it != end; ++it) {
+  // Some hardening schemes grant only partial permission to
+  // /proc. Because of that, we want to keep iterating even if we get
+  // a failure. Track if we've gotten any success, and return based on
+  // that instead of from an individual iteration. (This does mean
+  // that if you have no permissions, you may get a bunch of verbose
+  // logs saying so. See https://github.com/osquery/osquery/issues/5709
+  bool anySuccess = false;
+
+  for (; it != end; ++it) {
+    try {
       if (!boost::filesystem::is_directory(it->status())) {
         continue;
       }
@@ -159,10 +167,17 @@ Status procEnumerateProcesses(UserData& user_data,
       if (ret == false) {
         break;
       }
+
+      anySuccess = true;
+    } catch (const boost::filesystem::filesystem_error& e) {
+      VLOG(1) << "Exception iterating Linux processes: " << e.what()
+              << "Iterating onward\n";
     }
-  } catch (const boost::filesystem::filesystem_error& e) {
-    VLOG(1) << "Exception iterating Linux processes: " << e.what();
-    return Status(1, e.what());
+  }
+
+  if (!anySuccess) {
+    VLOG(1) << "No success iterating linux /proc. Permissions problems?\n";
+    return Status(1, "No success iterating linux /proc");
   }
 
   return Status(0);

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -176,7 +176,7 @@ Status procEnumerateProcesses(UserData& user_data,
 
   if (!anySuccess) {
     VLOG(1) << "No success iterating linux /proc\n";
-    return Success::failure("No success iterating linux /proc");
+    return Status::failure("No success iterating linux /proc");
   }
 
   return Status(0);
@@ -227,7 +227,7 @@ Status procEnumerateProcessDescriptors(const std::string& pid,
     }
   } catch (boost::filesystem::filesystem_error& e) {
     VLOG(1) << "Exception iterating process file descriptors: " << e.what();
-    return Success::failure(e.what());
+    return Status::failure(e.what());
   }
 
   return Status(0);

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -170,14 +170,13 @@ Status procEnumerateProcesses(UserData& user_data,
 
       anySuccess = true;
     } catch (const boost::filesystem::filesystem_error& e) {
-      VLOG(1) << "Exception iterating Linux processes: " << e.what()
-              << "Iterating onward\n";
+      VLOG(1) << "Exception iterating Linux /proc: " << e.what();
     }
   }
 
   if (!anySuccess) {
-    VLOG(1) << "No success iterating linux /proc. Permissions problems?\n";
-    return Status(1, "No success iterating linux /proc");
+    VLOG(1) << "No success iterating linux /proc\n";
+    return Success::failure("No success iterating linux /proc");
   }
 
   return Status(0);
@@ -228,7 +227,7 @@ Status procEnumerateProcessDescriptors(const std::string& pid,
     }
   } catch (boost::filesystem::filesystem_error& e) {
     VLOG(1) << "Exception iterating process file descriptors: " << e.what();
-    return Status(1, e.what());
+    return Success::failure(e.what());
   }
 
   return Status(0);

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -170,13 +170,12 @@ Status procEnumerateProcesses(UserData& user_data,
 
       anySuccess = true;
     } catch (const boost::filesystem::filesystem_error& e) {
-      VLOG(1) << "Exception iterating Linux /proc: " << e.what();
+      VLOG(1) << "Exception enumerating /proc: " << e.what();
     }
   }
 
   if (!anySuccess) {
-    VLOG(1) << "No success iterating linux /proc\n";
-    return Status::failure("No success iterating linux /proc");
+    return Status::failure("Unsuccessful enumerating /proc");
   }
 
   return Status(0);


### PR DESCRIPTION
As described in #5709, some permissions schemes do not have full
permission on /proc. Move the try/catch block into the loop, and allow
iteration despite errors.

Track whether we've had any success and base the failure off of it.

fixes: #5709

I'm not convinced this is quite right, but it seems worth review
