### PR TITLE
Use a distinct carver request_id

### DIFF
--- a/osquery/carver/CMakeLists.txt
+++ b/osquery/carver/CMakeLists.txt
@@ -25,7 +25,6 @@ function(generateOsqueryCarver)
     osquery_core
     osquery_carver_utils
     osquery_dispatcher
-    osquery_distributed
     osquery_filesystem
     osquery_hashing
     osquery_remote_utility

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -16,7 +16,6 @@
 #include <osquery/carver/carver.h>
 #include <osquery/carver/carver_utils.h>
 #include <osquery/database/database.h>
-#include <osquery/distributed/distributed.h>
 #include <osquery/filesystem/fileops.h>
 #include <osquery/core/flags.h>
 #include <osquery/hashing/hashing.h>
@@ -122,7 +121,14 @@ void CarverRunnable::start() {
       paths.insert(path);
     }
 
-    auto requestId = Distributed::getCurrentRequestId();
+    std::string requestId;
+    if (doc.HasMember("request_id") && doc["request_id"].IsString()) {
+      requestId = doc["request_id"].GetString();
+    } else {
+      // Handle stored requests from older osquery versions.
+      requestId = createCarveGuid();
+    }
+
     doCarve(paths, guid, requestId);
   }
 

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -17,6 +17,10 @@
 
 #include <osquery/carver/carver_utils.h>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 namespace osquery {
 
 CLI_FLAG(bool,
@@ -58,7 +62,12 @@ void updateCarveValue(const std::string& guid,
   }
 }
 
