### PR TITLE
Linux: Support AF_PACKET sockets.

### DIFF
--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -128,6 +128,12 @@ function(generateOsqueryFilesystemTest)
     )
   endif()
 
+  if(DEFINED PLATFORM_LINUX)
+    list(APPEND source_files
+      tests/linux/proc_tests.cpp
+    )
+  endif()
+
   add_osquery_executable(osquery_filesystem_filesystemtests-test ${source_files})
 
   target_link_libraries(osquery_filesystem_filesystemtests-test PRIVATE

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -58,6 +58,17 @@ const std::map<int, std::string> kLinuxProtocolNames = {
     {IPPROTO_RAW, "raw"},
 };
 
+const std::string kPacketPathSuffix{"packet"};
+
+// For sockets without state (eg. raw sockets).
+const std::string kSocketStateNone{"NONE"};
+
+// Index of protocol number in /proc/net/packet file.
+const std::size_t kPacketLineProtocolIndex{3U};
+
+// Index of inode number in /proc/net/packet file.
+const std::size_t kPacketLineInodeIndex{8U};
+
 const std::vector<std::string> tcp_states = {"UNKNOWN",
                                              "ESTABLISHED",
                                              "SYN_SENT",
@@ -81,6 +92,34 @@ Status procGetProcessNamespaces(
 Status procReadDescriptor(const std::string& process,
                           const std::string& descriptor,
                           std::string& result);
+
+/// From an hex encoded address and its socket family, read from
+/// a /proc/net file, decode the address and return a string.
+///
+/// @param encoded_address The encoded address as a string.
+/// @param int The family to use to decode address (AF_INET, AF_INET6).
+std::string procDecodeAddressFromHex(const std::string& encoded_address,
+                                     int family);
+
+/// From an encoded unsigned short (host port, protocol), decode it and
+/// return it as an unsigned short
+///
+/// @param encoded_port The encoded port as a string.
+unsigned short procDecodeUnsignedShortFromHex(const std::string& encoded_port);
+
+/// Parse the contents issued from a /proc/net/packet file and fill the socket
+/// info list structure.
+///
+/// @param family The family to set in the SocketInfo entry.
+/// @param protocol The protocol entries to result; If 0, return all.
+/// @param net_ns The network namespace to set in the SocketInfo entry.
+/// @param content The /proc/net/packet content to parse.
+/// @param result The SocketInfo list structure to fill with the parsed results.
+Status procGetSocketListPacket(int family,
+                               int protocol,
+                               ino_t net_ns,
+                               const std::string& content,
+                               SocketInfoList& result);
 
 /// This function parses the inode value in the destination of a user namespace
 /// symlink; fail if the namespace name is now what we expect

--- a/osquery/filesystem/tests/linux/proc_tests.cpp
+++ b/osquery/filesystem/tests/linux/proc_tests.cpp
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+#include <osquery/filesystem/linux/proc.h>
+
+#ifndef ETH_P_ALL
+#define ETH_P_ALL 0x0003
+#endif
+
+#ifndef ETH_P_LLDP
+#define ETH_P_LLDP 0x88cc
+#endif
+
+namespace osquery {
+namespace {
+class LinuxProc : public testing::Test {};
+
+TEST_F(LinuxProc, testProcGetSocketListPacketValidInput) {
+  Status status;
+  SocketInfoList socket_list;
+
+  int expected_socket_index;
+  SocketInfoList expected_sockets = {
+      {"154955523", 42, AF_PACKET, ETH_P_ALL, "", 0, "", 0, "", "NONE"},
+      {"154955524", 42, AF_PACKET, ETH_P_LLDP, "", 0, "", 0, "", "NONE"}};
+
+  std::string test_input =
+      "sk               RefCnt Type Proto  Iface R Rmem   User   Inode\n"
+      "000000007cb3dfdb 3      3    0003   0     1 113784 0      154955523\n"
+      "000000003f7450c6 3      3    88cc   0     1 0      0      154955524";
+
+  status = procGetSocketListPacket(AF_PACKET, 0, 42, test_input, socket_list);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(2, socket_list.size());
+
+  for (uint index = 0; index < socket_list.size(); ++index) {
+    EXPECT_EQ(expected_sockets[index].family, socket_list[index].family);
+    EXPECT_EQ(expected_sockets[index].protocol, socket_list[index].protocol);
+    EXPECT_EQ(expected_sockets[index].socket, socket_list[index].socket);
+    EXPECT_EQ(expected_sockets[index].state, socket_list[index].state);
+  };
+
+  // Reset the list for filter by protocol test (filtering with ETH_P_LLDP)
+  socket_list.clear();
+
+  status = procGetSocketListPacket(
+      AF_PACKET, ETH_P_LLDP, 42, test_input, socket_list);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(1, socket_list.size());
+
+  // This test is returning the 2nd expected result entry.
+  expected_socket_index = 1;
+  EXPECT_EQ(expected_sockets[expected_socket_index].family,
+            socket_list[0].family);
+  EXPECT_EQ(expected_sockets[expected_socket_index].protocol,
+            socket_list[0].protocol);
+  EXPECT_EQ(expected_sockets[expected_socket_index].socket,
+            socket_list[0].socket);
+  EXPECT_EQ(expected_sockets[expected_socket_index].state,
+            socket_list[0].state);
+
+  // Reset the list for filter by protocol test (filtering with ETH_P_ALL)
+  socket_list.clear();
+
+  status = procGetSocketListPacket(
+      AF_PACKET, ETH_P_ALL, 42, test_input, socket_list);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(1, socket_list.size());
+
+  // This test is returning the 1st expected result entry.
+  expected_socket_index = 0;
+  EXPECT_EQ(expected_sockets[expected_socket_index].family,
+            socket_list[0].family);
+  EXPECT_EQ(expected_sockets[expected_socket_index].protocol,
+            socket_list[0].protocol);
+  EXPECT_EQ(expected_sockets[expected_socket_index].socket,
+            socket_list[0].socket);
+  EXPECT_EQ(expected_sockets[expected_socket_index].state,
+            socket_list[0].state);
+}
+
+TEST_F(LinuxProc, testProcGetSocketListPacketValidInvalidHeader) {
+  Status status;
+  SocketInfoList socket_list;
+
+  std::string test_input =
+      "invalid_sk               RefCnt Type Proto  Iface R Rmem   User"
+      "   Inode\n"
+      "000000007cb3dfdb 3      3    0003   0     1 113784 0      154955523\n"
+      "000000003f7450c6 3      3    88cc   0     1 0      0      154955524";
+
+  status = procGetSocketListPacket(AF_PACKET, 0, 42, test_input, socket_list);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(0, socket_list.size());
+}
+
+TEST_F(LinuxProc, testProcGetSocketListPacketValidInvalidContent) {
+  Status status;
+  SocketInfoList socket_list;
+
+  std::string test_input =
+      "sk               RefCnt Type Proto  Iface R Rmem   User   Inode\n"
+      "000000007cb3dfdb 3      3    0003   0     1 113784 0      154955523\n"
+      "000000003f7450c6 3      3    88";
+
+  status = procGetSocketListPacket(AF_PACKET, 0, 42, test_input, socket_list);
+
+  // Only consider parsed valid/entries.
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(1, socket_list.size());
+
+  EXPECT_EQ(AF_PACKET, socket_list[0].family);
+  EXPECT_EQ(ETH_P_ALL, socket_list[0].protocol);
+  EXPECT_EQ("154955523", socket_list[0].socket);
+  EXPECT_EQ("NONE", socket_list[0].state);
+}
+
+} // namespace
+} // namespace osquery

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -123,6 +123,15 @@ QueryData genOpenSockets(QueryContext& context) {
                "to acquire basic socket information for AF_UNIX: "
             << status.what();
       }
+
+      // protocol is 0, we want all protocols here.
+      status = procGetSocketList(AF_PACKET, 0, ns, pid, socket_list);
+      if (!status.ok()) {
+        VLOG(1)
+            << "Results for process_open_sockets might be incomplete. Failed "
+               "to acquire basic socket information for AF_PACKET: "
+            << status.what();
+      }
     }
   }
 


### PR DESCRIPTION
AF_PACKET sockets will now be listed along inet, inet6, unix families.

This will allow listing sockets opened by popular software such as tcpdump.