### PR TITLE
Update documentation to build in the right dir

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -47,7 +47,7 @@ cd osquery
 # Build osquery
 mkdir build; cd build
 cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..
-cmake --build . -j10 # where 10 is the number of parallel build jobs
+cmake --build .. -j10 # where 10 is the number of parallel build jobs
 ```
 
 ## macOS


### PR DESCRIPTION
The documentation invokes cmake in the parent directory

```
cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..
```

means when you build you must build in the parent directory.

```
cmake --build .. -j10 # where 10 is the number of parallel build jobs
```

- [x] Read the `CONTRIBUTING.md` guide on the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target,  
      if not move the committed files to the stage area,
      build the `format` target to format, then re-commit.
      More information is available on the wiki.
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.