### PR TITLE
VM metadata table for Yandex.Cloud

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -49,6 +49,7 @@ function(generateOsqueryTablesTableimplementations)
 
   target_link_libraries(osquery_tables_tableimplementations INTERFACE
     osquery_tables_cloud_azure
+    osquery_tables_cloud_ycloud
   )
 
   target_link_libraries(osquery_tables_tableimplementations INTERFACE

--- a/osquery/tables/cloud/CMakeLists.txt
+++ b/osquery/tables/cloud/CMakeLists.txt
@@ -11,6 +11,7 @@ function(osqueryTablesCloudMain)
   endif()
 
   generateOsqueryTablesCloudAzure()
+  generateOsqueryTablesCloudYCloud()
 endfunction()
 
 function(generateOsqueryTablesCloudAws)
@@ -39,6 +40,19 @@ function(generateOsqueryTablesCloudAzure)
     osquery_cxx_settings
     osquery_logger
     osquery_utils_azure
+    thirdparty_boost
+  )
+endfunction()
+
+function(generateOsqueryTablesCloudYCloud)
+  add_osquery_library(osquery_tables_cloud_ycloud EXCLUDE_FROM_ALL
+    ycloud/ycloud_instance_metadata.cpp
+  )
+
+  target_link_libraries(osquery_tables_cloud_ycloud PUBLIC
+    osquery_cxx_settings
+    osquery_logger
+    osquery_utils_ycloud
     thirdparty_boost
   )
 endfunction()

