### PR TITLE
Refactor watcher out of singleton pattern

### DIFF
--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -120,7 +120,7 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
     osquery::FLAGS_disable_events = true;
     osquery::FLAGS_disable_caching = true;
     // The shell may have loaded table extensions, if not, disable the manager.
-    if (!osquery::Watcher::get().hasManagedExtensions() &&
+    if (!osquery::Watcher::hasManagedExtensions() &&
         Flag::isDefault("disable_extensions")) {
       osquery::FLAGS_disable_extensions = true;
     }


### PR DESCRIPTION
My eventual goal is to add an IPC to the Watcher. Before I do this I would like to simplify the code. I noticed that `Watcher` does not need to be a singleton. 