### PR TITLE
Docs: bring the YARA wiki page up to date

### DIFF
--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -10,7 +10,8 @@ distributed with a `.yar` or `.yara` filename extension, although any extension 
 
 ## YARA Configuration
 
-The configuration for osquery is simple. Here is an example config:
+The configuration for osquery is simple. Here is an example config, grouping some YARA rule files from the local
+filesystem:
 
 ```json
 {
@@ -94,9 +95,8 @@ osquery> select * from yara where path like '%' and sigurl='sig_url_2';
 YARA rule strings are omitted from output by default, to prevent disclosure in osquery's results and logs. To include
 the YARA rules in the `sigrule` column, set the `enable_yara_string` flag to `true`.
 
-#### Allowed Domains
-
-TODO
+By nature of the design described above, your source URL for YARA rules (`sigurl`) can only be one of the URLs in the
+osquery config (in the `signature_urls` section). This is your explicit list of allowed source domains for YARA rules.
 
 #### Notes
 
@@ -260,3 +260,9 @@ issue with the YARA rule(s), but, the first thing to check is whether the same r
 command-line utility: `yara64.exe myYaraRule.yar fileToScan.foo`. You will be able to get more helpful messages
 about the compile error. If, however, this actually works as intended, then perhaps you've found a bug! Please let
 the osquery team know, on Slack or by opening an issue on GitHub.
+
+### Error loading YARA rules: 8
+
+At this time, osquery only supports loading _plaintext_ YARA rules/signatures, which it compiles itself at runtime. If
+these rules have already been compiled into their binary form (_e.g._ with the `yarac` CLI tool), osquery will
+generate an error trying to load the rules.

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -48,9 +48,9 @@ by osquery, are monitored for changes and processed by the
 The second thing to notice is the `yara` section, which contains the configuration to use for YARA within osquery. The
 `yara` section contains two keys: `signatures` and `file_paths`. The `signatures` key contains a set of arbitrary key
 names, called "signature groups." The value for each of these groups are the paths to the signature files that will be
-compiled and stored within osquery. The paths to the signature files can be absolute or relative to
-```/etc/osquery/yara/```. The `file_paths` key maps the category name for an event described in the global `file_paths`
-section to a signature grouping to use when scanning.
+compiled and stored within osquery. The paths to the signature files must be absolute paths (not relative paths). The
+`file_paths` key maps the category name for an event described in the global `file_paths` section to a signature
+grouping to use when scanning.
 
 For example, when a file in `/usr/bin/` and `/usr/sbin/` is changed it will be scanned with `sig_group_1`, which
 consists of `foo.yar` and `bar.yar`. When a file in `/Users/%/tmp/` (recursively) is changed it will be scanned with `sig_group_1` and `sig_group_2`, which consists of all three signature files.
@@ -157,10 +157,10 @@ In order to determine where to scan, the `path` constraint must be a full path t
 you must use `LIKE` if you want to use a wildcard pattern.
 
 Once the `where` is out of the way, you must specify the "what" part. This is done through either the
-`sigfile` or `sig_group` constraints. The `sigfile` constraint can be either an absolute path to a signature
-file on disk or a path relative to `/var/osquery/`. The signature file will be compiled only for the execution
-of this one query and removed afterwards. The `sig_group` constraint must consist of a named signature grouping
-from your configuration file.
+`sigfile` or `sig_group` constraints. The `sigfile` constraint must be an absolute path to a signature
+file on the filesystem, not a elative path. The signature file will be compiled only for the execution
+of this one query and removed afterwards. The `sig_group` constraint must consist of a named signature
+grouping from your configuration file.
 
 Here are some examples of the `yara` table in action:
 

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -74,8 +74,8 @@ osquery> select * from yara where path like '%' and sigurl='sig_url_2';
 +-------------------------+--------------+-------+-----------+---------+---------+---------+------+-----------+
 ```
 
-Use of `enable_yara_sigurl` also protects the YARA rules from disclosure in osquery's results and logs. To restore
-the default output that includes the YARA rules in the `sigrule` column, set the `disable_yara_string_private` flag.
+YARA rule strings are omitted from output by default, to prevent disclosure in osquery's results and logs. To include
+the YARA rules in the `sigrule` column, set the `enable_yara_string` flag to `true`.
 
 #### Allowed Domains
 
