### PR TITLE
Fix pids column in docker_container_stats table

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -855,7 +855,7 @@ QueryData genContainerStats(QueryContext& context) {
       Row r;
       r["id"] = id;
       r["name"] = container.get<std::string>("name", "");
-      r["pids"] = container.get<int>("pids_stats.current", 0);
+      r["pids"] = INTEGER(container.get<int>("pids_stats.current", 0));
       const std::string& read = container.get<std::string>("read", "");
       long read_unix_time = getUnixTime(read, false);
       r["read"] = BIGINT(read_unix_time);


### PR DESCRIPTION
Was missing a string conversion so it ended up empty.
