### PR TITLE
audit: socket_events improvements

### DIFF
--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -132,7 +132,7 @@ A sample socket_event log entry looks like this:
   "action": "added",
   "columns": {
     "time": "1527895541",
-    "success": "1",
+    "status": "succeeded",
     "remote_port": "80",
     "action": "connect",
     "auid": "1000",
@@ -151,6 +151,22 @@ A sample socket_event log entry looks like this:
 ```
 
 If you would like to log UNIX domain sockets use the hidden flag: `--audit_allow_unix`. This will put considerable strain on the system as many default actions use domain sockets. You will also need to explicitly select the `socket` column from the `socket_events` table.
+
+The `success` column has been deprecated and replaced with `status`:
+| Status value | Description |
+|-|-|
+| failed | Definitely failed |
+| succeeded | Definitely succeeded |
+| inprogress | The socket operation has been marked as "in progress" (EINPROGRESS) and osquery can't determine whether it will succeed or not. Reserved for syscalls that support non-blocking operations (O_NONBLOCK) such as `connect`. |
+
+
+The behavior of the socket_events table can be changed with the following boolean flags:
+
+| Flag | Description |
+|-|-|
+| --audit_allow_sockets | Allow the audit publisher to install socket-related rules |
+| --audit_allow_unix | Allow socket events to collect domain sockets |
+| --audit_allow_failed_socket_events | Include rows for socket events that have failed |
 
 ## Troubleshooting Audit-based process and socket auditing on Linux
 

--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -157,8 +157,8 @@ The `success` column has been deprecated and replaced with `status`:
 |-|-|
 | failed | Definitely failed |
 | succeeded | Definitely succeeded |
-| inprogress | The socket operation has been marked as "in progress" (EINPROGRESS) and osquery can't determine whether it will succeed or not. Reserved for syscalls that support non-blocking operations (O_NONBLOCK) such as `connect`. |
-
+| in_progress | The `connect`()` syscall has been marked as "in progress" (EINPROGRESS) and osquery can't determine whether it will succeed or not. Reserved for non-blocking sockets. |
+| no_client | The `accept` or `accept4` syscall returned with EAGAIN since there were not incoming connections. Reserved for non-blocking sockets. |
 
 The behavior of the socket_events table can be changed with the following boolean flags:
 
@@ -167,6 +167,8 @@ The behavior of the socket_events table can be changed with the following boolea
 | --audit_allow_sockets | Allow the audit publisher to install socket-related rules |
 | --audit_allow_unix | Allow socket events to collect domain sockets |
 | --audit_allow_failed_socket_events | Include rows for socket events that have failed |
+| --audit_allow_accept_socket_events | Include rows for accept socket events |
+| --audit_allow_null_accept_socket_events | Allow non-blocking accept() syscalls that returned EAGAIN/EWOULDBLOCK |
 
 ## Troubleshooting Audit-based process and socket auditing on Linux
 

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -24,6 +24,7 @@ function(generateOsqueryEvents)
       linux/inotify.cpp
       linux/syslog.cpp
       linux/udev.cpp
+      linux/socket_events.cpp
     )
 
     if(OSQUERY_BUILD_BPF)

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -352,7 +352,7 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
   if (FLAGS_audit_allow_sockets) {
     VLOG(1) << "Enabling audit rules for the socket_events table";
 
-    for (int syscall : kSocketEventsSyscalls) {
+    for (int syscall : getSocketEventsSyscalls()) {
       monitored_syscall_list_.insert(syscall);
     }
   }

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -26,6 +26,7 @@ struct UserAuditEventData final {
 
 struct SyscallAuditEventData final {
   std::uint64_t syscall_number;
+  bool succeeded;
 
   pid_t process_id;
   pid_t parent_process_id;
@@ -150,9 +151,11 @@ class AuditEventPublisher final
   static std::string executable_path_;
 
   /// Aggregates raw event records into audit events
-  static void ProcessEvents(AuditEventContextRef event_context,
-                            const std::vector<AuditEventRecord>& record_list,
-                            AuditTraceContext& trace_context) noexcept;
+  static void ProcessEvents(
+      AuditEventContextRef event_context,
+      const std::vector<AuditEventRecord>& record_list,
+      AuditTraceContext& trace_context,
+      const std::set<int>& syscalls_allowed_to_fail) noexcept;
 
  private:
   /// Netlink reader
@@ -160,6 +163,9 @@ class AuditEventPublisher final
 
   /// This is where audit records are assembled
   AuditTraceContext audit_trace_context_;
+
+  /// Syscalls allowed to fail (captured even if success=no)
+  std::set<int> syscalls_allowed_to_fail_;
 };
 
 /// Extracts the specified audit event record from the given audit event

--- a/osquery/events/linux/socket_events.cpp
+++ b/osquery/events/linux/socket_events.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/flags.h>
+#include <osquery/events/linux/socket_events.h>
+
+#include <asm/unistd.h>
+
+namespace osquery {
+
+FLAG(bool,
+     audit_allow_accept_socket_events,
+     true,
+     "Include rows for accept socket events");
+
+namespace {
+
+const std::set<int> kBaseSyscallSet = {__NR_bind, __NR_connect};
+
+}
+
+std::set<int> getSocketEventsSyscalls() {
+  auto syscall_set = kBaseSyscallSet;
+
+  if (FLAGS_audit_allow_accept_socket_events) {
+    syscall_set.insert(__NR_accept);
+    syscall_set.insert(__NR_accept4);
+  }
+
+  return syscall_set;
+}
+
+} // namespace osquery

--- a/osquery/events/linux/socket_events.h
+++ b/osquery/events/linux/socket_events.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <asm/unistd.h>
-
 #include <set>
 
-const std::set<int> kSocketEventsSyscalls = {
-  __NR_bind,
-  __NR_connect};
+namespace osquery {
+
+std::set<int> getSocketEventsSyscalls();
+
+}

--- a/osquery/events/tests/CMakeLists.txt
+++ b/osquery/events/tests/CMakeLists.txt
@@ -93,7 +93,10 @@ function(generateOsqueryEventsTestsSyslogtestsTest)
 endfunction()
 
 function(generateOsqueryEventsTestsAudittestsTest)
-  add_osquery_executable(osquery_events_tests_audittests-test linux/audit_tests.cpp)
+  add_osquery_executable(osquery_events_tests_audittests-test
+    linux/audit_tests.cpp
+    linux/socket_events.cpp
+  )
 
   target_link_libraries(osquery_events_tests_audittests-test PRIVATE
     osquery_cxx_settings

--- a/osquery/events/tests/linux/audit_tests.cpp
+++ b/osquery/events/tests/linux/audit_tests.cpp
@@ -20,6 +20,7 @@
 #include <osquery/core/tables.h>
 
 #include "osquery/events/linux/auditdnetlink.h"
+#include "osquery/events/linux/socket_events.h"
 #include "osquery/tests/test_util.h"
 
 namespace osquery {

--- a/osquery/events/tests/linux/audit_tests.cpp
+++ b/osquery/events/tests/linux/audit_tests.cpp
@@ -20,15 +20,11 @@
 #include <osquery/core/tables.h>
 
 #include "osquery/events/linux/auditdnetlink.h"
-#include "osquery/events/linux/socket_events.h"
 #include "osquery/tests/test_util.h"
 
 namespace osquery {
 
 DECLARE_bool(audit_allow_unix);
-
-/// Internal audit subscriber (socket events) testable methods.
-extern void parseSockAddr(const std::string& saddr, Row& r, bool& unix_socket);
 
 using StringMap = std::map<std::string, std::string>;
 
@@ -104,34 +100,4 @@ bool SimpleUpdate(size_t t, const StringMap& f, StringMap& m) {
   return true;
 }
 
-TEST_F(AuditTests, test_parse_sock_addr) {
-  Row r;
-  std::string msg = "02001F907F0000010000000000000000";
-  bool unix_socket;
-  parseSockAddr(msg, r, unix_socket);
-  ASSERT_FALSE(r["remote_address"].empty());
-  EXPECT_EQ(r["remote_address"], "127.0.0.1");
-  EXPECT_EQ(r["family"], "2");
-  EXPECT_EQ(r["remote_port"], "8080");
-
-  Row r3;
-  std::string msg2 = "0A001F9100000000FE80000000000000022522FFFEB03684000000";
-  parseSockAddr(msg2, r3, unix_socket);
-  ASSERT_FALSE(r3["remote_address"].empty());
-  EXPECT_EQ(r3["remote_address"], "fe80:0000:0000:0000:0225:22ff:feb0:3684");
-  EXPECT_EQ(r3["remote_port"], "8081");
-
-  auto socket_flag = FLAGS_audit_allow_unix;
-  FLAGS_audit_allow_unix = true;
-  Row r4;
-  std::string msg3 = "01002F746D702F6F7371756572792E656D0000";
-  parseSockAddr(msg3, r4, unix_socket);
-  ASSERT_FALSE(r4["socket"].empty());
-  EXPECT_EQ(r4["socket"], "/tmp/osquery.em");
-
-  msg3 = "0100002F746D702F6F7371756572792E656D";
-  parseSockAddr(msg3, r4, unix_socket);
-  EXPECT_EQ(r4["socket"], "/tmp/osquery.em");
-  FLAGS_audit_allow_unix = socket_flag;
-}
 }

--- a/osquery/events/tests/linux/process_file_events_tests.cpp
+++ b/osquery/events/tests/linux/process_file_events_tests.cpp
@@ -53,6 +53,8 @@ void DumpRowList(const std::vector<Row>& row_list) {
 }
 
 TEST_F(AuditdFimTests, row_emission) {
+  static const std::set<int> kSyscallsAllowedToFail{};
+
   std::vector<AuditEventRecord> event_record_list;
 
   // Parse the raw messages and make sure we get the right amount
@@ -81,8 +83,10 @@ TEST_F(AuditdFimTests, row_emission) {
   auto event_context = std::make_shared<AuditEventContext>();
   AuditTraceContext audit_trace_context;
 
-  AuditEventPublisher::ProcessEvents(
-      event_context, event_record_list, audit_trace_context);
+  AuditEventPublisher::ProcessEvents(event_context,
+                                     event_record_list,
+                                     audit_trace_context,
+                                     kSyscallsAllowedToFail);
 
   EXPECT_EQ(audit_trace_context.size(), 0U);
   EXPECT_EQ(event_context->audit_events.size(), 71U);

--- a/osquery/events/tests/linux/socket_events.cpp
+++ b/osquery/events/tests/linux/socket_events.cpp
@@ -1,0 +1,328 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <asm/unistd.h>
+
+#include <gtest/gtest.h>
+
+#include <osquery/events/linux/auditdnetlink.h>
+#include <osquery/events/linux/auditeventpublisher.h>
+#include <osquery/tables/events/linux/socket_events.h>
+
+namespace osquery {
+
+namespace {
+
+extern const AuditEvent kSucceededConnectEvent;
+extern const AuditEvent kSucceededBindEvent;
+
+} // namespace
+
+class SocketEventsTableTests : public testing::Test {};
+
+TEST_F(SocketEventsTableTests, successful_blocking_connect_syscall) {
+  for (const auto& allow_failed_events : {true, false}) {
+    std::vector<Row> emitted_row_list;
+    auto status = SocketEventSubscriber::ProcessEvents(
+        emitted_row_list, {kSucceededConnectEvent}, allow_failed_events);
+
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(emitted_row_list.size(), 1);
+    EXPECT_EQ(emitted_row_list.front()["success"], "1");
+    EXPECT_EQ(emitted_row_list.front()["status"], "succeeded");
+  }
+}
+
+TEST_F(SocketEventsTableTests, failed_blocking_connect_syscall) {
+  auto audit_event = kSucceededConnectEvent;
+  auto& syscall_data = boost::get<SyscallAuditEventData>(audit_event.data);
+
+  syscall_data.succeeded = false;
+  audit_event.record_list.at(0).fields["success"] = "no";
+  audit_event.record_list.at(0).fields["exit"] = std::to_string(-EBADF);
+
+  for (const auto& allow_failed_events : {true, false}) {
+    std::vector<Row> emitted_row_list;
+    auto status = SocketEventSubscriber::ProcessEvents(
+        emitted_row_list, {audit_event}, allow_failed_events);
+
+    EXPECT_TRUE(status.ok());
+
+    if (allow_failed_events) {
+      ASSERT_EQ(emitted_row_list.size(), 1);
+      EXPECT_EQ(emitted_row_list.front()["success"], "0");
+      EXPECT_EQ(emitted_row_list.front()["status"], "failed");
+
+    } else {
+      EXPECT_TRUE(emitted_row_list.empty());
+    }
+  }
+}
+
+TEST_F(SocketEventsTableTests, succeeded_non_blocking_connect_syscall) {
+  auto audit_event = kSucceededConnectEvent;
+  auto& syscall_data = boost::get<SyscallAuditEventData>(audit_event.data);
+
+  syscall_data.succeeded = false;
+  audit_event.record_list.at(0).fields["success"] = "no";
+  audit_event.record_list.at(0).fields["exit"] = std::to_string(-EINPROGRESS);
+
+  for (const auto& allow_failed_events : {true, false}) {
+    std::vector<Row> emitted_row_list;
+    auto status = SocketEventSubscriber::ProcessEvents(
+        emitted_row_list, {audit_event}, allow_failed_events);
+
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(emitted_row_list.size(), 1);
+    EXPECT_EQ(emitted_row_list.front()["success"], "1");
+    EXPECT_EQ(emitted_row_list.front()["status"], "inprogress");
+  }
+}
+
+TEST_F(SocketEventsTableTests, succeeded_bind_syscall) {
+  for (const auto& allow_failed_events : {true, false}) {
+    std::vector<Row> emitted_row_list;
+    auto status = SocketEventSubscriber::ProcessEvents(
+        emitted_row_list, {kSucceededBindEvent}, allow_failed_events);
+
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(emitted_row_list.size(), 1);
+    EXPECT_EQ(emitted_row_list.front()["success"], "1");
+    EXPECT_EQ(emitted_row_list.front()["status"], "succeeded");
+  }
+}
+
+TEST_F(SocketEventsTableTests, failed_bind_syscall) {
+  auto audit_event = kSucceededBindEvent;
+  auto& syscall_data = boost::get<SyscallAuditEventData>(audit_event.data);
+
+  syscall_data.succeeded = false;
+  audit_event.record_list.at(0).fields["success"] = "no";
+
+  for (const auto& errnor_value : {-EINPROGRESS, -EBADF}) {
+    audit_event.record_list.at(0).fields["exit"] = std::to_string(errnor_value);
+
+    for (const auto& allow_failed_events : {true, false}) {
+      std::vector<Row> emitted_row_list;
+      auto status = SocketEventSubscriber::ProcessEvents(
+          emitted_row_list, {audit_event}, allow_failed_events);
+
+      EXPECT_TRUE(status.ok());
+
+      if (allow_failed_events) {
+        ASSERT_EQ(emitted_row_list.size(), 1);
+        EXPECT_EQ(emitted_row_list.front()["success"], "0");
+        EXPECT_EQ(emitted_row_list.front()["status"], "failed");
+
+      } else {
+        EXPECT_TRUE(emitted_row_list.empty());
+      }
+    }
+  }
+}
+
+namespace {
+
+// clang-format off
+const AuditEvent kSucceededConnectEvent{
+  AuditEvent::Type::Syscall,
+
+  SyscallAuditEventData{
+    // syscall id, and whether the 'success' field was set to 'yes'
+    __NR_connect,
+    true,
+
+    // pid, ppid
+    39598,
+    39590,
+
+    // uid, auid, euid, fsuid, suid
+    1000,
+    1000,
+    1000,
+    1000,
+    1000,
+
+    // gid, egid, fsgid, sgid
+    1000,
+    1000,
+    1000,
+    1000,
+
+    // Binary path, from the 'exe' field
+    "/usr/bin/curl",
+  },
+
+  {
+    {
+      AUDIT_SYSCALL,
+      1,
+      "1629377973.356:1276",
+      {
+        { "arch", "c000003e" },
+        { "syscall", "42" },
+        { "success", "yes" },
+        { "exit", "0" },
+        { "a0", "7" },
+        { "a1", "7fb5de285d0c" },
+        { "a2", "10" },
+        { "a3", "7fb5df747291" },
+        { "items", "0" },
+        { "ppid", "39590" },
+        { "pid", "39598" },
+        { "auid", "1000" },
+        { "uid", "1000" },
+        { "gid", "1000" },
+        { "euid", "1000" },
+        { "suid", "1000" },
+        { "fsuid", "1000" },
+        { "egid", "1000" },
+        { "sgid", "1000" },
+        { "fsgid", "1000" },
+        { "tty", "pts1" },
+        { "ses", "2" },
+        { "comm", "curl" },
+        { "exe", "/usr/bin/curl" },
+        { "subj", "unconfined" },
+        { "key", "" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_SOCKADDR,
+      2,
+      "1629377973.356:1276",
+      {
+        { "saddr", "020000357F000035900600D8B57F0000" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_PROCTITLE,
+      3,
+      "1629377973.356:1276",
+      {
+        { "proctitle", "6375726C0068747470733A2F2F6769746875622E636F6D" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_EOE,
+      4,
+      "1629377973.356:1276",
+      { },
+      ""
+    }
+  }
+};
+// clang-format on
+
+// clang-format off
+const AuditEvent kSucceededBindEvent{
+  AuditEvent::Type::Syscall,
+
+  SyscallAuditEventData{
+    // syscall id, and whether the 'success' field was set to 'yes'
+    __NR_bind,
+    true,
+
+    // pid, ppid
+    48359,
+    39590,
+
+    // uid, auid, euid, fsuid, suid
+    1000,
+    1000,
+    1000,
+    1000,
+    1000,
+
+    // gid, egid, fsgid, sgid
+    1000,
+    1000,
+    1000,
+    1000,
+
+    // Binary path, from the 'exe' field
+    "/usr/bin/nc.openbsd",
+  },
+
+  {
+    {
+      AUDIT_SYSCALL,
+      1,
+      "1629382051.394:1296",
+      {
+        { "arch", "c000003e" },
+        { "syscall", "49" },
+        { "success", "yes" },
+        { "exit", "0" },
+        { "a0", "3" },
+        { "a1", "55ea21a222d0" },
+        { "a2", "10" },
+        { "a3", "7fff5c13e390" },
+        { "items", "0" },
+        { "ppid", "39590" },
+        { "pid", "48359" },
+        { "auid", "1000" },
+        { "uid", "1000" },
+        { "gid", "1000" },
+        { "euid", "1000" },
+        { "suid", "1000" },
+        { "fsuid", "1000" },
+        { "egid", "1000" },
+        { "sgid", "1000" },
+        { "fsgid", "1000" },
+        { "tty", "pts1" },
+        { "ses", "2" },
+        { "comm", "nc" },
+        { "exe", "/usr/bin/nc.openbsd" },
+        { "subj", "unconfined" },
+        { "key", "" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_SOCKADDR,
+      2,
+      "1629382051.394:1296",
+      {
+        { "saddr", "02001F907F0000010000000000000000" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_PROCTITLE,
+      3,
+      "1629382051.394:1296",
+      {
+        { "proctitle", "6E63002D6C003132372E302E302E310038303830" },
+      },
+      ""
+    },
+
+    {
+      AUDIT_EOE,
+      4,
+      "1629382051.394:1296",
+      { },
+      ""
+    }
+  }
+};
+// clang-format on
+
+} // namespace
+
+} // namespace osquery

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -128,6 +128,9 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     }
 
     const auto& event_data = boost::get<SyscallAuditEventData>(event.data);
+    if (!event_data.succeeded) {
+      continue;
+    }
 
     bool is_exec_syscall{false};
     bool is_kill_syscall{false};

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -1230,6 +1230,10 @@ Status ProcessFileEventSubscriber::ProcessEvents(
     }
 
     const auto& event_data = boost::get<SyscallAuditEventData>(event.data);
+    if (!event_data.succeeded) {
+      continue;
+    }
+
     if (!L_ShouldHandle(event_data.syscall_number)) {
       continue;
     }

--- a/osquery/tables/events/linux/socket_events.h
+++ b/osquery/tables/events/linux/socket_events.h
@@ -26,10 +26,16 @@ class SocketEventSubscriber final
   /// Processes the updates received from the callback
   static Status ProcessEvents(std::vector<Row>& emitted_row_list,
                               const std::vector<AuditEvent>& event_list,
-                              bool allow_failed_socket_events) noexcept;
+                              bool allow_failed_socket_events,
+                              bool allow_unix_socket_events) noexcept;
 
   /// Returns the set of syscalls that this subscriber can handle
   static const std::set<int>& GetSyscallSet() noexcept;
+
+  /// Parses the "saddr" field of an AUDIT_SOCKADDR record
+  static bool parseSockAddr(const std::string& saddr,
+                            Row& row,
+                            bool& unix_socket);
 };
 
 } // namespace osquery

--- a/osquery/tables/events/linux/socket_events.h
+++ b/osquery/tables/events/linux/socket_events.h
@@ -27,7 +27,9 @@ class SocketEventSubscriber final
   static Status ProcessEvents(std::vector<Row>& emitted_row_list,
                               const std::vector<AuditEvent>& event_list,
                               bool allow_failed_socket_events,
-                              bool allow_unix_socket_events) noexcept;
+                              bool allow_unix_socket_events,
+                              bool allow_null_accept_events,
+                              bool allow_null_accept_socket_events) noexcept;
 
   /// Returns the set of syscalls that this subscriber can handle
   static const std::set<int>& GetSyscallSet() noexcept;

--- a/osquery/tables/events/linux/socket_events.h
+++ b/osquery/tables/events/linux/socket_events.h
@@ -24,9 +24,9 @@ class SocketEventSubscriber final
   Status Callback(const ECRef& ec, const SCRef& sc);
 
   /// Processes the updates received from the callback
-  static Status ProcessEvents(
-      std::vector<Row>& emitted_row_list,
-      const std::vector<AuditEvent>& event_list) noexcept;
+  static Status ProcessEvents(std::vector<Row>& emitted_row_list,
+                              const std::vector<AuditEvent>& event_list,
+                              bool allow_failed_socket_events) noexcept;
 
   /// Returns the set of syscalls that this subscriber can handle
   static const std::set<int>& GetSyscallSet() noexcept;

--- a/osquery/tables/events/tests/linux/process_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/process_events_tests.cpp
@@ -54,6 +54,8 @@ void GenerateAuditEvent(std::vector<AuditEventRecord>& record_list,
 
 void GenerateEventContext(std::shared_ptr<AuditEventContext>& event_context,
                           const RawAuditEvent& audit_event) {
+  static const std::set<int> kSyscallsAllowedToFail{};
+
   event_context.reset();
 
   std::vector<AuditEventRecord> record_list;
@@ -65,7 +67,7 @@ void GenerateEventContext(std::shared_ptr<AuditEventContext>& event_context,
   AuditTraceContext audit_trace_context;
 
   AuditEventPublisher::ProcessEvents(
-      event_context, record_list, audit_trace_context);
+      event_context, record_list, audit_trace_context, kSyscallsAllowedToFail);
 
   EXPECT_EQ(audit_trace_context.size(), 0U);
   EXPECT_EQ(event_context->audit_events.size(), 1U);

--- a/specs/posix/socket_events.table
+++ b/specs/posix/socket_events.table
@@ -6,7 +6,7 @@ schema([
     Column("path", TEXT, "Path of executed file"),
     Column("fd", TEXT, "The file description for the process socket"),
     Column("auid", BIGINT, "Audit User ID"),
-    Column("status", TEXT, "Either 'succeeded', 'failed', or 'inprogress' (reserved for non-blocking sockets)"),
+    Column("status", TEXT, "Either 'succeeded', 'failed', 'in_progress' (connect() on non-blocking socket) or 'no_client' (null accept() on non-blocking socket)"),
     Column("family", INTEGER, "The Internet protocol family ID"),
     Column("protocol", INTEGER, "The network protocol ID",
         hidden=True),

--- a/specs/posix/socket_events.table
+++ b/specs/posix/socket_events.table
@@ -6,7 +6,7 @@ schema([
     Column("path", TEXT, "Path of executed file"),
     Column("fd", TEXT, "The file description for the process socket"),
     Column("auid", BIGINT, "Audit User ID"),
-    Column("success", INTEGER, "The socket open attempt status"),
+    Column("status", TEXT, "Either 'succeeded', 'failed', or 'inprogress' (reserved for non-blocking sockets)"),
     Column("family", INTEGER, "The Internet protocol family ID"),
     Column("protocol", INTEGER, "The network protocol ID",
         hidden=True),
@@ -19,6 +19,7 @@ schema([
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
+    Column("success", INTEGER, "Deprecated. Use the 'status' column instead", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("socket_events@socket_events::genTable")


### PR DESCRIPTION
This PR adds support for non-blocking sockets to the Audit-based socket_events table for Linux.

Changes:
 * The `success` column has been deprecated (hidden). This was always reporting `1` since the audit event publisher was originally filtering out all the syscall events that had the `success=no` field in the AUDIT_SYSCALL record
 * A new `status` column has been added, supporting four values: **failed**, **succeeded**, **in_progress** (`connect` on a non-blocking socket) or **no_client** (`accept` on a non-blocking socket with no incoming connection ready)
 * The `--audit_allow_failed_socket_events` boolean flag has been added and can be used to include failed events in the table (default is to **false**)
 * The `--audit_allow_null_accept_socket_events` boolean can be used to include **accept** events on non-blocking socket that returned with EAGAIN/EWOULDBLOCK