### PR TITLE
Improve speed of osquery shutdown procedure

### DIFF
--- a/osquery/core/shutdown.cpp
+++ b/osquery/core/shutdown.cpp
@@ -53,6 +53,12 @@ void waitForShutdown() {
       lock, [] { return (kShutdownData.requested) ? true : false; });
 }
 
+bool waitTimeoutOrShutdown(std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(kShutdownData.request_mutex);
+  return kShutdownData.request_signal.wait_for(
+      lock, timeout, [] { return kShutdownData.requested.load(); });
+}
+
 void requestShutdown(int retcode) {
   static std::once_flag thrown;
   std::call_once(thrown, [&retcode]() {

--- a/osquery/core/shutdown.h
+++ b/osquery/core/shutdown.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <csignal>
 #include <string>
 
@@ -38,6 +39,15 @@ void setShutdownExitCode(int retcode);
  * This method should be called before Initializer::shutdown.
  */
 void waitForShutdown();
+
+/**
+ * @brief Wait either the timeout or until a #requestShutdown is issued.
+ *
+ * This method is meant to provide a sleep interruptible by the shutdown
+ * procedure. Especially useful when having to do long sleeps during retries,
+ * like during an enrollment failure.
+ */
+bool waitTimeoutOrShutdown(std::chrono::milliseconds timeout);
 
 /**
  * @brief Check if something has requested a shutdown.

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -267,7 +267,7 @@ void SchedulerRunner::start() {
   }
 
   // Scheduler ended.
-  if (!interrupted()) {
+  if (!interrupted() && request_shutdown_on_expiration) {
     LOG(INFO) << "The scheduler ended after " << timeout_ << " seconds";
     requestShutdown();
   }

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -70,6 +70,11 @@ class SchedulerRunner : public InternalRunnable {
   std::chrono::milliseconds time_drift_;
 
   const std::chrono::milliseconds max_time_drift_;
+
+  /// Tests should not always trigger a shutdown when the scheduler expires,
+  /// so let tests decide when this should happen.
+  FRIEND_TEST(TLSConfigTests, test_runner_and_scheduler);
+  bool request_shutdown_on_expiration{true};
 };
 
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query);
@@ -79,4 +84,4 @@ void startScheduler();
 
 /// Helper scheduler start with variable settings for testing.
 void startScheduler(unsigned long int timeout, size_t interval);
-}
+} // namespace osquery

--- a/plugins/config/tests/tls_config_tests.cpp
+++ b/plugins/config/tests/tls_config_tests.cpp
@@ -113,8 +113,12 @@ TEST_F(TLSConfigTests, test_runner_and_scheduler) {
   Config::get().load();
 
   // Start a scheduler runner for 3 seconds.
-  ASSERT_TRUE(
-      Dispatcher::addService(std::make_shared<SchedulerRunner>(1, 1)).ok());
+  {
+    auto scheduler_runner = std::make_shared<SchedulerRunner>(1, 1);
+    scheduler_runner->request_shutdown_on_expiration = false;
+
+    ASSERT_TRUE(Dispatcher::addService(scheduler_runner).ok());
+  }
   // Reload our instance config.
   ASSERT_TRUE(Config::get().load().ok());
 


### PR DESCRIPTION
Make the quadratic backoff sleep during the enrollment retry procedure
interruptible by the shutdown.
Same for TLS requests retries.

Avoid any subsequent attempt to enroll during the shutdown procedure.

This partially addresses #7068 
