### PR TITLE
bpf: Improve publisher reliability

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -29,11 +29,13 @@ function(generateOsqueryEvents)
 
     if(OSQUERY_BUILD_BPF)
       list(APPEND source_files
+        linux/bpf/bpferrorstate.cpp
         linux/bpf/bpfeventpublisher.cpp
         linux/bpf/filesystem.cpp
         linux/bpf/processcontextfactory.cpp
         linux/bpf/setrlimit.cpp
         linux/bpf/systemstatetracker.cpp
+        linux/bpf/serializers.cpp
       )
     endif()
 
@@ -121,6 +123,7 @@ function(generateOsqueryEvents)
 
     if(OSQUERY_BUILD_BPF)
       list(APPEND platform_public_header_files
+        linux/bpf/bpferrorstate.h
         linux/bpf/bpfeventpublisher.h
         linux/bpf/filesystem.h
         linux/bpf/ifilesystem.h
@@ -129,6 +132,7 @@ function(generateOsqueryEvents)
         linux/bpf/processcontextfactory.h
         linux/bpf/setrlimit.h
         linux/bpf/systemstatetracker.h
+        linux/bpf/serializers.h
         linux/bpf/uniquedir.h
       )
     endif()

--- a/osquery/events/linux/bpf/bpferrorstate.cpp
+++ b/osquery/events/linux/bpf/bpferrorstate.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/events/linux/bpf/bpferrorstate.h>
+#include <osquery/logger/logger.h>
+
+namespace osquery {
+
+namespace ebpfpub = tob::ebpfpub;
+
+void updateBpfErrorState(
+    BPFErrorState& bpf_error_state,
+    const ebpfpub::IPerfEventReader::ErrorCounters& perf_error_counters) {
+  bpf_error_state.perf_error_counters.invalid_event +=
+      perf_error_counters.invalid_event;
+
+  bpf_error_state.perf_error_counters.lost_events +=
+      perf_error_counters.lost_events;
+
+  bpf_error_state.perf_error_counters.invalid_probe_output +=
+      perf_error_counters.invalid_probe_output;
+
+  bpf_error_state.perf_error_counters.invalid_event_data +=
+      perf_error_counters.invalid_event_data;
+}
+
+void reportAndClearBpfErrorState(BPFErrorState& bpf_error_state) {
+  if (bpf_error_state.perf_error_counters.invalid_probe_output != 0U) {
+    VLOG(1) << "Invalid BPF probe output error count: "
+            << bpf_error_state.perf_error_counters.invalid_probe_output;
+  }
+
+  if (bpf_error_state.perf_error_counters.invalid_event != 0U) {
+    VLOG(1) << "Invalid BPF probe event id count: "
+            << bpf_error_state.perf_error_counters.invalid_event;
+  }
+
+  if (bpf_error_state.perf_error_counters.invalid_event_data != 0U) {
+    VLOG(1) << "Invalid BPF event data count: "
+            << bpf_error_state.perf_error_counters.invalid_event_data;
+  }
+
+  if (bpf_error_state.perf_error_counters.lost_events != 0U) {
+    VLOG(1) << "Lost BPF event count: "
+            << bpf_error_state.perf_error_counters.lost_events;
+  }
+
+  if (bpf_error_state.probe_error_counter != 0U) {
+    VLOG(1) << "Buffers/strings that could not be captured by the probe: "
+            << bpf_error_state.probe_error_counter;
+  }
+
+  if (!bpf_error_state.errored_tracer_list.empty()) {
+    std::string tracer_list;
+
+    for (auto tracer_it = bpf_error_state.errored_tracer_list.begin();
+         tracer_it != bpf_error_state.errored_tracer_list.end();
+         ++tracer_it) {
+      if (tracer_it != bpf_error_state.errored_tracer_list.begin()) {
+        tracer_list += ", ";
+      }
+
+      auto tracer_id = *tracer_it;
+      tracer_list += std::to_string(tracer_id);
+    }
+
+    VLOG(1)
+        << "Failed to process one or more events from the following tracers: " +
+               tracer_list;
+  }
+
+  bpf_error_state = {};
+}
+
+} // namespace osquery

