### PR TITLE
Fix extensions crash on shutdown

### DIFF
--- a/docs/wiki/development/osquery-sdk.md
+++ b/docs/wiki/development/osquery-sdk.md
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();
-  return 0;
+  return runner.shutdown(0);
 }
 ```
 

--- a/external/examples/config_plugin/main.cpp
+++ b/external/examples/config_plugin/main.cpp
@@ -39,5 +39,5 @@ int main(int argc, char* argv[]) {
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();
-  return 0;
+  return runner.shutdown(0);
 }

--- a/external/examples/read_only_table/main.cpp
+++ b/external/examples/read_only_table/main.cpp
@@ -48,5 +48,5 @@ int main(int argc, char* argv[]) {
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();
-  return 0;
+  return runner.shutdown(0);
 }

--- a/external/examples/writable_table/main.cpp
+++ b/external/examples/writable_table/main.cpp
@@ -306,5 +306,5 @@ int main(int argc, char* argv[]) {
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();
-  return 0;
+  return runner.shutdown(0);
 }

--- a/tools/codegen/templates/osquery_extension_group_main.cpp.in
+++ b/tools/codegen/templates/osquery_extension_group_main.cpp.in
@@ -27,5 +27,5 @@ int main(int argc, char* argv[]) {
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();
-  return 0;
+  return runner.shutdown(0);
 }


### PR DESCRIPTION
The crash was happening due to the ExtensionWatcher thread still running
and attempting to call the watch() function,
while the extension was exiting.

Use the Initializer::shutdown() function so that all threads/services are stopped before
exiting.

Also update the documentation with the example extension.