### PR TITLE
Prevent race condition between shutdown and worker or extension launch

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -164,6 +164,7 @@ void Watcher::setExtension(const std::string& extension,
 }
 
 void Watcher::reset(const PlatformProcess& child) {
+  std::unique_lock<std::mutex> lock(new_processes_mutex_);
   if (child == getWorker()) {
     worker_ = std::make_shared<PlatformProcess>();
     resetWorkerCounters(0);
@@ -180,6 +181,7 @@ void Watcher::reset(const PlatformProcess& child) {
 }
 
 void Watcher::loadExtensions() {
+  std::unique_lock<std::mutex> lock(new_processes_mutex_);
   auto autoload_paths = osquery::loadExtensions();
   for (const auto& path : autoload_paths) {
     setExtension(path, std::make_shared<PlatformProcess>());
@@ -250,6 +252,12 @@ void WatcherRunner::start() {
 
       // The watcher failed, create a worker.
       createWorker();
+
+      // The createWorker function can request a shutdown on error,
+      // or be interrupted by a stop request, do not continue if that happens.
+      if (interrupted() || shutdownRequested()) {
+        break;
+      }
     }
 
     // After inspecting the worker, check the extensions.
@@ -274,6 +282,8 @@ void WatcherRunner::start() {
 }
 
 void WatcherRunner::stop() {
+  std::unique_lock<std::mutex> lock(watcher_->new_processes_mutex_);
+
   auto stop_extension = [this](
                             const std::string& extension_name,
                             const std::shared_ptr<PlatformProcess> extension) {
@@ -293,8 +303,9 @@ void WatcherRunner::stop() {
         stop_extension, extension.first, extension.second);
   }
 
-  if (watcher_->getWorker().isValid()) {
-    stopChild(watcher_->getWorker());
+  auto& worker = watcher_->getWorker();
+  if (worker.isValid()) {
+    stopChild(worker);
   }
 
   for (auto& thread : stop_extensions_threads) {
@@ -563,6 +574,15 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 }
 
 void WatcherRunner::createWorker() {
+  std::unique_lock<std::mutex> lock(watcher_->new_processes_mutex_);
+
+  // A stop request can arrive from a different thread,
+  // we should therefore avoid to launch a worker
+  // that will be immediately stopped.
+  if (interrupted()) {
+    return;
+  }
+
   watcher_->workerStartTime(getUnixTime());
 
   if (watcher_->getState(watcher_->getWorker()).last_respawn_time >
@@ -629,6 +649,15 @@ void WatcherRunner::createWorker() {
 }
 
 void WatcherRunner::createExtension(const std::string& extension) {
+  std::unique_lock<std::mutex> lock(watcher_->new_processes_mutex_);
+
+  // A stop request can arrive from a different thread,
+  // we should therefore avoid to launch an extension
+  // that will be immediately stopped.
+  if (interrupted()) {
+    return;
+  }
+
   {
     if (watcher_->getState(extension).last_respawn_time >
         getUnixTime() - getWorkerLimit(WatchdogLimitType::RESPAWN_LIMIT)) {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <string>
+#include <thread>
 
 #ifndef WIN32
 #include <unistd.h>
@@ -216,6 +217,9 @@ class Watcher : private boost::noncopyable {
   /// Record the exit status of the most recent worker.
   std::atomic<int> worker_status_{-1};
 
+  /// Used to synchronize a process start with an attempt to stop such process
+  std::mutex new_processes_mutex_;
+
  private:
   friend class WatcherRunner;
   FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
@@ -331,4 +335,4 @@ class WatcherWatcherRunner : public InternalRunnable {
 
 /// Get a performance limit by name and optional level.
 uint64_t getWorkerLimit(WatchdogLimitType limit);
-}
+} // namespace osquery


### PR DESCRIPTION
Due to a race condition between the shutdown procedure part
handled by the WatcherRunner::stop and the execution of a new worker
or extension, it's possible that a worker or extension is left running
after the watcher process has exited.

This happens because when requested to shutdown
the WatcherRunner::stop function might not find any extensions or workers
to stop, but they are about to be launched.
This means that the stop function will return not having stopped any
process and the watcher will still start a worker or an extension,
and then finally realize that it has to interrupt and exit,
leaving the child processes running.

This is especially problematic with workers because if starting and
stopping osquery quickly, due to the issue above sometimes at the next
osquery service start, a worker process will still be running briefly,
and this causes the new osquery instance to fail to run,
causing a failure in the service start.

NOTE: This is a best effort attempt to fix this there might be (and there are) other issues related to this.

Namely something that's partially related is: https://github.com/osquery/osquery/issues/5233
And I've also noticed that we have two different handlers of the extensions lifetime/lifecycle, namely the WatcherRunner and the ExtensionManagerWatcher, which both try to shutdown an extension in different ways and the ExtensionManagerWatcher is always failing (I'll open an issue about this).