### PR TITLE
Pin the packaging repo within GitHub workflows

### DIFF
--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: ${{ env.CONTAINER }}
+      image: ${{ jobs.check_code_style.env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ env.CONTAINER }}
+      image: ${{ jobs.build_linux.env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -238,10 +238,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ env.PACKAGING_REPO }} \
+        git clone ${{ jobs.build_linux.env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ env.PACKAGING_COMMIT }}
+        git checkout ${{ jobs.build_linux.env.PACKAGING_COMMIT }}
         popd
 
     # One of the tests in the test suit will spawn a Docker container

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -239,9 +239,8 @@ jobs:
       run: |
         git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
-        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        cd ${{ steps.build_paths.outputs.PACKAGING }}
         git checkout ${{ env.PACKAGING_COMMIT }}
-        popd
 
     # One of the tests in the test suit will spawn a Docker container
     # using this socket. Allow the unprivileged user we created

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -26,6 +26,12 @@ on:
     tags:
       - '*'
 
+# Please remember to update values for both x86 and aarch64 workflows.
+env:
+  PACKAGING_REPO: https://github.com/osquery/osquery-packaging
+  PACKAGING_COMMIT: 3946326992b49c4b962ef998a2c7924efa80aa26
+  CONTAINER: osquery/builder18.04:0aa3775ce
+
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
 # and generating packages that are later attached to the commit
@@ -37,7 +43,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: ${{ env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -155,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: ${{ env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -232,8 +238,11 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone https://github.com/osquery/osquery-packaging \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
+        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
+        popd
 
     # One of the tests in the test suit will spawn a Docker container
     # using this socket. Allow the unprivileged user we created

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -30,7 +30,6 @@ on:
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
   PACKAGING_COMMIT: 3946326992b49c4b962ef998a2c7924efa80aa26
-  CONTAINER: osquery/builder18.04:0aa3775ce
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
@@ -43,7 +42,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: ${{ jobs.check_code_style.env.CONTAINER }}
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -161,7 +160,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ jobs.build_linux.env.CONTAINER }}
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -238,10 +237,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ jobs.build_linux.env.PACKAGING_REPO }} \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ jobs.build_linux.env.PACKAGING_COMMIT }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
         popd
 
     # One of the tests in the test suit will spawn a Docker container

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -34,7 +34,6 @@ on:
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
   PACKAGING_COMMIT: 3946326992b49c4b962ef998a2c7924efa80aa26
-  CONTAINER: osquery/builder18.04:0aa3775ce
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
@@ -47,7 +46,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: ${{ jobs.check_code_style.env.CONTAINER }}
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -104,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ jobs.check_source_code.env.CONTAINER }}
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -219,7 +218,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ jobs.build_linux.env.CONTAINER }}
+      image: osquery/builder18.04:0aa3775ce
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -305,10 +304,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ jobs.build_linux.env.PACKAGING_REPO }} \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ jobs.build_linux.env.PACKAGING_COMMIT }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
         popd
 
     # One of the tests in the test suit will spawn a Docker container
@@ -552,10 +551,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ jobs.build_macos.env.PACKAGING_REPO }} \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ jobs.build_macos.env.PACKAGING_COMMIT }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
         popd
 
     - name: Update the cache (ccache)
@@ -833,9 +832,9 @@ jobs:
     - name: Clone the osquery-packaging repository
       run: |
         cd w
-        git clone ${{ jobs.build_windows.env.PACKAGING_REPO }}
+        git clone ${{ env.PACKAGING_REPO }}
         cd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ jobs.build_windows.env.PACKAGING_COMMIT }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (git submodules)
       uses: actions/cache@v2

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -30,6 +30,12 @@ on:
     branches:
       - '*'
 
+# Please remember to update values for both x86 and aarch64 workflows.
+env:
+  PACKAGING_REPO: https://github.com/osquery/osquery-packaging
+  PACKAGING_COMMIT: 3946326992b49c4b962ef998a2c7924efa80aa26
+  CONTAINER: osquery/builder18.04:0aa3775ce
+
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
 # and generating packages that are later attached to the commit
@@ -41,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: ${{ env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -98,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: ${{ env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -213,7 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: ${{ env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -299,8 +305,11 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone https://github.com/osquery/osquery-packaging \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
+        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
+        popd
 
     # One of the tests in the test suit will spawn a Docker container
     # using this socket. Allow the unprivileged user we created
@@ -543,8 +552,11 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone https://github.com/osquery/osquery-packaging \
+        git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
+        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
+        popd
 
     - name: Update the cache (ccache)
       uses: actions/cache@v2
@@ -821,7 +833,9 @@ jobs:
     - name: Clone the osquery-packaging repository
       run: |
         cd w
-        git clone https://github.com/osquery/osquery-packaging
+        git clone ${{ env.PACKAGING_REPO }}
+        cd ${{ steps.build_paths.outputs.PACKAGING }}
+        git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (git submodules)
       uses: actions/cache@v2

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: ${{ env.CONTAINER }}
+      image: ${{ jobs.check_code_style.env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ env.CONTAINER }}
+      image: ${{ jobs.check_source_code.env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: ${{ env.CONTAINER }}
+      image: ${{ jobs.build_linux.env.CONTAINER }}
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -305,10 +305,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ env.PACKAGING_REPO }} \
+        git clone ${{ jobs.build_linux.env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ env.PACKAGING_COMMIT }}
+        git checkout ${{ jobs.build_linux.env.PACKAGING_COMMIT }}
         popd
 
     # One of the tests in the test suit will spawn a Docker container
@@ -552,10 +552,10 @@ jobs:
 
     - name: Clone the osquery-packaging repository
       run: |
-        git clone ${{ env.PACKAGING_REPO }} \
+        git clone ${{ jobs.build_macos.env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         pushd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ env.PACKAGING_COMMIT }}
+        git checkout ${{ jobs.build_macos.env.PACKAGING_COMMIT }}
         popd
 
     - name: Update the cache (ccache)
@@ -833,9 +833,9 @@ jobs:
     - name: Clone the osquery-packaging repository
       run: |
         cd w
-        git clone ${{ env.PACKAGING_REPO }}
+        git clone ${{ jobs.build_windows.env.PACKAGING_REPO }}
         cd ${{ steps.build_paths.outputs.PACKAGING }}
-        git checkout ${{ env.PACKAGING_COMMIT }}
+        git checkout ${{ jobs.build_windows.env.PACKAGING_COMMIT }}
 
     - name: Update the cache (git submodules)
       uses: actions/cache@v2

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -306,9 +306,8 @@ jobs:
       run: |
         git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
-        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        cd ${{ steps.build_paths.outputs.PACKAGING }}
         git checkout ${{ env.PACKAGING_COMMIT }}
-        popd
 
     # One of the tests in the test suit will spawn a Docker container
     # using this socket. Allow the unprivileged user we created
@@ -553,9 +552,8 @@ jobs:
       run: |
         git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
-        pushd ${{ steps.build_paths.outputs.PACKAGING }}
+        cd ${{ steps.build_paths.outputs.PACKAGING }}
         git checkout ${{ env.PACKAGING_COMMIT }}
-        popd
 
     - name: Update the cache (ccache)
       uses: actions/cache@v2


### PR DESCRIPTION
This allows us to make changes to the packaging repo without interrupting open osquery PRs. We can then make a testable changes to osquery when ready.