### PR TITLE
Run GH Actions workflows on all tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
       - 'master'
 
     tags:
-      - 'v*'
+      - '*'
 
   pull_request:
     branches:


### PR DESCRIPTION
I think this fixes a bug, where we do not use `v*` but rather the exact semantic version number in tags.