### PR TITLE
Move CI to using docker from osquery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v9
+      image: osquery/builder18.04:7882f9bb1
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v9
+      image: osquery/builder18.04:7882f9bb1
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -211,7 +211,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: trailofbits/osquery:ubuntu-18.04-toolchain-v9
+      image: osquery/builder18.04:7882f9bb1
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:7882f9bb1
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:7882f9bb1
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -211,7 +211,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:7882f9bb1
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:


### PR DESCRIPTION
This moves the CI to using `osquery/builder18.04` Which comes from https://github.com/osquery/osquery/pull/7011

the `0aa3775ce` tag is from a recent main branch build