### PR TITLE
Add TimeoutStopSec to systemd service files

### DIFF
--- a/tools/deployment/linux_packaging/deb/osqueryd.service
+++ b/tools/deployment/linux_packaging/deb/osqueryd.service
@@ -13,6 +13,7 @@ ExecStart=/opt/osquery/bin/osqueryd \
 Restart=on-failure
 KillMode=control-group
 KillSignal=SIGTERM
+TimeoutStopSec=15
 CPUQuota=20%
 
 [Install]

--- a/tools/deployment/linux_packaging/rpm/osqueryd.service
+++ b/tools/deployment/linux_packaging/rpm/osqueryd.service
@@ -13,6 +13,7 @@ ExecStart=/opt/osquery/bin/osqueryd \
 Restart=on-failure
 KillMode=control-group
 KillSignal=SIGTERM
+TimeoutStopSec=15
 CPUQuota=20%
 
 [Install]


### PR DESCRIPTION
Set value to 5 seconds for consistency with the logic in the init
scripts.

<!-- Thank you for contributing to osquery! -->

It's not entirely clear to me that the default behavior of systemd would not be adequate, but we have noticed some race conditions in our deployments. We disable osqueryd before upgrading certain files when new versions are pushed and then re-enable it, and sometimes we get alerts from osqueryd for things that happen in the first few seconds. We are hoping this change addresses the issue. However, I believe this is an appropriate fix either way because it makes the systemd service file consistent with the logic in the init script.