### PR TITLE
Allow carver endpoints to differ from base url

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -265,7 +265,10 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   // Construct the uri we post our data back to:
   auto startUri = TLSRequestHelper::makeURI(FLAGS_carver_start_endpoint);
   Request<TLSTransport, JSONSerializer> startRequest(startUri);
-  startRequest.setOption("hostname", FLAGS_tls_hostname);
+  if ((FLAGS_carver_start_endpoint.rfind("http://", 0) != 0) &&
+      (FLAGS_carver_start_endpoint.rfind("https://", 0) != 0)) {
+    startRequest.setOption("hostname", FLAGS_tls_hostname);
+  }
 
   // Perform the start request to get the session id
   PlatformFile pFile(path, PF_OPEN_EXISTING | PF_READ);
@@ -308,7 +311,10 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
 
   auto contUri = TLSRequestHelper::makeURI(FLAGS_carver_continue_endpoint);
   Request<TLSTransport, JSONSerializer> contRequest(contUri);
-  contRequest.setOption("hostname", FLAGS_tls_hostname);
+  if ((FLAGS_carver_continue_endpoint.rfind("http://", 0) != 0) &&
+      (FLAGS_carver_continue_endpoint.rfind("https://", 0) != 0)) {
+    contRequest.setOption("hostname", FLAGS_tls_hostname);
+  }
   for (size_t i = 0; i < blkCount; i++) {
     std::vector<char> block(FLAGS_carver_block_size, 0);
     auto r = pFile.read(block.data(), FLAGS_carver_block_size);


### PR DESCRIPTION
The start and continue endpoints for carver requires their endpoints to
have the same hostname as FLAGS_tls_hostname.

Fixed: #4108

To submit a PR please make sure to follow the next steps:

- [X] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [X] Ensure the code is formatted building the `format_check` target,  
      if not move the committed files to the stage area,
      build the `format` target to format, then re-commit.
      More information is available on the wiki.
- [X] Ensure your PR contains a single logical change.
- [X] Ensure your PR contains tests for the changes you're submitting.
  - I looked for similar tests, but this logic doesn't seem to be tested as is. I wanted to start a discussion about this.
- [X] Describe your changes with as much detail as you can.
- [X] Link any issues this PR is related to.