### PR TITLE
Support optionally building with ThreadSanitizer (TSan)

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -101,7 +101,19 @@ function(setupBuildFlags)
       list(APPEND posix_common_link_options
         -fsanitize=address
       )
+    endif()
 
+    if(OSQUERY_ENABLE_THREAD_SANITIZER)
+      list(APPEND posix_common_compile_options
+        -fsanitize=thread
+      )
+
+      list(APPEND posix_common_link_options
+        -fsanitize=thread
+      )
+    endif()
+
+    if(OSQUERY_ENABLE_ADDRESS_SANITIZER OR OSQUERY_ENABLE_THREAD_SANITIZER)
       # Get more precise stack traces
       list(APPEND posix_common_compile_options
         -fno-omit-frame-pointer

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -73,6 +73,10 @@ option(OSQUERY_BUILD_ROOT_TESTS "Whether to enable and build tests that require 
 
 option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
 
+if(DEFINED PLATFORM_POSIX)
+  option(OSQUERY_ENABLE_THREAD_SANITIZER "Whether to enable Thread Sanitizer")
+endif()
+
 if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_WINDOWS)
   option(OSQUERY_BUILD_FUZZERS "Whether to build fuzzing harnesses")
 


### PR DESCRIPTION
Adds `OSQUERY_ENABLE_THREAD_SANITIZER` CMake flag to optionally build with ThreadSanitizer enabled on POSIX platforms