### PR TITLE
Make Group ID columns consistent across Windows tables

### DIFF
--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -128,12 +128,12 @@ uint32_t getGidFromSid(PSID sid) {
 
     // If none of the above worked, User may not have a Local Group
     if (gid == static_cast<uint32_t>(-1)) {
-      // Fallback to using its RID from its USER_INFO_3 struct
+      // Fallback to using its RID from its USER_INFO_4 struct
       NetApiBufferFree(userBuff); // free the level 0 buff from above
-      userInfoLevel = 3;
+      userInfoLevel = 4;
       ret = NetUserGetInfo(nullptr, uname.data(), userInfoLevel, &userBuff);
       if (ret == NERR_Success) {
-        gid = LPUSER_INFO_3(userBuff)->usri3_primary_group_id;
+        gid = LPUSER_INFO_4(userBuff)->usri4_primary_group_id;
       }
     }
   }

--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -60,7 +60,7 @@ uint32_t getGidFromSid(PSID sid) {
   DWORD unameSize = 0;
   DWORD domNameSize = 1;
 
-  // LookupAccountSid first gets the size of the username buff required.
+  // LookupAccountSid first gets the size of the name buff required
   LookupAccountSidW(
       nullptr, sid, nullptr, &unameSize, nullptr, &domNameSize, &eUse);
   std::vector<wchar_t> uname(unameSize);
@@ -76,9 +76,11 @@ uint32_t getGidFromSid(PSID sid) {
   if (accountFound == 0) {
     return static_cast<uint32_t>(-1);
   }
-  // USER_INFO_3 struct contains the RID (uid) of our user
-  DWORD userInfoLevel = 3;
+
+  // Use NetUserGetInfo() level 0 to get username
+  DWORD userInfoLevel = 0;
   LPBYTE userBuff = nullptr;
+  LPLOCALGROUP_USERS_INFO_0 userGroupsBuff = nullptr;
   auto gid = static_cast<uint32_t>(-1);
   auto ret = NetUserGetInfo(nullptr, uname.data(), userInfoLevel, &userBuff);
 
@@ -88,12 +90,47 @@ uint32_t getGidFromSid(PSID sid) {
     auto toks = osquery::split(sidString, "-");
     gid = tryTo<uint32_t>(toks.at(toks.size() - 1), 10).takeOr(gid);
     LocalFree(sidString);
-
   } else if (ret == NERR_Success) {
-    gid = LPUSER_INFO_3(userBuff)->usri3_primary_group_id;
+    // Use NetUserGetLocalGroups to get a Local Group GID for this user
+    LPWSTR userName = LPUSER_INFO_0(userBuff)->usri0_name;
+    WORD level = 0;
+    DWORD flags = 0;
+    DWORD prefMaxLen = MAX_PREFERRED_LENGTH;
+    DWORD entriesRead = 0;
+    DWORD totalEntries = 0;
+    std::unique_ptr<BYTE[]> sidSmartPtr = nullptr;
+    PSID sidPtr = nullptr;
+
+    ret = NetUserGetLocalGroups(nullptr,
+                                userName,
+                                level,
+                                flags,
+                                (LPBYTE*)&userGroupsBuff,
+                                prefMaxLen,
+                                &entriesRead,
+                                &totalEntries);
+
+    if (ret == NERR_Success) {
+      LPLOCALGROUP_USERS_INFO_0 pTmpBuf;
+      DWORD i;
+
+      // A user often has more than one local group, but we only return the
+      // first!
+      if (userGroupsBuff != NULL) {
+        // From group name to group SID to the RID (osquery concept of GID):
+        sidSmartPtr = getSidFromUsername(userGroupsBuff->lgrui0_name);
+        if (sidSmartPtr != nullptr) {
+          sidPtr = static_cast<PSID>(sidSmartPtr.get());
+          auto rid = getRidFromSid(sidPtr);
+          gid = rid;
+        }
+      }
+    }
   }
 
   NetApiBufferFree(userBuff);
+  NetApiBufferFree(userGroupsBuff);
+
   return gid;
 }
 

--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -124,12 +124,12 @@ uint32_t getGidFromSid(PSID sid) {
           gid = rid;
         }
       }
