### PR TITLE
Implement infinite enrollment retries

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -236,11 +236,15 @@ The **tls** endpoint path, e.g.: `/api/v1/logger` when using the **tls** logger 
 
 See the **tls**/[remote](../deployment/remote.md) plugin documentation. An enrollment process will be used to allow server-side implemented authentication and identification/authorization. You must provide an endpoint relative to the `--tls_hostname` URI.
 
-`--tls_enroll_max_attempts=3`
+`--tls_enroll_max_attempts=12`
 
-The total number of attempts that will be made to the remote enroll server if a
-request fails. If an attempt fails, it will be retried with exponential
-backoff, up to the max number of attempts set.
+The total number of attempts that will be made to the remote enroll server if a request fails.
+If an attempt fails, it will be retried up to the max number of attempts set, with exponential backoff limited by the flag `--tls_enroll_max_interval`.
+If the flag is set to 0, the amount of attempts will be infinite.
+
+`--tls_enroll_max_interval=600`
+
+Maximum wait time in seconds between enroll retry attempts. This works in conjuction with `--tls_enroll_max_attempts`, and affects both the limited and the infinite attempts case.
 
 `--logger_tls_period=3`
 

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -87,7 +87,8 @@ std::string TLSEnrollPlugin::enroll() {
 
   bool should_shutdown = false;
 
-  for (;;) {
+  while (FLAGS_tls_enroll_max_attempts == 0 ||
+         attempt <= FLAGS_tls_enroll_max_attempts) {
     auto status = requestKey(uri, node_key);
     if (status.ok() || attempt == FLAGS_tls_enroll_max_attempts) {
       break;

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -33,11 +33,12 @@ namespace osquery {
 DECLARE_string(enroll_secret_path);
 DECLARE_bool(disable_enrollment);
 
-CLI_FLAG(uint64,
-         tls_enroll_max_attempts,
-         12,
-         "Number of attempts to retry a TLS enroll request, it used to be the "
-         "same as [config_tls_max_attempts]");
+CLI_FLAG(
+    uint64,
+    tls_enroll_max_attempts,
+    12,
+    "Number of attempts to retry a TLS enroll request; if 0 the attempts "
+    "will be infinite. It used to be the same as [config_tls_max_attempts].");
 
 CLI_FLAG(uint64,
          tls_enroll_max_interval,

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -36,9 +36,8 @@ DECLARE_bool(disable_enrollment);
 CLI_FLAG(uint64,
          tls_enroll_max_attempts,
          12,
-         "The total number of attempts that will be made to the remote enroll "
-         "server if a request fails; if 0 the attempts will be infinite. It "
-         "used to be the same as [config_tls_max_attempts].");
+         "The total number of attempts that will be made to the enroll "
+         "endpoint if a request fails, 0 for infinite");
 
 CLI_FLAG(uint64,
          tls_enroll_max_interval,

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -33,12 +33,12 @@ namespace osquery {
 DECLARE_string(enroll_secret_path);
 DECLARE_bool(disable_enrollment);
 
-CLI_FLAG(
-    uint64,
-    tls_enroll_max_attempts,
-    12,
-    "Number of attempts to retry a TLS enroll request; if 0 the attempts "
-    "will be infinite. It used to be the same as [config_tls_max_attempts].");
+CLI_FLAG(uint64,
+         tls_enroll_max_attempts,
+         12,
+         "The total number of attempts that will be made to the remote enroll "
+         "server if a request fails; if 0 the attempts will be infinite. It "
+         "used to be the same as [config_tls_max_attempts].");
 
 CLI_FLAG(uint64,
          tls_enroll_max_interval,

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -110,7 +110,7 @@ std::string TLSEnrollPlugin::enroll() {
     }
 
     should_shutdown =
-        waitTimeoutOrShutdown(std::chrono::milliseconds(interval * 1000UL));
+        waitTimeoutOrShutdown(std::chrono::milliseconds(interval * 1000));
 
     if (should_shutdown) {
       LOG(WARNING)

--- a/plugins/remote/enroll/tls_enroll.cpp
+++ b/plugins/remote/enroll/tls_enroll.cpp
@@ -35,9 +35,14 @@ DECLARE_bool(disable_enrollment);
 
 CLI_FLAG(uint64,
          tls_enroll_max_attempts,
-         3,
+         12,
          "Number of attempts to retry a TLS enroll request, it used to be the "
          "same as [config_tls_max_attempts]");
+
+CLI_FLAG(uint64,
+         tls_enroll_max_interval,
+         600,
+         "Maximum wait time in seconds between enroll retry attempts");
 
 /// Enrollment TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,
@@ -73,23 +78,43 @@ std::string TLSEnrollPlugin::enroll() {
   }
 
   std::string node_key;
-  bool should_shutdown = false;
   VLOG(1) << "TLSEnrollPlugin requesting a node enroll key from: " << uri;
-  for (size_t i = 1; i <= FLAGS_tls_enroll_max_attempts && !should_shutdown;
-       i++) {
+
+  std::uint64_t attempt = 1;
+  std::uint64_t interval_step = 1;
+  std::uint64_t interval = 0;
+
+  bool should_shutdown = false;
+
+  for (;;) {
     auto status = requestKey(uri, node_key);
-    if (status.ok() || i == FLAGS_tls_enroll_max_attempts) {
+    if (status.ok() || attempt == FLAGS_tls_enroll_max_attempts) {
       break;
     }
+
+    // Increase attempts only if we haven't chosen infinite retries
+    if (FLAGS_tls_enroll_max_attempts > 0) {
+      ++attempt;
+    }
+
     LOG(WARNING) << "Failed enrollment request to " << uri << " ("
                  << status.what() << ") retrying...";
 
-    should_shutdown =
-        waitTimeoutOrShutdown(std::chrono::milliseconds(i * i * 1000));
-  }
+    interval =
+        std::min(interval_step * interval_step, FLAGS_tls_enroll_max_interval);
 
-  if (should_shutdown) {
-    LOG(WARNING) << "Enrollment attempts interrupted due to a shutdown request";
+    if (interval < FLAGS_tls_enroll_max_interval) {
+      ++interval_step;
+    }
+
+    should_shutdown =
+        waitTimeoutOrShutdown(std::chrono::milliseconds(interval * 1000UL));
+
+    if (should_shutdown) {
+      LOG(WARNING)
+          << "Enrollment attempts interrupted due to a shutdown request";
+      break;
+    }
   }
 
   return node_key;


### PR DESCRIPTION
Setting the flag tls_enroll_max_attempts to 0 enables infinite
enrollment retries.
The interval between retries is limited by a new flag,
tls_enroll_max_interval, which defaults to 5 minutes,
so that it doesn't indefinitely increase.
The interval limit works also with limited retries.

Also increased the default attempts number to 12,
to come up to around 10 minutes of retries, at each enrollment round.

Partially implements https://github.com/osquery/osquery/issues/7082