### PR TITLE
packaging: update windows icon reference and include query packs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,19 @@ function(generateInstallDirectives)
     )
 
   elseif(PLATFORM_WINDOWS)
+
+    # CMake doesn't prefer 'Program Files' on x64 platforms, more information
+    # here: https://gitlab.kitware.com/cmake/cmake/-/issues/18312
+    # This is a workaround, to ensure that we leverage 'Program Files' when
+    # on a 64 bit system.
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+      if(CMAKE_SIZEOF_VOID_P MATCHES "8") 
+        set(CMAKE_INSTALL_PREFIX "/Program Files/${CMAKE_PROJECT_NAME}" CACHE PATH "" FORCE) 
+      else() 
+        set(CMAKE_INSTALL_PREFIX "/Program Files (x86)/${CMAKE_PROJECT_NAME}" CACHE PATH "" FORCE) 
+      endif() 
+    endif()
+
     install(
       TARGETS osqueryd
       DESTINATION "osqueryd"
@@ -359,6 +372,11 @@ function(generateInstallDirectives)
       FILES "LICENSE"
       DESTINATION "/control"
       RENAME "LICENSE.txt"
+    )
+
+    install(
+      FILES "tools/deployment/windows_packaging/osquery.ico"
+      DESTINATION "/control"
     )
 
     install(
@@ -400,11 +418,6 @@ function(generateInstallDirectives)
     install(
       FILES "tools/deployment/windows_packaging/osquery_utils.ps1"
       DESTINATION "/control/nupkg/tools"
-    )
-
-    install(
-      FILES "tools/deployment/windows_packaging/osquery.ico"
-      DESTINATION "/control/msi"
     )
 
     install(

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -425,7 +425,7 @@ function New-ChocolateyPackage() {
     <copyright>Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the
 # root directory of this source tree.</copyright>
     <projectUrl>https://osquery.io</projectUrl>
-    <iconUrl>https://github.com/osquery/osquery/blob/master/tools/osquery.ico</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/osquery/osquery/master/tools/deployment/windows_packaging/osquery.ico</iconUrl>
     <licenseUrl>https://github.com/osquery/osquery/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/osquery/osquery</projectSourceUrl>

--- a/tools/deployment/windows_packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/windows_packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -72,7 +72,6 @@ New-Item -Force -Type directory -Path $logFolder
 $packageRoot = (Join-Path "$PSScriptRoot" "..")
 Copy-Item -Force -Recurse (Join-Path "$packageRoot" "certs") $targetFolder
 Copy-Item -Force -Recurse (Join-Path "$packageRoot" "osqueryd") $targetFolder
-Copy-Item -Force -Recurse (Join-Path "$packageRoot" "packs") $targetFolder
 
 # Grab the individual files
 Copy-Item -Force (Join-Path "$packageRoot" "manage-osqueryd.ps1") $targetFolder


### PR DESCRIPTION
## Summary:
This updates the artifacts produced for Windows packaging to make the osquery icon file placed in a more generic location for the `nupkg`, as well as brings along the query packs. The  [`nuspec` documentation](https://docs.microsoft.com/en-us/nuget/reference/nuspec#icon) specifies that the icon element of the nuspec should now just point to a file on disk. The CMake options don't seem to reflect this change yet, but we are making the move in order to have compliance with the chocolatey validation when we release our packages.

## Test Plan:
* Generate the osquery project with cmake, as per the usual

* Run the `install` target to place the package artifacts in the appropriate locations:
```
  -- Install configuration: "Release"
  -- Installing: C:/Program Files/osquery/osqueryd/osqueryd.exe
  -- Installing: C:/Program Files/osquery/./osqueryi.exe
  -- Installing: /control/nupkg/tools
  -- Installing: /control/nupkg/tools/chocolateyBeforeModify.ps1
  -- Installing: /control/nupkg/tools/chocolateyinstall.ps1
  -- Installing: /control/nupkg/tools/chocolateyuninstall.ps1
  -- Installing: /control/nupkg/extras/LICENSE.txt
  -- Installing: /control/LICENSE.txt
  -- Installing: C:/Program Files/osquery/./packs
  -- Installing: C:/Program Files/osquery/./packs/hardware-monitoring.conf
  -- Installing: C:/Program Files/osquery/./packs/incident-response.conf
  -- Installing: C:/Program Files/osquery/./packs/it-compliance.conf
  -- Installing: C:/Program Files/osquery/./packs/osquery-monitoring.conf
  -- Installing: C:/Program Files/osquery/./packs/ossec-rootkit.conf
  -- Installing: C:/Program Files/osquery/./packs/osx-attacks.conf
  -- Installing: C:/Program Files/osquery/./packs/unwanted-chrome-extensions.conf
  -- Installing: C:/Program Files/osquery/./packs/vuln-management.conf
  -- Installing: C:/Program Files/osquery/./packs/windows-attacks.conf
  -- Installing: C:/Program Files/osquery/./packs/windows-hardening.conf
  -- Installing: /control/osquery.ico
  -- Installing: /control/nupkg/extras/VERIFICATION.txt
  -- Installing: C:/Program Files/osquery/./osquery.conf
  -- Installing: C:/Program Files/osquery/./osquery.man
  -- Installing: C:/Program Files/osquery/./manage-osqueryd.ps1
  -- Installing: C:/Program Files/osquery/./osquery_utils.ps1
  -- Installing: C:/Program Files/osquery/./osquery.flags
  -- Installing: /control/nupkg/extras/manage-osqueryd.ps1
  -- Installing: /control/nupkg/tools/osquery_utils.ps1
  -- Installing: /control/msi/osquery_wix_patch.xml
  -- Installing: C:/Program Files/osquery/certs/certs.pem
  -- Installing: C:/Program Files/osquery/log
```

* In the `osquery-package` repository, generate the cmake project, and then run the `package` target to generate the Chocolatey package:
```
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake -DOSQUERY_DATA_PATH="C:\" -DCPACK_GENERATOR=NuGet -DOSQUERY_PACKAGE_VERSION="4.8.0" -DOSQUERY_BITNESS=64 ../
-- Building for: Visual Studio 16 2019
-- Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.19042.
-- The C compiler identification is MSVC 19.28.29336.0
-- The CXX compiler identification is MSVC 19.28.29336.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/Nicholas/work/repos/osquery-packaging/build
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake -DOSQUERY_DATA_PATH="C:\" -DCPACK_GENERATOR=NuGet -DOSQUERY_PACKAGE_VERSION="4.8.0" -DOSQUERY_BITNESS=64 ../^C
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake --build . --config Release --target package
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/Users/Nicholas/work/repos/osquery-packaging/CMakeLists.txt
  CPack: Create package using NuGet
  CPack: Install projects
  CPack: - Install project: osquery [Release]
  CPack: Create package
  Attempting to build package from 'CPack.NuGet.nuspec'.
  Successfully created package 'C:\Users\Nicholas\work\repos\osquery-packaging\build\_CPack_Packages\win64\NuGet\osquery-4.8.0\osquery.4.8.0.nupkg'.
EXEC : warning : NU5110: The script file 'manage-osqueryd.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into
the 'tools' folder. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5110: The script file 'osquery_utils.ps1' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into th
e 'tools' folder. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'manage-osqueryd.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to ins
tall.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to insta
ll.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyBeforeModify.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Ren
ame it to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyinstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename i
t to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\chocolateyuninstall.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename
 it to install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
EXEC : warning : NU5111: The script file 'tools\osquery_utils.ps1' is not recognized by NuGet and hence will not be executed during installation of this package. Rename it to
 install.ps1, uninstall.ps1 or init.ps1 and place it directly under 'tools'. [C:\Users\Nicholas\work\repos\osquery-packaging\build\package.vcxproj]
  CPack: - package: C:/Users/Nicholas/work/repos/osquery-packaging/build/osquery.4.8.0.nupkg generated.
```

* Similarly, generate the MSI:
```
PS C:\Users\Nicholas\work\repos\osquery-packaging\build> cmake --build . --config Release --target package
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/Users/Nicholas/work/repos/osquery-packaging/CMakeLists.txt
  CPack: Create package using WIX
  CPack: Install projects
  CPack: - Install project: osquery [Release]
  CPack: -   Install component: osquery
  CPack: Create package
  CPack: - package: C:/Users/Nicholas/work/repos/osquery-packaging/build/osquery-4.8.0.msi generated.
```

* RUn through the normal testing flow to verify that the installer packages work as expected.
```
PS C:\Users\Nicholas\Desktop\tmp\testplan> choco install -yf osquery -s . --version 4.8.0 --params='/InstallService'
Chocolatey v0.10.15
Installing the following packages:
osquery
By installing you accept licenses for the packages.
osquery v4.8.0 already installed. Forcing reinstall of version '4.8.0'.
 Please use upgrade if you meant to upgrade to a new version.

osquery v4.8.0 (forced)
osquery package files install completed. Performing other installation steps.
C:\Program Files\osquery\log
True
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 ShimGen has successfully created a shim for osqueryi.exe
 ShimGen has successfully created a shim for osqueryd.exe
 The install of osquery was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

...

PS C:\Users\Nicholas\Desktop\tmp\testplan> & 'C:\Program Files\osquery\osqueryd\osqueryd.exe' --version
osqueryd.exe version 4.8.0-42-g8900da822-dirty
```