--- a/osquery/events/linux/bpf/bpferrorstate.h
+++ b/osquery/events/linux/bpf/bpferrorstate.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <ebpfpub/iperfeventreader.h>
+
+#include <unordered_set>
+
+namespace osquery {
+
+/// A container for all the error counters the publisher works with
+struct BPFErrorState final {
+  /// perf_output related errors
+  tob::ebpfpub::IPerfEventReader::ErrorCounters perf_error_counters{};
+
+  /// Errors reported by the BPF probes we have loaded; this can be
+  /// a failure to capture a string (example: open syscall) or a buffer
+  /// (example: a sockaddr_in structure)
+  std::size_t probe_error_counter{};
+
+  /// A list of the tracers that have generated events we could not
+  /// process correctly. This is likely caused by either lost events
+  /// or probe errors (see above)
+  std::unordered_set<std::uint64_t> errored_tracer_list;
+};
+
+/// Updates the error state structure with the given perf error counters
+void updateBpfErrorState(
+    BPFErrorState& bpf_error_state,
+    const tob::ebpfpub::IPerfEventReader::ErrorCounters& perf_error_counters);
+
+/// Logs the error state structure and then clears it
+void reportAndClearBpfErrorState(BPFErrorState& bpf_error_state);
+
+} // namespace osquery

--- a/osquery/events/linux/bpf/filesystem.cpp
+++ b/osquery/events/linux/bpf/filesystem.cpp
@@ -11,6 +11,7 @@
 #include <osquery/events/linux/bpf/uniquedir.h>
 
 #include <fcntl.h>
