### PR TITLE
Fix broadcasting empty logs to logger plugins

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -502,6 +502,12 @@ void relayStatusLogs(LoggerRelayMode relay_mode) {
     {
       WriteLock lock(kBufferedLogSinkLogs);
       auto& status_logs = BufferedLogSink::get().dump();
+
+      // Prevent serializing and broadcasting an empty response
+      if (status_logs.empty()) {
+        return;
+      }
+
       for (auto& log : status_logs) {
         // Copy the host identifier into each status log.
         log.identifier = identifier;


### PR DESCRIPTION
It is sometimes possible that multiple threads trying to serialize and
broadcast logs are enqueued. Each thread will broadcast all the logs
and if between two threads runs there's no new log to broadcast,
then the thread coming after a broadcast will find no logs,
broadcasting an empty log response instead of doing nothing.

Prevent this by checking that there are actually logs to be serialized
before broadcasting a response.

Fixes #7180 
