### PR TITLE
Always use BIGINT macro for 'long long' data

### DIFF
--- a/osquery/tables/system/windows/background_activities_moderator.cpp
+++ b/osquery/tables/system/windows/background_activities_moderator.cpp
@@ -50,7 +50,7 @@ QueryData genBackgroundActivitiesModerator(QueryContext& context) {
       if (r["path"] != "SequenceNumber" && r["path"] != "Version") {
         auto time_data = bKey.at("data").substr(0, 16);
         auto time_str = littleEndianToUnixTime(time_data);
-        r["last_execution_time"] = INTEGER(time_str);
+        r["last_execution_time"] = BIGINT(time_str);
       }
 
       results.push_back(r);

--- a/osquery/tables/system/windows/shellbags.cpp
+++ b/osquery/tables/system/windows/shellbags.cpp
@@ -173,7 +173,7 @@ void parseShellData(const std::string& shell_data,
     build_shellbag.push_back(ftp_data[1]);
     std::string full_path = osquery::join(build_shellbag, "\\");
     r["path"] = full_path;
-    r["accessed_time"] = INTEGER(unix_time);
+    r["accessed_time"] = BIGINT(unix_time);
     results.push_back(r);
     return;
   } else if (sig == "74" && shell_data.find("43465346") !=
@@ -304,9 +304,9 @@ void parseShellData(const std::string& shell_data,
     return;
   }
 
-  r["modified_time"] = INTEGER(file_entry.dos_modified);
-  r["created_time"] = INTEGER(file_entry.dos_created);
-  r["accessed_time"] = INTEGER(file_entry.dos_accessed);
+  r["modified_time"] = BIGINT(file_entry.dos_modified);
+  r["created_time"] = BIGINT(file_entry.dos_created);
+  r["accessed_time"] = BIGINT(file_entry.dos_accessed);
 
   build_shellbag.push_back(file_entry.path);
   long long mft_entry = file_entry.mft_entry;

--- a/osquery/tables/system/windows/userassist.cpp
+++ b/osquery/tables/system/windows/userassist.cpp
@@ -117,7 +117,7 @@ QueryData genUserAssist(QueryContext& context) {
             auto count = executionNum(assist_data);
             r["count"] = INTEGER(count);
           }
-          r["last_execution_time"] = INTEGER(time_str);
+          r["last_execution_time"] = BIGINT(time_str);
           r["sid"] = uKey.at("name");
           results.push_back(r);
         }

--- a/specs/windows/background_activities_moderator.table
+++ b/specs/windows/background_activities_moderator.table
@@ -2,7 +2,7 @@ table_name("background_activities_moderator")
 description("Background Activities Moderator (BAM) tracks application execution.")
 schema([
 	Column("path", TEXT, "Application file path."),
-	Column("last_execution_time", INTEGER, "Most recent time application was executed."),
+	Column("last_execution_time", BIGINT, "Most recent time application was executed."),
 	Column("sid", TEXT, "User SID."),
 ])
 implementation("background_activities_moderator@genBackgroundActivitiesModerator")

--- a/specs/windows/shellbags.table
+++ b/specs/windows/shellbags.table
@@ -4,9 +4,9 @@ schema([
     Column("sid", TEXT, "User SID"),
     Column("source", TEXT, "Shellbags source Registry file"),
     Column("path", TEXT, "Directory name."),
-    Column("modified_time", INTEGER, "Directory Modified time."),
-    Column("created_time", INTEGER, "Directory Created time."),
-    Column("accessed_time", INTEGER, "Directory Accessed time."),
+    Column("modified_time", BIGINT, "Directory Modified time."),
+    Column("created_time", BIGINT, "Directory Created time."),
+    Column("accessed_time", BIGINT, "Directory Accessed time."),
     Column("mft_entry", BIGINT, "Directory master file table entry."),
     Column("mft_sequence", INTEGER, "Directory master file table sequence."),
 ])

--- a/specs/windows/userassist.table
+++ b/specs/windows/userassist.table
@@ -2,7 +2,7 @@ table_name("userassist")
 description("UserAssist Registry Key tracks when a user executes an application from Windows Explorer.")
 schema([
     Column("path", TEXT, "Application file path."),
-    Column("last_execution_time", INTEGER, "Most recent time application was executed."),
+    Column("last_execution_time", BIGINT, "Most recent time application was executed."),
     Column("count", INTEGER, "Number of times the application has been executed."),
     Column("sid", TEXT, "User SID."),
 ])


### PR DESCRIPTION
Following up on #6897 this is basically the same deal: always use the `BIGINT` macro rather than the `INTEGER` macro when dealing with `long long` values, or they might generate warnings and not report data, the same as explained in the last PR.