### PR TITLE
Fix optimization for multiple queries using the same subscriber

### DIFF
--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -351,10 +351,7 @@ void EventFactory::configUpdate() {
       LOG(INFO) << "Subscriber expiration is too low: "
                 << subscriber->getName();
     }
-    subscriber->query_count_ = details.second.query_count;
-
-    WriteLock subscriber_lock(subscriber->event_query_record_);
-    subscriber->queries_.clear();
+    subscriber->resetQueryCount(details.second.query_count);
   }
 
   // If events are enabled configure the subscribers before publishers.

--- a/osquery/events/eventpublisherplugin.cpp
+++ b/osquery/events/eventpublisherplugin.cpp
@@ -69,7 +69,7 @@ void EventPublisherPlugin::fire(const EventContextRef& ec, EventTime time) {
     ec->id = ec_id;
     if (ec->time == 0) {
       if (time == 0) {
-        time = getUnixTime();
+        time = getTime();
       }
       ec->time = time;
     }
@@ -82,6 +82,10 @@ void EventPublisherPlugin::fire(const EventContextRef& ec, EventTime time) {
       fireCallback(subscription, ec);
     }
   }
+}
+
+uint64_t EventPublisherPlugin::getTime() const {
+  return getUnixTime();
 }
 
 void EventPublisherPlugin::configure() {}

--- a/osquery/events/eventpublisherplugin.h
+++ b/osquery/events/eventpublisherplugin.h
@@ -142,6 +142,9 @@ class EventPublisherPlugin : public Plugin,
   virtual void fireCallback(const SubscriptionRef& sub,
                             const EventContextRef& ec) const = 0;
 
+  /// Return the current time (included to assist testing).
+  virtual uint64_t getTime() const;
+
   /// A lock for subscription manipulation.
   mutable Mutex subscription_lock_;
 

--- a/osquery/events/eventsubscriberplugin.h
+++ b/osquery/events/eventsubscriberplugin.h
@@ -114,6 +114,35 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   /// Determine if the subscriber should attempt optmization.
   virtual bool shouldOptimize() const;
 
+  /**
+   * @brief Return all events added by this EventSubscriber within start, stop.
+   *
+   * This is used internally (for the most part) by EventSubscriber::genTable.
+   *
+   * @param callback A callback encapsulating Row yield method.
+   * @param can_optimize If true then optimization can be considered.
+   * @param start_time Inclusive lower bound time limit.
+   * @param end_time Inclusive upper bound time limit.
+   * @return Set of event rows matching time limits.
+   */
+  void generateRows(std::function<void(Row)> callback,
+                    bool can_optimize,
+                    EventTime start_time,
+                    EventTime stop_stop);
+
+  /// Track a query execution.
+  virtual void setExecutedQuery(const std::string& query_name,
+                                uint64_t query_time);
+
+  /// Set the number of queries in the schedule using this subscriber.
+  void resetQueryCount(size_t count);
+
+  /// Return the smallest expiry window based on the query schedule.
+  size_t getMinExpiry();
+
+  /// Return either the current time or the oldest optimized time.
+  uint64_t getExpireTime();
+
  public:
   /**
    * @brief A single instance requirement for static callback facilities.
@@ -140,22 +169,6 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    */
   virtual void genTable(RowYield& yield, QueryContext& ctx) USED_SYMBOL;
 
-  /**
-   * @brief Return all events added by this EventSubscriber within start, stop.
-   *
-   * This is used internally (for the most part) by EventSubscriber::genTable.
-   *
-   * @param db_interface A database interface.
-   * @param callback A callback encapsulating Row yield method.
-   * @param start_time Inclusive lower bound time limit.
-   * @param end_time Inclusive upper bound time limit.
-   * @return Set of event rows matching time limits.
-   */
-  void generateRows(IDatabaseInterface& db_interface,
-                    std::function<void(Row)> callback,
-                    EventTime start_time,
-                    EventTime stop_stop);
-
   /// Number of Subscription%s this EventSubscriber has used.
   size_t numSubscriptions() const;
 
@@ -164,9 +177,6 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
   /// Compare the number of queries run against the queries configured.
   virtual bool executedAllQueries() const;