-    } 
+    }
 
     // If none of the above worked, User may not have a Local Group
     if (gid == static_cast<uint32_t>(-1)) {
       // Fallback to using its RID from its USER_INFO_3 struct
-      NetApiBufferFree(userBuff);  // free the level 0 buff from above
+      NetApiBufferFree(userBuff); // free the level 0 buff from above
       userInfoLevel = 3;
       ret = NetUserGetInfo(nullptr, uname.data(), userInfoLevel, &userBuff);
       if (ret == NERR_Success) {

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -220,7 +220,7 @@ void processLocalAccounts(const std::set<std::string>& selectedUids,
         // Will return empty string on fail
         auto sid = LPUSER_INFO_4(userLvl4Buff)->usri4_user_sid;
         auto uid = getUidFromSid(sid);
-        auto gid = LPUSER_INFO_4(userLvl4Buff)->usri4_primary_group_id;
+        auto gid = getGidFromSid(sid);
         auto sidString = psidToString(sid);
         processedSids.insert(sidString);
 


### PR DESCRIPTION
Closes #4264 by changing the behavior of `users` and `processes` to retrieve Group IDs the same way that `groups` does. See the issue for a longer explanation.

With the corrected behavior, observe that the `gid` values are of Local Groups and are consistent across tables, making it possible to `JOIN` on this column:

```
osquery> select * from users;
+------+-----+------------+------------+--------------------+-------------------------------------------------------------------------------------------------+---------------------------------------------+-----------------------------+-----------------------------------------------+---------+
| uid  | gid | uid_signed | gid_signed | username           | description                                                                                     | directory                                   | shell                       | uuid                                          | type    |
+------+-----+------------+------------+--------------------+-------------------------------------------------------------------------------------------------+---------------------------------------------+-----------------------------+-----------------------------------------------+---------+
| 500  | 544 | 500        | 544        | Administrator      | Built-in account for administering the computer/domain                                          |                                             | C:\Windows\system32\cmd.exe | S-1-5-21-1834681238-529199191-1868829719-500  | local   |
| 503  | 581 | 503        | 581        | DefaultAccount     | A user account managed by the system.                                                           |                                             | C:\Windows\system32\cmd.exe | S-1-5-21-1834681238-529199191-1868829719-503  | local   |
| 501  | 546 | 501        | 546        | Guest              | Built-in account for guest access to the computer/domain                                        |                                             | C:\Windows\system32\cmd.exe | S-1-5-21-1834681238-529199191-1868829719-501  | local   |
| 1002 | 544 | 1002       | 544        | mmyers             |                                                                                                 | C:\Users\mmyers                             | C:\Windows\system32\cmd.exe | S-1-5-21-1834681238-529199191-1868829719-1002 | local   |
| 504  | 513 | 504        | 513        | WDAGUtilityAccount | A user account managed and used by the system for Windows Defender Application Guard scenarios. |                                             | C:\Windows\system32\cmd.exe | S-1-5-21-1834681238-529199191-1868829719-504  | local   |
| 18   | 18  | 18         | 18         | SYSTEM             |                                                                                                 | %systemroot%\system32\config\systemprofile  | C:\Windows\system32\cmd.exe | S-1-5-18                                      | special |
| 19   | 19  | 19         | 19         | LOCAL SERVICE      |                                                                                                 | %systemroot%\ServiceProfiles\LocalService   | C:\Windows\system32\cmd.exe | S-1-5-19                                      | special |
| 20   | 20  | 20         | 20         | NETWORK SERVICE    |                                                                                                 | %systemroot%\ServiceProfiles\NetworkService | C:\Windows\system32\cmd.exe | S-1-5-20                                      | special |
+------+-----+------------+------------+--------------------+-------------------------------------------------------------------------------------------------+---------------------------------------------+-----------------------------+-----------------------------------------------+---------+
osquery> SELECT uid, gid from processes where path like "%osquery%";
+------+-----+
| uid  | gid |
+------+-----+
| 1002 | 544 |
+------+-----+
osquery> select * from groups;
+-----+------------+-------------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| gid | gid_signed | groupname                           | group_sid    | comment                                                                                                                                                                                                        |
+-----+------------+-------------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 579 | 579        | Access Control Assistance Operators | S-1-5-32-579 | Members of this group can remotely query authorization attributes and permissions for resources on this computer.                                                                                              |
| 544 | 544        | Administrators                      | S-1-5-32-544 | Administrators have complete and unrestricted access to the computer/domain                                                                                                                                    |
| 551 | 551        | Backup Operators                    | S-1-5-32-551 | Backup Operators can override security restrictions for the sole purpose of backing up or restoring files                                                                                                      |
| 569 | 569        | Cryptographic Operators             | S-1-5-32-569 | Members are authorized to perform cryptographic operations.                                                                                                                                                    |
| 562 | 562        | Distributed COM Users               | S-1-5-32-562 | Members are allowed to launch, activate and use Distributed COM objects on this machine.                                                                                                                       |
| 573 | 573        | Event Log Readers                   | S-1-5-32-573 | Members of this group can read event logs from local machine                                                                                                                                                   |
| 546 | 546        | Guests                              | S-1-5-32-546 | Guests have the same access as members of the Users group by default, except for the Guest account which is further restricted                                                                                 |
| 578 | 578        | Hyper-V Administrators              | S-1-5-32-578 | Members of this group have complete and unrestricted access to all features of Hyper-V.                                                                                                                        |
| 568 | 568        | IIS_IUSRS                           | S-1-5-32-568 | Built-in group used by Internet Information Services.                                                                                                                                                          |
| 556 | 556        | Network Configuration Operators     | S-1-5-32-556 | Members in this group can have some administrative privileges to manage configuration of networking features                                                                                                   |
| 559 | 559        | Performance Log Users               | S-1-5-32-559 | Members of this group may schedule logging of performance counters, enable trace providers, and collect event traces both locally and via remote access to this computer                                       |
| 558 | 558        | Performance Monitor Users           | S-1-5-32-558 | Members of this group can access performance counter data locally and remotely                                                                                                                                 |
| 547 | 547        | Power Users                         | S-1-5-32-547 | Power Users are included for backwards compatibility and possess limited administrative powers                                                                                                                 |
| 555 | 555        | Remote Desktop Users                | S-1-5-32-555 | Members in this group are granted the right to logon remotely                                                                                                                                                  |
| 580 | 580        | Remote Management Users             | S-1-5-32-580 | Members of this group can access WMI resources over management protocols (such as WS-Management via the Windows Remote Management service). This applies only to WMI namespaces that grant access to the user. |
| 552 | 552        | Replicator                          | S-1-5-32-552 | Supports file replication in a domain                                                                                                                                                                          |
| 581 | 581        | System Managed Accounts Group       | S-1-5-32-581 | Members of this group are managed by the system.                                                                                                                                                               |
| 545 | 545        | Users                               | S-1-5-32-545 | Users are prevented from making accidental or intentional system-wide changes and can run most applications                                                                                                    |
+-----+------------+-------------------------------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
osquery> select users.uid, users.username, groups.gid, groups.groupname from users join groups join user_groups on users.uid=user_groups.uid and groups.gid=user_groups.gid;
+------+----------------+-----+-------------------------------+
| uid  | username       | gid | groupname                     |
+------+----------------+-----+-------------------------------+
| 500  | Administrator  | 544 | Administrators                |
| 503  | DefaultAccount | 581 | System Managed Accounts Group |
| 501  | Guest          | 546 | Guests                        |
| 1002 | mmyers         | 544 | Administrators                |
| 1002 | mmyers         | 545 | Users                         |
+------+----------------+-----+-------------------------------+
```