### PR TITLE
Prevent osquery from killing itself when the --force flag is used

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -313,6 +313,11 @@ Status checkStalePid(const std::string& content) {
     return Status::success();
   }
 
+  // The pid points to our own process, ignore
+  if (pid == PlatformProcess::getCurrentPid()) {
+    return Status::success();
+  }
+
   PlatformProcess target(pid);
   int status = 0;
 


### PR DESCRIPTION
We also avoid doing any query to the running processes
if we know that the pid in the pidfile corresponds
to our own process.

Partially addresses https://github.com/osquery/osquery/issues/5233