### PR TITLE
Prevent the audit event system from using too much memory

### DIFF
--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -81,6 +81,27 @@ struct AuditdContext final {
 
   /// When set to true, the audit handle is (re)acquired
   std::atomic_bool acquire_handle{true};
+
+  /// Amount of records that are yet to be fully processed. Used for throttling
+  /// the netlink reader if the thread processing records cannot keep up
+  std::atomic<std::size_t> unprocessed_records_amount{};
+
+  /// Amount of records that have been parsed but that still need to be consumed
+  /// by the publisher. Used for throttling the thread processing records if the
+  /// publisher cannot empty the backlog fast enough
+  std::atomic<std::size_t> processed_records_backlog{};
+
+  /// Timestamp of the last Netlink records reading throttling message
+  std::uint64_t last_netlink_throttling_message_time{};
+
+  /// Timestamp of the last records processing throttling message
+  std::uint64_t last_processing_throttling_message_time{};
+
+  /// Count of loops done during Netlink records reading throttling
+  std::uint32_t netlink_throttling_count{};
+
+  /// Count of loops done during records processing throttling
+  std::uint32_t processing_throttling_count{};
 };
 
 using AuditdContextRef = std::shared_ptr<AuditdContext>;


### PR DESCRIPTION
- Reduced the amount of audit records read as a batch
  from 4096 to 1024, to reduce the average number of them
  that has to be kept in memory.

- Introduced a throttling mechanism between the netlink reader
  and the records processing, and then between the records processing
  and the audit publisher, which generates events.
  This is to ensure that it's not possible to have a backlog that's
  always increasing and that's bigger of a certain amount.

- Prevent some unnecessary work happening in the processing thread,
  by always sleeping for 1 second if there's no records to be processed.
  
We noticed that in environments where:
  1. Audit is used and a continuous amount of audit records is captured
  2. There's a limited CPU availability due to few cores and high CPU load, or the osquery worker process CPU usage is limited through the use of cgroups
  
Then osquery would sometime start using an indefinitely increasing amount of memory.

This is caused by the presence of two internal backlog caches, one for records to be processed after being just read from the netlink socket, and the other for records that have been processed but that need to be transformed into events by the publisher.
If the thread processing the records was slow enough, and continued to be so, then the intermediate cache between it and the netlink reader thread which was providing the records, would indefinitely increase.
Although we haven't observed it, depending on the kernel thread scheduling, the same could happen between the publisher thread and the records processing thread.
That's why there are two points which attempt to throttle operations.

An additional note is that we've reduced the amount of records read on each netlink reader loop from 4k to 1k, because this permits to process records sooner and keep less of them in memory.
Moreover if the threshold of records in the backlog is passed, the amount beyond the threshold is much smaller than before.

The reason why we don't outright drop records when beyond the threshold, it's because we want to support spikes of events that may momentarily fill up the backlog, and in that situation if the spike lasts for a short time, then no events need to be dropped.

This fix should also slightly improve CPU usage in a situation where the CPU load is temporarily high and the backlog is getting big. In this situation with the previous implementation, when the CPU load drops and osquery can catch up, it might consume a high amount of CPU, for enough time for the watchdog to decide that the worker process has to be killed.

