### PR TITLE
Fix osquery_info build_platform column value on Linux

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -115,8 +115,8 @@ function(setupBuildFlags)
       set(osquery_linux_common_defines
         LINUX=1
         OSQUERY_LINUX=1
-        OSQUERY_BUILD_DISTRO=centos7
-        OSQUERY_BUILD_PLATFORM=linux
+        OSQUERY_BUILD_DISTRO="centos7"
+        OSQUERY_BUILD_PLATFORM="linux"
       )
 
       set(osquery_linux_common_link_options
@@ -186,8 +186,8 @@ function(setupBuildFlags)
         APPLE=1
         DARWIN=1
         BSD=1
-        OSQUERY_BUILD_PLATFORM=darwin
-        OSQUERY_BUILD_DISTRO=10.12
+        OSQUERY_BUILD_PLATFORM="darwin"
+        OSQUERY_BUILD_DISTRO="10.12"
       )
 
       target_compile_options(cxx_settings INTERFACE
@@ -316,8 +316,8 @@ function(setupBuildFlags)
       WINDOWS=1
       WIN32_LEAN_AND_MEAN
       OSQUERY_WINDOWS=1
-      OSQUERY_BUILD_PLATFORM=windows
-      OSQUERY_BUILD_DISTRO=10
+      OSQUERY_BUILD_PLATFORM="windows"
+      OSQUERY_BUILD_DISTRO="10"
       BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE=1
       UNICODE
       _UNICODE

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -211,8 +211,8 @@ QueryData genOsqueryInfo(QueryContext& context) {
   r["config_valid"] = Config::get().isValid() ? INTEGER(1) : INTEGER(0);
   r["extensions"] =
       (pingExtension(FLAGS_extensions_socket).ok()) ? "active" : "inactive";
-  r["build_platform"] = STR(OSQUERY_BUILD_PLATFORM);
-  r["build_distro"] = STR(OSQUERY_BUILD_DISTRO);
+  r["build_platform"] = OSQUERY_BUILD_PLATFORM;
+  r["build_distro"] = OSQUERY_BUILD_DISTRO;
   r["start_time"] = INTEGER(getStartTime());
   if (Initializer::isWorker()) {
     r["watcher"] = INTEGER(PlatformProcess::getLauncherProcess()->pid());

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -82,7 +82,7 @@ PlatformType operator|(PlatformType a, PlatformType b);
 #error The build must define OSQUERY_BUILD_DISTRO.
 #endif
 
-#define OSQUERY_PLATFORM STR(OSQUERY_BUILD_PLATFORM)
+#define OSQUERY_PLATFORM OSQUERY_BUILD_PLATFORM
 
 /// Identifies the build platform of either the core extension.
 extern const std::string kSDKPlatform;


### PR DESCRIPTION
The value of build_platform in the osquery_info table
is currently controlled by the value of the preprocessor macro
OSQUERY_BUILD_PLATFORM, which is hardcoded to `linux` as a macro
passed via CLI.
That macro is then stringified, but the issue is that the `linux`
keyword is also a macro, which gets expanded to 1.

To avoid this collisions, we can set the preprocessor macro value
as a string already from CLI and remove the stringification,
which will prevent further problematic expansions.

We do the same also for the other string macro OSQUERY_BUILD_DISTRO.

NOTE: This is a quick fix for the described issue specifically; the values presented in those columns have additional issues described here: https://github.com/osquery/osquery/issues/7253
