### PR TITLE
[AWS] Optionally enable debug option and restrict content-type header size for PUT req

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -458,7 +458,7 @@ Response Client::put(Request& req,
                      std::string const& content_type) {
   req.method(beast_http::verb::put);
   req.body() = body;
-  if (!content_type.empty()) {
+  if (!content_type.empty() && content_type.size() < 512) {
     req.set(beast_http::field::content_type, content_type);
   }
   return sendHTTPRequest(req);
@@ -480,7 +480,7 @@ Response Client::put(Request& req,
                      std::string const& content_type) {
   req.method(beast_http::verb::put);
   req.body() = std::move(body);
-  if (!content_type.empty()) {
+  if (!content_type.empty() && content_type.size() < 512) {
     req.set(beast_http::field::content_type, content_type);
   }
   return sendHTTPRequest(req);

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -213,10 +213,9 @@ std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
   } catch (const std::exception& e) {
     /* NOTE: This exception must NOT be passed by reference. */
     LOG(ERROR) << "Exception making HTTP "
-               << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request.GetMethod())
-               << " request to URL ("
-               << url
-               << "): " << e.what();
+               << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(
+                      request.GetMethod())
+               << " request to URL (" << url << "): " << e.what();
     return nullptr;
   }
 

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -80,7 +80,7 @@ FLAG(string,
      aws_proxy_password,
      "",
      "Proxy password for use in AWS client config");
-FLAG(bool, aws_enable_debugging, false, "Enable AWS SDK debug logging");
+FLAG(bool, aws_debug, false, "Enable AWS SDK debug logging");
 
 /// EC2 instance latestmetadata URL
 const std::string kEc2MetadataUrl =
@@ -368,7 +368,7 @@ void initAwsSdk() {
   try {
     std::call_once(once_flag, []() {
       Aws::SDKOptions options;
-      if (FLAGS_aws_enable_debugging) {
+      if (FLAGS_aws_debug) {
         options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
       }
       options.httpOptions.httpClientFactory_create_fn = []() {


### PR DESCRIPTION
This PR:

* adds a `aws_enable_debugging` FLAG option, to enable AWS-SDK debug logging
* restrics header size for `content-type` in PUT requests to a reasonable length 

This fixes the `ec2_instance_tags` table, and other timeout issues with AWS PUT requests that we been seeing on an IMDSv2 enforced instance
