### PR TITLE
Update paths, and remove deprecated Facebook names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,7 +474,7 @@ function(generateInstallDirectives)
 
     install(
       TARGETS osqueryd
-      DESTINATION "bin"
+      DESTINATION "/opt/osquery/bin"
     )
 
     execute_process(
@@ -484,12 +484,12 @@ function(generateInstallDirectives)
 
     install(
       FILES "${CMAKE_CURRENT_BINARY_DIR}/osqueryi"
-      DESTINATION "bin"
+      DESTINATION "/opt/osquery/bin"
     )
 
     install(
       FILES "tools/deployment/osqueryctl"
-      DESTINATION "bin"
+      DESTINATION "/opt/osquery/bin"
     )
 
     install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,7 +474,7 @@ function(generateInstallDirectives)
 
     install(
       TARGETS osqueryd
-      DESTINATION "/opt/osquery/bin"
+      DESTINATION "bin"
     )
 
     execute_process(
@@ -484,12 +484,12 @@ function(generateInstallDirectives)
 
     install(
       FILES "${CMAKE_CURRENT_BINARY_DIR}/osqueryi"
-      DESTINATION "/opt/osquery/bin"
+      DESTINATION "bin"
     )
 
     install(
       FILES "tools/deployment/osqueryctl"
-      DESTINATION "/opt/osquery/bin"
+      DESTINATION "bin"
     )
 
     install(

--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -662,7 +662,7 @@ Consider the default recipe:
 
 ```ruby
 # Domain used by the macOS LaunchDaemon.
-domain = 'com.facebook.osquery.osqueryd'
+domain = 'io.osquery.agent'
 config_path = '/var/osquery/osquery.conf'
 pid_path = '/var/osquery/osquery.pid'
 flagfile = '/var/osquery/osquery.flags'
@@ -740,7 +740,7 @@ And the following files/templates used by the recipe:
 </plist>
 ```
 
-**files/default/com.facebook.osquery.osqueryd.conf**
+**files/default/io.osquery.agent.conf**
 
 ```shell
 # logfilename                         [owner:group]  mode count size   when  flags [/pid_file] [sig_num]

--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -154,7 +154,7 @@ $ sudo osqueryctl start
 $ sudo osqueryctl config-check
 E0118 17:10:09.520731 1913696256 init.cpp:421] [Ref #1629] osqueryd initialize failed: Could not open RocksDB
 $ sudo osqueryctl status
-com.facebook.osqueryd is running. pid: 81943
+io.osquery.agent is running. pid: 81943
 $ sudo osqueryctl stop
 $ sudo osqueryctl config-check || echo 'config has an error'
 ```

--- a/docs/wiki/installation/custom-packages.md
+++ b/docs/wiki/installation/custom-packages.md
@@ -38,14 +38,14 @@ The macOS deployment is a bit more complicated and customizable compared to Linu
 This tool will build an OS X/macOS package with:
 
 - the **osqueryi** and **osqueryd** binaries
-- the [LaunchDaemon](https://github.com/osquery/osquery/blob/master/tools/deployment/com.facebook.osqueryd.plist) that is responsible for osqueryd
+- the [LaunchDaemon](https://github.com/osquery/osquery/blob/master/tools/deployment/io.osquery.agent.plist) that is responsible for osqueryd
 - the osqueryd config file that was specified via the command line using "-c"
 
 Here is the output from us running `make_osx_package.sh`:
 
 ```sh
 $ ./tools/deployment/make_osx_package.sh -c ~/Desktop/osquery.conf
-[+] no custom launchd path was defined. using ~/git/osquery/tools/deployment/com.facebook.osqueryd.plist
+[+] no custom launchd path was defined. using ~/git/osquery/tools/deployment/io.osquery.agent.plist
 [+] copying osquery binaries
 [+] copying osquery configurations
 [+] finalizing preinstall and postinstall scripts
@@ -59,13 +59,13 @@ You can now use your existing package distribution system ([JAMF](https://www.ja
 
 ### Custom LaunchDaemon
 
-If you want to modify the command-line arguments used to start `osqueryd`, copy and modify the [LaunchDaemon](https://github.com/osquery/osquery/blob/master/tools/com.facebook.osqueryd.plist), which is included with this repository, to suit your liking.
+If you want to modify the command-line arguments used to start `osqueryd`, copy and modify the [LaunchDaemon](https://github.com/osquery/osquery/blob/master/tools/io.osquery.agent.plist), which is included with this repository, to suit your liking.
 
 When you run **make_osx_package.sh**, include a `-l`/`--launchd-path` flag which indicates the path of your new LaunchDaemon. If specified, this will be used instead of the default LaunchDaemon. For example:
 
 ```sh
 $ ./tools/deployment/make_osx_package.sh -c /internal/osquery/osquery.conf \
-  -l /internal/osquery/com.facebook.osqueryd.plist
+  -l /internal/osquery/io.osquery.agent.plist
 ```
 
 ### Removing the LaunchDaemon

--- a/docs/wiki/installation/install-macos.md
+++ b/docs/wiki/installation/install-macos.md
@@ -11,7 +11,7 @@ Each osquery tag (release) builds a macOS package: [osquery.io/downloads](https:
 The default package creates the following structure:
 
 ```sh
-/private/var/osquery/com.facebook.osqueryd.plist
+/private/var/osquery/io.osquery.agent.plist
 /private/var/osquery/osquery.example.conf
 /private/var/log/osquery/
 /private/var/osquery/lenses/{*}.aug
@@ -36,8 +36,8 @@ sudo osqueryctl start
 
 # Or, install the example config and launch daemon yourself:
 sudo cp /var/osquery/osquery.example.conf /var/osquery/osquery.conf
-sudo cp /var/osquery/com.facebook.osqueryd.plist /Library/LaunchDaemons
-sudo launchctl load /Library/LaunchDaemons/com.facebook.osqueryd.plist
+sudo cp /var/osquery/io.osquery.agent.plist /Library/LaunchDaemons
+sudo launchctl load /Library/LaunchDaemons/io.osquery.agent.plist
 ```
 
 ### Removing osquery
@@ -45,16 +45,16 @@ sudo launchctl load /Library/LaunchDaemons/com.facebook.osqueryd.plist
 To remove osquery from a macOS system, run the following commands:
 
 ```sh
-# Unload and remove com.facebook.osquery.plist launchdaemon
-sudo launchctl unload /Library/LaunchDaemons/com.facebook.osqueryd.plist
-sudo rm /Library/LaunchDaemons/com.facebook.osqueryd.plist
+# Unload and remove io.osquery.agent.plist launchdaemon
+sudo launchctl unload /Library/LaunchDaemons/io.osquery.agent.plist
+sudo rm /Library/LaunchDaemons/io.osquery.agent.plist
 
 # Remove files/directories created by osquery installer pkg
 sudo rm -rf /private/var/log/osquery
 sudo rm -rf /private/var/osquery
 sudo rm /usr/local/bin/osquery*
 
-sudo pkgutil --forget com.facebook.osquery
+sudo pkgutil --forget io.osquery.agent
 ```
 
 ## Running osquery

--- a/tools/windows_resources.rc.in
+++ b/tools/windows_resources.rc.in
@@ -7,7 +7,7 @@
 #define VER_PRODUCTVERSION          @osquery_version_major@,@osquery_version_minor@,@osquery_version_patch@,0
 #define VER_PRODUCTVERSION_STR      "@osquery_version@\0"
 
-#define VER_COMPANYNAME_STR         "Osquery"
+#define VER_COMPANYNAME_STR         "Osquery Foundation"
 #define VER_FILEDESCRIPTION_STR     "osquery daemon and shell"
 #define VER_INTERNALNAME_STR        "osquery"
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the root directory of this source tree."

--- a/tools/windows_resources.rc.in
+++ b/tools/windows_resources.rc.in
@@ -7,7 +7,7 @@
 #define VER_PRODUCTVERSION          @osquery_version_major@,@osquery_version_minor@,@osquery_version_patch@,0
 #define VER_PRODUCTVERSION_STR      "@osquery_version@\0"
 
-#define VER_COMPANYNAME_STR         "Facebook"
+#define VER_COMPANYNAME_STR         "Osquery"
 #define VER_FILEDESCRIPTION_STR     "osquery daemon and shell"
 #define VER_INTERNALNAME_STR        "osquery"
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, The osquery authors. See LICENSE file found in the root directory of this source tree."


### PR DESCRIPTION
Changes to update the various facebook names to the osquery ones.

I tried to get the paths as well. I might have missed a couple

Closes: #7159