### PR TITLE
chrome_extensions: Compute the identifier from the 'key' property

### DIFF
--- a/osquery/tables/applications/chrome/chrome_extensions.cpp
+++ b/osquery/tables/applications/chrome/chrome_extensions.cpp
@@ -90,8 +90,15 @@ QueryData genChromeExtensions(QueryContext& context) {
 
       row["install_timestamp"] = BIGINT(converted_timestamp);
 
-      row["identifier"] =
-          SQL_TEXT(getExtensionProfileSettingsValue(extension, "identifier"));
+      row["referenced_identifier"] = SQL_TEXT(
+          getExtensionProfileSettingsValue(extension, "referenced_identifier"));
+
+      if (extension.opt_computed_identifier.has_value()) {
+        const auto& computed_identifier = *extension.opt_computed_identifier;
+        row["identifier"] = SQL_TEXT(computed_identifier);
+      } else {
+        row["identifier"] = SQL_TEXT("");
+      }
 
       // This column has been deprecated and is marked as hidden. It will
       // be removed in a future version

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -15,6 +15,8 @@
 #include <osquery/logger/logger.h>
 #include <osquery/tables/applications/chrome/utils.h>
 #include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/base64.h>
+#include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/info/platform_type.h>
 
 namespace osquery {
@@ -137,6 +139,8 @@ const ExtensionPropertyMap kExtensionPropertyList = {
     {ExtensionProperty::Type::StringArray,
      "optional_permissions",
      "optional_permissions"},
+
+    {ExtensionProperty::Type::String, "key", "key"},
 };
 
 /// Active extension profile settings
@@ -869,7 +873,7 @@ Status getExtensionProfileSettings(
         extension_path);
   }
 
-  profile_settings["identifier"] = extension_id;
+  profile_settings["referenced_identifier"] = extension_id;
 
   for (const auto& property_name : kExtensionProfileSettingsList) {
     const auto& opt_property = extension_obj.get_child_optional(property_name);
@@ -946,6 +950,15 @@ Status getExtensionFromSnapshot(
   std::stringstream stream;
   pt::write_json(stream, parsed_manifest, false);
   output.manifest_json = stream.str();
+
+  // Attempt to compute the real extension identifier
+  auto identifier_exp = computeExtensionIdentifier(output);
+  if (identifier_exp.isError()) {
+    LOG(ERROR) << identifier_exp.getError().getMessage();
+
+  } else {
+    output.opt_computed_identifier = identifier_exp.take();
+  }
 
   extension = std::move(output);
   return Status::success();
@@ -1163,6 +1176,66 @@ std::string getExtensionProfileSettingsValue(
 
   static_cast<void>(succeeded);
   return value;
+}
+
+ExpectedExtensionKey computeExtensionIdentifier(
+    const ChromeProfile::Extension& extension) {
+  auto extension_key_it = extension.properties.find("key");
+  if (extension_key_it == extension.properties.end()) {
+    return ExpectedExtensionKey::failure(
+        ExtensionKeyError::MissingProperty,
+        "The 'key' property is missing from the extension manifest");
+  }
+
+  const auto& encoded_key = extension_key_it->second;
+
+  auto decoded_key = base64::decode(encoded_key);
+  if (decoded_key.empty()) {
+    return ExpectedExtensionKey::failure(
+        ExtensionKeyError::InvalidValue,
+        "The 'key' property of the extension manifest could not be properly "
+        "base64 decoded");
+  }
+
+  auto decoded_key_hash =
+      hashFromBuffer(HASH_TYPE_SHA256, decoded_key.data(), decoded_key.size());
+  if (decoded_key_hash.size() != 64) {
+    return ExpectedExtensionKey::failure(
+        ExtensionKeyError::HashingError,
+        "The 'key' property of the extension manifest could not be properly "
+        "sha256 hashed");
+  }
+
+  auto hash_prefix = decoded_key_hash.substr(0, 32U);
+
+  std::string identifier;
+  identifier.reserve(hash_prefix.size());
+
+  std::string buffer(1, '\x00');
+
+  for (auto c : hash_prefix) {
+    buffer[0] = c;
+
+    auto as_int_exp = tryTo<int>(buffer, 16);
+    if (as_int_exp.isError()) {
+      return ExpectedExtensionKey::failure(
+          ExtensionKeyError::TransformationError,
+          "Failed to transform the 'key' property of the extension manifest");
+    }
+
+    auto as_int = as_int_exp.take();
+
+    auto ascii = 'a' + as_int;
+    if (ascii < 0x61 || ascii > 0x122) {
+      return ExpectedExtensionKey::failure(
+          ExtensionKeyError::TransformationError,
+          "Failed to transform the 'key' property of the extension manifest");
+    }
+
+    identifier.push_back(static_cast<char>(ascii));
+  }
+
+  return ExpectedExtensionKey::success(identifier);
 }
 
 } // namespace tables

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <osquery/core/tables.h>
@@ -118,6 +119,9 @@ struct ChromeProfile final {
 
     /// The 'matches' entries inside 'content_scripts'
     ContentScriptsEntryList content_scripts_matches;
+
+    /// The extension id, computed from the 'key' property
+    boost::optional<std::string> opt_computed_identifier;
   };
 
   /// A list of extensions
@@ -194,6 +198,19 @@ using ExpectedUnixTimestamp = Expected<std::int64_t, ConversionError>;
 
 /// Converts a timestamp from Webkit to Unix format
 ExpectedUnixTimestamp webkitTimeToUnixTimestamp(const std::string& timestamp);
+
+enum class ExtensionKeyError {
+  MissingProperty,
+  InvalidValue,
+  HashingError,
+  TransformationError,
+};
+
+using ExpectedExtensionKey = Expected<std::string, ExtensionKeyError>;
+
+/// Computes the extension id based on the given key
+ExpectedExtensionKey computeExtensionIdentifier(
+    const ChromeProfile::Extension& extension);
 
 } // namespace tables
 

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -6,7 +6,8 @@ schema([
     Column("name", TEXT, "Extension display name"),
     Column("profile", TEXT, "The name of the Chrome profile that contains this extension"),
     Column("profile_path", TEXT, "The profile path"),
-    Column("identifier", TEXT, "Extension identifier (folder name)"),
+    Column("referenced_identifier", TEXT, "Extension identifier, as specified by the preferences file. Empty if the extension is not in the profile."),
+    Column("identifier", TEXT, "Extension identifier, computed from its manifest. Empty in case of error."),
     Column("version", TEXT, "Extension-supplied version"),
     Column("description", TEXT, "Extension-optional description"),
     Column("default_locale", TEXT, "Default locale supported by extension", aliases=["locale"]),
@@ -26,6 +27,7 @@ schema([
     Column("install_time", TEXT, "Extension install time, in its original Webkit format"),
     Column("install_timestamp", BIGINT, "Extension install time, converted to unix time"),
     Column("manifest_json", TEXT, "The manifest file of the extension", hidden=True),
+    Column("key", TEXT, "The extension key, from the manifest file", hidden=True),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/tests/integration/tables/chrome_extensions.cpp
+++ b/tests/integration/tables/chrome_extensions.cpp
@@ -34,6 +34,7 @@ TEST_F(chromeExtensions, test_sanity) {
                            {"profile", NormalType},
                            {"profile_path", NormalType},
                            {"identifier", NormalType},
+                           {"referenced_identifier", NormalType},
                            {"version", NormalType},
                            {"description", NormalType},
                            {"default_locale", NormalType},


### PR DESCRIPTION
## Changes
 - The `identifier` column now contains the identifier built from the `key` property of the extension manifest.
 - The identifier used in the **Preferences**/**Secure Preferences** profile to reference extensions is now stored in the `referenced_identifier` column.

Fixes: #7093