### PR TITLE
Make sure that the file action "MOVED_TO" is tracked with yara events.

### DIFF
--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -129,7 +129,7 @@ void YARAEventSubscriber::configure() {
 
 Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
                                      const FileSubscriptionContextRef& sc) {
-  if (ec->action != "UPDATED" && ec->action != "CREATED" && 
+  if (ec->action != "UPDATED" && ec->action != "CREATED" &&
       ec->action != "MOVED_TO") {
     return Status(1, "Invalid action");
   }

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -129,7 +129,8 @@ void YARAEventSubscriber::configure() {
 
 Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
                                      const FileSubscriptionContextRef& sc) {
-  if (ec->action != "UPDATED" && ec->action != "CREATED" && ec->action != "MOVED_TO") {
+  if (ec->action != "UPDATED" && ec->action != "CREATED" && 
+      ec->action != "MOVED_TO") {
     return Status(1, "Invalid action");
   }
 

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -129,7 +129,7 @@ void YARAEventSubscriber::configure() {
 
 Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
                                      const FileSubscriptionContextRef& sc) {
-  if (ec->action != "UPDATED" && ec->action != "CREATED") {
+  if (ec->action != "UPDATED" && ec->action != "CREATED" && ec->action != "MOVED_TO") {
     return Status(1, "Invalid action");
   }
 


### PR DESCRIPTION
When you enable the yara_events table and you map certain rulesets to directories, the rules will only check files if they have the action **CREATED** or **UPDATED**. Because of this, Osquery will eventually miss some files being moved around by bad actors. The `mv` command is a command that is often used to move files around, so if a bad actor moves a file around it is important that those get scanned with corresponding yara rules as well. 

The specific action that should be tracked, included in this PR, is **MOVED_TO**. 

This action corresponds to the following file event on Darwin-based systems: **kFSEventStreamEventFlagItemRenamed**
And to the following file event on linux-based systems: **IN_MOVED_TO**

This fix will make sure that this action is also being tracked.

PS: Maybe it is a good idea to also track the action **MOVED_FROM**? Although files would already have been caught if they appear in the directory we track that action from.
