### PR TITLE
[libs][yara] enable and compile the macho module on macOS

### DIFF
--- a/libraries/cmake/source/yara/CMakeLists.txt
+++ b/libraries/cmake/source/yara/CMakeLists.txt
@@ -70,6 +70,7 @@ function(yaraMain)
     target_sources(thirdparty_yara PRIVATE
       "${library_root}/proc/mach.c"
       "${library_root}/modules/magic/magic.c"
+      "${library_root}/modules/macho/macho.c"
     )
   else()
     message(FATAL_ERROR "Unsupported platform")
@@ -128,6 +129,7 @@ function(yaraMain)
       USE_MACH_PROC
       HAVE_MEMMEM=1
       HAVE_TIMEGM=1
+      MACHO_MODULE
     )
 
     target_link_libraries(thirdparty_yara PUBLIC


### PR DESCRIPTION
We don't have libyara's macho module compiled and enabled currently, this causes `yara: compilation error` for signature files including the macho module
  

```yara
import "macho"
rule macho
{
    condition:
        uint32(0) == 0xfeedface or uint32(0) == 0xfeedfacf
}
```

```
osquery> select * from yara where path like '/tmp/%' and sigfile = '/tmp/macho_test.sig' and count > 0;
+---------------+---------+-------+-----------+---------------------+---------+------+
| path          | matches | count | sig_group | sigfile             | strings | tags |
+---------------+---------+-------+-----------+---------------------+---------+------+
| /tmp/osqueryd | macho   | 1     |           | /tmp/macho_test.sig |         |      |
+---------------+---------+-------+-----------+---------------------+---------+------+
```