### PR TITLE
Trigger event cleanup checks every 256 events

### DIFF
--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -178,8 +178,9 @@ Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
           index_entry.end(), event_id_list.begin(), event_id_list.end());
     }
 
+    cleanup_events = (((event_count_ % kEventsCheckpoint) + row_list.size()) >
+                      kEventsCheckpoint);
     event_count_ += row_list.size();
-    cleanup_events = ((event_count_ % kEventsCheckpoint) == 0U);
   }
 
   // Use the last EventID and a checkpoint bucket size to periodically apply


### PR DESCRIPTION
This is applying the suggestion from Slack here: https://osquery.slack.com/archives/C08V7KTJB/p1622484876086800

In the current code, an event cleanup is triggered sort of randomly when we have counted `% 256 == 0` events. I think the intention is to try to cleanup every checkpoint, meaning each time we collect another batch of 256 events.