### PR TITLE
Update `augeas` table to use native pattern matching (BREAKING)

### DIFF
--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -160,7 +160,7 @@ std::string patternFromOsquery(const std::string& input,
   // assume the caller knows what it's doing.
   std::string pattern = isPath ? "/files" + input : input;
 
-  // Augeas presents data as a slash seperated tree. It uses `/*` as a
+  // Augeas presents data as a slash separated tree. It uses `/*` as a
   // single level wildcard, and `//*` as a recursive wildcard. However,
   // sqlite uses % as a wildcard. To allow for LIKE expressions, we need
   // to convert.

--- a/osquery/tables/system/tests/posix/augeas_tests.cpp
+++ b/osquery/tables/system/tests/posix/augeas_tests.cpp
@@ -118,7 +118,7 @@ TEST_F(AugeasTests, select_augeas_load_wildcards) {
 
 TEST_F(AugeasTests, select_file_wildcards) {
   // These are a bit funny. Augeas doesn't do partial matches,
-  // and because file is a real file, you have to be carefuly
+  // and because file is a real file, you have to be careful
   // with trailing slashes.
   ASSERT_EQ(
       SQL("select * from augeas where path LIKE '/etc/hosts/%'").rows().size(),


### PR DESCRIPTION
Add querying by LIKE to the augeas table. This fixes querying the
`/augeas` part of the tree, and should additionally improve the behavior
around file paths.

Prior, there is implicit magic that makes the path part work -- we
append `//*` the augeas recursive wildcard. This combined with sqlite
filtering made it appear to work for simple trailing wildcards. But, it
would fail for leading or infix wildcards.

This replaces that with some additional routines to allow wildcard
conversion. The UX is a bit weird, in that `path` should _not_ have a
trailing wildcard, and the behavior of `%` vs `%%` is different. But
this feels like the simplest bridge between osquery and augeas.

The current problem is mostly clearly visible with `select * from augeas where node like "/augeas/load/%";` returning zero results.

We could consider whether to keep using `/files//*` as the default
pattern or not.