### PR TITLE
Correct documentation about logger_mode value format

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -403,9 +403,9 @@ The default behavior is to also write status logs to stderr. Set this flag to fa
 
 Directory path for `ERROR`/`WARN`/`INFO` and query result logging by the **filesystem** plugin.
 
-`--logger_mode=420`
+`--logger_mode=416`
 
-File mode for output log files by the **filesystem** plugin (provided as an octal string). Note that this affects both the query result log and the status logs. **Warning**: If run as root, log files may contain sensitive information!
+File mode for output log files by the **filesystem** plugin (provided in decimal form). Note that this affects both the query result log and the status logs. **Warning**: If run as root, log files may contain sensitive information!
 
 `--logger_rotate=false`
 


### PR DESCRIPTION
The value passed to the logger_mode option it's not an
octal string, but a decimal number, since gflags doesn't
support octal parsing.
So an octal of 0640 translates to 416 in decimal.

Also correct the value shown as an example,
since the current default is 0640 (416), not 0644 (420).
