### PR TITLE
Change windows messages to verbose

### DIFF
--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -269,8 +269,8 @@ Status getProcessCommandLineLegacy(HANDLE proc,
   RTL_USER_PROCESS_PARAMETERS upp;
   auto s = getUserProcessParameters(proc, upp, pid);
   if (!s.ok()) {
-    LOG(INFO) << "Failed to get PEB UPP for " << pid << " with "
-              << GetLastError();
+    VLOG(1) << "Failed to get PEB UPP for " << pid << " with "
+            << GetLastError();
     return s;
   }
 
@@ -335,8 +335,8 @@ Status getProcessCurrentDirectory(HANDLE proc,
   RTL_USER_PROCESS_PARAMETERS upp;
   auto s = getUserProcessParameters(proc, upp, pid);
   if (!s.ok()) {
-    LOG(INFO) << "Failed to get PEB UPP for " << pid << " with "
-              << GetLastError();
+    VLOG(1) << "Failed to get PEB UPP for " << pid << " with "
+            << GetLastError();
     return s;
   }
 
@@ -363,7 +363,7 @@ void getProcessPathInfo(HANDLE& proc,
   SecureZeroMemory(path.data(), kMaxPathSize);
   auto ret = QueryFullProcessImageNameW(proc, 0, path.data(), &out);
   if (ret != TRUE) {
-    LOG(INFO) << "Failed to lookup path information for process " << pid;
+    VLOG(1) << "Failed to lookup path information for process " << pid;
   } else {
     r["path"] = SQL_TEXT(wstringToString(path.data()));
   }
@@ -377,7 +377,7 @@ void getProcessPathInfo(HANDLE& proc,
   std::string currDir{""};
   auto s = getProcessCurrentDirectory(proc, currDir, pid);
   if (!s.ok()) {
-    LOG(INFO) << "Failed to get cwd for " << pid << " with " << GetLastError();
+    VLOG(1) << "Failed to get cwd for " << pid << " with " << GetLastError();
   } else {
     r["cwd"] = SQL_TEXT(currDir);
   }

--- a/osquery/tables/system/windows/windows_crashes.cpp
+++ b/osquery/tables/system/windows/windows_crashes.cpp
@@ -629,7 +629,7 @@ QueryData genCrashLogs(QueryContext& context) {
 
   if (!fs::exists(dumpFolderLocation) ||
       !fs::is_directory(dumpFolderLocation)) {
-    LOG(ERROR) << "No crash dump directory found";
+    VLOG(1) << "No crash dump directory found";
     return results;
   }
 


### PR DESCRIPTION
These  messages seem very noisy. Given the frequency of them, I suspect
they represent assumptions that don't always hold, and not outright
errors.

If any of the windows folks feel otherwise I'd love to know...

Fixes: #7022
