### PR TITLE
Fix check for PIE support

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -656,6 +656,8 @@ jobs:
 
       run: |
         cmake -G "Unix Makefiles" \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.architecture }}" \
           -DCMAKE_OSX_DEPLOYMENT_TARGET="${{ steps.xcode_selector.outputs.DEPLOYMENT_TARGET }}" \
           -DCMAKE_BUILD_TYPE:STRING="${{ matrix.build_type }}" \

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -1,11 +1,13 @@
-if(NOT DEFINED OSQUERY_TOOLCHAIN_SYSROOT)
-    include(CheckPIESupported)
-    check_pie_supported()
-    if(NOT CMAKE_C_LINK_PIE_SUPPORT OR NOT CMAKE_CXX_LINK_PIE_SUPPORT)
-        message(FATAL_ERROR "The linker for the current compiler do not support -fPIE or -pie")
-    endif()
+
+if(DEFINED PLATFORM_POSIX)
+  include(CheckPIESupported)
+  check_pie_supported()
+  if(NOT CMAKE_C_LINK_PIE_SUPPORTED OR NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+      message(FATAL_ERROR "The linker for the current compiler does not support -fPIE or -pie")
+  endif()
+
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -83,7 +83,7 @@ cd osquery
 
 # Configure
 mkdir build; cd build
-cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 ..
+cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
 
 # Build
 cmake --build . -j $(sysctl -n hw.ncpu)


### PR DESCRIPTION
- The check was never done when using a system toolchain
  due to an incorrect test on the toolchain sysroot variable.

- Correct a typo in the names of the variables that the PIE check sets
  when PIE is supported.
  
NOTE: This wasn't negatively affecting the official builds on any platform, or any build done with our toolchain. It was already building correctly with PIE. Builds using a system compiler though (like with oss-fuzz), were not PIE.

EDIT: Changed the description to reflect the status after the latest changes.