### PR TITLE
Add `expand_env` sql function for expanding environment variables in queries

### DIFF
--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -74,6 +74,7 @@ function(generateOsquerySql)
   add_test(NAME osquery_sql_tests_virtualtabletests-test COMMAND osquery_sql_tests_virtualtabletests-test)
   add_test(NAME osquery_sql_tests_sqliteutilstests-test COMMAND osquery_sql_tests_sqliteutilstests-test)
   add_test(NAME osquery_sql_tests_sqlitehashingstests-test COMMAND osquery_sql_tests_sqlitehashingtests-test)
+  add_test(NAME osquery_sql_tests_sqlitestringtests-test COMMAND osquery_sql_tests_sqlitestringtests-test)
 endfunction()
 
 osquerySqlMain()

--- a/osquery/sql/tests/CMakeLists.txt
+++ b/osquery/sql/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ function(osquerySqlMain)
   generateOsquerySqlTestsVirtualtableTestsTest()
   generateOsquerySqlTestsSqliteutiltestsTest()
   generateOsquerySqlTestsSqlitehashingtestsTest()
+  if(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_MACOS OR DEFINED PLATFORM_WINDOWS)
+    generateOsquerySqlTestsSqlitestringtestsTest()
+  endif()
 endfunction()
 
 function(generateOsquerySqlTestsSqltestutils)
@@ -89,6 +92,19 @@ function(generateOsquerySqlTestsSqlitehashingtestsTest)
     osquery_database
     osquery_sql
     osquery_sql_tests_sqltestutils
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsquerySqlTestsSqlitestringtestsTest)
+  add_osquery_executable(osquery_sql_tests_sqlitestringtests-test sqlite_string_tests.cpp)
+
+  target_link_libraries(osquery_sql_tests_sqlitestringtests-test PRIVATE
+    osquery_cxx_settings
+    osquery_database
+    osquery_sql
+    osquery_sql_tests_sqltestutils
+    osquery_utils
     thirdparty_googletest
   )
 endfunction()

--- a/osquery/sql/tests/sqlite_string_tests.cpp
+++ b/osquery/sql/tests/sqlite_string_tests.cpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/system.h>
+#include <osquery/registry/registry_interface.h>
+#include <osquery/sql/sql.h>
+#include <osquery/utils/system/env.h>
+
+#include <gtest/gtest.h>
+
+namespace osquery {
+class SQLitePlatformTests : public testing::Test {
+ public:
+  void SetUp() override {
+    platformSetup();
+    registryAndPluginInit();
+
+    setEnvVar("OSQUERY_TEST", "TEST_VARIABLE");
+  }
+};
+
+TEST_F(SQLitePlatformTests, test_expand_with_no_variable) {
+  std::string input_variable;
+#ifdef WIN32
+  input_variable = "%NoVariable%";
+#else
+  input_variable = "$NoVariable";
+#endif
+
+  Row r;
+  r["var"] = input_variable;
+
+  SQL sql = SQL("SELECT expand_env(\"" + input_variable + "\") AS var");
+
+#ifdef WIN32
+  EXPECT_TRUE(sql.ok());
+  EXPECT_EQ(sql.rows().size(), 1U);
+  EXPECT_EQ(sql.rows()[0], r);
+#else
+  EXPECT_FALSE(sql.ok());
+  EXPECT_EQ(sql.rows().size(), 0U);
+#endif
+}
+
+TEST_F(SQLitePlatformTests, test_expand_with_no_specifier) {
+  Row r;
+  r["var"] = "NoVariable";
+
+  SQL sql = SQL("SELECT expand_env(\"NoVariable\") AS var");
+  EXPECT_TRUE(sql.ok());
+  EXPECT_EQ(sql.rows().size(), 1U);
+  EXPECT_EQ(sql.rows()[0], r);
+}
+
+TEST_F(SQLitePlatformTests, test_expand_with_variable) {
+  Row r;
+  r["var"] = "TEST_VARIABLE-WITH_TEST_STRING";
+  std::string input_variable;
+#ifdef WIN32
+  input_variable = "%OSQUERY_TEST%";
+#else
+  input_variable = "$OSQUERY_TEST";
+#endif
+
+  SQL sql = SQL("SELECT expand_env(\"" + input_variable +
+                "-WITH_TEST_STRING\") AS var");
+  EXPECT_TRUE(sql.ok());
+  EXPECT_EQ(sql.rows().size(), 1U);
+  EXPECT_EQ(sql.rows()[0], r);
+
+#ifndef WIN32
+  input_variable = "${OSQUERY_TEST}";
+
+  sql = SQL("SELECT expand_env(\"" + input_variable +
+            "-WITH_TEST_STRING\") AS var");
+  EXPECT_TRUE(sql.ok());
+  EXPECT_EQ(sql.rows().size(), 1U);
+  EXPECT_EQ(sql.rows()[0], r);
+#endif
+}
+} // namespace osquery

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -28,7 +28,6 @@ bool unsetEnvVar(const std::string& name);
  */
 boost::optional<std::string> getEnvVar(const std::string& name);
 
-#ifdef WINDOWS
 /**
  * @brief Returns the input, with any environment variables present expanded.
  *
@@ -36,6 +35,7 @@ boost::optional<std::string> getEnvVar(const std::string& name);
  */
 boost::optional<std::string> expandEnvString(const std::string& input);
 
+#ifdef WINDOWS
 /**
  * Splits the input into command line arguments, according to the system's
  * rules.

--- a/osquery/utils/system/posix/env.cpp
+++ b/osquery/utils/system/posix/env.cpp
@@ -13,7 +13,7 @@
 #include <boost/optional.hpp>
 
 #include <stdlib.h>
-
+#include <wordexp.h>
 
 namespace osquery {
 
@@ -33,6 +33,25 @@ boost::optional<std::string> getEnvVar(const std::string& name) {
     return std::string(value);
   }
   return boost::none;
+}
+
+boost::optional<std::string> expandEnvString(const std::string& input) {
+  wordexp_t p;
+  int result = wordexp(input.c_str(), &p, WRDE_NOCMD | WRDE_UNDEF);
+  if (result) {
+    VLOG(1) << "Failed to expand environment string: " << result;
+    return boost::none;
+  }
+  std::stringstream expandedString;
+  for (size_t i = 0; i < p.we_wordc; i++) {
+    if (i > 0) {
+      expandedString << " ";
+    }
+    expandedString << p.we_wordv[i];
+  }
+
+  wordfree(&p);
+  return expandedString.str();
 }
 
 } // namespace osquery


### PR DESCRIPTION
When querying tables it would be useful to be able to use environment variables so that across an estate of machines where actual paths differ but the environment variables can be used.
For example %PROGRAMDATA% on one machine could be C:\ProgramData but on another D:\ProgramData.

To resolve this we could add a new sql function to expand variables in a given string.
`select expand_env("%PROGRAMDATA%");`
```
+-----------------------------+
| expand_env("%PROGRAMDATA%") |
+-----------------------------+
| C:\ProgramData              |
+-----------------------------+
```

There are some caveats with the linux implementation.

- The wordexp function interprets the string as a terminal would so command substitution can be used as a result we have used a flag that causes the expansion to fail - WRDE_NOCMD.
-  If the environment variable does not exist wordexp (as the terminal would) evaluates it to an empty string. In this case we have used a flag that causes the expansion to fail - WRDE_UNDEF. Reasoning for this is if you are using a path that is partially made up of a variable e.g "$HOME/another/folder" would result as "/another/folder" which could cause the query to run against a completely incorrect path and would return misleading results - so I thought failing was a better alternative.
