### PR TITLE
Add more tests for events expiration

### DIFF
--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -342,14 +342,16 @@ void EventFactory::configUpdate() {
 
     RecursiveLock lock(ef.factory_lock_);
     auto subscriber = ef.getEventSubscriber(details.first);
-    subscriber->min_expiration_ = details.second.max_interval * 3;
-    subscriber->min_expiration_ += (60 - (subscriber->min_expiration_ % 60));
+    auto min_expiry = details.second.max_interval * 3;
+    min_expiry += (60 - (min_expiry % 60));
+    subscriber->setMinExpiry(min_expiry);
 
     // Emit a warning for each subscriber affected by the small expiration.
     auto expiry = subscriber->getEventsExpiry();
-    if (expiry > 0 && subscriber->min_expiration_ > expiry) {
-      LOG(INFO) << "Subscriber expiration is too low: "
-                << subscriber->getName();
+    if (expiry > 0 && min_expiry > expiry) {
+      LOG(INFO) << "The minimum events expiration timeout for "
+                << subscriber->getName()
+                << " has been adjusted: " << min_expiry;
     }
     subscriber->resetQueryCount(details.second.query_count);
   }

--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -233,6 +233,10 @@ size_t EventSubscriberPlugin::getMinExpiry() {
   return expiry;
 }
 
+void EventSubscriberPlugin::setMinExpiry(size_t expiry) {
+  min_expiration_ = expiry;
+}
+
 uint64_t EventSubscriberPlugin::getExpireTime() {
   if (query_count_ == 0) {
     return getTime();

--- a/osquery/events/eventsubscriberplugin.h
+++ b/osquery/events/eventsubscriberplugin.h
@@ -140,6 +140,9 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   /// Return the smallest expiry window based on the query schedule.
   size_t getMinExpiry();
 
+  /// Set a minimum expiration windows based on the query schedule.
+  void setMinExpiry(size_t expiry);
+
   /// Return either the current time or the oldest optimized time.
   uint64_t getExpireTime();
 
@@ -324,6 +327,7 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   FRIEND_TEST(EventsTests, test_event_subscriber_configure);
   FRIEND_TEST(EventsTests, test_event_toggle_subscribers);
   FRIEND_TEST(EventSubscriberPluginTests, getExpireTime);
+  FRIEND_TEST(EventSubscriberPluginTests, getEventsExpiry);
   FRIEND_TEST(EventSubscriberPluginTests, generateRowsWithExpiry);
   FRIEND_TEST(EventSubscriberPluginTests, generateRowsWithOptimize);
 


### PR DESCRIPTION
This adds more tests for event subscribers. Specifically, this tests when a "minimum expiration" is needed. In these cases there are multiple queries in the schedule with different intervals. The minimum expiration assures that all queries have run before any event is expired.