### PR TITLE
Fix XattrTests failing due to unexpected attribute name

### DIFF
--- a/osquery/filesystem/tests/posix/xattrs.cpp
+++ b/osquery/filesystem/tests/posix/xattrs.cpp
@@ -85,10 +85,12 @@ TEST_F(XattrTests, getExtendedAttributeNameList) {
                                              test_file_path.string());
 
   ASSERT_TRUE(status.ok());
-  ASSERT_EQ(kTestAttributeList.size(), attribute_name_list.size());
+  ASSERT_GE(attribute_name_list.size(), kTestAttributeList.size());
 
-  for (const auto& attribute_name : attribute_name_list) {
-    EXPECT_TRUE(kTestAttributeList.count(attribute_name) > 0U);
+  for (const auto& attribute_name : kTestAttributeList) {
+    EXPECT_TRUE(std::find(attribute_name_list.begin(),
+                          attribute_name_list.end(),
+                          attribute_name.first) != attribute_name_list.end());
   }
 }
 


### PR DESCRIPTION
The extended attributes present on a test file
might not be only the ones set by the test itself.
If SELinux is installed for instance, an additional extended attribute
is present.
Therefore instead of requiring that the list of attribute names
is exactly the one set by the test, verify that the attribute names
we expect are present in the list.

Fixes #6870
