### PR TITLE
Avoid string copies when looping through cron search dirs

### DIFF
--- a/osquery/tables/system/posix/crontab.cpp
+++ b/osquery/tables/system/posix/crontab.cpp
@@ -109,7 +109,7 @@ QueryData genCronTabImpl(QueryContext& context, Logger& logger) {
 
   file_list.push_back(kSystemCron);
 
-  for (const auto cron_dir : kCronSearchDirs) {
+  for (const auto& cron_dir : kCronSearchDirs) {
     osquery::listFilesInDirectory(cron_dir, file_list);
   }
 


### PR DESCRIPTION
Fixes a long ignored warning:
```
/Users/smjert/Development/osquery/src/osquery/tables/system/posix/crontab.cpp:112:19: warning: loop variable 'cron_dir' of type 'const std::__1::basic_string<char>' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-analysis]
  for (const auto cron_dir : kCronSearchDirs) {
                  ^
/Users/smjert/Development/osquery/src/osquery/tables/system/posix/crontab.cpp:112:8: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
  for (const auto cron_dir : kCronSearchDirs) {
       ^~~~~~~~~~~~~~~~~~~~~
                  &
```