### PR TITLE
Add feature to skip denylist for event-based queries

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -339,7 +339,9 @@ Maximum number of events to buffer in the backing store while waiting for a quer
 
 `--events_enforce_denylist=false`
 
-This controls whether denylisted queries that operate on a "*_events" (event-based) table skip denylist enforcement. These queries operate on meta-generated table logic so performance issues are unavoidable and it does not make sense to denylist. Skipping these queries may lead to adverse and opposite effects because events will buffer longer and impact RocksDB storage.
+This controls whether watchdog denylisting is enforced on queries using "*_events" (event-based) tables. As these these queries operate on meta-generated table logic, performance issues are unavoidable. It does not make sense to denylist. Enforcing this may lead to adverse and opposite effects because events will buffer longer and impact RocksDB storage.
+
+This only considers queries that are entirely event-based. For example `SELECT * FROM process_events` is considered, but `SELECT * FROM process_events join time` is not.
 
 It is not recommended to set this to `true`.
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -337,6 +337,12 @@ Since event rows are only "added" it does not make sense to emit "removed" resul
 
 Maximum number of events to buffer in the backing store while waiting for a query to "drain" them (if and only if the events are old enough to be expired out, see above). For example, the default value indicates that a maximum of the `50000` most recent events will be stored. The right value for *your* osquery deployment, if you want to avoid missed/dropped events, should be considered based on the combination of your host's event occurrence frequency and the interval of your scheduled queries of those tables.
 
+`--events_enforce_denylist=false`
+
+This controls whether denylisted queries that operate on a "*_events" (event-based) table skip denylist enforcement. These queries operate on meta-generated table logic so performance issues are unavoidable and it does not make sense to denylist. Skipping these queries may lead to adverse and opposite effects because events will buffer longer and impact RocksDB storage.
+
+It is not recommended to set this to `true`.
+
 ### Windows-only events control flags
 
 `--enable_ntfs_event_publisher           Enables the NTFS event publisher`

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -29,6 +29,7 @@
 #include <osquery/database/database.h>
 #include <osquery/dispatcher/dispatcher.h>
 #include <osquery/events/eventfactory.h>
+#include <osquery/events/events.h>
 #include <osquery/hashing/hashing.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry.h>
