### PR TITLE
[AWS] Support custom endpoints for Kinesis and Firehose.

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -41,9 +41,13 @@ When logging to Kinesis Streams, the stream name must be specified with `aws_kin
 
 Setting `aws_kinesis_random_partition_key` to `true` will use random partition keys when sending data to Kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream. Note that using this setting will result in the logs of each host distributed across shards, so do not use it if you need logs from each host to be processed by a consistent shard. The default for this setting is `false`.
 
+Custom endpoint for non-AWS Kinesis implementations can be specified with `aws_kinesis_endpoint`.
+
 ### Kinesis Firehose
 
 Similarly for Kinesis Firehose delivery streams, the stream name must be specified with `aws_firehose_stream`, and the period can be configured with `aws_firehose_period`.
+
+Custom endpoint for non-AWS Firehose implementations can be specified with `aws_firehose_endpoint`.
 
 ### Sample Config File
 

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -491,11 +491,11 @@ bool isEc2Instance() {
   return is_ec2_instance;
 }
 
-Status getAWSRegion(std::string& region, bool sts) {
+Status getAWSRegion(std::string& region, bool sts, bool validate_region) {
   // First try using the explicit region flags (STS or otherwise).
   if (sts && !FLAGS_aws_sts_region.empty()) {
     auto index = kAwsRegions.find(FLAGS_aws_sts_region);
-    if (index != kAwsRegions.end()) {
+    if (index != kAwsRegions.end() || !validate_region) {
       VLOG(1) << "Using AWS STS region from flag: " << FLAGS_aws_sts_region;
       region = FLAGS_aws_sts_region;
       return Status(0);
@@ -506,7 +506,7 @@ Status getAWSRegion(std::string& region, bool sts) {
 
   if (!FLAGS_aws_region.empty()) {
     auto index = kAwsRegions.find(FLAGS_aws_region);
-    if (index != kAwsRegions.end()) {
+    if (index != kAwsRegions.end() || !validate_region) {
       VLOG(1) << "Using AWS region from flag: " << FLAGS_aws_region;
       region = FLAGS_aws_region;
       return Status(0);

--- a/osquery/utils/aws/tests/aws_util_tests.cpp
+++ b/osquery/utils/aws/tests/aws_util_tests.cpp
@@ -135,6 +135,11 @@ TEST_F(AwsUtilTests, test_get_region) {
   ASSERT_EQ(Status(1, "Invalid aws_region specified: foo"),
             getAWSRegion(region));
 
+  // Test disabled region validation.
+  FLAGS_aws_region = "foo";
+  ASSERT_EQ(Status(0), getAWSRegion(region, false, false));
+  ASSERT_EQ("foo", region);
+
   // Reset aws_region flag.
   FLAGS_aws_region = "";
 

--- a/plugins/logger/aws_firehose.cpp
+++ b/plugins/logger/aws_firehose.cpp
@@ -32,11 +32,16 @@ FLAG(uint64,
 
 FLAG(string, aws_firehose_stream, "", "Name of Firehose stream for logging")
 
+FLAG(string, aws_firehose_endpoint, "", "Custom Firehose endpoint");
+
 Status FirehoseLoggerPlugin::setUp() {
   initAwsSdk();
 
-  forwarder_ = std::make_shared<FirehoseLogForwarder>(
-      "aws_firehose", FLAGS_aws_firehose_period, 500);
+  forwarder_ =
+      std::make_shared<FirehoseLogForwarder>("aws_firehose",
+                                             FLAGS_aws_firehose_period,
+                                             500,
+                                             FLAGS_aws_firehose_endpoint);
   Status s = forwarder_->setUp();
   if (!s.ok()) {
     LOG(ERROR) << "Error initializing Firehose logger: " << s.getMessage();

--- a/plugins/logger/aws_firehose.h
+++ b/plugins/logger/aws_firehose.h
@@ -38,8 +38,9 @@ class FirehoseLogForwarder final : public IFirehoseLogForwarder {
  public:
   FirehoseLogForwarder(const std::string& name,
                        uint64_t log_period,
-                       uint64_t max_lines)
-      : IFirehoseLogForwarder(name, log_period, max_lines) {}
+                       uint64_t max_lines,
+                       const std::string& endpoint_override)
+      : IFirehoseLogForwarder(name, log_period, max_lines, endpoint_override) {}
 
  protected:
   Status internalSetup() override;

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -49,10 +49,12 @@ FLAG(bool,
      false,
      "Disable status logs processing");
 
+FLAG(string, aws_kinesis_endpoint, "", "Custom Kinesis endpoint");
+
 Status KinesisLoggerPlugin::setUp() {
   initAwsSdk();
   forwarder_ = std::make_shared<KinesisLogForwarder>(
-      "aws_kinesis", FLAGS_aws_kinesis_period, 500);
+      "aws_kinesis", FLAGS_aws_kinesis_period, 500, FLAGS_aws_kinesis_endpoint);
   Status s = forwarder_->setUp();
   if (!s.ok()) {
     LOG(ERROR) << "Error initializing Kinesis logger: " << s.getMessage();

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -36,8 +36,9 @@ class KinesisLogForwarder final : public IKinesisLogForwarder {
  public:
   KinesisLogForwarder(const std::string& name,
                       uint64_t log_period,
-                      uint64_t max_lines)
-      : IKinesisLogForwarder(name, log_period, max_lines) {}
+                      uint64_t max_lines,
+                      const std::string& endpoint_override)
+      : IKinesisLogForwarder(name, log_period, max_lines, endpoint_override) {}
 
  protected:
   Status internalSetup() override;

--- a/plugins/logger/aws_log_forwarder.h
+++ b/plugins/logger/aws_log_forwarder.h
@@ -37,12 +37,16 @@ class AwsLogForwarder : public BufferedLogForwarder {
   using Result = ResultType;
 
  public:
-  AwsLogForwarder(const std::string& name, size_t log_period, size_t max_lines)
+  AwsLogForwarder(const std::string& name,
+                  size_t log_period,
+                  size_t max_lines,
+                  const std::string& endpoint_override)
       : BufferedLogForwarder(std::string("AwsLogForwarder:") + name,
                              name,
                              std::chrono::seconds(log_period),
                              max_lines),
-        name_(name) {}
+        name_(name),
+        endpoint_override_(endpoint_override) {}
 
   /// Common plugin initialization
   Status setUp() override {
@@ -51,7 +55,7 @@ class AwsLogForwarder : public BufferedLogForwarder {
       return s;
     }
 
-    s = makeAWSClient<Client>(client_);
+    s = makeAWSClient<Client>(client_, "", true, endpoint_override_);
     if (!s.ok()) {
       return s;
     }
@@ -331,5 +335,8 @@ class AwsLogForwarder : public BufferedLogForwarder {
 
   /// Logger name; used when printing messages
   std::string name_;
+
+  /// Service endpoint override
+  std::string endpoint_override_;
 };
 }

--- a/plugins/logger/tests/aws_kinesis_logger_tests.cpp
+++ b/plugins/logger/tests/aws_kinesis_logger_tests.cpp
@@ -57,7 +57,8 @@ using IDummyLogForwarder =
 
 class DummyLogForwarder final : public IDummyLogForwarder {
  public:
-  DummyLogForwarder() : IDummyLogForwarder("dummy", 10, 50) {}
+  DummyLogForwarder()
+      : IDummyLogForwarder("dummy", 10, 50, "http://example.com") {}
 
  protected:
   Status internalSetup() override {


### PR DESCRIPTION
Added `--aws_firehose_endpoint` and `--aws_kinesis_endpoint` flags to support non-AWS Kinesis and Firehose implementations. Setting the flag disables AWS region validation.