### PR TITLE
Website: Note windows support for yara

### DIFF
--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -38,7 +38,7 @@ from gentable import *
 PLATFORM_DIRS = {
     "specs": ["darwin", "linux", "windows", "freebsd"],
     "utility": ["darwin", "linux", "freebsd", "windows"],
-    "yara": ["darwin", "linux"],
+    "yara": ["darwin", "linux", "windows"],
     "smart": ["darwin", "linux"],
     "darwin": ["darwin"],
     "freebsd": ["freebsd"],


### PR DESCRIPTION
Update the website generation tooling to reflect that the yara table
supports windows.

Relates to: #6564
Closes: https://github.com/osquery/osquery-site/issues/212

