### PR TITLE
Add Edge & EdgeBeta to `chrome_extensions` on macOS

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -66,6 +66,8 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::Brave, "Library/Application Support/BraveSoftware/Brave-Browser"},
     {ChromeBrowserType::Chromium, "Library/Application Support/Chromium"},
     {ChromeBrowserType::Yandex, "Library/Application Support/Yandex/YandexBrowser"},
+    {ChromeBrowserType::Edge, "Library/Application Support/Microsoft Edge"},
+    {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
     {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"}};
 // clang-format on
 


### PR DESCRIPTION
This commit:
 - adds the necessary path for microsoft edge on macos so that
 installed for that browser included in the chrome_extensions table

Why?
 - Edge for macOS extensions aren't currently picked up by the chrome
 extensions table

Note that some of the properties (install_time, for one) may not be populated 
for extensions not installed from the Chrome Web Store, but I think that is 
existing behavior on windows as well.


To test this, I: 

 - installed Microsoft Edge for Mac and Edge Beta for Mac 
 - for each, installed an extension from the chrome web store and the edge web store
 - ran `select name from users cross join chrome extensions ce on users.uid = ce.uid where name like '<EXTENSION_NAME>';`

prior to this patch, the query returned nothing. after this patch, the expected extensions were reported.