### PR TITLE
Change windows calculation for `physical_memory`

### DIFF
--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -45,15 +45,24 @@ QueryData genSystemInfo(QueryContext& context) {
     r["cpu_logical_cores"] = INTEGER(numProcs);
     wmiResultsProc[0].GetLong("NumberOfCores", numProcs);
     r["cpu_physical_cores"] = INTEGER(numProcs);
-    wmiResults[0].GetString("TotalPhysicalMemory", r["physical_memory"]);
     wmiResults[0].GetString("Manufacturer", r["hardware_vendor"]);
     wmiResults[0].GetString("Model", r["hardware_model"]);
   } else {
     r["cpu_logical_cores"] = "-1";
     r["cpu_physical_cores"] = "-1";
-    r["physical_memory"] = "-1";
     r["hardware_vendor"] = "-1";
     r["hardware_model"] = "-1";
+  }
+
+  // Physical memory size is reported from Win32_PhysicalMemory. See
+  // TotalPhysicalMemory at
+  // https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
+  const WmiRequest wmiSystemReqMem("select * from Win32_PhysicalMemory");
+  const std::vector<WmiResultItem>& wmiResultsMem = wmiSystemReqMem.results();
+  if (wmiResultsMem.empty()) {
+    r["physical_memory"] = "-1";
+  } else {
+    wmiResultsMem[0].GetString("Capacity", r["physical_memory"]);
   }
 
   QueryData regResults;

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -77,7 +77,7 @@ QueryData genSystemInfo(QueryContext& context) {
       }
       sum += std::stoull(capacityStr);
     }
-    r["physical_memory"] = BIGINT(sum); // FIXME, need typecast?
+    r["physical_memory"] = BIGINT(sum);
   }
 
   QueryData regResults;

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -72,7 +72,7 @@ QueryData genSystemInfo(QueryContext& context) {
     } else {
       LOG(INFO)
           << "Got error trying to determine the physically installed memory: "
-          << std::to_string(::GetLastError());
+          << std::to_string(lastError);
     }
     r["physical_memory"] = "-1";
   }


### PR DESCRIPTION
On windows, physical memory is more correctly reported through the
`Win32_PhysicalMemory` wmi class.

The prior `Win32_ComputerSystem` mechanism reported the amount available
to the OS, which did not include anything held by the bios.

From https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
> Total size of physical memory. Be aware that, under some circumstances, this property may not return an accurate value for the physical memory. For example, it is not accurate if the BIOS is using some of the physical memory. For an accurate value, use the Capacity property in Win32_PhysicalMemory instead.

(Thanks @terracatta and Kolide)