### PR TITLE
Handle events optimization edge cases

### DIFF
--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -337,7 +337,7 @@ std::string EventSubscriberPlugin::toIndex(std::uint64_t i) {
 
 void EventSubscriberPlugin::setOptimizeData(IDatabaseInterface& db_interface,
                                             EventTime time,
-                                            size_t eid) {
+                                            EventID eid) {
   // Store the optimization time and eid.
   std::string query_name;
   db_interface.getDatabaseValue(
@@ -360,7 +360,7 @@ EventTime EventSubscriberPlugin::timeFromRecord(const std::string& record) {
 
 void EventSubscriberPlugin::getOptimizeData(IDatabaseInterface& db_interface,
                                             EventTime& o_time,
-                                            size_t& o_eid,
+                                            EventID& o_eid,
                                             std::string& query_name) {
   // Read the optimization time for the current executing query.
   db_interface.getDatabaseValue(
@@ -383,7 +383,7 @@ void EventSubscriberPlugin::getOptimizeData(IDatabaseInterface& db_interface,
     db_interface.getDatabaseValue(
         kEvents, "optimize_eid." + query_name, content);
 
-    o_eid = tryTo<std::size_t>(content).takeOr(std::size_t{0});
+    o_eid = tryTo<EventID>(content).takeOr(EventID{0});
   }
 }
 

--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -263,23 +263,25 @@ void EventSubscriberPlugin::generateRows(std::function<void(Row)> callback,
     setExecutedQuery(query_name, start_time);
   }
 
-  auto last = generateRows(this->context,
-                           getDatabase(),
-                           callback,
-                           start_time,
-                           stop_time,
-                           optimize_eid);
+  {
+    auto last = generateRows(this->context,
+                             getDatabase(),
+                             callback,
+                             start_time,
+                             stop_time,
+                             optimize_eid);
+
+    if (can_optimize && shouldOptimize()) {
+      if (last != this->context.event_index.end()) {
+        auto last_eid = last->second.empty() ? 0 : last->second.back();
+        setOptimizeData(getDatabase(), last->first, last_eid);
+      }
+    }
+  }
 
   if (executedAllQueries()) {
     expireEventBatches(
         this->context, getDatabase(), getMinExpiry(), getExpireTime());
-  }
-
-  if (can_optimize && shouldOptimize()) {
-    if (last != this->context.event_index.end()) {
-      auto last_eid = last->second.empty() ? 0 : last->second.back();
-      setOptimizeData(getDatabase(), last->first, last_eid);
-    }
   }
 }
 

--- a/osquery/events/eventsubscriberplugin.h
+++ b/osquery/events/eventsubscriberplugin.h
@@ -230,13 +230,15 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * @param callback A callback encapsulating Row yield method.
    * @param start_time Inclusive lower bound time limit.
    * @param end_time Inclusive upper bound time limit.
-   * @return Set of event rows matching time limits.
+   * @param last_eid (optional) The last visited event id.
+   * @return The upper bound time or 0 if there were no events in the range.
    */
-  static void generateRows(Context& context,
-                           IDatabaseInterface& db_interface,
-                           std::function<void(Row)> callback,
-                           EventTime start_time,
-                           EventTime end_time);
+  static EventIndex::iterator generateRows(Context& context,
+                                           IDatabaseInterface& db_interface,
+                                           std::function<void(Row)> callback,
+                                           EventTime start_time,
+                                           EventTime end_time,
+                                           EventID last_eid = 0);
 
   explicit EventSubscriberPlugin(EventSubscriberPlugin const&) = delete;
   EventSubscriberPlugin& operator=(EventSubscriberPlugin const&) = delete;
@@ -282,24 +284,6 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
   /// Do not respond to periodic/scheduled/triggered event expiration requests.
   bool expire_events_{true};
-
-  /**
-   * @brief Optimize subscriber selects by tracking the last select time.
-   *
-   * Event subscribers may optimize selects when used in a daemon schedule by
-   * requiring an event 'time' constraint and otherwise applying a minimum time
-   * as the last time the scheduled query ran.
-   */
-  EventTime optimize_time_{0};
-
-  /**
-   * @brief Last event ID returned while using events-optimization.
-   *
-   * A time with second precision is not sufficient, but it works for index
-   * retrieval. While sorting using the time optimization, discard events
-   * before or equal to the optimization ID.
-   */
-  size_t optimize_eid_{0};
 
   /// The minimum acceptable expiration, based on the query schedule.
   std::atomic<size_t> min_expiration_{0};

--- a/osquery/events/eventsubscriberplugin.h
+++ b/osquery/events/eventsubscriberplugin.h
@@ -191,13 +191,13 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
   static void setOptimizeData(IDatabaseInterface& db_interface,
                               EventTime time,
-                              size_t eid);
+                              EventID eid);
 
   static EventTime timeFromRecord(const std::string& record);
 
   static void getOptimizeData(IDatabaseInterface& db_interface,
                               EventTime& o_time,
-                              size_t& o_eid,
+                              EventID& o_eid,
                               std::string& query_name);
 
   static EventID generateEventIdentifier(Context& context);

--- a/osquery/events/tests/eventsubscriberplugin.cpp
+++ b/osquery/events/tests/eventsubscriberplugin.cpp
@@ -103,7 +103,7 @@ TEST_F(EventSubscriberPluginTests, getOptimizeData) {
       mocked_database, kEventTime, kEventIdentifier);
 
   EventTime event_time{};
-  std::size_t event_id{};
+  EventID event_id{};
   std::string query_name;
   EventSubscriberPlugin::getOptimizeData(
       mocked_database, event_time, event_id, query_name);
@@ -334,7 +334,7 @@ TEST_F(EventSubscriberPluginTests, generateRowsWithOptimize) {
   EXPECT_EQ(10U, callback_count);
 
   const EventTime event_time{0U};
-  const std::size_t event_id{0U};
+  const EventID event_id{0U};
   subscriber.setOptimizeData(mocked_database, event_time, event_id);
 
   callback_count = 0;

--- a/osquery/events/tests/eventsubscriberplugin.cpp
+++ b/osquery/events/tests/eventsubscriberplugin.cpp
@@ -214,7 +214,7 @@ TEST_F(EventSubscriberPluginTests, generateRows) {
   last = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 2, 1);
   EXPECT_EQ(callback_count, 0U);
-  EXPECT_EQ(last->first, 0U);
+  EXPECT_EQ(last, context.event_index.end());
 
   last = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 0, 0);
@@ -234,7 +234,7 @@ TEST_F(EventSubscriberPluginTests, generateRows) {
   last = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 10, 15);
   EXPECT_EQ(callback_count, 20U);
-  EXPECT_EQ(last->first, 0U);
+  EXPECT_EQ(last, context.event_index.end());
 }
 
 class FakeEventSubscriberPlugin : public EventSubscriberPlugin {

--- a/osquery/events/tests/eventsubscriberplugin.cpp
+++ b/osquery/events/tests/eventsubscriberplugin.cpp
@@ -186,6 +186,9 @@ TEST_F(EventSubscriberPluginTests, expireEventBatches) {
   EventSubscriberPlugin::expireEventBatches(context, mocked_database, 0, 0);
   EXPECT_EQ(context.event_index.size(), 10U);
 
+  EventSubscriberPlugin::expireEventBatches(context, mocked_database, 1, 0);
+  EXPECT_EQ(context.event_index.size(), 10U);
+
   EventSubscriberPlugin::expireEventBatches(context, mocked_database, 1, 5);
   EXPECT_EQ(context.event_index.size(), 5U);
 }
@@ -207,22 +210,31 @@ TEST_F(EventSubscriberPluginTests, generateRows) {
   std::size_t callback_count{0U};
   auto callback = [&callback_count](Row) { ++callback_count; };
 
-  EventSubscriberPlugin::generateRows(context, mocked_database, callback, 2, 1);
+  EventIndex::iterator last;
+  last = EventSubscriberPlugin::generateRows(
+      context, mocked_database, callback, 2, 1);
   EXPECT_EQ(callback_count, 0U);
+  EXPECT_EQ(last->first, 0U);
 
-  EventSubscriberPlugin::generateRows(context, mocked_database, callback, 0, 0);
+  last = EventSubscriberPlugin::generateRows(
+      context, mocked_database, callback, 0, 0);
   EXPECT_EQ(callback_count, 10U);
+  EXPECT_EQ(last->first, 9U);
 
-  EventSubscriberPlugin::generateRows(context, mocked_database, callback, 0, 4);
+  last = EventSubscriberPlugin::generateRows(
+      context, mocked_database, callback, 0, 4);
   EXPECT_EQ(callback_count, 15U);
+  EXPECT_EQ(last->first, 4U);
 
-  EventSubscriberPlugin::generateRows(context, mocked_database, callback, 5, 9);
+  last = EventSubscriberPlugin::generateRows(
+      context, mocked_database, callback, 5, 9);
   EXPECT_EQ(callback_count, 20U);
+  EXPECT_EQ(last->first, 9U);
 
-  EventSubscriberPlugin::generateRows(
+  last = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 10, 15);
-
   EXPECT_EQ(callback_count, 20U);
+  EXPECT_EQ(last->first, 0U);
 }
 
 class FakeEventSubscriberPlugin : public EventSubscriberPlugin {
@@ -326,18 +338,20 @@ TEST_F(EventSubscriberPluginTests, generateRowsWithOptimize) {
   subscriber.setOptimizeData(mocked_database, event_time, event_id);
 
   callback_count = 0;
-  subscriber.setTime(2);
   subscriber.setShouldOptimize(true);
-  subscriber.generateRows(callback, true, 0, 0);
-  EXPECT_EQ(10U, callback_count);
+  subscriber.generateRows(callback, true, 0, 5);
+  EXPECT_EQ(6U, callback_count);
   EXPECT_EQ(1U, subscriber.queries_.size());
-  EXPECT_EQ(1U, subscriber.optimize_time_);
 
   // This should continue from the optimized placement.
   callback_count = 0;
   subscriber.generateRows(callback, true, 0, 0);
+  EXPECT_EQ(4U, callback_count);
+  EXPECT_EQ(1U, subscriber.queries_.size());
+
+  callback_count = 0;
+  subscriber.generateRows(callback, true, 0, 0);
   ASSERT_FALSE(subscriber.executedAllQueries());
-  EXPECT_EQ(9U, callback_count);
-  EXPECT_EQ(1U, subscriber.optimize_time_);
+  EXPECT_EQ(0U, callback_count);
 }
 } // namespace osquery


### PR DESCRIPTION
This is "part 2" of #7055.

The previous fix improved the optimization handling but did not handle an edge case where events would be produced in the same second the last query ended. This had been handled by tracking the "last visited" EventID within a time window.

This PR implements the same "visited" tracking as before.