### PR TITLE
Remove flaky test decorators for python tests

### DIFF
--- a/tools/tests/test_example_queries.py
+++ b/tools/tests/test_example_queries.py
@@ -20,18 +20,15 @@ import utils
 
 
 class ExampleQueryTests(test_base.QueryTester):
-    @test_base.flaky
     def test_cross_platform_queries(self):
         self._execute_set(PLATFORM_EXAMPLES["specs"])
 
-    @test_base.flaky
     def test_platform_specific_queries(self):
         posix = ["darwin", "linux"]
         if utils.platform() in posix:
             self._execute_set(PLATFORM_EXAMPLES["posix"])
         self._execute_set(PLATFORM_EXAMPLES[utils.platform()])
 
-    @test_base.flaky
     def test_utility_queries(self):
         self._execute_set(PLATFORM_EXAMPLES["utility"])
 

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -25,8 +25,7 @@ EXTENSION_TIMEOUT = 10
 
 
 class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
-
-    def test_1_daemon_without_extensions(self):
+    def test_daemon_without_extensions(self):
         # Start the daemon without thrift, prefer no watchdog because the tests
         # kill the daemon very quickly.
         daemon = self._run_daemon({
@@ -40,8 +39,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertFalse(client.open())
         daemon.kill()
 
-    @test_base.flaky
-    def test_2_daemon_api(self):
+    def test_daemon_api(self):
         daemon = self._run_daemon({"disable_watchdog": True})
         self.assertTrue(daemon.isAlive())
 
@@ -72,8 +70,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill()
 
-    @test_base.flaky
-    def test_3_example_extension(self):
+    def test_example_extension(self):
         daemon = self._run_daemon({"disable_watchdog": True})
         self.assertTrue(daemon.isAlive())
 
@@ -137,8 +134,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         extension.kill()
         daemon.kill()
 
-    @test_base.flaky
-    def test_4_extension_dies(self):
+    def test_extension_dies(self):
         daemon = self._run_daemon({
             "disable_watchdog": True,
             "extensions_interval": "0",
@@ -191,8 +187,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         # The extension should tear down as well
         self.assertTrue(extension.isDead(extension.pid))
 
-    @test_base.flaky
-    def test_5_extension_timeout(self):
+    def test_extension_timeout(self):
         # Start an extension without a daemon, with a timeout.
         extension = self._run_extension(timeout=EXTENSION_TIMEOUT)
         self.assertTrue(extension.isAlive())
@@ -219,8 +214,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         daemon.kill(True)
         extension.kill()
 
-    @test_base.flaky
-    def test_6_extensions_autoload(self):
+    def test_extensions_autoload(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
@@ -242,8 +236,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @test_base.flaky
-    def test_6_extensions_directory_autoload(self):
+    def test_extensions_directory_autoload(self):
         utils.copy_file(test_base.ARGS.build + "/osquery/example_extension.ext",
             test_base.CONFIG_DIR)
         loader = test_base.Autoloader([test_base.CONFIG_DIR])
@@ -266,8 +259,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @test_base.flaky
-    def test_7_extensions_autoload_watchdog(self):
+    def test_extensions_autoload_watchdog(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
@@ -288,8 +280,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @test_base.flaky
-    def test_8_external_config(self):
+    def test_external_config(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
@@ -312,8 +303,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @test_base.flaky
-    def test_9_external_config_update(self):
+    def test_external_config_update(self):
         # Start an extension without a daemon, with a timeout.
         extension = self._run_extension(timeout=EXTENSION_TIMEOUT)
         self.assertTrue(extension.isAlive())
@@ -360,8 +350,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         extension.kill()
         daemon.kill()
 
-    @test_base.flaky
-    def test_91_extensions_settings(self):
+    def test_extensions_settings(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -19,8 +19,7 @@ import test_base
 
 
 class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
-    @test_base.flaky
-    def test_1_daemon_without_watchdog(self):
+    def test_daemon_without_watchdog(self):
         daemon = self._run_daemon({
             "disable_watchdog": True,
             "disable_extensions": True,
@@ -28,8 +27,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(daemon.isAlive())
         daemon.kill()
 
-    @test_base.flaky
-    def test_2_daemon_with_option(self):
+    def test_daemon_with_option(self):
         logger_path = test_base.getTestDirectory(test_base.TEMP_DIR)
         daemon = self._run_daemon(
             {
@@ -64,8 +62,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(len(data) > 0)
         daemon.kill()
 
-    @test_base.flaky
-    def test_3_daemon_with_watchdog(self):
+    def test_daemon_with_watchdog(self):
         # This test does not join the service threads properly (waits for int).
         if os.environ.get('SANITIZE') is not None:
             return
@@ -87,8 +84,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         # dies when the watcher goes away
         self.assertTrue(daemon.isDead(children[0]))
 
-    @test_base.flaky
-    def test_3_daemon_lost_worker(self):
+    def test_daemon_lost_worker(self):
         # Test that killed workers are respawned by the watcher
         if os.environ.get('SANITIZE') is not None:
             return
@@ -118,8 +114,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         children = daemon.getChildren()
         self.assertTrue(len(children) > 0)
 
-    @test_base.flaky
-    def test_4_daemon_sighup(self):
+    def test_daemon_sighup(self):
         # A hangup signal should not do anything to the daemon.
         daemon = self._run_daemon({
             "disable_watchdog": True,
@@ -131,8 +126,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         os.kill(daemon.proc.pid, sig)
         self.assertTrue(daemon.isAlive())
 
-    @test_base.flaky
-    def test_5_daemon_sigint(self):
+    def test_daemon_sigint(self):
         # An interrupt signal will cause the daemon to stop.
         daemon = self._run_daemon({
             "disable_watchdog": True,
@@ -148,8 +142,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         if os.name != "nt":
             self.assertEqual(daemon.retcode, 0)
 
-    @test_base.flaky
-    def test_6_logger_mode(self):
+    def test_logger_mode(self):
         logger_path = test_base.getTestDirectory(test_base.TEMP_DIR)
         test_mode = 0o754  # Strange mode that should never exist
         daemon = self._run_daemon(
@@ -194,7 +187,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
         daemon.kill()
 
-    def test_7_logger_stdout(self):
+    def test_logger_stdout(self):
         logger_path = test_base.getTestDirectory(test_base.TEMP_DIR)
         daemon = self._run_daemon({
             "disable_watchdog": True,
@@ -216,7 +209,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(pathDoesntExist())
         daemon.kill()
 
-    def test_8_hostid_uuid(self):
+    def test_hostid_uuid(self):
         # Test added to test using UUID as hostname ident for issue #3195
         daemon = self._run_daemon({
             "disable_watchdog": True,
@@ -230,7 +223,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(daemon.isAlive())
         daemon.kill()
 
-    def test_9_hostid_instance(self):
+    def test_hostid_instance(self):
         daemon = self._run_daemon({
             "disable_watchdog": True,
             "disable_extensions": True,

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -27,7 +27,6 @@ def allowed_platform(qp):
 
 
 class ReleaseTests(test_base.QueryTester):
-    @test_base.flaky
     def test_pack_queries(self):
         packs = {}
         PACKS_DIR = SOURCE_DIR + "/packs"

--- a/tools/tests/test_windows_service.py
+++ b/tools/tests/test_windows_service.py
@@ -281,8 +281,7 @@ class OsquerydTest(unittest.TestCase):
         except subprocess.CalledProcessError:
             return ('', '')
 
-    @test_base.flaky
-    def test_1_install_run_stop_uninstall_windows_service(self):
+    def test_install_run_stop_uninstall_windows_service(self):
         name = 'osqueryd_test_{}'.format(self.test_instance)
         code, _ = installService(name, self.bin_path)
         self.assertEqual(code, 0)
@@ -323,8 +322,7 @@ class OsquerydTest(unittest.TestCase):
         code, _ = queryService(name)
         self.assertEqual(code, 1060)
 
-    @test_base.flaky
-    def test_2_thrash_windows_service(self):
+    def test_thrash_windows_service(self):
         # Install the service
         name = 'osqueryd_test_{}'.format(self.test_instance)
         code, _ = installService(name, self.bin_path)
@@ -375,4 +373,3 @@ if __name__ == '__main__':
     assertUserIsAdmin()
     with test_base.CleanChildProcesses():
         test_base.Tester().run()
-    unittest.main()


### PR DESCRIPTION
We should try to remove the flakiness from tests instead of marking them as flaky and attempting to retry.