### PR TITLE
Add an option to enable incremental linking on Windows

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -274,7 +274,6 @@ function(setupBuildFlags)
 
     set(windows_common_link_options
       /SUBSYSTEM:CONSOLE
-      /INCREMENTAL:NO
       ntdll.lib
       ole32.lib
       oleaut32.lib
@@ -301,6 +300,16 @@ function(setupBuildFlags)
       gdi32.lib
       mswsock.lib
     )
+
+    if(OSQUERY_ENABLE_INCREMENTAL_LINKING)
+      list(APPEND windows_common_link_options
+        /INCREMENTAL
+      )
+    else()
+      list(APPEND windows_common_link_options
+        /INCREMENTAL:NO
+      )
+    endif()
 
     set(osquery_windows_common_defines
       WIN32=1

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -82,6 +82,10 @@ if(DEFINED PLATFORM_LINUX)
   endif()
 endif()
 
+if(DEFINED PLATFORM_WINDOWS)
+  option(OSQUERY_ENABLE_INCREMENTAL_LINKING "Whether to enable or disable incremental linking (/INCREMENTAL or /INCREMENTAL:NO). Enabling it greatly increases disk usage")
+endif()
+
 option(OSQUERY_ENABLE_CLANG_TIDY "Enables clang-tidy support")
 set(OSQUERY_CLANG_TIDY_CHECKS "-checks=cert-*,cppcoreguidelines-*,performance-*,portability-*,readability-*,modernize-*,bugprone-*" CACHE STRING "List of checks performed by clang-tidy")
 


### PR DESCRIPTION
Add OSQUERY_ENABLE_INCREMENTAL_LINKING which adds
/INCREMENTAL if it's enabled, to improve linking speed
when relinking executables.
This greatly increases the amount of disk space used
(around 50GB now, with tests), so default is off
and /INCREMENTAL:NO is used.
