### PR TITLE
Watchdog should wait for the worker to shutdown

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -115,7 +115,7 @@ CLI_FLAG(bool, daemonize, false, "Attempt to daemonize (POSIX only)");
 CLI_FLAG(uint64,
          alarm_timeout,
          15,
-         "Seconds to wait for a graceful shutdown. Minimum is 4");
+         "Seconds to allow for shutdown. Minimum is 10");
 
 FLAG(bool, ephemeral, false, "Skip pidfile and database state checks");
 
@@ -706,4 +706,4 @@ void Initializer::shutdownNow(int retcode) {
   platformTeardown();
   _Exit(retcode);
 }
-}
+} // namespace osquery

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -112,7 +112,10 @@ DECLARE_bool(enable_numeric_monitoring);
 CLI_FLAG(bool, S, false, "Run as a shell process");
 CLI_FLAG(bool, D, false, "Run as a daemon process");
 CLI_FLAG(bool, daemonize, false, "Attempt to daemonize (POSIX only)");
-CLI_FLAG(uint64, alarm_timeout, 4, "Seconds to wait for a graceful shutdown");
+CLI_FLAG(uint64,
+         alarm_timeout,
+         15,
+         "Seconds to wait for a graceful shutdown. Minimum is 4");
 
 FLAG(bool, ephemeral, false, "Skip pidfile and database state checks");
 
@@ -160,7 +163,19 @@ void signalHandler(int num) {
 
   Initializer::requestShutdown(rc);
 }
+
+bool validateAlarmTimeout(const char* flagname, std::uint64_t value) {
+  if (value < 10) {
+    osquery::systemLog("Alarm timeout cannot be lower than 10 seconds");
+    std::cerr << "Alarm timeout cannot be lower than 10 seconds" << std::endl;
+    return false;
+  }
+
+  return true;
+}
 } // namespace
+
+DEFINE_validator(alarm_timeout, &validateAlarmTimeout);
 
 static inline void printUsage(const std::string& binary, ToolType tool) {
   // Parse help options before gflags. Only display osquery-related options.

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -51,6 +51,7 @@
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
 #include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/data_logger.h>
 #include <osquery/logger/logger.h>
 #include <osquery/process/process.h>
 #include <osquery/sql/sql.h>
@@ -58,10 +59,10 @@
 #ifdef WIN32
 #include "osquery/core/windows/wmi.h"
 #endif
-#include "osquery/utils/info/tool_type.h"
-#include "osquery/utils/info/platform_type.h"
-#include "osquery/utils/conversions/tryto.h"
 #include "osquery/utils/config/default_paths.h"
+#include "osquery/utils/conversions/tryto.h"
+#include "osquery/utils/info/platform_type.h"
+#include "osquery/utils/info/tool_type.h"
 #ifdef WIN32
 #include <osquery/utils/conversions/windows/strings.h>
 #endif
@@ -377,14 +378,13 @@ Status createPidFile() {
   return status;
 }
 
-bool PlatformProcess::cleanup() const {
+bool PlatformProcess::cleanup(std::chrono::milliseconds timeout) const {
   if (!isValid()) {
     return false;
   }
 
   size_t delay = 0;
-  auto timeout = (FLAGS_alarm_timeout + 1) * 1000;
-  while (delay < timeout) {
+  while (delay < static_cast<size_t>(timeout.count())) {
     int status = 0;
     if (checkStatus(status) == PROCESS_EXITED) {
       return true;

--- a/osquery/distributed/CMakeLists.txt
+++ b/osquery/distributed/CMakeLists.txt
@@ -18,6 +18,8 @@ function(generateOsqueryDistributed)
     distributed.cpp
   )
 
+  enableLinkWholeArchive(osquery_distributed)
+
   target_link_libraries(osquery_distributed PUBLIC
     osquery_cxx_settings
     osquery_core

--- a/osquery/process/process.h
+++ b/osquery/process/process.h
@@ -119,7 +119,7 @@ class PlatformProcess : private boost::noncopyable {
    *
    * @return true if the process was cleaned, otherwise false.
    */
-  bool cleanup() const;
+  bool cleanup(std::chrono::milliseconds timeout) const;
 
   /// Returns whether the PlatformProcess object is valid
   bool isValid() const {

--- a/osquery/worker/ipc/linux/linux_table_container_ipc.cpp
+++ b/osquery/worker/ipc/linux/linux_table_container_ipc.cpp
@@ -247,7 +247,7 @@ void LinuxTableContainerIPC::stopContainerWorker() {
                    << " did not stop in a timely fashion, so it will be "
                       "forcefully terminated";
         process.kill();
-        process.cleanup();
+        process.cleanup(max_delay);
       }
     };
 


### PR DESCRIPTION
- Wait for the worker to shutdown
- Increase the default alarm timeout to 15 seconds, but limit the minimum to 10
- Stop extensions and the worker in parallel, so that the time it takes
  to stop them doesn't always fully add up.

Fixes https://github.com/osquery/osquery/issues/7073

The alarm timeout has been increased to a default of 15 seconds which is ample time and should be below the most common services timeout for each platform (last time I checked 20 seconds are the timeout for macOS, other platforms have more).

The minimum limit of 10 seconds is to give some breathing space for the processes to close, especially the worker if it's processing some query. With that limit the worker would actually have 6 seconds to close gracefully and 2 to close brutally/via SIGKILL.
I think that in general to avoid corruption of the DB it's better to leave some time so that the processes can close gracefully.
