### PR TITLE
Remove duplicated osquery_utils_aws_tests-test

### DIFF
--- a/osquery/utils/azure/CMakeLists.txt
+++ b/osquery/utils/azure/CMakeLists.txt
@@ -27,13 +27,6 @@ function(generateOsqueryUtilsAzure)
   )
 
   generateIncludeNamespace(osquery_utils_azure "osquery/utils/azure" "FILE_ONLY" ${public_header_files})
-
-  add_test(NAME osquery_utils_aws_tests-test COMMAND osquery_utils_aws_tests-test)
-
-  set_tests_properties(
-    osquery_utils_aws_tests-test
-    PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
-  )
 endfunction()
 
 osqueryUtilsAzureMain()


### PR DESCRIPTION
The test osquery_utils_aws_tests-test has been incorrectly duplicated
into the osquery_utils_azure context.