### PR TITLE
Augeas Table: Don't autoload system lenses

### DIFF
--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -121,7 +121,9 @@ class AugeasHandle {
   void initialize() {
     std::call_once(initialized, [this]() {
       this->aug = aug_init(
-          nullptr, FLAGS_augeas_lenses.c_str(), AUG_NO_ERR_CLOSE | AUG_NO_LOAD);
+          nullptr,
+          FLAGS_augeas_lenses.c_str(),
+          AUG_NO_ERR_CLOSE | AUG_NO_LOAD | AUG_NO_STDINC | AUG_SAVE_NOOP);
       // Handle initialization errors.
       if (this->aug == nullptr) {
         LOG(ERROR) << "An error has occurred while trying to initialize augeas";


### PR DESCRIPTION
While playing with augeas, I noticed it loaded the lenses that were
already on my machine (at /usr/local/share/augeas/lenses). This was an
unwelcome surprise.

I'm not sure if this was previously intended or not. I assume not, since
there is some versioning with the lenses, and we ship our own.
This adds the load flags to ignore anything on the existing system path.
And disable saving while I'm here.

Note that this is, potentially, an API change. Though I think it's
adding consistency

Fixes: #6974