+#include <sys/stat.h>
 
 namespace osquery {
 
@@ -137,6 +138,23 @@ bool Filesystem::enumFiles(int dirfd, EnumFilesCallback callback) const {
   }
 
   return true;
+}
+
+bool Filesystem::fileExists(bool& exists,
+                            int dirfd,
+                            const std::string& name) const {
+  struct stat file_stats {};
+  if (fstatat(dirfd, name.c_str(), &file_stats, 0) == 0) {
+    exists = true;
+    return true;
+
+  } else if (errno == ENOENT) {
+    exists = false;
+    return true;
+
+  } else {
+    return false;
+  }
 }
 
 Status IFilesystem::create(Ref& obj) {

--- a/osquery/events/linux/bpf/filesystem.h
+++ b/osquery/events/linux/bpf/filesystem.h
@@ -36,6 +36,10 @@ class Filesystem final : public IFilesystem {
 
   virtual bool enumFiles(int dirfd, EnumFilesCallback callback) const override;
 
+  virtual bool fileExists(bool& exists,
+                          int dirfd,
+                          const std::string& name) const override;
+
  private:
   Filesystem() = default;
 

--- a/osquery/events/linux/bpf/ifilesystem.h
+++ b/osquery/events/linux/bpf/ifilesystem.h
@@ -60,6 +60,11 @@ class IFilesystem {
   /// \brief Enumerates all the files in the given directory
   virtual bool enumFiles(int dirfd, EnumFilesCallback callback) const = 0;
 
+  /// \brief Checks whether the given file exists or not
+  virtual bool fileExists(bool& exists,
+                          int dirfd,
+                          const std::string& name) const = 0;
+
   IFilesystem(const IFilesystem&) = delete;
   IFilesystem& operator=(const IFilesystem&) = delete;
 };

--- a/osquery/events/linux/bpf/isystemstatetracker.h
+++ b/osquery/events/linux/bpf/isystemstatetracker.h
@@ -95,6 +95,9 @@ class ISystemStateTracker {
   ISystemStateTracker(const ISystemStateTracker&) = delete;
   ISystemStateTracker& operator=(const ISystemStateTracker&) = delete;
 
+  /// \brief Resets the internal state, taking a new /proc snapshot
+  virtual Status restart() = 0;
+
   /// \brief Creates a new process, in response to an fork, vfork or clone
   /// syscall Once the method has updated the internal state, it will also emit
   /// a new event

--- a/osquery/events/linux/bpf/serializers.cpp
+++ b/osquery/events/linux/bpf/serializers.cpp
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/events/linux/bpf/serializers.h>
+
+#include <fcntl.h>
+
+#ifndef MAX_HANDLE_SZ
+#define MAX_HANDLE_SZ 128
+#endif
+
+namespace osquery {
+
+const ParameterListMap kParameterListMap = {
+    {"connect",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"uservaddr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       "addrlen"},
+
+      {"addrlen",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"accept",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"upeer_sockaddr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       "upeer_addrlen"},
+
+      {"upeer_addrlen",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::IntegerPtr,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       4U}}},
+
+    {"accept4",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"upeer_sockaddr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       "upeer_addrlen"},
+
+      {"upeer_addrlen",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::IntegerPtr,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       4U},
+
+      {"flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"bind",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"umyaddr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       "addrlen"},
+
+      {"addrlen",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"clone",
+     {{"clone_flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"newsp",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"parent_tidptr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::IntegerPtr,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       8U},
+
+      {"child_tidptr",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::IntegerPtr,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       8U},
+
+      {"tls",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"execve",
+     {{"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       {}},
+
+      {"argv",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Argv,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       10U},
+
+      {"envp",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"execveat",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       {}},
+
+      {"argv",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Argv,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       10U},
+
+      {"envp",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"name_to_handle_at",
+     {{"dfd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"name",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"handle",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       static_cast<std::size_t>(8U + MAX_HANDLE_SZ)},
+
+      {"mnt_id",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::IntegerPtr,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       8U},
+
+      {"flag",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"creat",
+     {{"pathname",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"mode",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"mknod",
+     {{"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"mode",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"dev",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"mknodat",
+     {{"dfd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"mode",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"dev",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"open",
+     {{"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"mode",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"openat",
+     {{"dfd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"mode",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"openat2",
+     {{"dfd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}},
+
+      {"how",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       "usize"},
+
+      {"usize",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"open_by_handle_at",
+     {{"mountdirfd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U},
+
+      {"handle",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Buffer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       static_cast<std::size_t>(8U + MAX_HANDLE_SZ)},
+
+      {"flags",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"chdir",
+     {{"filename",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::String,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::Out,
+       {}}}},
+
+    {"fchdir",
+     {{"fd",
+       tob::ebpfpub::IFunctionTracer::Parameter::Type::Integer,
+       tob::ebpfpub::IFunctionTracer::Parameter::Mode::In,
+       8U}}},
+
+    {"vfork", {}},
+    {"fork", {}},
+};
+
+} // namespace osquery

--- a/osquery/events/linux/bpf/serializers.h
+++ b/osquery/events/linux/bpf/serializers.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <ebpfpub/ifunctiontracer.h>
+
+namespace osquery {
+
+using ParameterListMap =
+    std::unordered_map<std::string,
+                       tob::ebpfpub::IFunctionTracer::ParameterList>;
+
+extern const ParameterListMap kParameterListMap;
+
+} // namespace osquery

--- a/osquery/events/linux/bpf/systemstatetracker.h
+++ b/osquery/events/linux/bpf/systemstatetracker.h
@@ -27,6 +27,8 @@ class SystemStateTracker final : public ISystemStateTracker {
 
   virtual ~SystemStateTracker() override;
 
+  virtual Status restart() override;
+
   virtual bool createProcess(
       const tob::ebpfpub::IFunctionTracer::Event::Header& event_header,
       pid_t process_id,
@@ -131,6 +133,8 @@ class SystemStateTracker final : public ISystemStateTracker {
       Context& context,
       IProcessContextFactory& process_context_factory,
       pid_t process_id);
+
+  static Status expireProcessContexts(Context& context, IFilesystem& fs);
 
   static bool createProcess(
       Context& context,

--- a/osquery/events/tests/linux/bpf/bpfeventpublisher.cpp
+++ b/osquery/events/tests/linux/bpf/bpfeventpublisher.cpp
@@ -649,7 +649,7 @@ TEST_F(BPFEventPublisherTests, processCreatEvent) {
   bpf_event.header.exit_code = static_cast<std::uint64_t>(-1);
 
   // clang-format off
-  bpf_event.in_field_map.insert(
+  bpf_event.out_field_map.insert(
     {
       "pathname",
 
@@ -720,7 +720,7 @@ TEST_F(BPFEventPublisherTests, processMknodatEvent) {
     }
 
     if ((i & 2) != 0) {
-      bpf_event.in_field_map.insert({filename_field.name, filename_field});
+      bpf_event.out_field_map.insert({filename_field.name, filename_field});
     }
 
     auto succeeded =
@@ -735,7 +735,7 @@ TEST_F(BPFEventPublisherTests, processMknodatEvent) {
   bpf_event.header.exit_code = static_cast<std::uint64_t>(-1);
 
   bpf_event.in_field_map.insert({mode_field.name, mode_field});
-  bpf_event.in_field_map.insert({filename_field.name, filename_field});
+  bpf_event.out_field_map.insert({filename_field.name, filename_field});
 
   auto succeeded =
       BPFEventPublisher::processMknodatEvent(state_tracker, bpf_event);
@@ -839,7 +839,7 @@ TEST_F(BPFEventPublisherTests, processOpenEvent) {
     }
 
     if ((i & 2) != 0) {
-      bpf_event.in_field_map.insert({filename_field.name, filename_field});
+      bpf_event.out_field_map.insert({filename_field.name, filename_field});
     }
 
     auto succeeded =
@@ -853,7 +853,7 @@ TEST_F(BPFEventPublisherTests, processOpenEvent) {
   // the syscall fails
   bpf_event.header.exit_code = static_cast<std::uint64_t>(-1);
 
-  bpf_event.in_field_map.insert({filename_field.name, filename_field});
+  bpf_event.out_field_map.insert({filename_field.name, filename_field});
   bpf_event.in_field_map.insert({flags_field.name, flags_field});
 
   auto succeeded =
@@ -1049,7 +1049,7 @@ TEST_F(BPFEventPublisherTests, processChdirEvent) {
   bpf_event.header.exit_code = static_cast<std::uint64_t>(-1);
 
   // clang-format off
-  bpf_event.in_field_map.insert(
+  bpf_event.out_field_map.insert(
     {
       "filename",
 

--- a/osquery/events/tests/linux/bpf/mockedfilesystem.cpp
+++ b/osquery/events/tests/linux/bpf/mockedfilesystem.cpp
@@ -33,7 +33,7 @@ bool MockedFilesystem::open(tob::utils::UniqueFd& fd,
   if (path == "/proc/1001") {
     fd.reset(0xFFFFFF1);
 
-  } else if (path == "/proc/") {
+  } else if (path == "/proc/" || path == "/proc") {
     fd.reset(0xFFFFFF2);
 
   } else if (path == "/proc/1234567") {
@@ -137,6 +137,18 @@ bool MockedFilesystem::enumFiles(int dirfd, EnumFilesCallback callback) const {
   } else {
     throw std::logic_error(
         "Invalid dirfd specified in MockedFilesystem::enumFiles");
+  }
+
+  return true;
+}
+
+bool MockedFilesystem::fileExists(bool& exists,
+                                  int dirfd,
+                                  const std::string& name) const {
+  if (dirfd == 0xFFFFFF2 && (name == "1000" || name == "1001")) {
+    exists = true;
+  } else {
+    exists = false;
   }
 
   return true;

--- a/osquery/events/tests/linux/bpf/mockedfilesystem.h
+++ b/osquery/events/tests/linux/bpf/mockedfilesystem.h
@@ -36,6 +36,10 @@ class MockedFilesystem final : public IFilesystem {
                     std::size_t max_size) const override;
 
   virtual bool enumFiles(int dirfd, EnumFilesCallback callback) const override;
+
+  virtual bool fileExists(bool& exists,
+                          int dirfd,
+                          const std::string& name) const override;
 };
 
 } // namespace osquery

--- a/osquery/events/tests/linux/bpf/systemstatetracker.cpp
+++ b/osquery/events/tests/linux/bpf/systemstatetracker.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "bpftestsmain.h"
+#include "mockedfilesystem.h"
 #include "mockedprocesscontextfactory.h"
 #include "utils.h"
 
@@ -1363,4 +1364,24 @@ TEST_F(SystemStateTrackerTests, expireFileHandleEntries) {
   EXPECT_EQ(context.file_handle_struct_map.size(), 1U);
   EXPECT_EQ(context.file_handle_struct_index.size(), 1U);
 }
+
+TEST_F(SystemStateTrackerTests, expireProcessContexts) {
+  SystemStateTracker::Context context;
+
+  context.process_map.insert(
+      {kBaseBPFEventHeader.process_id, ProcessContext{}});
+
+  context.process_map.insert(
+      {kBaseBPFEventHeader.process_id + 1, ProcessContext{}});
+
+  context.process_map.insert(
+      {kBaseBPFEventHeader.process_id + 2, ProcessContext{}});
+
+  MockedFilesystem mocked_filesystem;
+  EXPECT_EQ(context.process_map.size(), 3U);
+
+  SystemStateTracker::expireProcessContexts(context, mocked_filesystem);
+  EXPECT_EQ(context.process_map.size(), 1U);
+}
+
 } // namespace osquery


### PR DESCRIPTION
When capturing syscall events that emit strings (i.e.: chdir()) or buffers (i.e.: connect()), there's a chance the memory we need to access has not been mapped yet (page fault), causing events to lack some of the syscall parameters we need for tracking system state.

This PR improves the BPF publisher reliability by capturing strings on syscall exit (as opposed to using the on enter program), increasing chances that the buffers we need are accessible when our probes run. 