### PR TITLE
enable container stats on docker containers that don't have traditional networks

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -898,10 +898,10 @@ QueryData genContainerStats(QueryContext& context) {
           BIGINT(container.get<uint64_t>("memory_stats.max_usage", 0));
       r["memory_limit"] =
           BIGINT(container.get<uint64_t>("memory_stats.limit", 0));
-      r["network_rx_bytes"] =
-          getNetworkBytes(container.get_child("networks"), "rx_bytes");
-      r["network_tx_bytes"] =
-          getNetworkBytes(container.get_child("networks"), "tx_bytes");
+      r["network_rx_bytes"] = getNetworkBytes(
+          container.get_child("networks", pt::ptree()), "rx_bytes");
+      r["network_tx_bytes"] = getNetworkBytes(
+          container.get_child("networks", pt::ptree()), "tx_bytes");
       results.push_back(r);
     } catch (const pt::ptree_error& e) {
       VLOG(1) << "Error getting docker container stats " << id << ": "


### PR DESCRIPTION
docker containers without traditional network config fail to report cpu, memory and storage stats because the code attempts to query net_rx and tx.  This results in a ptree error for the "networks" node not being found:

`Error getting docker container stats 5e27b6a92a3fb7f4988993da46522655ce42242b7930471fc4aa9e437a3bd246: No such node (networks)`

This patch returns an empty ptree as default for the network calls if the node is not found.  This allows you to collect container stats (excluding networking info) on docker containers that don't have traditional network setups.

Thanks for the help @solarkennedy