### PR TITLE
Alternate check for packageIdentifiers key

### DIFF
--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -471,9 +471,9 @@ void genPkgInstallHistoryEntry(const pt::ptree& entry, QueryData& results) {
   // some packages do not set packageIdentifiers, allow it to be
   // empty. Empirically this seems to be os packages, but we can't
   // assume that.
-  if (const auto& identifiers =
-          entry.get_child_optional("packageIdentifiers")) {
-    for (const auto& package_identifier : *identifiers) {
+  auto it = entry.find("packageIdentifiers");
+  if (it != entry.not_found()) {
+    for (const auto& package_identifier : *it) {
       r["package_id"] = package_identifier.second.get<std::string>("");
       results.push_back(r);
     }

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -473,7 +473,7 @@ void genPkgInstallHistoryEntry(const pt::ptree& entry, QueryData& results) {
   // assume that.
   auto it = entry.find("packageIdentifiers");
   if (it != entry.not_found()) {
-    for (const auto& package_identifier : *it) {
+    for (const auto& package_identifier : it) {
       r["package_id"] = package_identifier.second.get<std::string>("");
       results.push_back(r);
     }

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -473,7 +473,7 @@ void genPkgInstallHistoryEntry(const pt::ptree& entry, QueryData& results) {
   // assume that.
   auto it = entry.find("packageIdentifiers");
   if (it != entry.not_found()) {
-    for (const auto& package_identifier : it) {
+    for (const auto& package_identifier : it->second) {
       r["package_id"] = package_identifier.second.get<std::string>("");
       results.push_back(r);
     }


### PR DESCRIPTION
I am confused as to why this sometimes throws an exception of type `boost::wrapexcept<boost::property_tree::ptree_bad_path>: No such node (packageIdentifiers)` with the `get_child_optional` API. I am trying an alternative.