### PR TITLE
Fix mem leak regression with Windows' sids API

### DIFF
--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -66,12 +66,7 @@ QueryData queryLogonSessions(QueryContext& context) {
           kLogonTypeToStr.find(SECURITY_LOGON_TYPE(session_data->LogonType))
               ->second;
       r["session_id"] = INTEGER(session_data->Session);
-      LPWSTR sid = nullptr;
-      if (ConvertSidToStringSidW(session_data->Sid, &sid)) {
-        r["logon_sid"] = wstringToString(sid);
-      }
-      LocalFree(sid);
-
+      r["logon_sid"] = psidToString(session_data->Sid);
       r["logon_time"] = BIGINT(longIntToUnixtime(session_data->LogonTime));
       r["logon_server"] = wstringToString(session_data->LogonServer.Buffer);
       r["dns_domain_name"] =

--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -70,9 +70,8 @@ QueryData queryLogonSessions(QueryContext& context) {
       if (ConvertSidToStringSidW(session_data->Sid, &sid)) {
         r["logon_sid"] = wstringToString(sid);
       }
-      if (sid) {
-        LocalFree(sid);
-      }
+      LocalFree(sid);
+
       r["logon_time"] = BIGINT(longIntToUnixtime(session_data->LogonTime));
       r["logon_server"] = wstringToString(session_data->LogonServer.Buffer);
       r["dns_domain_name"] =

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -125,6 +125,7 @@ void genUser(const std::string& sidString, QueryData& results) {
     ret = LookupAccountSidW(
         nullptr, sid, accntName, &accntNameLen, domName, &domNameLen, &eUse);
     r["username"] = ret != 0 ? wstringToString(accntName) : "";
+    LocalFree(sid);
 
     // Also attempt to get the user account description comment. Move on if
     // NetUserGetInfo returns an error, as it will for some system accounts.


### PR DESCRIPTION
Closes #6979 fixing a small regression introduced in #6782 that undid part of #6714 

It's easy to forget to free memory with "Caller must free this parameter" APIs like `ConvertStringSidToSidA`, fixed before in https://github.com/osquery/osquery/pull/6714 (we even forgot to do it in the wrapper we created for `ConvertSidToSidStringA`, see https://github.com/osquery/osquery/pull/6548 that fixed that).

Because a wrapper for `ConvertSidToSidStringA`, I found one place that I changed to use that, instead of the raw API, saving a few lines of code. But in the future, to avoid similar problems with `ConvertStringSidToSidA`, we'd have to make our own wrapper class for `sid` that implemented RAII as noted by @Breakwell.