### PR TITLE
Allow tests and SDK to reset dispatcher state

### DIFF
--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -159,7 +159,7 @@ class Dispatcher : private boost::noncopyable {
   /// When a service ends, it will remove itself from the dispatcher.
   static void removeService(const InternalRunnable* service);
 
- private:
+ public:
   /// For testing only, reset the stopping status for unittests.
   void resetStopping();
 


### PR DESCRIPTION
This allows external code/tests such as extensions to call `Dispatcher::resetStopping`. This is helpful when testing end to end osquery state.

Extensions might start osqueryd and then call `startExtension` and want to manage state where osqueryd restarts.