@@ -408,6 +409,12 @@ void Config::removeFiles(const std::string& source) {
  */
 static inline bool denylistExpired(uint64_t blt, const ScheduledQuery& query) {
   if (getUnixTime() > blt) {
+    return true;
+  }
+
+  if (!enforceEventsDenylist(query.query)) {
+    // This is an events-based query and denylisting is not being enforced for
+    // these types of queries.
     return true;
   }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -242,9 +242,13 @@ bool enforceDenylist(const std::string& query) {
     return true;
   }
 
+  auto tables = QueryPlanner(query).tables();
+  if (tables.empty()) {
+    return true;
+  }
+
   // Check if the query only operates on event subscribers.
   // If it does, skip the denylist enforcement.
-  auto tables = QueryPlanner(query).tables();
   std::set<std::string> table_set(tables.begin(), tables.end());
   auto event_tables = EventFactory::subscriberNames();
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -236,22 +236,21 @@ void SchedulerRunner::start() {
 
   for (; (end == 0) || (i <= end); ++i) {
     auto start_time_point = std::chrono::steady_clock::now();
-    Config::get().scheduledQueries(
-        ([&i](const std::string& name, const ScheduledQuery& query) {
-          if (query.splayed_interval > 0 && i % query.splayed_interval == 0) {
-            TablePlugin::kCacheInterval = query.splayed_interval;
-            TablePlugin::kCacheStep = i;
-            const auto status = launchQuery(name, query);
-            monitoring::record(
-                (boost::format("scheduler.query.%s.%s.status.%s") %
-                 query.pack_name % query.name %
-                 (status.ok() ? "success" : "failure"))
-                    .str(),
-                1,
-                monitoring::PreAggregationType::Sum,
-                true);
-          }
-        }));
+    Config::get().scheduledQueries(([&i](const std::string& name,
+                                         const ScheduledQuery& query) {
+      if (query.splayed_interval > 0 && i % query.splayed_interval == 0) {
+        TablePlugin::kCacheInterval = query.splayed_interval;
+        TablePlugin::kCacheStep = i;
+        const auto status = launchQuery(name, query);
+        monitoring::record((boost::format("scheduler.query.%s.%s.status.%s") %
+                            query.pack_name % query.name %
+                            (status.ok() ? "success" : "failure"))
+                               .str(),
+                           1,
+                           monitoring::PreAggregationType::Sum,
+                           true);
+      }
+    }));
 
     maybeRunDecorators(i);
     maybeReloadSchedule(i);

--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -275,20 +275,20 @@ bool EventFactory::exists(const std::string& name_id) {
   return (getInstance().event_subs_.count(name_id) > 0);
 }
 
-std::vector<std::string> EventFactory::publisherTypes() {
+std::set<std::string> EventFactory::publisherTypes() {
   RecursiveLock lock(getInstance().factory_lock_);
-  std::vector<std::string> types;
+  std::set<std::string> types;
   for (const auto& publisher : getInstance().event_pubs_) {
-    types.push_back(publisher.first);
+    types.insert(publisher.first);
   }
   return types;
 }
 
-std::vector<std::string> EventFactory::subscriberNames() {
+std::set<std::string> EventFactory::subscriberNames() {
   RecursiveLock lock(getInstance().factory_lock_);
-  std::vector<std::string> names;
+  std::set<std::string> names;
   for (const auto& subscriber : getInstance().event_subs_) {
-    names.push_back(subscriber.first);
+    names.insert(subscriber.first);
   }
   return names;
 }

--- a/osquery/events/eventfactory.h
+++ b/osquery/events/eventfactory.h
@@ -138,10 +138,10 @@ class EventFactory : private boost::noncopyable {
   static bool exists(const std::string& sub);
 
   /// Return a list of publisher types, these are their registry names.
-  static std::vector<std::string> publisherTypes();
+  static std::set<std::string> publisherTypes();
 
   /// Return a list of subscriber registry names,
-  static std::vector<std::string> subscriberNames();
+  static std::set<std::string> subscriberNames();
 
   /// Set log forwarding by adding a logger receiver.
   static void addForwarder(const std::string& logger);

--- a/osquery/events/events.h
+++ b/osquery/events/events.h
@@ -7,10 +7,16 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <string>
+
 namespace osquery {
 
 /// Iterate the event publisher registry and create run loops for each using
 /// the event factory.
 void attachEvents();
+
+/// Return true if a query operates only on event-based tables and should be
+/// denylisted.
+bool enforceEventsDenylist(const std::string& query);
 
 } // namespace osquery

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -7,8 +7,10 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <chrono>
 #include <set>
 #include <string>
+#include <thread>
 
 #include <osquery/carver/carver_utils.h>
 #include <osquery/core/flags.h>
@@ -65,6 +67,22 @@ static void executeCarve(sqlite3_context* ctx) {
   kFunctionCarvePaths.clear();
 }
 
+static void sqlSleep(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
+  if (argc != 1 && SQLITE_INTEGER != sqlite3_value_type(argv[0])) {
+    sqlite3_result_int(ctx, 0);
+    return;
+  }
+
+  auto seconds = sqlite3_value_int(argv[0]);
+  if (seconds < 0) {
+    sqlite3_result_int(ctx, 0);
+    return;
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
+  sqlite3_result_int(ctx, seconds);
+}
+
 void registerOperationExtensions(sqlite3* db) {
   sqlite3_create_function(db,
                           "carve",
@@ -74,5 +92,8 @@ void registerOperationExtensions(sqlite3* db) {
                           nullptr,
                           addCarveFile,
                           executeCarve);
+
+  sqlite3_create_function(
+      db, "sleep", 1, SQLITE_UTF8, nullptr, sqlSleep, nullptr, nullptr);
 }
 } // namespace osquery


### PR DESCRIPTION
While debugging https://github.com/osquery/osquery/issues/7112 we found adverse unintentional effects when queries for event-based tables are denylisted. This can lead to event loss and buffers thrashing at max.

~~This approach is not perfect, it uses a heuristic to check if a query applies to an event-based table by looking for the "_events" suffix. This pattern is enforced by our schema auditing, meaning there will be no false negatives. There can be false positives, for example "osquery_events".~~

I've also added a helper SQLite function `sleep` to be used for testing purposes only. Using this, I can simulate killing the worker and exercising the logic.