### PR TITLE
bugfix-7019: Free using WTSFreeMemoryEx for WTSEnumerateSessionsExW

### DIFF
--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -150,7 +150,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
   }
 
   if (pSessionInfo != nullptr) {
-    WTSFreeMemory(pSessionInfo);
+    WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, pSessionInfo, count);
     pSessionInfo = nullptr;
   }
 


### PR DESCRIPTION
Fix for #7019. As documented by @Breakwell , WTSEnumerateSessionsExW needs to be freed with a call to WTSFreeMemoryEx.