--- a/osquery/tables/cloud/ycloud/ycloud_instance_metadata.cpp
+++ b/osquery/tables/cloud/ycloud/ycloud_instance_metadata.cpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+// Keep this included first (See #6507).
+#include <osquery/remote/http_client.h>
+
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/ycloud/ycloud_util.h>
+
+namespace osquery {
+namespace tables {
+
+const std::string kMetadataEndpointColumn = "metadata_endpoint";
+
+QueryData genYCloudMetadata(QueryContext& context) {
+  QueryData results;
+  std::string defaultEndpoint =
+      "http://" + osquery::http::kInstanceMetadataAuthority;
+
+  std::vector<std::string> endpoints;
+
+  if (context.hasConstraint(kMetadataEndpointColumn, EQUALS)) {
+    auto constraints = context.constraints[kMetadataEndpointColumn].getAll();
+    if (!constraints.empty()) {
+      for (const auto& c : constraints) {
+        endpoints.push_back(c.expr);
+      }
+    }
+  }
+
+  if (endpoints.empty()) {
+    endpoints.push_back(defaultEndpoint);
+  }
+
+  for (const auto& endpoint : endpoints) {
+    JSON doc;
+    Row r;
+
+    Status s = fetchYCloudMetadata(doc, endpoint);
+    if (!s.ok()) {
+      TLOG << "Couldn't fetch metadata: endpoint" << endpoint
+           << " reason: " << s.what();
+      continue;
+    }
+
+    auto [folderId, zone] =
+        getFolderIdAndZoneFromZoneField(getYCloudKey(doc, "zone"));
+    r["instance_id"] = getYCloudKey(doc, "id");
+    r["folder_id"] = folderId;
+    r["zone"] = zone;
+    r["name"] = getYCloudKey(doc, "name");
+    r["description"] = getYCloudKey(doc, "description");
+    r["hostname"] = getYCloudKey(doc, "hostname");
+    r["ssh_public_key"] = getYCloudSshKey(doc);
+    r["serial_port_enabled"] = getSerialPortEnabled(doc);
+    r[kMetadataEndpointColumn] = endpoint;
+
+    results.push_back(r);
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/utils/CMakeLists.txt
+++ b/osquery/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ function(osqueryUtilsMain)
   add_subdirectory("conversions")
   add_subdirectory("versioning")
   add_subdirectory("schemer")
+  add_subdirectory("ycloud")
 
   if(OSQUERY_BUILD_TESTS)
     generateOsqueryUtilsUtilstestsTest()

--- a/osquery/utils/ycloud/CMakeLists.txt
+++ b/osquery/utils/ycloud/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+function(osqueryUtilsYCloudMain)
+    if(OSQUERY_BUILD_TESTS)
+        add_subdirectory("tests")
+    endif()
+
+    generateOsqueryUtilsYCloud()
+endfunction()
+
+function(generateOsqueryUtilsYCloud)
+    add_osquery_library(osquery_utils_ycloud EXCLUDE_FROM_ALL
+            ycloud_util.cpp
+            )
+
+    target_link_libraries(osquery_utils_ycloud PUBLIC
+            osquery_cxx_settings
+            osquery_remote_httpclient
+            osquery_remote_transports_transportstls
+            osquery_utils_json
+            osquery_utils_status
+            )
+
+    set(public_header_files
+            ycloud_util.h
+            )
+
+    generateIncludeNamespace(osquery_utils_ycloud "osquery/utils/ycloud" "FILE_ONLY" ${public_header_files})
+
+    add_test(NAME osquery_utils_ycloud_tests-test COMMAND osquery_utils_ycloud_tests-test)
+
+    set_tests_properties(
+            osquery_utils_ycloud_tests-test
+            PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
+    )
+endfunction()
+
+osqueryUtilsYCloudMain()

--- a/osquery/utils/ycloud/tests/CMakeLists.txt
+++ b/osquery/utils/ycloud/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+function(osqueryUtilsYCloudTestsMain)
+    generateOsqueryUtilsYCloudTestsYCloudTest()
+endfunction()
+
+function(generateOsqueryUtilsYCloudTestsYCloudTest)
+    add_osquery_executable(osquery_utils_ycloud_tests-test ycloud.cpp)
+
+    target_link_libraries(osquery_utils_ycloud_tests-test PRIVATE
+            osquery_cxx_settings
+            osquery_core
+            osquery_extensions
+            osquery_extensions_implthrift
+            osquery_registry
+            osquery_utils_ycloud
+            tests_helper
+            thirdparty_googletest
+            thirdparty_boost
+            )
+endfunction()
+
+osqueryUtilsYCloudTestsMain()

--- a/osquery/utils/ycloud/tests/ycloud.cpp
+++ b/osquery/utils/ycloud/tests/ycloud.cpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+#include <osquery/utils/ycloud/ycloud_util.h>
+
+namespace osquery {
+namespace {
+
+class YCloudUtilsTests : public testing::Test {};
+
+TEST_F(YCloudUtilsTests, pass) {
+  const std::string zone = "projects/b1g1slgali4fssudpn26/zones/ru-central1-a";
+  auto [folder_id, zone_id] = getFolderIdAndZoneFromZoneField(zone);
+  EXPECT_EQ(folder_id, "b1g1slgali4fssudpn26");
+  EXPECT_EQ(zone_id, "ru-central1-a");
+}
+
+TEST_F(YCloudUtilsTests, fail) {
+  const std::string zone = "projects/b1g1slgali4fssudpn26/zones-ru-central1-a";
+  auto [folder_id, zone_id] = getFolderIdAndZoneFromZoneField(zone);
+  EXPECT_EQ(folder_id, "");
+  EXPECT_EQ(zone_id, "");
+}
+
+} // namespace
+} // namespace osquery

--- a/osquery/utils/ycloud/ycloud_util.cpp
+++ b/osquery/utils/ycloud/ycloud_util.cpp
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Keep this included first (See #6507).
+#include <osquery/remote/http_client.h>
+
+#include <boost/algorithm/string.hpp>
+#include <osquery/core/core.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/split.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/ycloud/ycloud_util.h>
+
+namespace http = osquery::http;
+
+namespace osquery {
+
+const std::string kYCloudMetadataPathAndQuery =
+    "/computeMetadata/v1/instance/?alt=json&recursive=true";
+const std::string kAttributes = "attributes";
+const int kYCloudMetadataTimeout = 3;
+
+std::tuple<std::string, std::string> getFolderIdAndZoneFromZoneField(
+    const std::string& zone) {
+  if (boost::algorithm::starts_with(zone, "projects/")) {
+    auto s = osquery::split(zone, "/");
+    if (s.size() >= 4) {
+      return {s[1], s[3]};
+    }
+  }
+
+  return {"", ""};
+}
+
+std::string getSerialPortEnabled(JSON& doc) {
+  const std::string kSerialPortFlag = "serial-port-enable";
+
+  if (!doc.doc().HasMember(kAttributes)) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes].IsObject()) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes].HasMember(kSerialPortFlag)) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes][kSerialPortFlag].IsString()) {
+    return "";
+  }
+
+  return doc.doc()[kAttributes][kSerialPortFlag].GetString();
+}
+
+std::string getYCloudSshKey(JSON& doc) {
+  const std::string kSshKeys = "ssh-keys";
+
+  if (!doc.doc().HasMember(kAttributes)) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes].IsObject()) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes].HasMember(kSshKeys)) {
+    return "";
+  }
+
+  if (!doc.doc()[kAttributes][kSshKeys].IsString()) {
+    return "";
+  }
+
+  return doc.doc()[kAttributes][kSshKeys].GetString();
+}
+
+std::string getYCloudKey(JSON& doc, const std::string& key) {
+  if (!doc.doc().HasMember(key)) {
+    return "";
+  }
+
+  if (!doc.doc()[key].IsString()) {
+    return "";
+  }
+
+  return doc.doc()[key].GetString();
+}
+
+Status fetchYCloudMetadata(JSON& doc, const std::string& endpoint) {
+  http::Request request(endpoint + kYCloudMetadataPathAndQuery);
+  http::Client::Options opts;
+  http::Response response;
+
+  opts.timeout(kYCloudMetadataTimeout);
+  http::Client client(opts);
+
+  request << http::Request::Header("Metadata-Flavor", "Google");
+
+  try {
+    response = client.get(request);
+  } catch (const std::system_error& e) {
+    return Status(1, "Couldn't request " + endpoint + ": " + e.what());
+  }
+
+  if (response.result_int() != 200) {
+    return Status(1,
+                  "YCloud metadata service responded with " +
+                      std::to_string(response.result_int()));
+  }
+
+  auto s = doc.fromString(response.body());
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (!doc.doc().IsObject()) {
+    return Status(1, "YCloud metadata service response isn't a JSON object");
+  }
+
+  return Status::success();
+}
+
+} // namespace osquery

