### PR TITLE
Respect `read_max` flag when hashing using ssdeep

### DIFF
--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -197,7 +197,8 @@ bool FileHashCache::load(const std::string& path,
 
 Status genSsdeepForFile(const std::string& path, std::string& ssdeep_hash) {
 #ifdef OSQUERY_POSIX
-  auto size = std::filesystem::file_size(path);
+  boost::filesystem::path p = path;
+  auto size = boost::filesystem::file_size(p);
   if (size > FLAGS_read_max) {
     return Status::failure(
         "ssdeep failed because file size exceeds read_max: " + path);

--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -197,8 +197,12 @@ bool FileHashCache::load(const std::string& path,
 
 Status genSsdeepForFile(const std::string& path, std::string& ssdeep_hash) {
 #ifdef OSQUERY_POSIX
+  boost::system::error_code ec;
   boost::filesystem::path p = path;
-  auto size = boost::filesystem::file_size(p);
+  auto size = boost::filesystem::file_size(p, ec);
+  if (ec.value() != boost::system::errc::success) {
+    return Status::failure("failed to determine file size: " + path);
+  }
   if (size > FLAGS_read_max) {
     return Status::failure(
         "ssdeep failed because file size exceeds read_max: " + path);

--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -199,7 +199,8 @@ Status genSsdeepForFile(const std::string& path, std::string& ssdeep_hash) {
 #ifdef OSQUERY_POSIX
   auto size = std::filesystem::file_size(path);
   if (size > FLAGS_read_max) {
-    return Status::failure("ssdeep failed because file size exceeds read_max: " + path);
+    return Status::failure(
+        "ssdeep failed because file size exceeds read_max: " + path);
   }
   ssdeep_hash.resize(FUZZY_MAX_RESULT, '\0');
   auto did_ssdeep_fail =

--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -51,6 +51,8 @@ HIDDEN_FLAG(uint32,
             20,
             "Number of milliseconds to delay after hashing");
 
+DECLARE_uint64(read_max);
+
 namespace tables {
 
 /// Clear this amount of rows every time cache eviction is triggered.
@@ -195,6 +197,10 @@ bool FileHashCache::load(const std::string& path,
 
 Status genSsdeepForFile(const std::string& path, std::string& ssdeep_hash) {
 #ifdef OSQUERY_POSIX
+  auto size = std::filesystem::file_size(path);
+  if (size > FLAGS_read_max) {
+    return Status::failure("ssdeep failed because file size exceeds read_max: " + path);
+  }
   ssdeep_hash.resize(FUZZY_MAX_RESULT, '\0');
   auto did_ssdeep_fail =
       fuzzy_hash_filename(path.c_str(), &ssdeep_hash.front());


### PR DESCRIPTION
**Current Behaviour:** all the columns of `hash` table respect the `read_max` parameter, except `ssdeep` one:

```
$ dd if=/dev/urandom of=/tmp/temp100m bs=1m count=100

osquery> select * from file where path = '/tmp/temp100m';
      path = /tmp/temp100m
 directory = /tmp
  filename = temp100m
     inode = 23579345
       uid = 501
       gid = 0
      mode = 0644
    device = 0
      size = 104857600
block_size = 4096
     atime = 1635514968
     mtime = 1635514957
     ctime = 1635514957
     btime = 1635514957
hard_links = 1
   symlink = 0
      type = regular
 bsd_flags =

osquery> select * from hash where path = '/tmp/temp100m';
W1029 19:13:48.575589 319819264 filesystem.cpp:140] Cannot read /tmp/temp100m size exceeds limit: 104857600 > 52428800
     path = /tmp/temp100m
directory = /tmp
      md5 =
     sha1 =
   sha256 =
   ssdeep = 3145728:9YMq2A0dZIz0Dekp7/29h9o4RKocGQZhWAQg+u2zsZRvGc:+N0d+zkeOKRKCQZEwbvGc

```

This change will make `ssdeep` respect the `read_max` parameter too:

```
osquery> select * from hash where path = '/tmp/temp100m';
W1029 19:25:40.648039 469794304 filesystem.cpp:140] Cannot read /tmp/temp100m size exceeds limit: 104857600 > 52428800
W1029 19:25:40.648102 469794304 glog_logger.cpp:34] ssdeep failed because file size exceeds read_max: /tmp/temp100m
     path = /tmp/temp100m
directory = /tmp
      md5 =
     sha1 =
   sha256 =
   ssdeep =
```

This was previously discussed in office hours: https://github.com/osquery/foundation/blob/master/docs/office-hours/20210622_meeting_notes.md#read_max-parameter-and-ssdeep