### PR TITLE
Do not let osquery create multiple copies of the extension running at once

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -302,6 +302,11 @@ void WatcherRunner::stop() {
 }
 
 void WatcherRunner::watchExtensions() {
+  // Do not take restart actions until the delay time has passed.
+  if (getUnixTime() < delayedTime()) {
+    return;
+  }
+
   // Loop over every managed extension and check sanity.
   for (const auto& extension : watcher_->extensions()) {
     // Check the extension status, causing a wait.
@@ -312,9 +317,6 @@ void WatcherRunner::watchExtensions() {
 
     // If the extension is alive and watched, check sanity
     if (ext_valid && FLAGS_enable_extensions_watchdog) {
-      if (getUnixTime() < delayedTime()) {
-        return;
-      }
       auto s = isChildSane(*extension.second);
       if (!s.ok()) {
         std::stringstream error;

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -302,11 +302,6 @@ void WatcherRunner::stop() {
 }
 
 void WatcherRunner::watchExtensions() {
-  // Do not take restart actions until the delay time has passed.
-  if (getUnixTime() < delayedTime()) {
-    return;
-  }
-
   // Loop over every managed extension and check sanity.
   for (const auto& extension : watcher_->extensions()) {
     // Check the extension status, causing a wait.
@@ -317,6 +312,9 @@ void WatcherRunner::watchExtensions() {
 
     // If the extension is alive and watched, check sanity
     if (ext_valid && FLAGS_enable_extensions_watchdog) {
+      if (getUnixTime() < delayedTime()) {
+        return;
+      }
       auto s = isChildSane(*extension.second);
       if (!s.ok()) {
         std::stringstream error;


### PR DESCRIPTION
Related issue: https://github.com/osquery/osquery/issues/7171

With the existing behavior, osquery can launch multiple extensions if the running extension uses
a lot of CPU & RAM.

With the new behavior, osquery will never launch multiple extensions.
- if the extension watchdog is enabled, it will kill the old extension then relaunch a new one
- if the extension watchdog is not enabled, it will do nothing

osquery was ignoring the return of `extension.second->checkStatus` and instead looking at
`extension.second->isValid`. `isValid` is just "did the extension ever launch". With the change in
behavior this means that if the extension had been launched once, it would never be relaunched
