### PR TITLE
Fix StartupItemTest failing due to unexpected values

### DIFF
--- a/tests/integration/tables/startup_items.cpp
+++ b/tests/integration/tables/startup_items.cpp
@@ -12,6 +12,10 @@
 
 #include <osquery/tests/integration/tables/helper.h>
 
+#include <boost/algorithm/string/join.hpp>
+#include <map>
+#include <vector>
+
 namespace osquery {
 namespace table_tests {
 
@@ -27,14 +31,39 @@ TEST_F(StartupItemsTest, test_sanity) {
 
   ValidationMap row_map = {
       {"name", NonEmptyString},
-      {"path", NonEmptyString},
+      {"path", NormalType},
       {"args", NormalType},
-      {"type", SpecificValuesCheck{"Startup Item", "Login Item"}},
+      {"type", SpecificValuesCheck{"Startup Item", "systemd unit"}},
       {"source", NormalType},
-      {"status", SpecificValuesCheck{"enabled", "disabled"}},
+      {"status", NonEmptyString},
       {"username", NormalType},
   };
   validate_rows(data, row_map);
+
+  /* Check that the status column contains specific values which depend on the
+   * type */
+  std::vector<std::string> valid_systemd_status_values = {"active",
+                                                          "inactive",
+                                                          "failed",
+                                                          "maintenance",
+                                                          "reloading",
+                                                          "activating",
+                                                          "deactivating"};
+  for (const auto& row : data) {
+    if (row.at("type") == "Startup Item") {
+      /* Startup Items are scripts or .desktop files, so if they're present in
+       * the table it means they are enabled. There's no disabled state. */
+      EXPECT_EQ(row.at("status"), "enabled");
+    } else if (row.at("type") == "systemd unit") {
+      auto status = std::find(valid_systemd_status_values.begin(),
+                              valid_systemd_status_values.end(),
+                              row.at("status"));
+      EXPECT_EQ(status, valid_systemd_status_values.end())
+          << "Expected status to be one of "
+          << boost::algorithm::join(valid_systemd_status_values, ", ")
+          << ", but " << row.at("status") << " has been found";
+    }
+  }
 }
 
 } // namespace table_tests


### PR DESCRIPTION
The "path" column for a systemd unit row can be empty.

Added missing possible values for the "status" column,
when the "type" column value is "systemd unit".

Removed "Login Item" as a possible value for the "type" column,
since now "Startup Item" is used.

Removed "disabled" as a possible value for the "status" column,
since it's not returned anymore and due to the type "Startup Item"
being either a script or a .desktop file, which do not have a disabled state;
if they need to be they'll just be removed
and they won't appear in the table anymore.

Separately check for the "status" column possible values
since they differ based on the "type" column value.

Fixes #6869 
