### PR TITLE
Fix memory issue in Windows fileops

### DIFF
--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1702,6 +1702,7 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
 
   if (GetFileInformationByHandle(file_handle, &file_info) == 0) {
     CloseHandle(file_handle);
+    LocalFree(security_descriptor);
     return Status(-1,
                   "GetFileInformationByHandle failed for " + path.string() +
                       " with " + std::to_string(GetLastError()));


### PR DESCRIPTION
This PR fixes a memory issue in the Windows fileops `platformStat` function (missing call to LocalFree API).