### PR TITLE
Add additional paths to `apps` and `launchd`

### DIFF
--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -55,6 +55,7 @@ const std::vector<std::string> kHomeDirSearchPaths = {
 const std::vector<std::string> kSystemSearchPaths = {
     "/Applications",
     "/System/Library/Core Services/Applications",
+    "/Library/Apple/System/Library/CoreServices",
     "/Users/Shared/Applications",
 };
 

--- a/osquery/tables/system/darwin/launchd.cpp
+++ b/osquery/tables/system/darwin/launchd.cpp
@@ -30,6 +30,8 @@ const std::vector<std::string> kLaunchdSearchPaths = {
     "/Library/LaunchDaemons",
     "/System/Library/LaunchAgents",
     "/Library/LaunchAgents",
+    "/Library/Apple/System/Library/LaunchDaemons",
+    "/Library/Apple/System/Library/LaunchAgents",
 };
 
 const std::vector<std::string> kUserLaunchdSearchPaths = {

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -28,7 +28,7 @@ namespace tables {
 const std::vector<std::string> kPkgReceiptPaths = {
     "/private/var/db/receipts/",
     "/Library/Receipts/",
-    "/Library/Apple/System/Library/Receipts"};
+    "/Library/Apple/System/Library/Receipts/"};
 
 const std::vector<std::string> kPkgReceiptUserPaths = {
     "/Library/Receipts/",

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -26,8 +26,9 @@ namespace osquery {
 namespace tables {
 
 const std::vector<std::string> kPkgReceiptPaths = {
-    "/private/var/db/receipts/", "/Library/Receipts/",
-};
+    "/private/var/db/receipts/",
+    "/Library/Receipts/",
+    "/Library/Apple/System/Library/Receipts"};
 
 const std::vector<std::string> kPkgReceiptUserPaths = {
     "/Library/Receipts/",


### PR DESCRIPTION
While digging around some system services, we noticed that they were
missing from osquery. This looks akin to #7138, the paths changed

I did a quick review of the other paths, and I didn't see anything else
missing. I'm sure they'll turn up...

