### PR TITLE
Fix CODEOWNERS syntax to allow committers and TSC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,8 +5,7 @@
 # precedence.
 
 # General write access
-* @osquery/osquery-committers
-* @osquery/technical-steering-committee
+* @osquery/osquery-committers @osquery/technical-steering-committee
 
 .github/workflows @osquery/osquery-build-wardens
 


### PR DESCRIPTION
The intention is to allow `osquery/osquery-committers` or `osquery/technical-steering-committee`