### PR TITLE
Change logger_mode flag to be actually interpreted as an octal

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -405,8 +405,8 @@ Directory path for `ERROR`/`WARN`/`INFO` and query result logging by the **files
 
 `--logger_mode=0640`
 
-File mode for output log files by the **filesystem** plugin (provided as an octal string). Note that this affects both the query result log and the status logs and only works on POSIX platforms.
-**Warning**: If run as root, log files may contain sensitive information! Also, versions previous to osquery 5.0.0 were actually interpreting it as a number in decimal format, not octal.
+File mode for output log files by the **filesystem** plugin, provided as an octal string. Note that this affects both the query result log and the status logs and only works on POSIX platforms. (Versions previous to osquery 5.0.0 were incorrectly interpreting `logger_mode` as a number in decimal format, not octal.)
+**Warning**: If run as root, log files may contain sensitive information! 
 
 `--logger_rotate=false`
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -403,9 +403,10 @@ The default behavior is to also write status logs to stderr. Set this flag to fa
 
 Directory path for `ERROR`/`WARN`/`INFO` and query result logging by the **filesystem** plugin.
 
-`--logger_mode=420`
+`--logger_mode=0640`
 
-File mode for output log files by the **filesystem** plugin (provided as an octal string). Note that this affects both the query result log and the status logs. **Warning**: If run as root, log files may contain sensitive information!
+File mode for output log files by the **filesystem** plugin (provided as an octal string). Note that this affects both the query result log and the status logs and only works on POSIX platforms.
+**Warning**: If run as root, log files may contain sensitive information! Also, versions previous to osquery 5.0.0 were actually interpreting it as a number in decimal format, not octal.
 
 `--logger_rotate=false`
 

--- a/plugins/logger/CMakeLists.txt
+++ b/plugins/logger/CMakeLists.txt
@@ -135,6 +135,7 @@ function(generatePluginsLoggerFilesystemlogger)
     plugins_logger_commondeps
     osquery_filesystem
     osquery_utils_config
+    osquery_utils_conversions
   )
 
   set(public_header_files

--- a/plugins/logger/filesystem_logger.cpp
+++ b/plugins/logger/filesystem_logger.cpp
@@ -49,7 +49,7 @@ bool validateLoggerMode(const char* flagname, const std::string& value) {
 
   const auto logger_mode_octal = logger_mode_octal_exp.get();
 
-  if (logger_mode_octal > 07777) {
+  if (logger_mode_octal <= 0 || logger_mode_octal > 07777) {
     osquery::systemLog(kLoggerModeInvalidValueError);
     std::cerr << kLoggerModeInvalidValueError << std::endl;
     return false;

--- a/plugins/logger/filesystem_logger.cpp
+++ b/plugins/logger/filesystem_logger.cpp
@@ -24,7 +24,7 @@ namespace fs = boost::filesystem;
 namespace osquery {
 
 const std::string kLoggerModeInvalidValueError =
-    "logger_mode is not a valid UNIX permission";
+    "The logger_mode flag does not contain a valid UNIX permission";
 const std::string kLoggerModeConversionFailureError =
     "Failed to convert logger_mode string to octal";
 

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -157,16 +157,16 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
     def test_logger_mode(self):
         logger_path = test_base.getTestDirectory(test_base.TEMP_DIR)
-        test_mode = 0o754  # Strange mode that should never exist
+        test_mode = "0754" # Strange mode that should never exist
         daemon = self._run_daemon(
             {
                 "disable_watchdog": True,
                 "disable_extensions": True,
                 "disable_logging": False,
+                "logger_mode": test_mode,
             },
             options_only={
                 "logger_path": logger_path,
-                "logger_mode": test_mode,
                 "verbose": True,
             },
         )
@@ -196,7 +196,10 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
             if pth.find('.log') > 0 and os.name != "nt":
                 rpath = os.path.realpath(pth)
                 mode = os.stat(rpath).st_mode & 0o777
-                self.assertEqual(mode, test_mode)
+                # NOTE: We are converting test_mode in this way because
+                # the python integer to octal string conversion
+                # uses a format ("0o754") that's not supported by C++
+                self.assertEqual(mode, int(test_mode, 8))
 
         daemon.kill()
 


### PR DESCRIPTION
The logger_mode flag was actually interpreted as decimal format number,
not octal.
Now the flag is actually a string and is expected to represent an octal
number.
A validation function has been added to prevent invalid permission modes and
the flag itself is expected to be given at osquery startup only,
not changed during the execution.

This supersedes #7193