-
-  /// Track a query execution.
-  virtual void setExecutedQuery(const std::string& query_name);
 
   struct Context final {
     std::string database_namespace;
@@ -246,11 +256,20 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   /// See getType for lookup rational.
   virtual const std::string dbNamespace() const;
 
+  /// Return the current time (included to assist testing).
+  virtual uint64_t getTime() const;
+
+  /// Return the backing storage (included to assist testing).
+  virtual IDatabaseInterface& getDatabase() const;
+
   /// Get a handle to the EventPublisher.
   EventPublisherRef getPublisher() const;
 
   /// Remove all subscriptions from this subscriber.
   void removeSubscriptions();
+
+  /// Set the subscriber type and name on the managed context.
+  void setDatabaseNamespace();
 
   /// A helper value counting the number of fired events tracked by publishers.
   EventContextID event_count_{0};
@@ -263,9 +282,6 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
   /// Do not respond to periodic/scheduled/triggered event expiration requests.
   bool expire_events_{true};
-
-  /// When the last query hit this subscriber
-  std::size_t last_query_time_{};
 
   /**
    * @brief Optimize subscriber selects by tracking the last select time.
@@ -292,7 +308,7 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   std::atomic<size_t> query_count_{0};
 
   /// Set of queries that have used this subscriber table.
-  std::set<std::string> queries_;
+  std::map<std::string, uint64_t> queries_;
 
   /// Lock used when incrementing the EventID database index.
   Mutex event_id_lock_;
@@ -323,6 +339,8 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
   FRIEND_TEST(EventsTests, test_event_subscriber_configure);
   FRIEND_TEST(EventsTests, test_event_toggle_subscribers);
+  FRIEND_TEST(EventSubscriberPluginTests, getExpireTime);
+  FRIEND_TEST(EventSubscriberPluginTests, generateRowsWithExpiry);
   FRIEND_TEST(EventSubscriberPluginTests, generateRowsWithOptimize);
 
   friend class DBFakeEventSubscriber;

--- a/osquery/events/tests/mockedosquerydatabase.cpp
+++ b/osquery/events/tests/mockedosquerydatabase.cpp
@@ -28,9 +28,10 @@ const Row kBaseRow = {
 extern const std::string kEvents;
 extern const std::string kExecutingQuery;
 
-MockedOsqueryDatabase::MockedOsqueryDatabase() {
+void MockedOsqueryDatabase::generateEvents(const std::string& publisher,
+                                           const std::string& name) {
   EventSubscriberPlugin::Context context;
-  EventSubscriberPlugin::setDatabaseNamespace(context, "type", "name");
+  EventSubscriberPlugin::setDatabaseNamespace(context, publisher, name);
 
   auto row = kBaseRow;
 
@@ -113,7 +114,7 @@ Status MockedOsqueryDatabase::setDatabaseValue(const std::string& domain,
         key);
   }
 
-  key_map.insert({key, value});
+  key_map[key] = value;
   return Status::success();
 }
 

--- a/osquery/events/tests/mockedosquerydatabase.h
+++ b/osquery/events/tests/mockedosquerydatabase.h
@@ -17,8 +17,10 @@ class MockedOsqueryDatabase final : public IDatabaseInterface {
  public:
   mutable std::map<std::string, std::string> key_map;
 
-  MockedOsqueryDatabase();
+  MockedOsqueryDatabase() = default;
   virtual ~MockedOsqueryDatabase() override = default;
+
+  void generateEvents(const std::string& publisher, const std::string& name);
 
   virtual Status getDatabaseValue(const std::string& domain,
                                   const std::string& key,


### PR DESCRIPTION
This fixes a bug introduced in 4.7.0 where a schedule with multiple queries using the same event subscriber (and an event expiration lower than the maximum interval) would lose events.

Here is an example configuration:

```
{
  "schedule": {
    "query_1": { "query": "select eid from process_events", "interval": 5 },
    "query_2": { "query": "select count(1), '2' from process_events", "interval": 20 },
    "query_3": { "query": "select count(1), '3' from process_events", "interval": 40 }
  }
}
```

And an example invocation of osquery:

```
sudo ./osquery/osqueryd \
  --config_path ./config.json --logger_plugin=stdout \
  --ephemeral --disable_database  --allow_unsafe \
  --nodisable_audit --audit_allow_config --events_expiry=1
```