### PR TITLE
Restore thrift socket 5min timeout

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -182,7 +182,7 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
     if (socketExists(path)) {
       try {
         // Create a client with a 10-second receive timeout.
-        ExtensionManagerClient client(path, 10 * 1000);
+        ExtensionManagerClient client(path, 10);
         auto status = client.ping();
         return Status::success();
       } catch (const std::exception& /* e */) {

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -32,8 +32,6 @@
 
 #include "osquery/extensions/interface.h"
 
-#include <limits>
-
 #include <boost/chrono/include.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/lock_types.hpp>
@@ -42,6 +40,7 @@
 namespace osquery {
 
 FLAG(bool, thrift_verbose, false, "Enable the thrift log handler");
+FLAG(uint32, thrift_timeout, 300, "Timeout for thrift socket operations");
 
 using namespace apache::thrift;
 using namespace apache::thrift::protocol;
@@ -400,9 +399,6 @@ void ExtensionClientCore::init(const std::string& path, bool manager) {
 
   client_ = std::make_unique<ImplExtensionClient>();
   client_->socket = std::make_shared<TPlatformSocket>(path);
-#ifndef WIN32
-  client_->socket->setMaxRecvRetries(std::numeric_limits<int>::max());
-#endif
   client_->transport = std::make_shared<TBufferedTransport>(client_->socket);
   auto protocol = std::make_shared<TBinaryProtocol>(client_->transport);
 
@@ -427,8 +423,8 @@ ExtensionClientCore::~ExtensionClientCore() {
 void ExtensionClientCore::setTimeouts(size_t timeouts) {
 #if !defined(WIN32)
   // Windows TPipe does not support timeouts.
-  client_->socket->setRecvTimeout(timeouts);
-  client_->socket->setSendTimeout(timeouts);
+  client_->socket->setRecvTimeout(timeouts * 1000);
+  client_->socket->setSendTimeout(timeouts * 1000);
 #endif
 }
 
@@ -438,13 +434,13 @@ bool ExtensionClientCore::manager() {
 
 ExtensionClient::ExtensionClient(const std::string& path, size_t timeout) {
   init(path, false);
-  setTimeouts(timeout);
+  setTimeouts(timeout == 0 ? FLAGS_thrift_timeout : timeout);
 }
 
 ExtensionManagerClient::ExtensionManagerClient(const std::string& path,
                                                size_t timeout) {
   init(path, true);
-  setTimeouts(timeout);
+  setTimeouts(timeout == 0 ? FLAGS_thrift_timeout : timeout);
 }
 
 Status ExtensionClient::ping() {

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -322,7 +322,7 @@ class ExtensionClientCore : private boost::noncopyable {
    */
   void init(const std::string& path, bool manager = false);
 
-  /// Set the receive and send timeout.
+  /// Set the receive and send timeout in seconds.
   void setTimeouts(size_t timeout);
 
   /// Check if the client is an extension manager.
@@ -348,9 +348,9 @@ class ExtensionClient : public ExtensionClientCore, public ExtensionAPI {
    * @note The default timeout to wait for buffered (whole-content) responses
    * is 5 minutes.
    * @param path This is the socket path for the client communication.
-   * @param timeout [optional] time in milliseconds to wait for input.
+   * @param timeout [optional] time in seconds to wait for input.
    */
-  explicit ExtensionClient(const std::string& path, size_t timeout = 5000 * 60);
+  explicit ExtensionClient(const std::string& path, size_t timeout = 0);
   ~ExtensionClient();
 
  protected:
@@ -378,10 +378,9 @@ class ExtensionManagerClient : public ExtensionClient,
    * @brief Create a client to a manager extension.
    *
    * @param path This is the socket path for the manager communication.
-   * @param timeout [optional] time in milliseconds to wait for input.
+   * @param timeout [optional] time in seconds to wait for input.
    */
-  explicit ExtensionManagerClient(const std::string& path,
-                                  size_t timeout = 5000 * 60);
+  explicit ExtensionManagerClient(const std::string& path, size_t timeout = 0);
   ~ExtensionManagerClient();
 
  public:


### PR DESCRIPTION
We used to apply a timeout of 5minutes to thrift requests (and 10s for pings). This was unintentionally disabled when we added nearly infinite retries. The retry was added to mitigate what we handle with our patches to thrift to prevent erroring when an interrupt occurs.