### PR TITLE
seccomp_events table in osquery

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -65,6 +65,7 @@ DECLARE_bool(audit_allow_sockets);
 DECLARE_bool(audit_allow_user_events);
 DECLARE_bool(audit_allow_selinux_events);
 DECLARE_bool(audit_allow_apparmor_events);
+DECLARE_bool(audit_allow_seccomp_events);
 
 namespace {
 
@@ -98,12 +99,15 @@ bool ShouldHandle(const audit_reply& reply) noexcept {
     return FLAGS_audit_allow_selinux_events;
   }
 
+  if (reply.type == AUDIT_SECCOMP) {
+    return FLAGS_audit_allow_seccomp_events;
+  }
+
   switch (reply.type) {
   case NLMSG_NOOP:
   case NLMSG_DONE:
   case NLMSG_ERROR:
   case AUDIT_LIST_RULES:
-  case AUDIT_SECCOMP:
   case AUDIT_GET:
   case (AUDIT_GET + 1)...(AUDIT_LIST_RULES - 1):
   case (AUDIT_LIST_RULES + 1)...(AUDIT_FIRST_USER_MSG - 1):
@@ -734,7 +738,7 @@ void AuditdNetlinkParser::start() {
       }
 
       // We are not interested in all messages; only get the ones related to
-      // user events, syscalls, SELinux events and AppArmor events
+      // user events, seccomp, syscalls, SELinux events and AppArmor events
       if (!ShouldHandle(reply)) {
         continue;
       }

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -47,7 +47,6 @@ bool IsPublisherEnabled() noexcept {
           FLAGS_audit_allow_kill_process_events ||
           FLAGS_audit_allow_apparmor_events ||
           FLAGS_audit_allow_seccomp_events);
-
 }
 } // namespace
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -434,21 +434,6 @@ bool GetStringFieldFromMap(std::string& value,
   return true;
 }
 
-bool GetStringFieldFromIntMap(
-    std::string& value,
-    const std::unordered_map<std::uint64_t, std::string>& fields,
-    const std::uint64_t key,
-    const std::string& default_value) noexcept {
-  auto it = fields.find(key);
-  if (it == fields.end()) {
-    value = default_value;
-    return false;
-  }
-
-  value = it->second;
-  return true;
-}
-
 bool GetIntegerFieldFromMap(std::uint64_t& value,
                             const std::map<std::string, std::string>& field_map,
                             const std::string& field_name,

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -28,6 +28,7 @@ DECLARE_bool(audit_allow_user_events);
 DECLARE_bool(audit_allow_selinux_events);
 DECLARE_bool(audit_allow_kill_process_events);
 DECLARE_bool(audit_allow_apparmor_events);
+DECLARE_bool(audit_allow_seccomp_events);
 
 REGISTER(AuditEventPublisher, "event_publisher", "auditeventpublisher");
 
@@ -44,7 +45,9 @@ bool IsPublisherEnabled() noexcept {
           FLAGS_audit_allow_sockets || FLAGS_audit_allow_user_events ||
           FLAGS_audit_allow_selinux_events ||
           FLAGS_audit_allow_kill_process_events ||
-          FLAGS_audit_allow_apparmor_events);
+          FLAGS_audit_allow_apparmor_events ||
+          FLAGS_audit_allow_seccomp_events);
+
 }
 } // namespace
 
@@ -180,6 +183,19 @@ void AuditEventPublisher::ProcessEvents(
         audit_event.data = data;
         event_context->audit_events.push_back(audit_event);
       }
