### PR TITLE
Add a `secureboot` table for linux and windows

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -109,8 +109,6 @@ typedef struct {
 /// Constant for an invalid handle.
 const PlatformHandle kInvalidHandle = (PlatformHandle)-1;
 
-std::string lastErrorMessage(unsigned long);
-
 /**
  * @brief File access modes for PlatformFile.
  *

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1619,31 +1619,6 @@ std::string getFileAttribStr(unsigned long file_attributes) {
   return attribs;
 }
 
-std::string lastErrorMessage(unsigned long error_code) {
-  LPWSTR msg_buffer = nullptr;
-
-  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                     FORMAT_MESSAGE_IGNORE_INSERTS,
-                 NULL,
-                 error_code,
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                 (LPWSTR)&msg_buffer,
-                 0,
-                 NULL);
-
-  if (msg_buffer != NULL) {
-    auto error_message = wstringToString(msg_buffer);
-    LocalFree(msg_buffer);
-    msg_buffer = nullptr;
-
-    return error_message;
-  }
-
-  VLOG(1) << "FormatMessage failed for code (" << std::to_string(error_code)
-          << ")";
-  return std::string("Error code" + std::to_string(error_code) + "not found");
-}
-
 Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
   auto FLAGS_AND_ATTRIBUTES = FILE_ATTRIBUTE_ARCHIVE |
                               FILE_ATTRIBUTE_ENCRYPTED | FILE_ATTRIBUTE_HIDDEN |

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -305,6 +305,7 @@ function(generateOsqueryTablesSystemSystemtable)
   set(public_header_files
     efi_misc.h
     intel_me.hpp
+    secureboot.hpp
     smbios_utils.h
     system_utils.h
     user_groups.h

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -78,6 +78,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/process_open_pipes.cpp
       linux/processes.cpp
       linux/rpm_packages.cpp
+      linux/secureboot.cpp
       linux/shadow.cpp
       linux/shared_memory.cpp
       linux/smbios_tables.cpp
@@ -212,6 +213,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/programs.cpp
       windows/registry.cpp
       windows/scheduled_tasks.cpp
+      windows/secureboot.cpp
       windows/services.cpp
       windows/shared_resources.cpp
       windows/shellbags.cpp

--- a/osquery/tables/system/linux/secureboot.cpp
+++ b/osquery/tables/system/linux/secureboot.cpp
@@ -16,16 +16,11 @@ namespace osquery {
 namespace tables {
 
 // Linux directory for efi vars
-const char* efivarsPath = "/sys/firmware/efi/vars/";
+const std::string efivarsPath = "/sys/firmware/efi/vars/";
 
-int readBoolEfiVar(char* guid, char* name) {
-  uint len = strlen(name) + strlen(guid)+1;
-  char efivar[len];
-  strcpy(efivar, name);
-  strcat(efivar, "-");
-  strcat(efivar, var2);
+int readBoolEfiVar(std::string guid, std::string name) {
+  const std::string efivar = efivarsPath + name + '-' + guid;
 
-  auto efivar
   BYTE data;
 
   if (!readFile(path, data).ok()) {

--- a/osquery/tables/system/linux/secureboot.cpp
+++ b/osquery/tables/system/linux/secureboot.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/secureboot.hpp>
+
+namespace osquery {
+namespace tables {
+
+// Linux directory for efi vars
+const std::string efivarsPath = "/sys/firmware/efi/vars/";
+
+int readBoolEfiVar(char* guid, char* name) {
+  return -1;
+}
+
+QueryData genSecureBoot(QueryContext& context) {
+  QueryData results;
+
+  Row r;
+  r["secure_boot"] = readBoolEfiVar(kBootGUID, kSecureBootName);
+  r["setup_mode"] = readBoolEfiVar(kBootGUID, kSetupModeName);
+
+  results.push_back(r);
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/secureboot.cpp
+++ b/osquery/tables/system/linux/secureboot.cpp
@@ -9,23 +9,50 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/tables/system/secureboot.hpp>
 
 namespace osquery {
 namespace tables {
 
-// Linux directory for efi vars
-const std::string efivarsPath = "/sys/firmware/efi/vars/";
+// Linux has 2 places efivars can be accessed:
+//   /sys/firmware/efi/efivars -- Single file, world readable
+//   /sys/firmware/efi/vars    -- Split into attributes and data, only root
+//   readable
+//
+// There's not much documentation about the provenance of these two
+// interfaces. While the `vars` directory is more usable (having a
+// split data from attributes), the benefit of not requiring root
+// outweighs that.
+const std::string efivarsDir = "/sys/firmware/efi/efivars/";
 
 int readBoolEfiVar(std::string guid, std::string name) {
-  const std::string efivar = efivarsPath + name + '-' + guid;
+  const std::string efivarPath = efivarsDir + name + '-' + guid;
 
-  BYTE data;
+  // The first 4 bytes of efivars are attribute data, we don't need
+  // that data here, so we can just ignore it. The 5th byte is a
+  // boolean representation.
+  std::string efiData;
+  if (!readFile(efivarPath, efiData, 5).ok()) {
+    // FIXME: this is likely to mean it's unsupported by the
+    // kernel/boot/whatever. Probably don't log and return null?
+    TLOG << "Cannot read efivar file : " << efivarPath;
+    return -1;
+  }
 
-  if (!readFile(path, data).ok()) {
-    TLOG << "Cannot read efivar file : " << path
-      return -1;
+  if (efiData.length() != 5) {
+    TLOG << "Under read on efivar file : " << efivarPath;
+    return -1;
+  }
+
+  auto val = (int)(unsigned char)(efiData.back());
+
+  switch (val) {
+  case 0:
+    return 0;
+  case 1:
+    return 1;
   }
 
   return -1;
@@ -33,10 +60,15 @@ int readBoolEfiVar(std::string guid, std::string name) {
 
 QueryData genSecureBoot(QueryContext& context) {
   QueryData results;
-
   Row r;
-  r["secure_boot"] = readBoolEfiVar(kBootGUID, kSecureBootName);
-  r["setup_mode"] = readBoolEfiVar(kBootGUID, kSetupModeName);
+
+  // There's a kernel rate limit on non-root reads to the EFI
+  // filesystem of 100 reads per second. We could consider adding a
+  // sleep, as a means to a rate limit (this is what the efivar tool
+  // does), but this seems unlikely to be an issue in normal osquery
+  // use. So we do nothing, aside from note it here.
+  r["secure_boot"] = INTEGER(readBoolEfiVar(kEFIBootGUID, kEFISecureBootName));
+  r["setup_mode"] = INTEGER(readBoolEfiVar(kEFIBootGUID, kEFISetupModeName));
 
   results.push_back(r);
   return results;

--- a/osquery/tables/system/linux/secureboot.cpp
+++ b/osquery/tables/system/linux/secureboot.cpp
@@ -16,9 +16,23 @@ namespace osquery {
 namespace tables {
 
 // Linux directory for efi vars
-const std::string efivarsPath = "/sys/firmware/efi/vars/";
+const char* efivarsPath = "/sys/firmware/efi/vars/";
 
 int readBoolEfiVar(char* guid, char* name) {
+  uint len = strlen(name) + strlen(guid)+1;
+  char efivar[len];
+  strcpy(efivar, name);
+  strcat(efivar, "-");
+  strcat(efivar, var2);
+
+  auto efivar
+  BYTE data;
+
+  if (!readFile(path, data).ok()) {
+    TLOG << "Cannot read efivar file : " << path
+      return -1;
+  }
+
   return -1;
 }
 

--- a/osquery/tables/system/secureboot.hpp
+++ b/osquery/tables/system/secureboot.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief The EFI Boot GUID
+ *
+ * The secureboot variables are stored in under this guid. In string
+ * form, it's 8be4df61-93ca-11d2-aa0d-00e098032b8c
+ */
+const char* kBootGUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c";
+
+/**
+ * @brief The SecureMode variable name
+ */
+const char* kSecureBootName = "SecureBoot";
+
+/**
+ * @brief The SetupMode variable name
+ */
+
+const char* kSetupModeName = "SecureBoot";
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/secureboot.hpp
+++ b/osquery/tables/system/secureboot.hpp
@@ -29,7 +29,6 @@ const std::string kEFISecureBootName = "SecureBoot";
 /**
  * @brief The SetupMode variable name
  */
-
-const std::string kEFISetupModeName = "SecureBoot";
+const std::string kEFISetupModeName = "SetupMode";
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/secureboot.hpp
+++ b/osquery/tables/system/secureboot.hpp
@@ -18,17 +18,18 @@ namespace tables {
  * The secureboot variables are stored in under this guid. In string
  * form, it's 8be4df61-93ca-11d2-aa0d-00e098032b8c
  */
-const char* kBootGUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c";
+const std::string kEFIBootGUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c";
+const std::wstring kEFIBootGUIDwin = L"{8be4df61-93ca-11d2-aa0d-00e098032b8c}";
 
 /**
  * @brief The SecureMode variable name
  */
-const char* kSecureBootName = "SecureBoot";
+const std::string kEFISecureBootName = "SecureBoot";
 
 /**
  * @brief The SetupMode variable name
  */
 
-const char* kSetupModeName = "SecureBoot";
+const std::string kEFISetupModeName = "SecureBoot";
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/windows/secureboot.cpp
+++ b/osquery/tables/system/windows/secureboot.cpp
@@ -31,17 +31,20 @@ int readBoolEfiVar(std::wstring guid, std::wstring name) {
 
   if (bytesReturned <= 0) {
     auto lastError = GetLastError();
+    // FIXME: Consider not logging here. The no bios support is probably common
     auto errorString = lastError == 1 ? "Probably no bios support"
                                       : errorDwordToString(lastError);
 
     TLOG << "Unable to get EFI variable " << wstringToString(name).c_str()
          << ". Error: " << errorString;
+    // FIXME: Consider returning NULL instead?
     return -1;
   }
 
   if (bytesReturned != sizeof(BYTE)) {
     TLOG << "Unable to get EFI variable " << wstringToString(name).c_str()
          << ". ERROR_INVALID_DATA";
+    // FIXME: Consider returning NULL instead?
     return -1;
   }
 

--- a/osquery/tables/system/windows/secureboot.cpp
+++ b/osquery/tables/system/windows/secureboot.cpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/CustomCapability/Service/Client/uefi.cpp
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/secureboot.hpp>
+
+#include <windows.h>
+
+namespace osquery {
+namespace tables {
+
+int readBoolEfiVar(char* guid, char* name) {
+  BYTE variableStatus;
+  auto bytesReturned =
+      GetFirmwareEnvironmentVariable(name, guid, &variableStatus, sizeof(BYTE));
+
+  if (bytesReturned <= 0) {
+    TLOG << "Unable to get EFI variable " << name
+         << ". Error: " << std::to_string(GetLastError());
+    return -1;
+  }
+
+  if (bytesReturned != sizeof(BYTE)) {
+    TLOG << "Unable to get EFI variable " << name << ". ERROR_INVALID_DATA";
+    return -1;
+  }
+
+  if (secureBootStatus == 0) {
+    return 0;
+  }
+
+  return 1;
+}
+
+QueryData genSecureBoot(QueryContext& context) {
+  QueryData results;
+
+  Row r;
+  r["secure_boot"] = readBoolEfiVar(kBootGUID, kSecureBootName);
+  r["setup_mode"] = readBoolEfiVar(kBootGUID, kSetupModeName);
+
+  results.push_back(r);
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/secureboot.cpp
+++ b/osquery/tables/system/windows/secureboot.cpp
@@ -61,7 +61,7 @@ void readBoolEfiVar(Row& row,
     break;
   default:
     TLOG << "Unknown value in EFI variable " << wstringToString(name).c_str()
-         << ". Got: " << val;
+         << ". Got: " << res;
     row.emplace(column_name, "-1");
     break;
   }

--- a/osquery/tables/system/windows/secureboot.cpp
+++ b/osquery/tables/system/windows/secureboot.cpp
@@ -11,6 +11,7 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/tables/system/secureboot.hpp>
 #include <osquery/utils/conversions/windows/strings.h>

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -143,4 +143,12 @@ std::string swapEndianess(const std::string& endian_string) {
   return swap_string;
 }
 
+std::string errorDwordToString(DWORD errorMessageID) {
+  if (errorMessageID == 0) {
+    return std::string();
+  } else {
+    return std::system_category().message(errorMessageID);
+  }
+}
+
 } // namespace osquery

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -143,12 +143,29 @@ std::string swapEndianess(const std::string& endian_string) {
   return swap_string;
 }
 
-std::string errorDwordToString(DWORD errorMessageID) {
-  if (errorMessageID == 0) {
-    return std::string();
-  } else {
-    return std::system_category().message(errorMessageID);
+std::string errorDwordToString(DWORD error_code) {
+  LPWSTR msg_buffer = nullptr;
+
+  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                 NULL,
+                 error_code,
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 (LPWSTR)&msg_buffer,
+                 0,
+                 NULL);
+
+  if (msg_buffer != NULL) {
+    auto error_message = wstringToString(msg_buffer);
+    LocalFree(msg_buffer);
+    msg_buffer = nullptr;
+
+    return error_message;
   }
+
+  VLOG(1) << "FormatMessage failed for code (" << std::to_string(error_code)
+          << ")";
+  return std::string("Error code " + std::to_string(error_code) + " not found");
 }
 
 } // namespace osquery

--- a/osquery/utils/conversions/windows/strings.h
+++ b/osquery/utils/conversions/windows/strings.h
@@ -58,4 +58,12 @@ std::string bstrToString(const BSTR src);
  * @returns The swap endianess (little endian returns big endian, vice-versa)
  */
 std::string swapEndianess(const std::string& endian_string);
+
+/**
+ * @brief Windows helper function to convert error DWORD to string
+ *
+ * @returns The string representation of a windows error
+ */
+std::string errorDwordToString(DWORD errorMessageID);
+
 } // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -180,6 +180,7 @@ function(generateNativeTables)
     "linux/apparmor_events.table:linux"
     "linux/systemd_units.table:linux"
     "linwin/intel_me_info.table:linux,windows"
+    "linwin/secureboot.table:linux,windows"
     "lldpd/lldp_neighbors.table:linux,macos,freebsd"
     "kernel_info.table:linux,macos,windows"
     "macwin/certificates.table:macos,windows"

--- a/specs/linwin/secureboot.table
+++ b/specs/linwin/secureboot.table
@@ -1,0 +1,12 @@
+table_name("secureboot")
+description("Secure Boot UEFI Settings.")
+schema([
+    Column("secure_boot", INTEGER, "Whether secure boot is enabled")),
+    Column("setup_mode", INTEGER, "Whether setup mode is enabled")),
+])
+
+implementation("secureboot@genSecureBoot)
+fuzz_paths([
+  "/sys/firmware/efi/vars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c/data",
+  "/sys/firmware/efi/vars/SetupMode-8be4df61-93ca-11d2-aa0d-00e098032b8c/data",
+])

--- a/specs/linwin/secureboot.table
+++ b/specs/linwin/secureboot.table
@@ -1,11 +1,11 @@
 table_name("secureboot")
 description("Secure Boot UEFI Settings.")
 schema([
-    Column("secure_boot", INTEGER, "Whether secure boot is enabled")),
-    Column("setup_mode", INTEGER, "Whether setup mode is enabled")),
+    Column("secure_boot", INTEGER, "Whether secure boot is enabled"),
+    Column("setup_mode", INTEGER, "Whether setup mode is enabled"),
 ])
 
-implementation("secureboot@genSecureBoot)
+implementation("secureboot@genSecureBoot")
 fuzz_paths([
   "/sys/firmware/efi/vars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c/data",
   "/sys/firmware/efi/vars/SetupMode-8be4df61-93ca-11d2-aa0d-00e098032b8c/data",

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -177,6 +177,7 @@ function(generateTestsIntegrationTablesTestsTest)
       rpm_package_files.cpp
       rpm_packages.cpp
       selinux_events.cpp
+      secureboot.cpp
       shadow.cpp
       shared_memory.cpp
       smart_drive_info.cpp
@@ -306,6 +307,7 @@ function(generateTestsIntegrationTablesTestsTest)
       programs.cpp
       registry.cpp
       scheduled_tasks.cpp
+      secureboot.cpp
       services.cpp
       shared_resources.cpp
       shellbags.cpp

--- a/tests/integration/tables/secureboot.cpp
+++ b/tests/integration/tables/secureboot.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/tests/integration/tables/helper.h>
+
+#include <osquery/utils/info/platform_type.h>
+
+namespace osquery {
+namespace table_tests {
+
+class TimeExample : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(Secureboot, test_sanity) {
+  QueryData data = execute_query("select * from secureboot");
+
+  ASSERT_EQ(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"secure_boot", IntOrEmpty},
+      {"setup_mode", IntOrEmpty},
+  };
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/secureboot.cpp
+++ b/tests/integration/tables/secureboot.cpp
@@ -14,7 +14,7 @@
 namespace osquery {
 namespace table_tests {
 
-class TimeExample : public testing::Test {
+class Secureboot : public testing::Test {
  protected:
   void SetUp() override {
     setUpEnvironment();


### PR DESCRIPTION
Add a `secureboot` table for windows and linux. It works by reading the efivars.

Currently returns `0`, `1`, `NULL`, or `-1`.  (For false, true, unknown, error). I'm not sure I love the `-1`. I don't think we have consistency around those. 

Also extracted the `lastErrorMessage` helper function from it's unused location in `fileops` and moved it to a util class. (Amusingly I did this after I'd already written another version of it. But :shrug: may future me find it helpful)