### PR TITLE
ATC fails because journal_mode pragma is blocked by sqlite authorizer

### DIFF
--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -75,6 +75,7 @@ const std::unordered_set<std::string> kAllowedSQLitePragmas = {
     "table_info",
     "table_xinfo",
     "function_list",
+    "journal_mode",
 };
 
 class SQLiteDBManager;


### PR DESCRIPTION
From what I can tell we have to enable the journal mode pragma in order for the getSqliteJournalMode() function to work as advertised. As it stands it fails to retrieve the journal mode which has probably rebroken the issue in https://github.com/osquery/osquery/issues/5225. I'm in the midst of investigating another ATC issue at the moment, but this stood out as something we should probably fix.