### PR TITLE
Add ruby namespace to the thrift definition

### DIFF
--- a/osquery/extensions/thrift/osquery.thrift
+++ b/osquery/extensions/thrift/osquery.thrift
@@ -7,6 +7,7 @@
 
 namespace cpp osquery.extensions
 namespace py osquery.extensions
+namespace rb osquery.extensions
 
 /// Registry operations use a registry name, plugin name, request/response.
 typedef map<string, string> ExtensionPluginRequest


### PR DESCRIPTION
This adds an option to namespace ruby generated code, exactly like the other languages
