### PR TITLE
Setting non-required deb_packages fields as optional in test

### DIFF
--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -35,8 +35,8 @@ TEST_F(DebPackages, test_sanity) {
                              {"revision", NormalType},
                              {"status", NonEmptyString},
                              {"maintainer", NonEmptyString},
-                             {"section", NonEmptyString},
-                             {"priority", NonEmptyString}};
+                             {"section", NormalType},
+                             {"priority", NormalType}};
 
     validate_rows(rows, row_map);
 


### PR DESCRIPTION
`section` and `priority` fields are optional in the Debian spec, so valid packages can cause this test to fail.

Debian docs: https://www.debian.org/doc/debian-policy/ch-controlfields.html#binary-package-control-files-debian-control

This is a failure caused by a legitimate package that installs just fine, but has no `section`:
>        96: [----------] 1 test from DebPackages
>        96: [ RUN      ] DebPackages.test_sanity
>        96: /opt/build/osquery/tests/integration/tables/helper.cpp:167: Failure
>        96: Value of: validate_value_using_flags(value, flags)
>        96:   Actual: false
>        96: Expected: true
>        96: Standard validator of the column "section" with value "" failed
>        96: Row: {arch: "amd64", maintainer: "Maintainer", name: "package name", priority: "optional", revision: "", section: "", size: "61921", source: "", status: "install ok installed", version: "0.11.0"}
>        96: select *, pid_with_namespace, mount_namespace_id from deb_packages
>        96: /opt/build/osquery/tests/integration/tables/helper.cpp:167: Failure
>        96: Value of: validate_value_using_flags(value, flags)
>        96:   Actual: false
>        96: Expected: true
>        96: Standard validator of the column "section" with value "" failed
>        96: Row: {arch: "amd64", maintainer: "Maintainer", mount_namespace_id: "", name: "package name", pid_with_namespace: "0", priority: "optional", revision: "", section: "", size: "61921", source: "", status: "install ok installed", version: "0.11.0"}
>        96: [  FAILED  ] DebPackages.test_sanity (44 ms)
>        96: [----------] 1 test from DebPackages (44 ms total)