### PR TITLE
Adds update_cacert.sh to facilitate downloading Mozilla CA certificat…

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -14,9 +14,15 @@ The build type is chosen when building on Windows, through the `--config` option
 
 Note: the recommended system memory for building osquery is at least 8GB, or Clang may crash during the compilation of third-party dependencies.
 
-## Linux
+## Mozilla CA Certificates
 
-The root folder is assumed to be `/home/<user>`.
+osquery bundles a Mozilla CA certificate store. During building the file `$osquery_code/tools/deployment/certs.pem` is packaged and used as the default TLS CA certificates store.
+
+Published Mozilla CA certificates can be found [here](https://curl.se/docs/caextract.html).
+
+A script `$osquery_code/tools/deployment/update_cacerts.sh` is provided to ensure an up-to-date CA certificate store.
+
+To update osquery's CA certificate store post-build on Linux the file location is `/opt/osquery/share/osquery/certs/certs.pem`.
 
 **Ubuntu 18.04/18.10**
 
@@ -184,10 +190,10 @@ GTEST_FILTER=sharedMemory.* ctest -R <testName> -V #runs just the sharedMemory t
 Osquery uses `clang-format` to format its code, but it's not run on the whole project or files each time; it's run only on the modified lines instead,
 using custom scripts.
 
-On Linux the `clang-format` executable is shipped along with the osquery toolchain, and it is the recommended way to run it.  
+On Linux the `clang-format` executable is shipped along with the osquery toolchain, and it is the recommended way to run it.
 For the other platforms please refer to their **Install the prerequisites** section if you haven't already.
 
-On Windows remember to update the PATH environment variable with the `clang-format` root folder, so that the scripts can find it.  
+On Windows remember to update the PATH environment variable with the `clang-format` root folder, so that the scripts can find it.
 You should be able to find `clang-format` folder in the path where you installed either the Build Tools or the full Visual Studio, and from there `VC\Tools\Llvm\bin`.
 
 To verify that all the commits that are present on the branch but not on master are properly formatted, run the following command from the build folder:

--- a/tools/deployment/update_cacerts.sh
+++ b/tools/deployment/update_cacerts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Grabs the latest Mozilla CA certificate store
+# https://curl.se/docs/caextract.html
+# https://osquery.readthedocs.io/en/stable/development/building/#mozilla-ca-certificates
+
+set -euo pipefail
+
+# Restore timestamp of certs.pem on a fresh git clone
+#UNIX_TIME=$(git log -1 --format="%at" -- certs.pem)
+#TOUCH_TIME=$(sudo date -t $UNIX_TIME +'%Y%m%d%H%M.%S')
+#touch -t ${TOUCH_TIME} certs.pem
+
+# On macOS
+touch -t $(git log -1 --pretty=format:%cd --date=format:%Y%m%d%H%m.%S -- certs.pem) certs.pem
+
+# --time-cond will use timestamp of local certs.pem
+HTTP_CODE=$(curl --remote-name --time-cond certs.pem https://curl.se/ca/cacert.pem -w "%{http_code}")
+if [ $HTTP_CODE -eq 200 ]; then
+    echo "Downloaded new cacert.pem and comparing SHA256 checksum"
+    curl -s https://curl.se/ca/cacert.pem.sha256 -o cacert.pem.sha256sum
+    shasum -c cacert.pem.sha256sum
+    echo "Please manually update certs.pem"
+elif [ $HTTP_CODE -eq 304 ]; then
+    echo "Mozilla CA certificates have not been updated."
+else
+    echo "Curl response code: $HTTP_CODE :("
+fi


### PR DESCRIPTION
Hi osquery community,

This pull-requests adds **update_cacerts.sh** to facilitate future updates of **certs.pem** 

Background: https://curl.se/docs/caextract.html

Outcome 1) **certs.pem** is old
The latest version of **cacert.pem** is downloaded and checksum is verified.
```
git:(add_cacerts_script) ✗ bash update_cacerts.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  203k  100  203k    0     0  1995k      0 --:--:-- --:--:-- --:--:-- 2116k
Downloaded new cacert.pem and comparing SHA256 checksum
cacert.pem: OK
```
Outcome 2) **certs.pem** is up-to-date
```
git:(update_cacerts) ✗ bash update_cacerts.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Mozilla CA certificates have not been updated.
```