+
+      // Seccomp events
+    } else if (audit_event_record.type == AUDIT_SECCOMP) {
+      SeccompAuditEventData data;
+
+      parseSeccompEvent(audit_event_record, data);
+
+      AuditEvent audit_event;
+      audit_event.type = AuditEvent::Type::Seccomp;
+      audit_event.data = data;
+      audit_event.record_list.push_back(audit_event_record);
+      event_context->audit_events.push_back(audit_event);
+
     } else if (audit_event_record.type == AUDIT_SYSCALL) {
       if (audit_event_it != trace_context.end()) {
         VLOG(1) << "Received a duplicated event.";
@@ -419,6 +435,21 @@ bool GetStringFieldFromMap(std::string& value,
   return true;
 }
 
+bool GetStringFieldFromIntMap(
+    std::string& value,
+    const std::unordered_map<std::uint64_t, std::string>& fields,
+    const std::uint64_t key,
+    const std::string& default_value) noexcept {
+  auto it = fields.find(key);
+  if (it == fields.end()) {
+    value = default_value;
+    return false;
+  }
+
+  value = it->second;
+  return true;
+}
+
 bool GetIntegerFieldFromMap(std::uint64_t& value,
                             const std::map<std::string, std::string>& field_map,
                             const std::string& field_name,
@@ -447,6 +478,35 @@ std::string StripQuotes(const std::string& value) noexcept {
     return value.substr(1, value.length() - 2);
   } else {
     return value;
+  }
+}
+
+void parseSeccompEvent(const AuditEventRecord& record,
+                       SeccompAuditEventData& data) noexcept {
+  // Fill SeccompAuditEventData structure with data from audit_event_record
+  for (auto& field : data.fields) {
+    switch (field.second.which()) {
+    case 0: {
+      // string field
+      std::string value = "";
+      field.second =
+          GetStringFieldFromMap(value, record.fields, field.first) ? value : "";
+      break;
+    }
+    case 1: {
+      // int field
+      std::uint64_t value = 0;
+      int base = 10;
+      if (field.first == "arch" || field.first == "code") {
+        base = 16;
+      }
+      field.second =
+          GetIntegerFieldFromMap(value, record.fields, field.first, base)
+              ? value
+              : 0;
+      break;
+    }
+    }
   }
 }
 

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -65,13 +65,51 @@ struct AppArmorAuditEventData final {
                 {"ouid", 0}};
 };
 
+/*
+   Message example:
+   auid=65876 uid=0 gid=0 ses=12684 pid=18204 comm="qemu-system-x86"
+   exe="/usr/bin/qemu-system-x86_64" sig=0 arch=c000003e syscall=271 compat=0
+   ip=0x7f6ba2cdd811 code=0x7ffc0000
+ */
+struct SeccompAuditEventData final {
+  std::unordered_map<std::string, boost::variant<std::string, std::uint64_t>>
+      fields = {{"auid", 0}, // audit user ID (loginuid) of the user who started
+                             // the analyzed process
+                {"uid", 0}, // user ID
+                {"gid", 0}, // group ID
+                {"ses", 0}, // session ID
+                {"pid", 0}, // process ID
+
+                {"comm", ""}, // command-line name of the command that was
+                              // used to invoke the analyzed process
+
+                {"exe", ""}, // the path to the executable that was used
+                             // to invoke the analyzed process
+
+                {"sig", 0}, // signal value sent to process by seccomp
+
+                {"arch", 0}, // information about the CPU architecture
+                {"syscall", 0}, // type of the system call
+
+                {"compat", 0}, // result of in_compat_syscall()
+                               // is system call in compatibility mode
+
+                {"ip", ""}, // result of KSTK_EIP(current)
+                            // instruction pointer value
+
+                {"code", 0}}; // the seccomp action
+};
+
 /// Audit event descriptor
 struct AuditEvent final {
-  enum class Type { UserEvent, Syscall, SELinux, AppArmor };
+  enum class Type { UserEvent, Syscall, SELinux, AppArmor, Seccomp };
 
   Type type;
   boost::
-      variant<UserAuditEventData, SyscallAuditEventData, AppArmorAuditEventData>
+      variant<UserAuditEventData,
+              SyscallAuditEventData,
+              AppArmorAuditEventData,
+              SeccompAuditEventData>
           data;
 
   std::vector<AuditEventRecord> record_list;
@@ -136,6 +174,14 @@ bool GetStringFieldFromMap(
     const std::string& name,
     const std::string& default_value = std::string()) noexcept;
 
+/// Extracts the specified integer key from the given <std::uint64_t,
+/// std::string> unordered_map
+bool GetStringFieldFromIntMap(
+    std::string& value,
+    const std::unordered_map<std::uint64_t, std::string>& fields,
+    const std::uint64_t key,
+    const std::string& default_value = std::string()) noexcept;
+
 /// Extracts the specified integer key from the given string map
 bool GetIntegerFieldFromMap(
     std::uint64_t& value,
@@ -154,4 +200,7 @@ void CopyFieldFromMap(
 
 // Strips first and last quote from string if present
 std::string StripQuotes(const std::string& value) noexcept;
+
+void parseSeccompEvent(const AuditEventRecord& record,
+                       SeccompAuditEventData& data) noexcept;
 } // namespace osquery

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -173,14 +173,6 @@ bool GetStringFieldFromMap(
     const std::string& name,
     const std::string& default_value = std::string()) noexcept;
 
-/// Extracts the specified integer key from the given <std::uint64_t,
-/// std::string> unordered_map
-bool GetStringFieldFromIntMap(
-    std::string& value,
-    const std::unordered_map<std::uint64_t, std::string>& fields,
-    const std::uint64_t key,
-    const std::string& default_value = std::string()) noexcept;
-
 /// Extracts the specified integer key from the given string map
 bool GetIntegerFieldFromMap(
     std::uint64_t& value,

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -105,12 +105,11 @@ struct AuditEvent final {
   enum class Type { UserEvent, Syscall, SELinux, AppArmor, Seccomp };
 
   Type type;
-  boost::
-      variant<UserAuditEventData,
-              SyscallAuditEventData,
-              AppArmorAuditEventData,
-              SeccompAuditEventData>
-          data;
+  boost::variant<UserAuditEventData,
+                 SyscallAuditEventData,
+                 AppArmorAuditEventData,
+                 SeccompAuditEventData>
+      data;
 
   std::vector<AuditEventRecord> record_list;
 };

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -104,6 +104,7 @@ function(generateOsqueryTablesEventsEventstable)
 
     generateIncludeNamespace(osquery_tables_events_eventstable "osquery/tables/events" "FULL_PATH" ${platform_public_header_files})
 
+    add_test(NAME osquery_tables_events_tests_seccompeventstests-test COMMAND osquery_tables_events_tests_seccompeventstests-test)
     add_test(NAME osquery_tables_events_tests_selinuxeventstests-test COMMAND osquery_tables_events_tests_selinuxeventstests-test)
     add_test(NAME osquery_tables_events_tests_processeventstests-test COMMAND osquery_tables_events_tests_processeventstests-test)
   endif()

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -26,6 +26,7 @@ function(generateOsqueryTablesEventsEventstable)
       linux/process_events.cpp
       linux/process_file_events.cpp
       linux/selinux_events.cpp
+      linux/seccomp_events.cpp
       linux/socket_events.cpp
       linux/syslog_events.cpp
       linux/user_events.cpp
@@ -96,6 +97,7 @@ function(generateOsqueryTablesEventsEventstable)
       linux/bpf_process_events.h
       linux/bpf_socket_events.h
       linux/selinux_events.h
+      linux/seccomp_events.h
       linux/apparmor_events.h
       linux/socket_events.h
     )

--- a/osquery/tables/events/linux/seccomp_events.cpp
+++ b/osquery/tables/events/linux/seccomp_events.cpp
@@ -1,11 +1,10 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #include <osquery/core/flags.h>

--- a/osquery/tables/events/linux/seccomp_events.cpp
+++ b/osquery/tables/events/linux/seccomp_events.cpp
@@ -415,13 +415,13 @@ REGISTER(SeccompEventSubscriber, "event_subscriber", "seccomp_events");
 
 Status SeccompEventSubscriber::init() {
   if (!FLAGS_audit_allow_seccomp_events) {
-    return Status(1, "Seccomp subscriber disabled via configuration");
+    return Status::failure("Seccomp subscriber disabled via configuration");
   }
 
   auto sc = createSubscriptionContext();
   subscribe(&SeccompEventSubscriber::Callback, sc);
 
-  return Status();
+  return Status::success();
 }
 
 Status SeccompEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -435,13 +435,12 @@ Status SeccompEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     add(row);
   }
 
-  return Status();
+  return Status::success();
 }
 
 void SeccompEventSubscriber::parseEvent(const AuditEvent& event,
                                         Row& parsed_event) noexcept {
   const auto& event_data = boost::get<SeccompAuditEventData>(event.data);
-  // parsed_event["uptime"] = std::to_string(tables::getUptime());
   parsed_event["uptime"] = std::to_string(getUptime());
   std::uint64_t arch = 0;
   std::uint64_t value = 0;
@@ -518,6 +517,6 @@ Status SeccompEventSubscriber::processEvents(
     data.push_back(parsed_event);
   }
 
-  return Status();
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/tables/events/linux/seccomp_events.cpp
+++ b/osquery/tables/events/linux/seccomp_events.cpp
@@ -1,0 +1,524 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/core/flags.h>
+#include <osquery/events/linux/auditeventpublisher.h>
+#include <osquery/logger/logger.h>
+#include <osquery/registry/registry_factory.h>
+#include <osquery/tables/events/linux/seccomp_events.h>
+#include <osquery/utils/system/uptime.h>
+
+namespace osquery {
+
+const std::unordered_map<std::uint64_t, std::string>
+    SeccompEventSubscriber::seccomp_actions_map = {
+        {SECCOMP_RET_KILL_PROCESS, "KILL_PROCESS"},
+        {SECCOMP_RET_KILL_THREAD, "KILL_THREAD"},
+        {SECCOMP_RET_TRAP, "TRAP"},
+        {SECCOMP_RET_ERRNO, "ERRNO"},
+        {SECCOMP_RET_TRACE, "TRACE"},
+        {SECCOMP_RET_LOG, "LOG"},
+        {SECCOMP_RET_ALLOW, "ALLOW"}};
+
+const std::unordered_map<std::uint64_t, std::string>
+    SeccompEventSubscriber::arch_codes_map = {
+        {AUDIT_ARCH_X86_64, "X86_64"},
+        {AUDIT_ARCH_AARCH64, "AARCH64"},
+        {AUDIT_ARCH_ALPHA, "ALPHA"},
+        {AUDIT_ARCH_ARM, "ARM"},
+        {AUDIT_ARCH_ARMEB, "ARMEB"},
+        {AUDIT_ARCH_CRIS, "CRIS"},
+        {AUDIT_ARCH_FRV, "FRV"},
+        {AUDIT_ARCH_I386, "I386"},
+        {AUDIT_ARCH_IA64, "IA64"},
+        {AUDIT_ARCH_M32R, "M32R"},
+        {AUDIT_ARCH_M68K, "M68K"},
+        {AUDIT_ARCH_MICROBLAZE, "MICROBLAZE"},
+        {AUDIT_ARCH_MIPS, "MIPS"},
+        {AUDIT_ARCH_MIPSEL, "MIPSEL"},
+        {AUDIT_ARCH_MIPS64, "MIPS64"},
+        {AUDIT_ARCH_MIPS64N32, "MIPS64N32"},
+        {AUDIT_ARCH_MIPSEL64, "MIPSEL64"},
+        {AUDIT_ARCH_MIPSEL64N32, "MIPSEL64N32"},
+        {AUDIT_ARCH_OPENRISC, "OPENRISC"},
+        {AUDIT_ARCH_PARISC, "PARISC"},
+        {AUDIT_ARCH_PARISC64, "PARISC64"},
+        {AUDIT_ARCH_PPC, "PPC"},
+        {AUDIT_ARCH_PPC64, "PPC64"},
+        {AUDIT_ARCH_PPC64LE, "PPC64LE"},
+        {AUDIT_ARCH_S390, "S390"},
+        {AUDIT_ARCH_S390X, "S390X"},
+        {AUDIT_ARCH_SH, "SH"},
+        {AUDIT_ARCH_SHEL, "SHEL"},
+        {AUDIT_ARCH_SH64, "SH64"},
+        {AUDIT_ARCH_SHEL64, "SHEL64"},
+        {AUDIT_ARCH_SPARC, "SPARC"},
+        {AUDIT_ARCH_SPARC64, "SPARC64"},
+        {AUDIT_ARCH_TILEGX, "TILEGX"},
+        {AUDIT_ARCH_TILEGX32, "TILEGX32"},
+        {AUDIT_ARCH_TILEPRO, "TILEPRO"}};
+
+const std::unordered_map<std::uint64_t, std::string>
+    SeccompEventSubscriber::syscall_x86_64_map = {
+        {0, "read"},
+        {1, "write"},
+        {2, "open"},
+        {3, "close"},
+        {4, "stat"},
+        {5, "fstat"},
+        {6, "lstat"},
+        {7, "poll"},
+        {8, "lseek"},
+        {9, "mmap"},
+        {10, "mprotect"},
+        {11, "munmap"},
+        {12, "brk"},
+        {13, "rt_sigaction"},
+        {14, "rt_sigprocmask"},
+        {15, "rt_sigreturn"},
+        {16, "ioctl"},
+        {17, "pread64"},
+        {18, "pwrite64"},
+        {19, "readv"},
+        {20, "writev"},
+        {21, "access"},
+        {22, "pipe"},
+        {23, "select"},
+        {24, "sched_yield"},
+        {25, "mremap"},
+        {26, "msync"},
+        {27, "mincore"},
+        {28, "madvise"},
+        {29, "shmget"},
+        {30, "shmat"},
+        {31, "shmctl"},
+        {32, "dup"},
+        {33, "dup2"},
+        {34, "pause"},
+        {35, "nanosleep"},
+        {36, "getitimer"},
+        {37, "alarm"},
+        {38, "setitimer"},
+        {39, "getpid"},
+        {40, "sendfile"},
+        {41, "socket"},
+        {42, "connect"},
+        {43, "accept"},
+        {44, "sendto"},
+        {45, "recvfrom"},
+        {46, "sendmsg"},
+        {47, "recvmsg"},
+        {48, "shutdown"},
+        {49, "bind"},
+        {50, "listen"},
+        {51, "getsockname"},
+        {52, "getpeername"},
+        {53, "socketpair"},
+        {54, "setsockopt"},
+        {55, "getsockopt"},
+        {56, "clone"},
+        {57, "fork"},
+        {58, "vfork"},
+        {59, "execve"},
+        {60, "exit"},
+        {61, "wait4"},
+        {62, "kill"},
+        {63, "uname"},
+        {64, "semget"},
+        {65, "semop"},
+        {66, "semctl"},
+        {67, "shmdt"},
+        {68, "msgget"},
+        {69, "msgsnd"},
+        {70, "msgrcv"},
+        {71, "msgctl"},
+        {72, "fcntl"},
+        {73, "flock"},
+        {74, "fsync"},
+        {75, "fdatasync"},
+        {76, "truncate"},
+        {77, "ftruncate"},
+        {78, "getdents"},
+        {79, "getcwd"},
+        {80, "chdir"},
+        {81, "fchdir"},
+        {82, "rename"},
+        {83, "mkdir"},
+        {84, "rmdir"},
+        {85, "creat"},
+        {86, "link"},
+        {87, "unlink"},
+        {88, "symlink"},
+        {89, "readlink"},
+        {90, "chmod"},
+        {91, "fchmod"},
+        {92, "chown"},
+        {93, "fchown"},
+        {94, "lchown"},
+        {95, "umask"},
+        {96, "gettimeofday"},
+        {97, "getrlimit"},
+        {98, "getrusage"},
+        {99, "sysinfo"},
+        {100, "times"},
+        {101, "ptrace"},
+        {102, "getuid"},
+        {103, "syslog"},
+        {104, "getgid"},
+        {105, "setuid"},
+        {106, "setgid"},
+        {107, "geteuid"},
+        {108, "getegid"},
+        {109, "setpgid"},
+        {110, "getppid"},
+        {111, "getpgrp"},
+        {112, "setsid"},
+        {113, "setreuid"},
+        {114, "setregid"},
+        {115, "getgroups"},
+        {116, "setgroups"},
+        {117, "setresuid"},
+        {118, "getresuid"},
+        {119, "setresgid"},
+        {120, "getresgid"},
+        {121, "getpgid"},
+        {122, "setfsuid"},
+        {123, "setfsgid"},
+        {124, "getsid"},
+        {125, "capget"},
+        {126, "capset"},
+        {127, "rt_sigpending"},
+        {128, "rt_sigtimedwait"},
+        {129, "rt_sigqueueinfo"},
+        {130, "rt_sigsuspend"},
+        {131, "sigaltstack"},
+        {132, "utime"},
+        {133, "mknod"},
+        {134, "uselib"},
+        {135, "personality"},
+        {136, "ustat"},
+        {137, "statfs"},
+        {138, "fstatfs"},
+        {139, "sysfs"},
+        {140, "getpriority"},
+        {141, "setpriority"},
+        {142, "sched_setparam"},
+        {143, "sched_getparam"},
+        {144, "sched_setscheduler"},
+        {145, "sched_getscheduler"},
+        {146, "sched_get_priority_max"},
+        {147, "sched_get_priority_min"},
+        {148, "sched_rr_get_interval"},
+        {149, "mlock"},
+        {150, "munlock"},
+        {151, "mlockall"},
+        {152, "munlockall"},
+        {153, "vhangup"},
+        {154, "modify_ldt"},
+        {155, "pivot_root"},
+        {156, "_sysctl"},
+        {157, "prctl"},
+        {158, "arch_prctl"},
+        {159, "adjtimex"},
+        {160, "setrlimit"},
+        {161, "chroot"},
+        {162, "sync"},
+        {163, "acct"},
+        {164, "settimeofday"},
+        {165, "mount"},
+        {166, "umount2"},
+        {167, "swapon"},
+        {168, "swapoff"},
+        {169, "reboot"},
+        {170, "sethostname"},
+        {171, "setdomainname"},
+        {172, "iopl"},
+        {173, "ioperm"},
+        {174, "create_module"},
+        {175, "init_module"},
+        {176, "delete_module"},
+        {177, "get_kernel_syms"},
+        {178, "query_module"},
+        {179, "quotactl"},
+        {180, "nfsservctl"},
+        {181, "getpmsg"},
+        {182, "putpmsg"},
+        {183, "afs_syscall"},
+        {184, "tuxcall"},
+        {185, "security"},
+        {186, "gettid"},
+        {187, "readahead"},
+        {188, "setxattr"},
+        {189, "lsetxattr"},
+        {190, "fsetxattr"},
+        {191, "getxattr"},
+        {192, "lgetxattr"},
+        {193, "fgetxattr"},
+        {194, "listxattr"},
+        {195, "llistxattr"},
+        {196, "flistxattr"},
+        {197, "removexattr"},
+        {198, "lremovexattr"},
+        {199, "fremovexattr"},
+        {200, "tkill"},
+        {201, "time"},
+        {202, "futex"},
+        {203, "sched_setaffinity"},
+        {204, "sched_getaffinity"},
+        {205, "set_thread_area"},
+        {206, "io_setup"},
+        {207, "io_destroy"},
+        {208, "io_getevents"},
+        {209, "io_submit"},
+        {210, "io_cancel"},
+        {211, "get_thread_area"},
+        {212, "lookup_dcookie"},
+        {213, "epoll_create"},
+        {214, "epoll_ctl_old"},
+        {215, "epoll_wait_old"},
+        {216, "remap_file_pages"},
+        {217, "getdents64"},
+        {218, "set_tid_address"},
+        {219, "restart_syscall"},
+        {220, "semtimedop"},
+        {221, "fadvise64"},
+        {222, "timer_create"},
+        {223, "timer_settime"},
+        {224, "timer_gettime"},
+        {225, "timer_getoverrun"},
+        {226, "timer_delete"},
+        {227, "clock_settime"},
+        {228, "clock_gettime"},
+        {229, "clock_getres"},
+        {230, "clock_nanosleep"},
+        {231, "exit_group"},
+        {232, "epoll_wait"},
+        {233, "epoll_ctl"},
+        {234, "tgkill"},
+        {235, "utimes"},
+        {236, "vserver"},
+        {237, "mbind"},
+        {238, "set_mempolicy"},
+        {239, "get_mempolicy"},
+        {240, "mq_open"},
+        {241, "mq_unlink"},
+        {242, "mq_timedsend"},
+        {243, "mq_timedreceive"},
+        {244, "mq_notify"},
+        {245, "mq_getsetattr"},
+        {246, "kexec_load"},
+        {247, "waitid"},
+        {248, "add_key"},
+        {249, "request_key"},
+        {250, "keyctl"},
+        {251, "ioprio_set"},
+        {252, "ioprio_get"},
+        {253, "inotify_init"},
+        {254, "inotify_add_watch"},
+        {255, "inotify_rm_watch"},
+        {256, "migrate_pages"},
+        {257, "openat"},
+        {258, "mkdirat"},
+        {259, "mknodat"},
+        {260, "fchownat"},
+        {261, "futimesat"},
+        {262, "newfstatat"},
+        {263, "unlinkat"},
+        {264, "renameat"},
+        {265, "linkat"},
+        {266, "symlinkat"},
+        {267, "readlinkat"},
+        {268, "fchmodat"},
+        {269, "faccessat"},
+        {270, "pselect6"},
+        {271, "ppoll"},
+        {272, "unshare"},
+        {273, "set_robust_list"},
+        {274, "get_robust_list"},
+        {275, "splice"},
+        {276, "tee"},
+        {277, "sync_file_range"},
+        {278, "vmsplice"},
+        {279, "move_pages"},
+        {280, "utimensat"},
+        {281, "epoll_pwait"},
+        {282, "signalfd"},
+        {283, "timerfd_create"},
+        {284, "eventfd"},
+        {285, "fallocate"},
+        {286, "timerfd_settime"},
+        {287, "timerfd_gettime"},
+        {288, "accept4"},
+        {289, "signalfd4"},
+        {290, "eventfd2"},
+        {291, "epoll_create1"},
+        {292, "dup3"},
+        {293, "pipe2"},
+        {294, "inotify_init1"},
+        {295, "preadv"},
+        {296, "pwritev"},
+        {297, "rt_tgsigqueueinfo"},
+        {298, "perf_event_open"},
+        {299, "recvmmsg"},
+        {300, "fanotify_init"},
+        {301, "fanotify_mark"},
+        {302, "prlimit64"},
+        {303, "name_to_handle_at"},
+        {304, "open_by_handle_at"},
+        {305, "clock_adjtime"},
+        {306, "syncfs"},
+        {307, "sendmmsg"},
+        {308, "setns"},
+        {309, "getcpu"},
+        {310, "process_vm_readv"},
+        {311, "process_vm_writev"},
+        {312, "kcmp"},
+        {313, "finit_module"},
+        {314, "sched_setattr"},
+        {315, "sched_getattr"},
+        {316, "renameat2"},
+        {317, "seccomp"},
+        {318, "getrandom"},
+        {319, "memfd_create"},
+        {320, "kexec_file_load"},
+        {321, "bpf"},
+        {322, "execveat"},
+        {323, "userfaultfd"},
+        {324, "membarrier"},
+        {325, "mlock2"},
+        {326, "copy_file_range"},
+        {327, "preadv2"},
+        {328, "pwritev2"},
+        {329, "pkey_mprotect"},
+        {330, "pkey_alloc"},
+        {331, "pkey_free"},
+        {332, "statx"},
+        {333, "io_pgetevents"},
+        {334, "rseq"}};
+
+FLAG(bool,
+     audit_allow_seccomp_events,
+     false,
+     "Allow the audit publisher to process seccomp events");
+
+REGISTER(SeccompEventSubscriber, "event_subscriber", "seccomp_events");
+
+// namespace tables {
+// extern long getUptime();
+// }
+
+Status SeccompEventSubscriber::init() {
+  if (!FLAGS_audit_allow_seccomp_events) {
+    return Status(1, "Seccomp subscriber disabled via configuration");
+  }
+
+  auto sc = createSubscriptionContext();
+  subscribe(&SeccompEventSubscriber::Callback, sc);
+
+  return Status();
+}
+
+Status SeccompEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
+  QueryData data;
+  auto status = processEvents(data, ec->audit_events);
+  if (!status.ok()) {
+    return status;
+  }
+
+  for (auto& row : data) {
+    add(row);
+  }
+
+  return Status();
+}
+
+void SeccompEventSubscriber::parseEvent(const AuditEvent& event,
+                                        Row& parsed_event) noexcept {
+  const auto& event_data = boost::get<SeccompAuditEventData>(event.data);
+  // parsed_event["uptime"] = std::to_string(tables::getUptime());
+  parsed_event["uptime"] = std::to_string(getUptime());
+  std::uint64_t arch = 0;
+  std::uint64_t value = 0;
+
+  for (const auto& field : event_data.fields) {
+    switch (field.second.which()) {
+    case 0:
+      // string field
+      parsed_event[field.first] = boost::get<std::string>(field.second);
+      break;
+    case 1:
+      // int field
+      value = boost::get<const std::uint64_t>(field.second);
+      if (field.first == "arch") {
+        std::string symbolic_code_value = "";
+        arch = value;
+        parsed_event[field.first] =
+            GetStringFieldFromIntMap(symbolic_code_value,
+                                     SeccompEventSubscriber::arch_codes_map,
+                                     value)
+                ? symbolic_code_value
+                : std::to_string(value) + "(unknown)";
+        break;
+      }
+      if (field.first == "syscall" && arch == AUDIT_ARCH_X86_64) {
+        std::string symbolic_code_value = "";
+        parsed_event[field.first] =
+            GetStringFieldFromIntMap(symbolic_code_value,
+                                     SeccompEventSubscriber::syscall_x86_64_map,
+                                     value)
+                ? symbolic_code_value
+                : std::to_string(value) + "(unknown)";
+        break;
+      }
+      if (field.first == "syscall" && arch != AUDIT_ARCH_X86_64) {
+        parsed_event[field.first] = std::to_string(value);
+        break;
+      }
+      if (field.first == "code") {
+        std::string symbolic_code_value = "";
+        parsed_event[field.first] =
+            GetStringFieldFromIntMap(
+                symbolic_code_value,
+                SeccompEventSubscriber::seccomp_actions_map,
+                value)
+                ? symbolic_code_value
+                : std::to_string(value) + "(unknown)";
+        break;
+      }
+      parsed_event[field.first] = UNSIGNED_BIGINT(value);
+      break;
+    default:
+      continue;
+    }
+  }
+}
+
+Status SeccompEventSubscriber::processEvents(
+    QueryData& data, const std::vector<AuditEvent>& event_list) noexcept {
+  data.clear();
+
+  for (const auto& event : event_list) {
+    if (event.type != AuditEvent::Type::Seccomp) {
+      continue;
+    }
+
+    if (event.record_list.size() != 1) {
+      VLOG(1) << "SeccompEventSubscriber got record list";
+      continue;
+    }
+
+    Row parsed_event;
+    parseEvent(event, parsed_event);
+    data.push_back(parsed_event);
+  }
+
+  return Status();
+}
+} // namespace osquery

--- a/osquery/tables/events/linux/seccomp_events.h
+++ b/osquery/tables/events/linux/seccomp_events.h
@@ -1,11 +1,10 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #pragma once

--- a/osquery/tables/events/linux/seccomp_events.h
+++ b/osquery/tables/events/linux/seccomp_events.h
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <linux/audit.h>
+#include <linux/seccomp.h>
+
+#include <osquery/events/eventsubscriber.h>
+#include <osquery/events/linux/auditeventpublisher.h>
+
+namespace osquery {
+
+class SeccompEventSubscriber final
+    : public EventSubscriber<AuditEventPublisher> {
+  /// Mapping from seccomp action codes from seccomp.h to seccomp action names
+  static const std::unordered_map<std::uint64_t, std::string>
+      seccomp_actions_map;
+
+  /// Mapping from architecture codes from audit.h to architecture names
+  static const std::unordered_map<std::uint64_t, std::string> arch_codes_map;
+
+  /// Mapping from system call numbers to system call names for x86_64
+  static const std::unordered_map<std::uint64_t, std::string>
+      syscall_x86_64_map;
+
+  static void parseEvent(const AuditEvent& event, Row& parsed_event) noexcept;
+
+ public:
+  /// The process event subscriber declares an audit event type subscription.
+  Status init() override;
+
+  /// Kernel events matching the event type will fire.
+  Status Callback(const ECRef& ec, const SCRef& sc);
+
+  /// Processes the updates received from the callback
+  static Status processEvents(
+      QueryData& emitted_row_list,
+      const std::vector<AuditEvent>& event_list) noexcept;
+};
+} // namespace osquery

--- a/osquery/tables/events/linux/seccomp_events.h
+++ b/osquery/tables/events/linux/seccomp_events.h
@@ -15,6 +15,27 @@
 #include <osquery/events/eventsubscriber.h>
 #include <osquery/events/linux/auditeventpublisher.h>
 
+/* Additions to #include <linux/seccomp.h>
+ * Some used constants introduced only in kernel 4.14
+ * Osquery tries to be compatible to older kernel 
+ * so we define newer constants if they are missing in seccomp.h
+ * Constant values are taken from kernel tag v4.14
+ * https://github.com/torvalds/linux/blob/v4.14/include/uapi/linux/seccomp.h#L32
+ */
+#ifndef SECCOMP_RET_KILL_PROCESS
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U /* kill the process */
+#endif
+
+#ifndef SECCOMP_RET_KILL_THREAD
+#define SECCOMP_RET_KILL_THREAD  SECCOMP_RET_KILL /* kill the thread */
+#endif
+
+#ifndef SECCOMP_RET_LOG
+#define SECCOMP_RET_LOG          0x7ffc0000U /* allow after logging */
+#endif
+
+// End to #include <linux/seccomp.h> additions
+
 namespace osquery {
 
 class SeccompEventSubscriber final

--- a/osquery/tables/events/linux/seccomp_events.h
+++ b/osquery/tables/events/linux/seccomp_events.h
@@ -17,7 +17,7 @@
 
 /* Additions to #include <linux/seccomp.h>
  * Some used constants introduced only in kernel 4.14
- * Osquery tries to be compatible to older kernel 
+ * Osquery tries to be compatible to older kernel
  * so we define newer constants if they are missing in seccomp.h
  * Constant values are taken from kernel tag v4.14
  * https://github.com/torvalds/linux/blob/v4.14/include/uapi/linux/seccomp.h#L32

--- a/osquery/tables/events/linux/seccomp_events.h
+++ b/osquery/tables/events/linux/seccomp_events.h
@@ -27,11 +27,11 @@
 #endif
 
 #ifndef SECCOMP_RET_KILL_THREAD
-#define SECCOMP_RET_KILL_THREAD  SECCOMP_RET_KILL /* kill the thread */
+#define SECCOMP_RET_KILL_THREAD SECCOMP_RET_KILL /* kill the thread */
 #endif
 
 #ifndef SECCOMP_RET_LOG
-#define SECCOMP_RET_LOG          0x7ffc0000U /* allow after logging */
+#define SECCOMP_RET_LOG 0x7ffc0000U /* allow after logging */
 #endif
 
 // End to #include <linux/seccomp.h> additions

--- a/osquery/tables/events/tests/CMakeLists.txt
+++ b/osquery/tables/events/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ function(osqueryTablesEventsTestsMain)
   generateOsqueryTablesEventsTestsFileeventstestsTest()
 
   if(DEFINED PLATFORM_LINUX)
+    generateOsqueryTablesEventsTestsSeccompeventstestsTest()
     generateOsqueryTablesEventsTestsSelinuxeventstestsTest()
     generateOsqueryTablesEventsTestsProcesseventstestsTest()
 
@@ -20,6 +21,23 @@ function(osqueryTablesEventsTestsMain)
     generateOsqueryTablesEventsTestsPowershelleventstestsTest()
     generateOsqueryTablesEventsTestsWindowseventstestsTest()
   endif()
+endfunction()
+
+function(generateOsqueryTablesEventsTestsSeccompeventstestsTest)
+  add_osquery_executable(osquery_tables_events_tests_seccompeventstests-test linux/seccomp_events_tests.cpp)
+
+  target_link_libraries(osquery_tables_events_tests_seccompeventstests-test PRIVATE
+    osquery_cxx_settings
+    osquery_core
+    osquery_database
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_logger
+    osquery_registry
+    osquery_tables_events_eventstable
+    tests_helper
+    thirdparty_googletest
+  )
 endfunction()
 
 function(generateOsqueryTablesEventsTestsFileeventstestsTest)

--- a/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
@@ -1,0 +1,119 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#ifdef __linux__
+
+#include <gtest/gtest.h>
+
+#include "osquery/events/linux/auditeventpublisher.h"
+#include "osquery/tables/events/linux/seccomp_events.h"
+
+namespace osquery {
+class SeccompEventsTests : public testing::Test {
+ protected:
+  SeccompAuditEventData event_data;
+  AuditEvent audit_event;
+  AuditEventRecord fake_record;
+  std::vector<AuditEvent> event_list;
+  QueryData data;
+
+  void ProcessEventsWithParams(std::uint64_t syscall_num,
+                               std::uint64_t arch,
+                               std::uint64_t seccomp_action,
+                               Row& result) {
+    event_data.fields["syscall"] = syscall_num;
+    event_data.fields["arch"] = arch;
+    event_data.fields["code"] = seccomp_action;
+
+    audit_event.data = event_data;
+    event_list.push_back(audit_event);
+
+    data.clear();
+    SeccompEventSubscriber::processEvents(data, event_list);
+    result = data.back();
+    event_list.clear();
+  }
+
+  void SetUp() override {
+    event_data.fields["auid"] = 65876;
+    event_data.fields["uid"] = 0;
+    event_data.fields["gid"] = 0;
+    event_data.fields["ses"] = 162176;
+    event_data.fields["pid"] = 14970;
+    event_data.fields["comm"] = "qemu-system-x86";
+    event_data.fields["exe"] = "/usr/bin/qemu-system-x86_64";
+    event_data.fields["sig"] = 0;
+    event_data.fields["arch"] = AUDIT_ARCH_IA64;
+    event_data.fields["syscall"] = 1;
+    event_data.fields["compat"] = 0;
+    event_data.fields["ip"] = 0x7fe6aa0bf51d;
+    event_data.fields["code"] = SECCOMP_RET_ALLOW;
+
+    audit_event.type = AuditEvent::Type::Seccomp;
+    audit_event.record_list.push_back(fake_record);
+  }
+};
+
+TEST_F(SeccompEventsTests, test_basic_fields) {
+  Row result;
+  ProcessEventsWithParams(0, AUDIT_ARCH_IA64, SECCOMP_RET_ALLOW, result);
+
+  EXPECT_EQ(result["auid"], "65876");
+  EXPECT_EQ(result["uid"], "0");
+  EXPECT_EQ(result["gid"], "0");
+  EXPECT_EQ(result["ses"], "162176");
+  EXPECT_EQ(result["pid"], "14970");
+  EXPECT_EQ(result["comm"], "qemu-system-x86");
+  EXPECT_EQ(result["exe"], "/usr/bin/qemu-system-x86_64");
+  EXPECT_EQ(result["sig"], "0");
+  EXPECT_EQ(result["compat"], "0");
+  EXPECT_EQ(result["ip"], "140628672115997");
+}
+
+TEST_F(SeccompEventsTests, test_seccomp_value_decode_x86_64_1) {
+  Row result;
+  ProcessEventsWithParams(0, AUDIT_ARCH_X86_64, SECCOMP_RET_LOG, result);
+
+  EXPECT_EQ(result["syscall"], "read");
+  EXPECT_EQ(result["arch"], "X86_64");
+  EXPECT_EQ(result["code"], "LOG");
+}
+
+TEST_F(SeccompEventsTests, test_seccomp_value_decode_x86_64_2) {
+  Row result;
+  ProcessEventsWithParams(
+      88, AUDIT_ARCH_X86_64, SECCOMP_RET_KILL_PROCESS, result);
+
+  EXPECT_EQ(result["syscall"], "symlink");
+  EXPECT_EQ(result["arch"], "X86_64");
+  EXPECT_EQ(result["code"], "KILL_PROCESS");
+}
+
+TEST_F(SeccompEventsTests, test_seccomp_value_decode_x86_64_3) {
+  Row result;
+  ProcessEventsWithParams(
+      1337, AUDIT_ARCH_X86_64, SECCOMP_RET_KILL_THREAD, result);
+
+  EXPECT_EQ(result["syscall"], "1337(unknown)");
+  EXPECT_EQ(result["arch"], "X86_64");
+  EXPECT_EQ(result["code"], "KILL_THREAD");
+}
+
+TEST_F(SeccompEventsTests, test_seccomp_value_decode_mips) {
+  Row result;
+  ProcessEventsWithParams(13, AUDIT_ARCH_MIPS64, SECCOMP_RET_ERRNO, result);
+
+  EXPECT_EQ(result["syscall"], "13");
+  EXPECT_EQ(result["arch"], "MIPS64");
+  EXPECT_EQ(result["code"], "ERRNO");
+}
+} // namespace osquery
+
+#endif

--- a/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
@@ -1,11 +1,10 @@
 /**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2014-present, The osquery authors
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
 #ifdef __linux__

--- a/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/seccomp_events_tests.cpp
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#ifdef __linux__
-
 #include <gtest/gtest.h>
 
 #include "osquery/events/linux/auditeventpublisher.h"
@@ -114,5 +112,3 @@ TEST_F(SeccompEventsTests, test_seccomp_value_decode_mips) {
   EXPECT_EQ(result["code"], "ERRNO");
 }
 } // namespace osquery
-
-#endif

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -149,6 +149,7 @@ function(generateNativeTables)
     "freebsd/fbsd_kmods.table:freebsd"
     "freebsd/pkg_packages.table:freebsd"
     "linux/selinux_events.table:linux"
+    "linux/seccomp_events.table:linux"
     "linux/elf_symbols.table:linux"
     "linux/portage_use.table:linux"
     "linux/rpm_package_files.table:linux"

--- a/specs/linux/seccomp_events.table
+++ b/specs/linux/seccomp_events.table
@@ -1,0 +1,24 @@
+table_name("seccomp_events")
+
+description("A virtual table that tracks seccomp events.")
+
+schema([
+    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("uptime", BIGINT, "Time of execution in system uptime"),
+    Column("auid", UNSIGNED_BIGINT, "Audit user ID (loginuid) of the user who started the analyzed process"),
+    Column("uid", UNSIGNED_BIGINT, "User ID of the user who started the analyzed process"),
+    Column("gid", UNSIGNED_BIGINT, "Group ID of the user who started the analyzed process"),
+    Column("ses", UNSIGNED_BIGINT, "Session ID of the session from which the analyzed process was invoked"),
+    Column("pid", UNSIGNED_BIGINT, "Process ID"),
+    Column("comm", TEXT, "Command-line name of the command that was used to invoke the analyzed process"),
+    Column("exe", TEXT, "The path to the executable that was used to invoke the analyzed process"),
+    Column("sig", BIGINT, "Signal value sent to process by seccomp"),
+    Column("arch", TEXT, "Information about the CPU architecture"),
+    Column("syscall", TEXT, "Type of the system call"),
+    Column("compat", BIGINT, "Is system call in compatibility mode"),
+    Column("ip", TEXT, "Instruction pointer value"),
+    Column("code", TEXT, "The seccomp action"),
+])
+
+attributes(event_subscriber=True)
+implementation("seccomp_events@seccomp_events::genTable")


### PR DESCRIPTION
**Changes description**:

This PR adds a new `seccomp_events` table that contains events from [Seccomp](https://www.kernel.org/doc/html/v4.14/userspace-api/seccomp_filter.html). Seccomp is a Linux kernel security feature which allows to restrict the set of system calls application can make. Seccomp is one of the main components of any sandbox. Also, `seccomp_events` table makes Seccomp logs human readable for x86_64 systems.

**Motivation for the PR**:

Creating Seccomp security profile with exact whitelist of system calls is complicated for complex applications. Therefore, using Seccomp in terminating mode (`SECCOMP_RET_KILL`) can lead to huge production risks. Since Linux 4.14 Seccomp allows to log use of unauthorized system calls without application terminating (`SECCOMP_RET_LOG`). This Seccomp feature with `seccomp_events` table is bringing ability to create log-based Seccomp sandbox. 