@@ -197,6 +197,6 @@ For example:
 osquery> select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }';
 ```
 
-To use `sigrule`, first you must set the `enable_yara_table_extension` flag. Because allowing arbitrary YARA rules also
-allows the retrieval of arbitrary file data in the `strings` column, the `strings` column will default to providing no
-data unless you also set the `disable_yara_string_private` flag or `enable_yara_string` flag.
+Because allowing arbitrary YARA rules would also make it possible to retrieve arbitrary file data in the `strings`
+column, as a protection, the `strings` column will default to returning empty unless you also set the hidden flag
+`enable_yara_string` to `true` (its default is `false`).

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -53,7 +53,8 @@ compiled and stored within osquery. The paths to the signature files must be abs
 grouping to use when scanning.
 
 For example, when a file in `/usr/bin/` and `/usr/sbin/` is changed it will be scanned with `sig_group_1`, which
-consists of `foo.yar` and `bar.yar`. When a file in `/Users/%/tmp/` (recursively) is changed it will be scanned with `sig_group_1` and `sig_group_2`, which consists of all three signature files.
+consists of `foo.yar` and `bar.yar`. When a file in `/Users/%/tmp/` (recursively) is changed it will be scanned with
+`sig_group_1` and `sig_group_2`, which consists of all three signature files.
 
 ### Retrieving YARA Rules at Runtime
 
@@ -106,7 +107,7 @@ TODO
 ## Continuous monitoring using the yara_events table
 
 Using the configuration above you can see it in action. While osquery is running, we execute `touch /Users/wxs/tmp/foo`
-in another terminal. Here is the relevant queries to show what happened:
+in another terminal. Here are the relevant queries to show what was detected:
 
 ```sql
 osquery> SELECT * FROM file_events;
@@ -140,7 +141,6 @@ osquery> SELECT * FROM yara_events;
 | /Users/wxs/tmp/foo | tmp      | 1430078285 | CREATED | 33859499       | always_true | 1     |
 | /Users/wxs/tmp/foo | tmp      | 1430078524 | CREATED | 33860795       |             | 0     |
 +--------------------+----------+------------+---------+----------------+-------------+-------+
-osquery>
 ```
 
 As you can see, even though no matches were found, a row is still created and stored.

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -102,7 +102,8 @@ osquery config (in the `signature_urls` section). This is your explicit list of 
 
 - Retrieved YARA rules are retrieved only once and then cached; the cached copy is used until it is stale as specified
  by the HTTP `Last-Modified` header in the server's response.
-- The osquery agent currently has no support for authenticating to the server providing the YARA signatures.
+- The osquery agent always validates the HTTPS server certificate of the server providing the YARA signatures, but
+currently has no support for client authentication. YARA rule files must be accessible without authentication.
 
 ## Continuous monitoring using the yara_events table
 

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -185,3 +185,12 @@ osquery>
 ```
 
 The above is an example of using an absolute path for `sigfile` combined with `pattern`.
+
+### Inline YARA rules with sigrules
+
+Above, we documented how to query the `yara` table using YARA signatures specified in a local file or retrieved from a
+remote host. YARA rules can also be provided inline with the query, using the `sigrules` constraint column.
+
+To use `sigrules`, first you must set the `enable_yara_table_extension` flag. Because allowing arbitrary YARA rules also
+allows the retrieval of arbitrary file data in the `strings` column, the `strings` column will default to providing no
+data unless you also set the `disable_yara_string_private` flag.

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -186,11 +186,17 @@ osquery>
 
 The above is an example of using an absolute path for `sigfile` combined with `pattern`.
 
-### Inline YARA rules with sigrules
+### Inline YARA rules with sigrule
 
 Above, we documented how to query the `yara` table using YARA signatures specified in a local file or retrieved from a
-remote host. YARA rules can also be provided inline with the query, using the `sigrules` constraint column.
+remote host. YARA rules can also be provided inline with the query, using the `sigrule` constraint/column.
 
-To use `sigrules`, first you must set the `enable_yara_table_extension` flag. Because allowing arbitrary YARA rules also
+For example:
+
+```sql
+osquery> select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }';
+```
+
+To use `sigrule`, first you must set the `enable_yara_table_extension` flag. Because allowing arbitrary YARA rules also
 allows the retrieval of arbitrary file data in the `strings` column, the `strings` column will default to providing no
-data unless you also set the `disable_yara_string_private` flag.
+data unless you also set the `disable_yara_string_private` flag or `enable_yara_string` flag.


### PR DESCRIPTION
Resolves #7110 

- Removes outdated column `pattern` and explains the `WHERE path LIKE` syntax with examples
- Documents new flags and functionality added in the last year or so
- Clarifies some of the usage, and forms an initial version of a troubleshooting section
- Points to YARA rule-writing documentation
- Updates the examples with the current table schema
- I've tested all the examples myself (on Windows 10)