### PR TITLE
Do not start scheduler when shutting down

### DIFF
--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -97,14 +97,16 @@ int profile(int argc, char* argv[]) {
 void startDaemon(Initializer& runner) {
   runner.start();
 
-  // Conditionally begin the distributed query service
-  auto s = startDistributed();
-  if (!s.ok()) {
-    VLOG(1) << "Not starting the distributed query service: " << s.toString();
-  }
+  if (!shutdownRequested()) {
+    // Conditionally begin the distributed query service
+    auto s = startDistributed();
+    if (!s.ok()) {
+      VLOG(1) << "Not starting the distributed query service: " << s.toString();
+    }
 
-  // Begin the schedule runloop.
-  startScheduler();
+    // Begin the schedule runloop.
+    startScheduler();
+  }
 
   runner.waitForShutdown();
 }


### PR DESCRIPTION
This brings the daemon's start logic to mimic the shell.

In some rare instances where you are using `--config_check`, and where the daemon cannot start it's backing storage, osquery may crash. This removes the crashing potential.