### PR TITLE
Allow local modification of User-Agent

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -111,6 +111,11 @@ if("${THIRD_PARTY_REPOSITORY_URL}" STREQUAL "")
   set(THIRD_PARTY_REPOSITORY_URL "https://s3.amazonaws.com/osquery-packages")
 endif()
 
+# OSQUERY_UA_PREFIX sets the user-agent prefix, with the default of osquery/
+# osquery will append the version to this, resulting in ex osquery/4.1.1
+set(OSQUERY_UA_PREFIX "osquery/" CACHE STRING "Override the default useragent with this value")
+
 detectOsqueryVersion()
 
 message(STATUS "osquery version: ${OSQUERY_VERSION_INTERNAL}")
+message(STATUS "osquery user-agent prefix: ${OSQUERY_UA_PREFIX}")

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -22,7 +22,7 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-const std::string kTLSUserAgentBase = "osquery/";
+const std::string kTLSUserAgentBase = STR(OSQUERY_UA_PREFIX);
 
 /// TLS server hostname.
 CLI_FLAG(string,


### PR DESCRIPTION
These changes allow local modification of User-Agent used by osqueryd to
talk to a server back-end (i.e. for /config and /logger on a TLS
endpoint).

These changes do not affect the other place osqueryd uses User-Agent,
which is on curl table calls out.