### PR TITLE
[packaging] Remove extraneous lenses directory for augues on macOS

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -272,7 +272,7 @@ function(generateInstallTargets)
     install(DIRECTORY COMPONENT osquery DESTINATION /private/var/osquery)
 
     install(DIRECTORY "${augeas_lenses_path}" COMPONENT osquery
-            DESTINATION /private/var/osquery/lenses
+            DESTINATION /private/var/osquery
             FILES_MATCHING PATTERN "*.aug"
             PATTERN "tests" EXCLUDE)
 


### PR DESCRIPTION
Created a package of this branch and inspected it with `pkgutil` and `lsbom`

```
➜  build git:(augeas_lenses_path) ✗ man lsbom
➜  build git:(augeas_lenses_path) ✗ lsbom -s  $(pkgutil --bom osquery-4.6.0-71-g3d2d2ba0-dirty.pkg) | grep lenses
./private/var/osquery/lenses
./private/var/osquery/lenses/access.aug
./private/var/osquery/lenses/activemq_conf.aug
./private/var/osquery/lenses/activemq_xml.aug
./private/var/osquery/lenses/afs_cellalias.aug
./private/var/osquery/lenses/aliases.aug
./private/var/osquery/lenses/anacron.aug
./private/var/osquery/lenses/approx.aug
./private/var/osquery/lenses/apt_update_manager.aug
./private/var/osquery/lenses/aptcacherngsecurity.aug
./private/var/osquery/lenses/aptconf.aug
./private/var/osquery/lenses/aptpreferences.aug
./private/var/osquery/lenses/aptsources.aug
./private/var/osquery/lenses/authorized_keys.aug
./private/var/osquery/lenses/automaster.aug
./private/var/osquery/lenses/automounter.aug
./private/var/osquery/lenses/avahi.aug
./private/var/osquery/lenses/backuppchosts.aug
./private/var/osquery/lenses/bbhosts.aug
```

Fixes #6995 