### PR TITLE
Update to `chrome_extensions` to not error on uncommon cases

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -545,7 +545,7 @@ bool captureProfileSnapshotExtensionsFromPath(
 
       if (!status.ok()) {
         if (!isBuiltInChromeExtension(referenced_ext_path)) {
-          LOG(ERROR)
+          LOG(INFO)
               << "Failed to read the following manifest.json file: "
               << manifest_path.string()
               << ". The extension was referenced by the following profile: "


### PR DESCRIPTION
Playing with the new `chrome_extensions` I notice a couple of osquery errors, that do not seem like errors.

First, my machine has a bunch of blank `install_time` columns. When patching that, I was a bit confused by how the assignments worked, so I changed them. I'm still a bit unsure about passing the text value if it's an error. But this is, I think, equivalent to the code today. 

Second, on some not-recently-loaded profiles, I get this error:
```
E0401 14:20:57.133714 180438464 utils.cpp:548] Failed to read the following manifest.json file: /Applications/Google Chrome.app/Contents/Versions/66.0.3359.181/Google Chrome Framework.framework/Resources/gaia_auth/manifest.json. The extension was referenced by the following profile: /Users/seph/Library/Application Support/Google/Chrome/Profile 1
```

So I reduced that to `INFO`. But might even suggest verbose.
