### PR TITLE
Fix choco not failing when an error occurs during install or upgrade

### DIFF
--- a/tools/deployment/windows_packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/windows_packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -9,6 +9,8 @@
 
 #Requires -Version 3.0
 
+$ErrorActionPreference = "Stop"
+
 . (Join-Path "$PSScriptRoot" "osquery_utils.ps1")
 
 $packageParameters = $env:chocolateyPackageParameters


### PR DESCRIPTION
The powershell script used for installation and upgrade
do not stop when an error occurs in some command.
This causes chocolatey to proceed the installation/upgrade,
leading to a corrupted/incomplete installation.

Tell powershell to interrupt as soon as an error is hit.

Fixes #7181 
