### PR TITLE
Augeas Table: Fix output bug

### DIFF
--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -95,9 +95,10 @@ void matchAugeasPattern(augeas* aug,
       path = path.substr(6);
       // The caller is responsible for the matching memory.
       free(file);
-    } else {
-      // The iterator is currently pointing to a folder so we extract the path
-      // from the node.
+    } else if (node.compare(0, 6, "/files") == 0) {
+      // If the iterator is currently pointing to a directory, the
+      // node should appear in /files. Extract the path and from the
+      // node.
       path = node.substr(6);
     }
 
@@ -151,6 +152,27 @@ class AugeasHandle {
 static AugeasHandle kAugeasHandle;
 
 QueryData genAugeas(QueryContext& context) {
+  // Strategy for handling augeas
+  // (As informed by forensic examination of the underlying code)
+  //
+  // Augeas is a powerful tool for representing configuration files
+  // as a tree, and then querying against it. However, it's native
+  // interfaces don't feel osquery's underlying model. So we shim a bit.
+  //
+  // Augeas normally reads everything it can into a giant
+  // tree. Files are rooted at `/files`, while augeas is rooted at
+  // `/augeas`. Information is queried from augeas by running
+  // matches against the tree paths.  In contrast, osquery tends to
+  // operate by loading data at runtime, frequently by file path.
+  //
+  // We bridge these worlds, by adding a `path` column to the
+  // osquery output. This path is the filepath, and not the tree
+  // path.
+  //
+  // To query, we append the augeas wildcard, and then match. The
+  // returned path records have the appropriate value because they
+  // refer to real paths.
+
   kAugeasHandle.initialize();
 
   if (kAugeasHandle.error == true) {
@@ -158,7 +180,17 @@ QueryData genAugeas(QueryContext& context) {
   }
 
   augeas* aug = kAugeasHandle.aug;
-  aug_load(aug);
+
+  // Load everything. While it would be interesting to do this for
+  // only the requested files, it's not clearly possible to
+  // _unload_. So at present, load everything. (For reference, it
+  // takes abvout 0.3 seconds to run aug_load on seph's laptop.)
+  int ret = aug_load(aug);
+  if (ret != 0) {
+    LOG(ERROR) << "An error has occurred while trying to load augeas: "
+               << aug_error_message(aug);
+    return {};
+  }
 
   QueryData results;
   std::unordered_set<std::string> patterns;


### PR DESCRIPTION
Fix output bug where the augeas table incorrectly calculated path from
node.

Augeas stores it's data in a tree. Internal information is preseted in
`/augeas` and files are in `/files`. Osquery usually works with data by
path. The augeas table _assumed_ that all data was file data, and
indiscriminately tried to coerce a file object. This would result in
output like:

```
osquery> select * from augeas where node = "/augeas/load";
+--------------+-------+-------+--------+
| node         | value | label | path   |
+--------------+-------+-------+--------+
| /augeas/load |       | load  | s/load |
+--------------+-------+-------+--------+
```

Path should be null here. This is not a real file