### PR TITLE
Disable BPF events tests if OSQUERY_BUILD_BPF is false

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -158,10 +158,13 @@ function(generateOsqueryEvents)
 
   if(DEFINED PLATFORM_LINUX)
     add_test(NAME osquery_events_tests_syslogtests-test COMMAND osquery_events_tests_syslogtests-test)
-    add_test(NAME osquery_events_tests_bpftests-test COMMAND osquery_events_tests_bpftests-test)
     add_test(NAME osquery_events_tests_audittests-test COMMAND osquery_events_tests_audittests-test)
     add_test(NAME osquery_events_tests_processfileeventstests-test COMMAND osquery_events_tests_processfileeventstests-test)
     add_test(NAME osquery_events_tests_inotifytests-test COMMAND osquery_events_tests_inotifytests-test)
+
+    if(OSQUERY_BUILD_BPF)
+      add_test(NAME osquery_events_tests_bpftests-test COMMAND osquery_events_tests_bpftests-test)
+    endif()
   endif()
 
   if(DEFINED PLATFORM_MACOS)


### PR DESCRIPTION
With OSQUERY_BUILD_BPF=false, the `osquery_events_tests_bpftests-test` test is still added, which ends up failing since it was never built:

> Start 65: osquery_events_tests_bpftests-test
>        Could not find executable osquery_events_tests_bpftests-test
>        Looked in the following places:
>        osquery_events_tests_bpftests-test
>        osquery_events_tests_bpftests-test
>        Release/osquery_events_tests_bpftests-test
>        Release/osquery_events_tests_bpftests-test
>        Debug/osquery_events_tests_bpftests-test
>        Debug/osquery_events_tests_bpftests-test
>        MinSizeRel/osquery_events_tests_bpftests-test
>        MinSizeRel/osquery_events_tests_bpftests-test
>        RelWithDebInfo/osquery_events_tests_bpftests-test
>        RelWithDebInfo/osquery_events_tests_bpftests-test
>        Deployment/osquery_events_tests_bpftests-test
>        Deployment/osquery_events_tests_bpftests-test
>        Development/osquery_events_tests_bpftests-test
>        Development/osquery_events_tests_bpftests-test