### PR TITLE
Removing Keyboard Event Taps from osx-attacks pack

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -596,13 +596,6 @@
       "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
       "value": "Artifacts created by this malware"
     },
-    "Keyboard_Event_Taps": {
-      "query": "SELECT * FROM processes JOIN event_taps ON processes.pid = event_taps.tapping_process where event_taps.enabled = 1;",
-      "interval" : "3600",
-      "version": "3.3.0",
-      "description": "Finds processes that have active keyboard event taps, typically used by RATs and other malicious software for keylogging",
-      "value": "Process with keyboard event taps"
-    },
     "OSX_SearchAwesome": {
       "query" : "SELECT * FROM file \
          WHERE path = '/Applications/spi.app' OR \


### PR DESCRIPTION
This query is subject to quite a few false positives and does no filtering in the query itself. As an example, `/usr/libexec/gamecontrollerd` is a native MacOS utility that regularly hooks into taps and will cause false positives on every Mac that this pack runs on. 

As an example of how much whitelisting can be necessary to reduce FPs, please see https://github.com/palantir/osquery-configuration/blob/master/Classic/Endpoints/MacOS/osquery.conf#L79

TL;DR - My opinion is that we shouldn't put queries that are likely to generate many FPs in this pack.