### PR TITLE
Update the CI Linux Docker image

### DIFF
--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: osquery/builder18.04:2c2b85cbd
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -160,7 +160,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: osquery/builder18.04:2c2b85cbd
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/.github/workflows/build_x86.yml
+++ b/.github/workflows/build_x86.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: osquery/builder18.04:2c2b85cbd
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: osquery/builder18.04:2c2b85cbd
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -218,7 +218,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:0aa3775ce
+      image: osquery/builder18.04:2c2b85cbd
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
+++ b/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
@@ -10,7 +10,7 @@ RUN apt install -q -y wget gcc g++ libssl-dev make
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5.tar.gz
 RUN tar zxvf cmake-3.17.5.tar.gz
 RUN cd cmake-3.17.5 \
-	&& ./bootstrap -- -DCMAKE_BUILD_TYPE:STRING=Release \
+	&& ./bootstrap --parallel=`nproc` -- -DCMAKE_BUILD_TYPE:STRING=Release \
 	&& make -j`nproc` \
 	&& make install
 


### PR DESCRIPTION
- Update the Docker image by rebuilding it, to ensure certificates used
  are up to date.

- Improve the CMake bootstrap speed in the Dockerfile,
  by ensuring it uses all the available cores.
