### PR TITLE
Fix error in process_open_files around stoi vs stoul

### DIFF
--- a/osquery/tables/system/linux/process_open_pipes.cpp
+++ b/osquery/tables/system/linux/process_open_pipes.cpp
@@ -53,7 +53,7 @@ bool isUnconnectedPipe(ino_t inode, const InodeToPipesMap& pipe_partners) {
 int parseInode(const std::string& pipe_str) {
   std::smatch match;
   if (std::regex_search(pipe_str, match, std::regex("\\d+"))) {
-    return std::stoi(match[0]);
+    return std::stoul(match[0]);
   } else {
     return 0;
   }


### PR DESCRIPTION
Inode is a uint32, not an int.

Fixes: #6977

Co-authored-by: Stefano Bonicatti <stefano.bonicatti@gmail.com>
