### PR TITLE
Fix issues applying ACLs during chocolatey deployment

### DIFF
--- a/tools/deployment/windows_packaging/osquery_utils.ps1
+++ b/tools/deployment/windows_packaging/osquery_utils.ps1
@@ -71,16 +71,10 @@ function Set-SafePermissions {
     [string] $target = ''
   )
   if ($PSCmdlet.ShouldProcess($target)) {
-    $acl = Get-Acl $target
-
-    # First, to ensure success, we remove the entirety of the ACL
+    # Prepare an initially empty ACL with inheritance disabled, so that only the ACLs specified here will be applied
+    $acl = New-Object System.Security.AccessControl.DirectorySecurity
     $acl.SetAccessRuleProtection($true, $false)
-    foreach ($access in $acl.Access) {
-      $acl.RemoveAccessRule($access)
-    }
-    Set-Acl $target $acl
 
-    $acl = Get-Acl $target
     $inheritanceFlag = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
     $propagationFlag = [System.Security.AccessControl.PropagationFlags]::None
     $permType = [System.Security.AccessControl.AccessControlType]::Allow


### PR DESCRIPTION
Instead of applying the safe permissions ACLs in two phases,
one that removes all ACLs present on the target,
the other that puts the wanted ACLs, we create an ACL from
scratch that already contains the final state and apply that.

Fixes #7165