### PR TITLE
Add detection/handling for updated XProtect path in macOS Big Sur

### DIFF
--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -181,7 +181,7 @@ QueryData genXProtectEntries(QueryContext& context) {
 QueryData genXProtectMeta(QueryContext& context) {
   QueryData results;
   pt::ptree tree;
-  bool plistFound;
+  bool plistFound = false;
 
   for (const auto& dir : kPotentialXProtectDirs) {
     auto xprotect_meta = fs::path(dir) / "XProtect.meta.plist";

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -148,7 +148,7 @@ QueryData genXProtectReports(QueryContext& context) {
 }
 
 // returns boolean indicating whether a valid plist was found
-bool findAndParsePlist(fs::path plistPath, pt::ptree& tree) {
+inline bool findAndParsePlist(const fs::path& plistPath, pt::ptree& tree) {
   if (!osquery::pathExists(plistPath).ok()) {
     return false;
   }
@@ -180,8 +180,8 @@ QueryData genXProtectEntries(QueryContext& context) {
     return results;
   }
 
-  // if code execution continues to here, it means no valid plist was found.
-  VLOG(1) << "no valid XProtect.plist found in expected directories";
+  // If code execution continues to here, it means no valid plist was found.
+  VLOG(1) << "No valid XProtect.plist found in expected directories";
   return results;
 }
 
@@ -229,8 +229,8 @@ QueryData genXProtectMeta(QueryContext& context) {
     return results;
   }
 
-  // if code execution continues to here, it means no valid plist was found.
-  VLOG(1) << "no valid XProtect.meta.plist found in expected directories";
+  // If code execution continues to here, it means no valid plist was found.
+  VLOG(1) << "No valid XProtect.meta.plist found in expected directories";
 
   return results;
 }

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -164,7 +164,6 @@ bool findAndParsePlist(fs::path plistPath, pt::ptree& tree) {
 QueryData genXProtectEntries(QueryContext& context) {
   QueryData results;
   pt::ptree tree;
-  bool plistFound = false;
 
   for (const auto& dir : kPotentialXProtectDirs) {
     auto xprotect_path = fs::path(dir) / "XProtect.plist";
@@ -172,25 +171,23 @@ QueryData genXProtectEntries(QueryContext& context) {
     if (!validPlist) {
       continue;
     }
-    plistFound = true;
+
     if (tree.count("root") != 0) {
       for (const auto& it : tree.get_child("root")) {
         genXProtectEntry(it.second, results);
       }
     }
+    return results;
   }
 
-  if (!plistFound) {
-    VLOG(1) << "valid XProtect.plist not found in expected directories";
-  }
-
+  // if code execution continues to here, it means no valid plist was found.
+  VLOG(1) << "no valid XProtect.plist found in expected directories";
   return results;
 }
 
 QueryData genXProtectMeta(QueryContext& context) {
   QueryData results;
   pt::ptree tree;
-  bool plistFound = false;
 
   for (const auto& dir : kPotentialXProtectDirs) {
     auto xprotect_meta = fs::path(dir) / "XProtect.meta.plist";
@@ -198,7 +195,6 @@ QueryData genXProtectMeta(QueryContext& context) {
     if (!validPlist) {
       continue;
     }
-    plistFound = true;
     for (const auto& it : tree) {
       if (it.first == "JavaWebComponentVersionMinimum") {
         Row r;
@@ -230,10 +226,11 @@ QueryData genXProtectMeta(QueryContext& context) {
         }
       }
     }
+    return results;
   }
-  if (!plistFound) {
-    VLOG(1) << "valid XProtect.meta.plist not found in expected directories";
-  }
+
+  // if code execution continues to here, it means no valid plist was found.
+  VLOG(1) << "no valid XProtect.meta.plist found in expected directories";
 
   return results;
 }

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -29,9 +29,9 @@ namespace tables {
 /// the directory containing XProtect.plist and XProtect.meta.plist changes
 /// depending on the macOS version
 const std::vector<std::string> kPotentialXProtectDirs = {
-    "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/",
     "/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/"
     "Resources",
+    "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/",
 };
 
 /// Relative path for each user's logging directory

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -26,6 +26,8 @@ namespace fs = boost::filesystem;
 namespace osquery {
 namespace tables {
 
+/// the directory containing XProtect.plist and XProtect.meta.plist changes
+/// depending on the macOS version
 const std::vector<std::string> kPotentialXProtectDirs = {
     "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/",
     "/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/"


### PR DESCRIPTION
This commit:
 - updates the `xprotect_entries` and `xprotect_meta` tables so that
 they use the updated xprotect paths on macOS Big Sur (11.0 or 10.16)
 and later, while still using the existing paths for 10.15 and lower.

Why?
 - In macOS Big Sur, the location of the XProtect.plist and
 XProtect.meta.plist changed.

Closes #7137