### PR TITLE
custom curl_certificate timeouts would never be used

### DIFF
--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -438,7 +438,7 @@ QueryData genTLSCertificate(QueryContext& context) {
   }
 
   if (context.hasConstraint("timeout", EQUALS)) {
-    auto timeout =
+    timeout =
         tryTo<int>(*(context.constraints["timeout"].getAll(EQUALS).begin()), 10)
             .takeOr(DEFAULT_READ_TIMEOUT);
     if (timeout < 0) {


### PR DESCRIPTION
because of a bug in my implementation, custom timeouts in curl_certificate would never be honored.  This is because of too fine of scope for the timeout variable parsed from the constraint.  This PR, re-uses the outer scope timeout variable so that it is actually used by the rest of the table implementation.

Symptoms of this bug: if you set a custom timeout for curl_certificate, the table would no longer work.  This is because the SQL engine would filter out all of the results because the timeout specified in the constraint and what came back from the table implementation would always be different.  Unless of course, you set the timeout = 4 which was the default value that was always used.

That's a couple of hours of my life I can't back.  I'm mad at my last year self now.