### PR TITLE
pipe_channel not reading all data in a message

### DIFF
--- a/osquery/worker/ipc/posix/pipe_channel.cpp
+++ b/osquery/worker/ipc/posix/pipe_channel.cpp
@@ -113,22 +113,19 @@ Status PipeChannel::recvStringMessageImpl(std::string& message) {
   }
 
   message.resize(static_cast<size_t>(message_size));
-  result = read(read_pipe_fd,
-                reinterpret_cast<char*>(&message[0]),
-                static_cast<size_t>(message_size));
+  ssize_t pos = 0;
+  while (pos < message_size) {
+    result = read(read_pipe_fd,
+                  reinterpret_cast<char*>(&message[pos]),
+                  static_cast<size_t>(message_size - pos));
 
-  if (result < 0) {
-    return Status::failure(
-        errno,
-        "Failed to read the size of the message from the pipe of table " +
-            table_name_ + ", errno " + std::to_string(errno));
-  }
-
-  if (result != message_size) {
-    return Status::failure(
-        "Failed to read the entire message from the pipe of table " +
-        table_name_ + ", read only " + std::to_string(result) + "/" +
-        std::to_string(message_size) + " bytes");
+    if (result < 0) {
+      return Status::failure(
+          errno,
+          "Failed to read the message from the pipe of table " + table_name_ +
+              ", errno " + std::to_string(errno));
+    }
+    pos += result;
   }
 
   return Status::success();

--- a/osquery/worker/ipc/posix/pipe_channel.cpp
+++ b/osquery/worker/ipc/posix/pipe_channel.cpp
@@ -119,6 +119,11 @@ Status PipeChannel::recvStringMessageImpl(std::string& message) {
                   reinterpret_cast<char*>(&message[pos]),
                   static_cast<size_t>(message_size - pos));
 
+    if (result == 0) {
+      return Status::failure(
+          2, "Pipe to the table " + table_name_ + " closed while reading");
+    }
+
     if (result < 0) {
       return Status::failure(
           errno,


### PR DESCRIPTION
When reading data from a table using `generateInNamespace`, the pipe channel implementation would only try one `read` syscall to read the message from the osquery process running in the namespace.  Under certain circumstances, this single read call would be insufficient to read all the data in the message and the query would fail.

Example:
```
# osqueryi --json "SELECT source_table.* FROM deb_packages AS source_table JOIN docker_containers AS dc ON source_table.pid_with_namespace = dc.pid WHERE source_table.pid_with_namespace in (select pid from docker_containers);"
E0604 23:00:14.790307 256479 linux_table_container_ipc.cpp:446] Table deb_packages failed to retrieve QueryData from the container: Failed to read the entire message from the pipe of table deb_packages, read only 64436/113588 bytes
```

This PR fixes this problem by putting the `read` syscall in a loop that continues to read until all data has been returned.

cc @Smjert related to this thread: https://osquery.slack.com/archives/C08V7KTJB/p1621533600027800