### PR TITLE
Reduce excessive log messages from authorized_keys table implementation

### DIFF
--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -37,6 +37,11 @@ void genSSHkeysForUser(const std::string& uid,
 
     std::string keys_content;
 
+    if (!pathExists(keys_file).ok()) {
+      // no authorized key file present, keep going
+      continue;
+    }
+
     auto s = forensicReadFile(keys_file, keys_content, false, false);
     if (!s.ok()) {
       // Cannot read a specific keys file.


### PR DESCRIPTION
This table implementation produces a lot of unneeded error messages for files that don't exist when cross joining against all users on a system:

```
$ osqueryi "select * from authorized_keys cross join users"
W0922 13:52:54.039000 354004480 glog_logger.cpp:34] Cannot open file for reading: /Users/nabil/.ssh/authorized_keys2
```

This PR introduces a check to see if the file exists before attempting to open it.  If there's no file, it will continue silently.