### PR TITLE
Change to the `disk_encryption` table to support QueryContext

### DIFF
--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -462,7 +462,26 @@ QueryData genFDEStatus(QueryContext& context) {
     }
   }
 
-  auto block_devices = SQL::selectAllFrom("block_devices");
+  bool runSelectAll(true);
+  QueryData block_devices;
+
+  if (auto constraint_it = context.constraints.find("name");
+      constraint_it != context.constraints.end()) {
+    const auto& constraints = constraint_it->second;
+    for (const auto& name : constraints.getAll(EQUALS)) {
+      runSelectAll = false;
+
+      auto data = SQL::selectAllFrom("block_devices", "name", EQUALS, name);
+      for (const auto& row : data) {
+        block_devices.push_back(row);
+      }
+    }
+  }
+
+  if (runSelectAll) {
+    block_devices = SQL::selectAllFrom("block_devices");
+  }
+
   for (const auto& row : block_devices) {
     auto name = row.at("name");
     @autoreleasepool {

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -430,7 +430,7 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
 }
 
 bool isAPFS(const std::unordered_map<std::string, bool>& lookup,
-            const std::string key) {
+            const std::string& key) {
   auto it = lookup.find(key);
 
   if (it == lookup.end()) {

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -429,27 +429,46 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
   IOObjectRelease(service);
 }
 
-bool isAPFS(const QueryData& result) {
-  return !result.empty() && result[0].count("type") > 0 &&
-         result[0].at("type") == kAPFSFileSystem;
+bool isAPFS(const std::unordered_map<std::string, bool>& lookup,
+            const std::string key) {
+  auto it = lookup.find(key);
+
+  if (it == lookup.end()) {
+    return false;
+  }
+
+  // We only need to check the first mount -- the rest should be the same.
+  return it->second;
 }
 
 QueryData genFDEStatus(QueryContext& context) {
   QueryData results;
 
+  // For a given device, we need to tell if it's an apfs. We do this
+  // by looking at the type column from the mounts table. Fetch this
+  // here, so don't have to keep refetching.
+  std::unordered_map<std::string, bool> deviceIsAPFS;
+  for (const auto& row : SQL::selectAllFrom("mounts")) {
+    std::string device, type;
+    for (const auto& [k, v] : row) {
+      if (k == "device") {
+        device = v;
+      } else if (k == "type") {
+        type = v;
+      }
+    }
+    if (!device.empty() && !type.empty()) {
+      deviceIsAPFS[device] = type == kAPFSFileSystem;
+    }
+  }
+
   auto block_devices = SQL::selectAllFrom("block_devices");
   for (const auto& row : block_devices) {
     auto name = row.at("name");
-    // FIXME: fetching all mounts is not efficient, we need to
-    // fetch all mounts before loop
-    auto mount = SQL::selectAllFrom("mounts", "device", EQUALS, name);
     @autoreleasepool {
       const auto bsd_name = name.substr(kDeviceNamePrefix.size());
-      if (mount.size() > 1) {
-        assert(false && "Found multiple mounts for one device!");
-        LOG(ERROR) << "Found multiple mounts for " << name;
-      }
-      genFDEStatusForBSDName(bsd_name, row.at("uuid"), isAPFS(mount), results);
+      genFDEStatusForBSDName(
+          bsd_name, row.at("uuid"), isAPFS(deviceIsAPFS, name), results);
     }
   }
   return results;

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -116,10 +116,10 @@ QueryData genFDEStatus(QueryContext& context) {
 
   std::map<std::string, Row> encrypted_rows;
 
-  if (context.constraints.count("name") > 0 &&
-      context.constraints.at("name").exists(EQUALS)) {
+  auto constraint = context.constraints.find("name");
+  if (constraint != context.constraints.end() && constraint.exists(EQUALS)) {
     const auto uuid(""), parent_name("");
-    for (const auto& name : context.constraints.at("name").getAll(EQUALS)) {
+    for (const auto& name = constraint.getAll(EQUALS)) {
       genFDEStatusForBlockDevice(
           name, uuid, parent_name, encrypted_rows, results);
     }

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -86,7 +86,7 @@ void genFDEStatusForBlockDevice(const std::string& name,
     // If there's no good crypt status, check to see if we've already
     // defined the parent_name. If so, inherit data from there. This
     // works because the `SQL::selectAllFrom("block_devices")` is
-    // ordered enought. If that order proves inadequate, we may need
+    // ordered enough. If that order proves inadequate, we may need
     // to explicitly sort it.
   default:
     if (encrypted_rows.count(parent_name)) {

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -87,7 +87,7 @@ void genFDEStatusForBlockDevice(const std::string& name,
     // defined the parent_name. If so, inherit data from there. This
     // works because the `SQL::selectAllFrom("block_devices")` is
     // ordered enought. If that order proves inadequate, we may need
-    // to explicitely sort it.
+    // to explicitly sort it.
   default:
     if (encrypted_rows.count(parent_name)) {
       auto parent_row = encrypted_rows[parent_name];

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -116,10 +116,11 @@ QueryData genFDEStatus(QueryContext& context) {
 
   std::map<std::string, Row> encrypted_rows;
 
-  auto constraint = context.constraints.find("name");
-  if (constraint != context.constraints.end() && constraint.exists(EQUALS)) {
+  auto constraint = context.constraints["name"].getAll(EQUALS);
+  auto names = std::vector(constraint.begin(), constraint.end());
+  if (!names.empty()) {
     const auto uuid(""), parent_name("");
-    for (const auto& name = constraint.getAll(EQUALS)) {
+    for (const auto& name : names) {
       genFDEStatusForBlockDevice(
           name, uuid, parent_name, encrypted_rows, results);
     }

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -116,15 +116,20 @@ QueryData genFDEStatus(QueryContext& context) {
 
   std::map<std::string, Row> encrypted_rows;
 
-  auto constraint = context.constraints["name"].getAll(EQUALS);
-  auto names = std::vector(constraint.begin(), constraint.end());
-  if (!names.empty()) {
+  bool runSelectAll(true);
+
+  if (auto constraint_it = context.constraints.find("name");
+      constraint_it != context.constraints.end()) {
+    const auto& constraints = constraint_it->second;
     const auto uuid(""), parent_name("");
-    for (const auto& name : names) {
+    for (const auto& name : constraints.getAll(EQUALS)) {
+      runSelectAll = false;
       genFDEStatusForBlockDevice(
           name, uuid, parent_name, encrypted_rows, results);
     }
-  } else {
+  }
+
+  if (runSelectAll) {
     auto block_devices = SQL::selectAllFrom("block_devices");
     for (const auto& row : block_devices) {
       const auto name = (row.count("name") > 0) ? row.at("name") : "";
@@ -138,5 +143,5 @@ QueryData genFDEStatus(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/specs/posix/block_devices.table
+++ b/specs/posix/block_devices.table
@@ -11,4 +11,5 @@ schema([
     Column("type", TEXT, "Block device type string"),
     Column("label", TEXT, "Block device label string"),
 ])
+attributes(cacheable=True)
 implementation("block_devices@genBlockDevs")

--- a/specs/posix/block_devices.table
+++ b/specs/posix/block_devices.table
@@ -11,5 +11,4 @@ schema([
     Column("type", TEXT, "Block device type string"),
     Column("label", TEXT, "Block device label string"),
 ])
-attributes(cacheable=True)
 implementation("block_devices@genBlockDevs")

--- a/specs/posix/disk_encryption.table
+++ b/specs/posix/disk_encryption.table
@@ -1,7 +1,7 @@
 table_name("disk_encryption")
 description("Disk encryption status and information.")
 schema([
-    Column("name", TEXT, "Disk name"),
+    Column("name", TEXT, "Disk name", index=True),
     Column("uuid", TEXT, "Disk Universally Unique Identifier"),
     Column("encrypted", INTEGER, "1 If encrypted: true (disk is encrypted), else 0"),
     Column("type", TEXT, "Description of cipher type and mode if available"),
@@ -14,4 +14,5 @@ extended_schema(DARWIN, [
     Column("user_uuid", TEXT, "UUID of authenticated user if available"),
     Column("filevault_status", TEXT, "FileVault status with one of following values: on | off | unknown"),
 ])
+attributes(cacheable=True)
 implementation("disk_encryption@genFDEStatus")

--- a/specs/posix/disk_encryption.table
+++ b/specs/posix/disk_encryption.table
@@ -14,5 +14,4 @@ extended_schema(DARWIN, [
     Column("user_uuid", TEXT, "UUID of authenticated user if available"),
     Column("filevault_status", TEXT, "FileVault status with one of following values: on | off | unknown"),
 ])
-attributes(cacheable=True)
 implementation("disk_encryption@genFDEStatus")


### PR DESCRIPTION
While trying to understand some LVM things (which I incorrectly thought was a bug, see #7207) I noticed that these tables were very slow to work with.  Some updates to allow working with QueryContext
