### PR TITLE
Update `homebrew_packages` to include new prefix and allows specifying alternate prefixes

### DIFF
--- a/specs/darwin/homebrew_packages.table
+++ b/specs/darwin/homebrew_packages.table
@@ -4,6 +4,7 @@ schema([
     Column("name", TEXT, "Package name"),
     Column("path", TEXT, "Package install path"),
     Column("version", TEXT, "Current 'linked' version"),
+    Column("prefix", TEXT, "Homebrew install prefix", hidden=True, additional=True),
 ])
 attributes(cacheable=True)
 implementation("system/homebrew_packages@genHomebrewPackages")


### PR DESCRIPTION
Update the `homebrew_packages` to search in both of homebrew's default locations. As well as to allow the caller to specify the `prefix` to search.

There's a lot of `fs::path` and back to strings and back again here. But a lot of that seems to pre-exist. 

Fixes: #7108

