### PR TITLE
Put noisy thrift logs behind a flag

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -398,6 +398,10 @@ If `--host_identifier=specified` is set, use this value as the host identifier.
 
 Enable verbose informational messages.
 
+`--thrift_verbose=false`
+
+Enable thrift global output.
+
 `--logger_path=/var/log/osquery/`
 
 Directory path for `ERROR`/`WARN`/`INFO` and query results logging.

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -374,6 +374,8 @@ void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
   if (FLAGS_thrift_verbose) {
     GlobalOutput.setOutputFunction(
         [](const char* message) -> void { VLOG(1) << "Thrift: " << message; });
+  } else {
+    GlobalOutput.setOutputFunction([](const char* message) -> void {});
   }
 }
 

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -41,6 +41,8 @@
 
 namespace osquery {
 
+FLAG(bool, thrift_verbose, false, "Enable the thrift log handler");
+
 using namespace apache::thrift;
 using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
@@ -369,8 +371,10 @@ void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
         std::make_shared<extensions::ExtensionManagerProcessor>(handler);
   }
   // Set the global output function for thrift
-  GlobalOutput.setOutputFunction(
-      [](const char* message) -> void { VLOG(1) << "Thrift: " << message; });
+  if (FLAGS_thrift_verbose) {
+    GlobalOutput.setOutputFunction(
+        [](const char* message) -> void { VLOG(1) << "Thrift: " << message; });
+  }
 }
 
 void ExtensionRunnerInterface::stopServer() {


### PR DESCRIPTION
I've found using there's a log of noise around the extension code with verbose on:

```
I0214 19:32:04.267999  4932 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:04.268999  4932 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
I0214 19:32:04.526999  5004 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:04.582000  5004 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
I0214 19:32:07.620999  5596 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:07.620999  5596 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
I0214 19:32:07.734999  5608 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:07.735999  5608 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
I0214 19:32:11.105000  6068 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:11.105000  6068 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
I0214 19:32:11.134999  6060 impl_thrift.cpp:346] Thrift: TPipe ::GetOverlappedResult errored GLE=: errno = 109
I0214 19:32:11.136999  6060 impl_thrift.cpp:346] Thrift: TConnectedClient died: TPipe: GetOverlappedResult failed
```

I've placed it behind a flag so we can reduce the noise in verbose mode. 