### PR TITLE
Add utmp type name column to `last` table

### DIFF
--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -11,11 +11,37 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
 
 namespace osquery {
 namespace tables {
 
 namespace impl {
+
+std::string typeNameForType(const utmpx& ut) {
+  switch (ut.ut_type) {
+  case EMPTY:
+    return "empty";
+  case RUN_LVL:
+    return "run-level";
+  case BOOT_TIME:
+    return "boot-time";
+  case NEW_TIME:
+    return "new-time";
+  case OLD_TIME:
+    return "old-time";
+  case INIT_PROCESS:
+    return "init-process";
+  case LOGIN_PROCESS:
+    return "login-process";
+  case USER_PROCESS:
+    return "user-process";
+  case DEAD_PROCESS:
+    return "dead-process";
+  }
+
+  return "";
+}
 
 void genLastAccessForRow(const utmpx& ut, QueryData& results) {
   if (ut.ut_type == USER_PROCESS || ut.ut_type == DEAD_PROCESS) {
@@ -24,6 +50,7 @@ void genLastAccessForRow(const utmpx& ut, QueryData& results) {
     r["tty"] = TEXT(ut.ut_line);
     r["pid"] = INTEGER(ut.ut_pid);
     r["type"] = INTEGER(ut.ut_type);
+    r["type_name"] = TEXT(typeNameForType(ut));
     r["time"] = INTEGER(ut.ut_tv.tv_sec);
     r["host"] = TEXT(ut.ut_host);
     results.push_back(r);

--- a/specs/posix/last.table
+++ b/specs/posix/last.table
@@ -5,6 +5,7 @@ schema([
     Column("tty", TEXT, "Entry terminal"),
     Column("pid", INTEGER, "Process (or thread) ID"),
     Column("type", INTEGER, "Entry type, according to ut_type types (utmp.h)"),
+    Column("type_name", TEXT, "Entry type name, according to ut_type types (utmp.h)"),
     Column("time", INTEGER, "Entry timestamp"),
     Column("host", TEXT, "Entry hostname"),
 ])

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -37,6 +37,7 @@ TEST_F(last, test_sanity) {
       {"tty", NormalType},
       {"pid", NonNegativeInt},
       {"type", IntMinMaxCheck(7, 8)},
+      {"type_name", NormalType},
       {"time", NonNegativeInt},
       {"host", NormalType},
   };


### PR DESCRIPTION
The utmp numeric values can be impenetrable without referring to the
source code. Includde a column with a little more info.

I don't love the column name here. Suggestions welcome.

Closes: #7092

