### PR TITLE
Remove Buck leftovers that supported building with old versions of OpenSSL

### DIFF
--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -70,13 +70,9 @@ static std::string signature(X509* cert) {
   ASN1_BIT_STRING* sign = nullptr;
   std::string signature;
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-  X509_get0_signature(&sign, nullptr, cert);
-#else
   X509_get0_signature(
       const_cast<const ASN1_BIT_STRING**>(&sign), nullptr, cert);
-#endif
+
   auto sig_nid = X509_get_signature_nid(cert);
   if (sig_nid != NID_undef) {
     auto n = sign->length;
@@ -93,52 +89,6 @@ static std::string signature(X509* cert) {
   return signature;
 }
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-static std::string certificate_extensions(X509* cert, int nid) {
-  auto ci = cert->cert_info;
-  if (sk_X509_EXTENSION_num(ci->extensions) <= 0) {
-    return {};
-  }
-
-  for (auto i = 0; i < sk_X509_EXTENSION_num(ci->extensions); i++) {
-    auto ext_value =
-        (X509_EXTENSION*)sk_X509_EXTENSION_value(ci->extensions, i);
-    if (!ext_value) {
-      break;
-    }
-
-    if (OBJ_obj2nid(ext_value->object) == nid) {
-      auto bio_out = BIO_new(BIO_s_mem());
-      if (!X509V3_EXT_print(bio_out, ext_value, 0, 0)) {
-        M_ASN1_OCTET_STRING_print(bio_out, ext_value->value);
-      }
-
-      BUF_MEM* bio_buf = nullptr;
-      BIO_get_mem_ptr(bio_out, &bio_buf);
-
-      // remove the ending newline from the extension value
-      auto length = bio_buf->length;
-      if (bio_buf->data[length - 1] == '\n' ||
-          bio_buf->data[length - 1] == '\r') {
-        bio_buf->data[length - 1] = '\0';
-      }
-
-      if (bio_buf->data[length] == '\n' || bio_buf->data[length] == '\r') {
-        bio_buf->data[length] = '\0';
-      }
-      auto ident = std::string(bio_buf->data, bio_buf->length);
-
-      // Replace the newline character with the comma
-      std::replace(ident.begin(), ident.end(), '\n', ';');
-      BIO_free(bio_out);
-      return ident;
-    }
-  }
-
-  return {};
-}
-#else
 static std::string certificate_extensions(X509* cert, int nid) {
   auto extensions_stack = X509_get0_extensions(cert);
 
@@ -179,7 +129,6 @@ static std::string certificate_extensions(X509* cert, int nid) {
 
   return ident;
 }
-#endif
 
 bool has_cert_expired(X509* cert) {
   return X509_cmp_current_time(X509_get_notAfter(cert)) <= 0;
@@ -337,12 +286,8 @@ Status getTLSCertificate(const std::string& hostname,
                          int timeout) {
   SSL_library_init();
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-  const auto method = TLSv1_method();
-#else
   const auto method = TLS_method();
-#endif
+
   if (method == nullptr) {
     return Status::failure("Failed to create OpenSSL method object");
   }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -44,16 +44,6 @@ void genCertificate(X509* cert, const std::string& path, QueryData& results) {
   r["ca"] = (CertificateIsCA(cert)) ? INTEGER(1) : INTEGER(0);
   r["self_signed"] = (CertificateIsSelfSigned(cert)) ? INTEGER(1) : INTEGER(0);
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-  r["key_usage"] = genKeyUsage(cert->ex_kusage);
-  r["authority_key_id"] =
-      (cert->akid && cert->akid->keyid)
-          ? genKIDProperty(cert->akid->keyid->data, cert->akid->keyid->length)
-          : "";
-  r["subject_key_id"] =
-      (cert->skid) ? genKIDProperty(cert->skid->data, cert->skid->length) : "";
-#else
   r["key_usage"] = genKeyUsage(X509_get_key_usage(cert));
 
   const auto* cert_key_id = X509_get0_authority_key_id(cert);
@@ -63,7 +53,6 @@ void genCertificate(X509* cert, const std::string& path, QueryData& results) {
   cert_key_id = X509_get0_subject_key_id(cert);
   r["subject_key_id"] =
       cert_key_id ? genKIDProperty(cert_key_id->data, cert_key_id->length) : "";
-#endif
 
   r["serial"] = genSerialForCertificate(cert);
 

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -111,12 +111,7 @@ void genAlgorithmProperties(X509* cert,
       // The EVP_size for EC keys returns the maximum buffer for storing the
       // key data, it does not indicate the size/strength of the curve.
       if (nid == NID_X9_62_id_ecPublicKey) {
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-        const EC_KEY* ec_pkey = pkey->pkey.ec;
-#else
         const EC_KEY* ec_pkey = EVP_PKEY_get0_EC_KEY(pkey);
-#endif
         const EC_GROUP* ec_pkey_group = EC_KEY_get0_group(ec_pkey);
         int curve_nid = EC_GROUP_get_curve_name(ec_pkey_group);
         if (curve_nid != NID_undef) {
@@ -219,12 +214,8 @@ void genCommonName(X509* cert,
 
   ASN1_STRING* commonNameData = X509_NAME_ENTRY_get_data(commonNameEntry);
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-  const auto* data = ASN1_STRING_data(commonNameData);
-#else
   const auto* data = ASN1_STRING_get0_data(commonNameData);
-#endif
+
   common_name = std::string(reinterpret_cast<const char*>(data));
 }
 

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -76,20 +76,11 @@ TEST_F(CACertsTests, test_certificate_properties) {
 
   X509_check_ca(x_cert);
 
-// Temporary workaround for Buck compiling with an older openssl version
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-  const auto* subject_key_id = x_cert->skid;
-
-  ASSERT_NE(subject_key_id, nullptr);
-
-  auto skid = genKIDProperty(subject_key_id->data, subject_key_id->length);
-#else
   const auto* subject_key_id = X509_get0_subject_key_id(x_cert);
 
   ASSERT_NE(subject_key_id, nullptr);
 
   auto skid = genKIDProperty(subject_key_id->data, subject_key_id->length);
-#endif
 
   EXPECT_EQ("f2b99b00e0ee60d57c426ce3e64e3fdc6f6411c0", skid);
 


### PR DESCRIPTION
Follow-up to PR #6361 and #6799