### PR TITLE
Windows: Detect when an extension has not started

### DIFF
--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -99,7 +99,7 @@ bool PlatformProcess::killGracefully() const {
 
 ProcessState PlatformProcess::checkStatus(int& status) const {
   unsigned long exit_code = 0;
-  if (!isValid()) {  // see issue #7324
+  if (!isValid()) { // see issue #7324
     return PROCESS_ERROR;
   }
 

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -99,6 +99,10 @@ bool PlatformProcess::killGracefully() const {
 
 ProcessState PlatformProcess::checkStatus(int& status) const {
   unsigned long exit_code = 0;
+  if (!isValid()) {  // see issue #7324
+    return PROCESS_ERROR;
+  }
+
   if (!::GetExitCodeProcess(nativeHandle(), &exit_code)) {
     unsigned long last_error = GetLastError();
     if (last_error == ERROR_WAIT_NO_CHILDREN) {


### PR DESCRIPTION
Detect when a Windows extension has not started, which mirror how the Posix `PlatformProcess` operates. The problem was that `GetExitCodeProcess()` was being called with an invalid handle, which returns a value indicating that the process is still active. So, extensions were never executed.

The fix is to check if the handle is valid prior to checking if the process is alive.

fixes #7324