### PR TITLE
Copy JSON objects to avoid MemoryPool buildup

### DIFF
--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -114,9 +114,13 @@ Status ATCConfigParserPlugin::update(const std::string& source,
     return Status::success();
   }
 
-  auto obj = data_.getObject();
-  data_.copyFrom(cv->second.doc(), obj);
-  data_.add(kParserKey, obj);
+  {
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(cv->second.doc(), obj);
+    doc.add(kParserKey, obj);
+    data_ = std::move(doc);
+  }
 
   const auto& ac_tables = data_.doc()[kParserKey];
   auto tables = RegistryFactory::get().registry("table");

--- a/plugins/config/parsers/decorators.cpp
+++ b/plugins/config/parsers/decorators.cpp
@@ -136,6 +136,10 @@ Status DecoratorsConfigParserPlugin::update(const std::string& source,
     runDecorators(DECORATE_LOAD, 0, source);
   }
 
+  auto doc = JSON::newObject();
+  doc.copyFrom(data_.doc());
+  data_ = std::move(doc);
+
   return Status(0, "OK");
 }
 

--- a/plugins/config/parsers/events_parser.cpp
+++ b/plugins/config/parsers/events_parser.cpp
@@ -36,9 +36,11 @@ Status EventsConfigParserPlugin::update(const std::string& source,
                                         const ParserConfig& config) {
   auto events = config.find("events");
   if (events != config.end()) {
-    auto obj = data_.getObject();
-    data_.copyFrom(events->second.doc(), obj);
-    data_.add("events", obj, data_.doc());
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(events->second.doc(), obj);
+    doc.add("events", obj);
+    data_ = std::move(doc);
   }
   return Status();
 }

--- a/plugins/config/parsers/feature_vectors.cpp
+++ b/plugins/config/parsers/feature_vectors.cpp
@@ -32,9 +32,11 @@ Status FeatureVectorsConfigParserPlugin::update(const std::string& source,
     return Status::success();
   }
 
-  auto obj = data_.getObject();
-  data_.copyFrom(fv->second.doc(), obj);
-  data_.add(kFeatureVectorsRootKey, obj);
+  auto doc = JSON::newObject();
+  auto obj = doc.getObject();
+  doc.copyFrom(fv->second.doc(), obj);
+  doc.add(kFeatureVectorsRootKey, obj);
+  data_ = std::move(doc);
   return Status::success();
 }
 

--- a/plugins/config/parsers/file_paths.cpp
+++ b/plugins/config/parsers/file_paths.cpp
@@ -221,6 +221,10 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     updateExcludePaths(exclude_paths->second);
   }
 
+  auto doc = JSON::newObject();
+  doc.copyFrom(data_.doc());
+  data_ = std::move(doc);
+
   return Status::success();
 }
 

--- a/plugins/config/parsers/kafka_topics.cpp
+++ b/plugins/config/parsers/kafka_topics.cpp
@@ -26,9 +26,11 @@ Status KafkaTopicsConfigParserPlugin::update(const std::string& source,
                                              const ParserConfig& config) {
   auto topics = config.find(kKafkaTopicParserRootKey);
   if (topics != config.end()) {
-    auto obj = data_.getObject();
-    data_.copyFrom(topics->second.doc(), obj);
-    data_.add(kKafkaTopicParserRootKey, obj);
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(topics->second.doc(), obj);
+    doc.add(kKafkaTopicParserRootKey, obj);
+    data_ = std::move(doc);
   }
   return Status();
 }

--- a/plugins/config/parsers/logger.cpp
+++ b/plugins/config/parsers/logger.cpp
@@ -27,9 +27,11 @@ Status LoggerConfigParserPlugin::update(const std::string& /* source */,
 
   auto cv = config.find(kLoggerKey);
   if (cv != config.end()) {
-    auto obj = data_.getObject();
-    data_.copyFrom(cv->second.doc(), obj);
-    data_.add(kLoggerKey, obj);
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(cv->second.doc(), obj);
+    doc.add(kLoggerKey, obj);
+    data_ = std::move(doc);
   }
 
   return Status();

--- a/plugins/config/parsers/options.cpp
+++ b/plugins/config/parsers/options.cpp
@@ -53,15 +53,24 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
     return Status();
   }
 
-  if (!data_.doc().HasMember("options")) {
-    auto obj = data_.getObject();
-    data_.add("options", obj);
-  }
+  {
+    auto doc = JSON::newObject();
 
-  if (co->second.doc().IsObject()) {
-    auto obj = data_.getObject();
-    data_.copyFrom(co->second.doc(), obj);
-    data_.mergeObject(data_.doc()["options"], obj);
+    {
+      auto obj = doc.getObject();
+      if (data_.doc().HasMember("options")) {
+        doc.copyFrom(data_.doc()["options"], obj);
+      }
+      doc.add("options", obj);
+    }
+
+    if (co->second.doc().IsObject()) {
+      auto obj = doc.getObject();
+      doc.copyFrom(co->second.doc(), obj);
+      doc.mergeObject(doc.doc()["options"], obj);
+    }
+
+    data_ = std::move(doc);
   }
 
   const auto& options = data_.doc()["options"];

--- a/plugins/config/parsers/prometheus_targets.cpp
+++ b/plugins/config/parsers/prometheus_targets.cpp
@@ -26,9 +26,11 @@ Status PrometheusMetricsConfigParserPlugin::update(const std::string& source,
                                                    const ParserConfig& config) {
   auto prometheus_targets = config.find(kPrometheusParserRootKey);
   if (prometheus_targets != config.end()) {
-    auto obj = data_.getObject();
-    data_.copyFrom(prometheus_targets->second.doc(), obj);
-    data_.add(kPrometheusParserRootKey, obj);
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(prometheus_targets->second.doc(), obj);
+    doc.add(kPrometheusParserRootKey, obj);
+    data_ = std::move(doc);
   }
 
   return Status();

--- a/plugins/config/parsers/views.cpp
+++ b/plugins/config/parsers/views.cpp
@@ -40,9 +40,13 @@ Status ViewsConfigParserPlugin::update(const std::string& source,
     return Status(1);
   }
 
-  auto obj = data_.getObject();
-  data_.copyFrom(cv->second.doc(), obj);
-  data_.add("views", obj);
+  {
+    auto doc = JSON::newObject();
+    auto obj = doc.getObject();
+    doc.copyFrom(cv->second.doc(), obj);
+    doc.add("views", obj);
+    data_ = std::move(doc);
+  }
 
   const auto& views = data_.doc()["views"];
 


### PR DESCRIPTION
This is an alternative to https://github.com/osquery/osquery/pull/6945.

In this PR, the persistent copies of JSON documents within config parsers are replaced with new objects on each config update.