--- a/osquery/utils/ycloud/ycloud_util.h
+++ b/osquery/utils/ycloud/ycloud_util.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/status/status.h>
+
+namespace osquery {
+std::string getYCloudKey(JSON& doc, const std::string& key);
+std::string getYCloudSshKey(JSON& doc);
+std::string getSerialPortEnabled(JSON& doc);
+std::tuple<std::string, std::string> getFolderIdAndZoneFromZoneField(
+    const std::string& zone);
+Status fetchYCloudMetadata(JSON& doc, const std::string& endpoint);
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -71,6 +71,7 @@ function(generateNativeTables)
     utility/osquery_registry.table
     utility/osquery_schedule.table
     utility/time.table
+    ycloud_instance_metadata.table
   )
 
   if(TARGET_PROCESSOR STREQUAL "x86_64")

--- a/specs/ycloud_instance_metadata.table
+++ b/specs/ycloud_instance_metadata.table
@@ -1,0 +1,19 @@
+table_name("ycloud_instance_metadata")
+description("Yandex.Cloud instance metadata.")
+schema([
+    Column("instance_id", TEXT, "Unique identifier for the VM", index=True),
+    Column("folder_id", TEXT, "Folder identifier for the VM"),
+    Column("name", TEXT, "Name of the VM"),
+    Column("description", TEXT, "Description of the VM"),
+    Column("hostname", TEXT, "Hostname of the VM"),
+    Column("zone", TEXT, "Availability zone of the VM"),
+    Column("ssh_public_key", TEXT, "SSH public key. Only available if supplied at instance launch time"),
+    Column("serial_port_enabled", TEXT, "Indicates if serial port is enabled for the VM"),
+    Column("metadata_endpoint", TEXT, "Endpoint used to fetch VM metadata", index=True),
+])
+attributes(cacheable=True)
+implementation("cloud/ycloud_metadata@genYCloudMetadata")
+examples([
+    "select * from ycloud_instance_metadata",
+    "select * from ycloud_instance_metadata where metadata_endpoint=\"http://169.254.169.254\""
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -72,6 +72,7 @@ function(generateTestsIntegrationTablesTestsTest)
     device_file.cpp
     device_hash.cpp
     device_partitions.cpp
+    ycloud_instance_metadata.cpp
   )
 
   if(TARGET_PROCESSOR STREQUAL "x86_64")

--- a/tests/integration/tables/ycloud_instance_metadata.cpp
+++ b/tests/integration/tables/ycloud_instance_metadata.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class ycloudInstanceMetadata : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(ycloudInstanceMetadata, test_sanity) {
+  auto const data = execute_query("select * from ycloud_instance_metadata");
+  if (!data.empty()) {
+    ValidationMap row_map = {
+        {"instance_id", NormalType},
+        {"folder_id", NormalType},
+        {"name", NormalType},
+        {"description", NormalType},
+        {"hostname", NormalType},
+        {"zone", NormalType},
+        {"ssh_public_key", NormalType},
+        {"serial_port_enabled", NormalType},
+    };
+    validate_rows(data, row_map);
+  }
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
This PR introduces a new table `ycloud_instance_metadata` which allows to fetch virtual machine metadata in [Yandex.Cloud](https://cloud.yandex.com). The table is similar to `azure_instance_metadata` or `ec2_instance_metadata`.

The API for Yandex.Cloud metadata can be found at the [official documentation](https://cloud.yandex.com/docs/compute/concepts/vm-metadata).

I also added a way to override a metadata endpoint via constraints which is useful for tests.