### PR TITLE
Use epoch and counter for events-based queries

### DIFF
--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -182,6 +182,14 @@ class Query {
    */
   bool isNewQuery() const;
 
+  /// Determines if this is a first run or new query.
+  void getQueryStatus(uint64_t epoch,
+                      bool& fresh_results,
+                      bool& new_query) const;
+
+  /// Increment and return the query counter.
+  Status incrementCounter(bool reset, uint64_t& counter) const;
+
   /**
    * @brief Add a new set of results to the persistent storage.
    *
@@ -219,6 +227,12 @@ class Query {
                        uint64_t& counter,
                        DiffResults& dr,
                        bool calculate_diff = true) const;
+
+  /// A version of adding new results for events-based queries.
+  Status addNewEvents(QueryDataTyped current_qd,
+                      const uint64_t current_epoch,
+                      uint64_t& counter,
+                      DiffResults& dr) const;
 
   /**
    * @brief The most recent result set for a scheduled query.

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -41,6 +41,64 @@ TEST_F(QueryTests, test_private_members) {
   EXPECT_EQ(cf.query_, query.query);
 }
 
+TEST_F(QueryTests, test_increment_counter) {
+  auto query = getOsqueryScheduledQuery();
+  auto cf = Query("foobar", query);
+
+  uint64_t counter = 1;
+  auto status = cf.incrementCounter(true, counter);
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ(0, counter);
+
+  status = cf.incrementCounter(false, counter);
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ(1, counter);
+}
+
+TEST_F(QueryTests, test_get_query_status) {
+  auto query = getOsqueryScheduledQuery();
+  auto cf = Query("query_status", query);
+
+  // We have never seen this query before (it has no results yet either).
+  bool fresh_results = false;
+  bool new_query = false;
+  cf.getQueryStatus(100, fresh_results, new_query);
+  EXPECT_TRUE(fresh_results);
+  EXPECT_TRUE(new_query);
+
+  // Add results for this query (this action is not under test).
+  uint64_t counter = 0;
+  auto status = cf.addNewResults(getTestDBExpectedResults(), 100, counter);
+  ASSERT_TRUE(status.ok());
+
+  // The query has results and the query text has not changed.
+  fresh_results = false;
+  new_query = false;
+  cf.getQueryStatus(100, fresh_results, new_query);
+  EXPECT_FALSE(fresh_results);
+  EXPECT_FALSE(new_query);
+
+  // The epoch changed so the previous results are invalid.
+  fresh_results = false;
+  new_query = false;
+  cf.getQueryStatus(101, fresh_results, new_query);
+  EXPECT_TRUE(fresh_results);
+  EXPECT_FALSE(new_query);
+
+  // Add results for the new epoch (this action is not under test).
+  status = cf.addNewResults(getTestDBExpectedResults(), 101, counter);
+  ASSERT_TRUE(status.ok());
+
+  // The epoch is the same but the query text has changed.
+  fresh_results = false;
+  new_query = false;
+  query.query += " LIMIT 1";
+  auto cf2 = Query("query_status", query);
+  cf2.getQueryStatus(101, fresh_results, new_query);
+  EXPECT_FALSE(fresh_results);
+  EXPECT_TRUE(new_query);
+}
+
 TEST_F(QueryTests, test_add_and_get_current_results) {
   FLAGS_logger_numerics = true;
   // Test adding a "current" set of results to a scheduled query instance.

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -152,14 +152,16 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
   if (!FLAGS_events_optimize || !sql.eventBased()) {
     status = dbQuery.addNewResults(
         std::move(sql.rowsTyped()), item.epoch, item.counter, diff_results);
-    if (!status.ok()) {
-      std::string message = "Error adding new results to database for query " +
-                            name + ": " + status.what();
-      // If the database is not available then the daemon cannot continue.
-      requestShutdown(EXIT_CATASTROPHIC, message);
-    }
   } else {
-    diff_results.added = std::move(sql.rowsTyped());
+    status = dbQuery.addNewEvents(
+        std::move(sql.rowsTyped()), item.epoch, item.counter, diff_results);
+  }
+
+  if (!status.ok()) {
+    std::string message = "Error adding new results to database for query " +
+                          name + ": " + status.what();
+    // If the database is not available then the daemon cannot continue.
+    requestShutdown(EXIT_CATASTROPHIC, message);
   }
 
   if (!query.reportRemovedRows()) {


### PR DESCRIPTION
I noticed that "event based" queries do not include `epoch` or `counter` tracking in their logging. These are queries in the schedule against an events table like `SELECT * FROM file_events;`.

I tracked this down to some optimization path in the scheduler. I think our expectation is to include these.