-Status carvePaths(const std::set<std::string>& paths) {
+std::string createCarveGuid() {
+  return boost::uuids::to_string(boost::uuids::random_generator()());
+}
+
+Status carvePaths(const std::set<std::string>& paths,
+                  const std::string& request_id) {
   auto guid = generateNewUUID();
 
   JSON tree;
@@ -67,6 +76,7 @@ Status carvePaths(const std::set<std::string>& paths) {
   tree.add("status", kCarverStatusScheduled);
   tree.add("sha256", "");
   tree.add("size", -1);
+  tree.add("request_id", request_id);
 
   if (paths.size() > 1) {
     tree.add("path", osquery::join(paths, ","));

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <osquery/core/flags.h>
-#include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/logger/logger.h>
 #include <osquery/utils/conversions/join.h>
@@ -67,11 +66,12 @@ std::string createCarveGuid() {
 }
 
 Status carvePaths(const std::set<std::string>& paths,
-                  const std::string& request_id) {
-  auto guid = generateNewUUID();
+                  const std::string& request_id,
+                  std::string& carve_guid) {
+  carve_guid = createCarveGuid();
 
   JSON tree;
-  tree.add("carve_guid", guid);
+  tree.add("carve_guid", carve_guid);
   tree.add("time", getUnixTime());
   tree.add("status", kCarverStatusScheduled);
   tree.add("sha256", "");
@@ -92,6 +92,6 @@ Status carvePaths(const std::set<std::string>& paths,
   }
 
   kCarverPendingCarves = true;
-  return setDatabaseValue(kCarves, kCarverDBPrefix + guid, out);
+  return setDatabaseValue(kCarves, kCarverDBPrefix + carve_guid, out);
 }
 } // namespace osquery

--- a/osquery/carver/carver_utils.h
+++ b/osquery/carver/carver_utils.h
@@ -50,6 +50,9 @@ void updateCarveValue(const std::string& guid,
                       const std::string& key,
                       const std::string& value);
 
+/// Returns a UUID.
+std::string createCarveGuid();
+
 /**
  * @brief Request a file carve of the given paths.
  *
@@ -58,7 +61,11 @@ void updateCarveValue(const std::string& guid,
  * from unexpectedly blocking query execution. We do not want to wait for remote
  * servies to return before a query completes in this case.
  *
+ * @param paths A set of paths (directories and files) to carve.
+ * @param request_id A string identifier to be included in the carve response.
+ *
  * @return A status returning if the carves were scheduled successfully.
  */
-Status carvePaths(const std::set<std::string>& paths);
+Status carvePaths(const std::set<std::string>& paths,
+                  const std::string& request_id);
 } // namespace osquery

--- a/osquery/carver/carver_utils.h
+++ b/osquery/carver/carver_utils.h
@@ -63,9 +63,11 @@ std::string createCarveGuid();
  *
  * @param paths A set of paths (directories and files) to carve.
  * @param request_id A string identifier to be included in the carve response.
+ * @param carve_guid An output GUID identifying the carve request.
  *
  * @return A status returning if the carves were scheduled successfully.
  */
 Status carvePaths(const std::set<std::string>& paths,
-                  const std::string& request_id);
+                  const std::string& request_id,
+                  std::string& carve_guid);
 } // namespace osquery

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -176,9 +176,7 @@ TEST_F(CarverTests, test_expiration) {
 
   // Create 2 carve requests.
   std::string first_carve_guid;
-  auto first_request_id = createCarveGuid();
-  auto s =
-      osquery::carvePaths(getCarvePaths(), first_request_id, first_carve_guid);
+  auto s = osquery::carvePaths(getCarvePaths(), "request-id", first_carve_guid);
   ASSERT_TRUE(s.ok());
 
   std::string second_carve_guid;
@@ -201,9 +199,9 @@ TEST_F(CarverTests, test_expiration) {
     ASSERT_TRUE(s.ok());
 
     std::string guid(tree.doc()["carve_guid"].GetString());
-    EXPECT_EQ(guid, first_carve_guid);
+    EXPECT_FALSE(guid.empty());
     std::string request_id(tree.doc()["request_id"].GetString());
-    EXPECT_EQ(request_id, first_request_id);
+    EXPECT_EQ(request_id, "request-id");
 
     tree.add("time", 0);
     tree.add("status", kCarverStatusSuccess);
@@ -233,7 +231,7 @@ TEST_F(CarverTests, test_expiration) {
     ASSERT_TRUE(s.ok());
 
     std::string guid(tree.doc()["carve_guid"].GetString());
-    EXPECT_EQ(guid, second_carve_guid);
+    EXPECT_FALSE(guid.empty());
 
     // This time only update the time.
     // Expect the carve to have been successful.

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -8,9 +8,6 @@
  */
 
 #include <boost/filesystem.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #include <gtest/gtest.h>
 
@@ -53,10 +50,6 @@ class FakeCarver : public Carver {
 class FakeCarverRunner : public CarverRunner<FakeCarver> {
  public:
   FakeCarverRunner() : CarverRunner() {}
-};
-
-std::string genGuid() {
-  return boost::uuids::to_string(boost::uuids::random_generator()());
 };
 
 class CarverTests : public testing::Test {
@@ -117,7 +110,7 @@ class CarverTests : public testing::Test {
 };
 
 TEST_F(CarverTests, test_carve_files_locally) {
-  auto guid = genGuid();
+  auto guid = createCarveGuid();
   std::string requestId = "";
   FakeCarver carve(getCarvePaths(), guid, requestId);
 
@@ -136,7 +129,7 @@ TEST_F(CarverTests, test_carve_files_locally) {
 }
 
 TEST_F(CarverTests, test_carve) {
-  auto guid = genGuid();
+  auto guid = createCarveGuid();
   std::string requestId = "";
   FakeCarver carve(getCarvePaths(), guid, requestId);
   auto s = carve.carve();
@@ -145,7 +138,7 @@ TEST_F(CarverTests, test_carve) {
 
 TEST_F(CarverTests, test_schedule_carves) {
   // Request paths for carving.
-  auto s = osquery::carvePaths(getCarvePaths());
+  auto s = osquery::carvePaths(getCarvePaths(), "request-id");
   ASSERT_TRUE(s.ok());
 
   ASSERT_FALSE(FakeCarverRunner::running());
@@ -180,9 +173,9 @@ TEST_F(CarverTests, test_expiration) {
   }
 
   // Create 2 carve requests.
-  auto s = osquery::carvePaths(getCarvePaths());
+  auto s = osquery::carvePaths(getCarvePaths(), "request-id");
   ASSERT_TRUE(s.ok());
-  s = osquery::carvePaths(getCarvePaths());
+  s = osquery::carvePaths(getCarvePaths(), "request-id");
   ASSERT_TRUE(s.ok());
 
   {
@@ -249,7 +242,7 @@ TEST_F(CarverTests, test_expiration) {
 }
 
 TEST_F(CarverTests, test_carve_files_not_exists) {
-  auto guid = genGuid();
+  auto guid = createCarveGuid();
   std::string requestId = "";
   const std::set<std::string> notExistsCarvePaths = {
       (getFilesToCarveDir() / "not_exists").string()};

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -10,6 +10,10 @@
 #include <set>
 #include <string>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 #include <osquery/carver/carver_utils.h>
 #include <osquery/core/flags.h>
 #include <osquery/logger/logger.h>
@@ -52,8 +56,12 @@ static void addCarveFile(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
 static void executeCarve(sqlite3_context* ctx) {
   WriteLock lock(kFunctionCarveMutex);
   if (!FLAGS_carver_disable_function) {
-    carvePaths(kFunctionCarvePaths);
-    sqlite3_result_text(ctx, "Carve Started", 13, SQLITE_TRANSIENT);
+    auto request_id = createCarveGuid();
+    carvePaths(kFunctionCarvePaths, request_id);
+    sqlite3_result_text(ctx,
+                        std::string("Carve Started: " + request_id).c_str(),
+                        13,
+                        SQLITE_TRANSIENT);
   } else {
     LOG(WARNING) << "Carver as a function is disabled";
     sqlite3_result_text(ctx, "Carve Failed", 13, SQLITE_TRANSIENT);

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -56,15 +56,15 @@ static void addCarveFile(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
 static void executeCarve(sqlite3_context* ctx) {
   WriteLock lock(kFunctionCarveMutex);
   if (!FLAGS_carver_disable_function) {
-    auto request_id = createCarveGuid();
-    carvePaths(kFunctionCarvePaths, request_id);
+    std::string new_carve_guid;
+    carvePaths(kFunctionCarvePaths, createCarveGuid(), new_carve_guid);
     sqlite3_result_text(ctx,
-                        std::string("Carve Started: " + request_id).c_str(),
+                        std::string("Carve Started: " + new_carve_guid).c_str(),
                         13,
                         SQLITE_TRANSIENT);
   } else {
-    LOG(WARNING) << "Carver as a function is disabled";
-    sqlite3_result_text(ctx, "Carve Failed", 13, SQLITE_TRANSIENT);
+    sqlite3_result_text(
+        ctx, "Carve Failed: function disabled", 13, SQLITE_TRANSIENT);
   }
   kFunctionCarvePaths.clear();
 }

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -10,10 +10,6 @@
 #include <set>
 #include <string>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <osquery/carver/carver_utils.h>
 #include <osquery/core/flags.h>
 #include <osquery/logger/logger.h>

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -59,6 +59,7 @@ void enumerateCarves(QueryData& results) {
 
     stringToRow("sha256", r, tree);
     stringToRow("carve_guid", r, tree);
+    stringToRow("request_id", r, tree);
     stringToRow("status", r, tree);
     stringToRow("path", r, tree);
     r["carve"] = INTEGER(0);
@@ -89,7 +90,10 @@ QueryData genCarves(QueryContext& context) {
 
   if (context.constraints["carve"].exists(EQUALS) && paths.size() > 0 &&
       !FLAGS_disable_carver) {
-    carvePaths(paths);
+    // TODO(6727): This should introspect into the requesting action.
+    // Indicate if the initiator is a distributed query or the schedule.
+    auto request_id = createCarveGuid();
+    carvePaths(paths, request_id);
   }
   enumerateCarves(results);
 

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -29,7 +29,7 @@ inline void stringToRow(const std::string& key, Row& r, JSON& tree) {
   }
 }
 
-void enumerateCarves(QueryData& results) {
+void enumerateCarves(QueryData& results, const std::string& new_guid) {
   std::vector<std::string> carves;
   scanDatabaseKeys(kCarves, carves, kCarverDBPrefix);
 
@@ -62,7 +62,12 @@ void enumerateCarves(QueryData& results) {
     stringToRow("request_id", r, tree);
     stringToRow("status", r, tree);
     stringToRow("path", r, tree);
-    r["carve"] = INTEGER(0);
+
+    // This table can be used to request a new carve.
+    // If this is the case then return this single result.
+    auto new_request = (!new_guid.empty() && new_guid == r["carve_guid"]);
+    r["carve"] = INTEGER((new_request) ? 1 : 0);
+
     results.push_back(r);
   }
 }
@@ -88,14 +93,18 @@ QueryData genCarves(QueryContext& context) {
         return status;
       }));
 
-  if (context.constraints["carve"].exists(EQUALS) && paths.size() > 0 &&
-      !FLAGS_disable_carver) {
+  // A carve is requested if carve = 1 exists in the predicate.
+  auto requests = context.constraints["carve"].getAll<int>(EQUALS);
+  auto carve_requested = requests.find(1) != requests.end();
+
+  std::string new_carve_guid;
+  if (!FLAGS_disable_carver && carve_requested && !paths.empty()) {
     // TODO(6727): This should introspect into the requesting action.
     // Indicate if the initiator is a distributed query or the schedule.
     auto request_id = createCarveGuid();
-    carvePaths(paths, request_id);
+    carvePaths(paths, request_id, new_carve_guid);
   }
-  enumerateCarves(results);
+  enumerateCarves(results, new_carve_guid);
 
   return results;
 }

--- a/specs/carves.table
+++ b/specs/carves.table
@@ -7,6 +7,7 @@ schema([
     Column("path", TEXT, "The path of the requested carve", additional=True),
     Column("status", TEXT, "Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED"),
     Column("carve_guid", TEXT, "Identifying value of the carve session", index=True),
+    Column("request_id", TEXT, "Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)"),
     Column("carve", INTEGER, "Set this value to '1' to start a file carve", additional=True)
 ])
 implementation("forensic/carves@genCarves")


### PR DESCRIPTION
This is half of the solution for #6727. We do not want to use the last-most-recent distributed request ID for all carve requests. Carve requests can be initiated multiple ways, through a scheduled query, distributed query, shell query, etc.

This also improve the UX of the `carves` table. It will report the single row requested when `carve = 1` is used.

A follow up change should explore storing metadata with queries such that the virtual table can retrieve and use this data.