### PR TITLE
`curl` table now returns peer certificates even if the TLS handshake does not complete

### DIFF
--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -406,18 +406,18 @@ Status getTLSCertificate(const std::string& hostname,
 
   // blocking mode
   SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-
+  auto cert_failure = Status::failure("No certificate");
   ret = SSL_connect(ssl);
   if (ret != 1) {
-    return Status::failure("Failed to complete TLS handshake: " +
-                           std::to_string(ret));
+    cert_failure = Status::failure("Failed to begin TLS handshake: " +
+                                   std::to_string(ret));
   }
 
   auto delX509 = [](X509* cert) { X509_free(cert); };
   auto cert = std::unique_ptr<X509, decltype(delX509)>(
       SSL_get_peer_certificate(ssl), delX509);
   if (cert == nullptr) {
-    return Status::failure("No certificate");
+    return cert_failure;
   }
 
   Row r;


### PR DESCRIPTION
If you use the `curl_certificate` table against a service that requires a client certificate, osquery will not return a certificate even though it is provided as part of the failed handshake.   The following commands reproduce this problem:

```
openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes
openssl s_server -key key.pem -cert cert.pem -accept 5000 -www -Verify 1

osqueryi "select * from curl_certificate where hostname='localhost:5000';"
```

The expected output should be the certificate created in the line above.  But instead, no certificate is returned.

This change does not return from the `getTLSCertificate` function until it checks to see if there is a peer certificate in the SSL context.  If there is, it will proceed parsing it.  Otherwise, it will return the same errors it would have if the handshake failed.
