### PR TITLE
Allow custom cpu limit duration for the watchdog

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -88,7 +88,7 @@ Performance limit level (`0`=normal, `1`=restrictive, `-1`=disabled). The watchd
 
 The level limits are as follows:
 Memory: default 200M, restrictive 100M
-CPU: default 25% (for 9 seconds), restrictive 18% (for 9 seconds)
+CPU: default 10% (for 12 seconds), restrictive 5% (for 6 seconds)
 
 The normal level allows for 10 restarts if the limits are violated. The restrictive allows for only 4, then the service will be disabled. For both there is a linear backoff of 5 seconds, doubling each retry.
 
@@ -102,9 +102,19 @@ If this value is >0 then the watchdog level (`--watchdog_level`) for maximum mem
 
 `--watchdog_utilization_limit=0`
 
-If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 30% of a thread for more than 9 seconds of wall time. The length of sustained utilization is not independently configurable.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 10% of a thread for more than `--watchdog_latency_limit` seconds of wall time. The length of sustained utilization is configurable with `--watchdog_latency_limit`.
 
 This value is a maximum number of CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default is 90, meaning less 90 seconds of cpu time per 3 seconds of wall time is allowed.
+
+`--watchdog_latency_limit=0`
+
+If this value is >0 then the watchdog level (`--watchdog_level`) for time
+allowed to spend at maximum sustained CPU utilization is overridden. Use this
+if you would like to allow the `osqueryd` process to use more than the cpu
+utilization limit for longer than the defaults.
+
+This value is a duration in seconds that the watchdog allows osquery to spend
+at maximum sustained CPU utilization.
 
 `--watchdog_delay=60`
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -63,15 +63,20 @@ const auto kNumOfCPUs = boost::thread::physical_concurrency();
 const WatchdogLimitMap kWatchdogLimits = {
     // Maximum MB worker can privately allocate.
     {WatchdogLimitType::MEMORY_LIMIT, {200, 100, 10000}},
+
     // % of (User + System + Idle) CPU time worker can utilize
     // for LATENCY_LIMIT seconds.
     {WatchdogLimitType::UTILIZATION_LIMIT, {10, 5, 100}},
+
     // Number of seconds the worker should run, else consider the exit fatal.
     {WatchdogLimitType::RESPAWN_LIMIT, {4, 4, 1000}},
+
     // If the worker respawns too quickly, backoff on creating additional.
     {WatchdogLimitType::RESPAWN_DELAY, {5, 5, 1}},
+
     // Seconds of tolerable UTILIZATION_LIMIT sustained latency.
     {WatchdogLimitType::LATENCY_LIMIT, {12, 6, 1000}},
+
     // How often to poll for performance limit violations.
     {WatchdogLimitType::INTERVAL, {3, 3, 3}},
 };
@@ -94,6 +99,11 @@ CLI_FLAG(uint64,
          watchdog_utilization_limit,
          0,
          "Override watchdog profile CPU utilization limit");
+
+CLI_FLAG(uint64,
+         watchdog_latency_limit,
+         0,
+         "Override watchdog profile CPU utilization latency limit");
 
 CLI_FLAG(uint64,
          watchdog_delay,
@@ -726,6 +736,11 @@ uint64_t getWorkerLimit(WatchdogLimitType name) {
   if (name == WatchdogLimitType::UTILIZATION_LIMIT &&
       FLAGS_watchdog_utilization_limit > 0) {
     return FLAGS_watchdog_utilization_limit;
+  }
+
+  if (name == WatchdogLimitType::LATENCY_LIMIT &&
+      FLAGS_watchdog_latency_limit > 0) {
+    return FLAGS_watchdog_latency_limit;
   }
 
   auto level = FLAGS_watchdog_level;


### PR DESCRIPTION
[WIP] - Took a stab at implementing #7212. This functionality had some inconsistencies in the docs (around percentages, times, etc.), so I'm still not incredibly confident that this is correct.

I'd like to get some early feedback / corrections to make from maintainers.

Fixes: #7212