### PR TITLE
Allow tests to reset the restarting state

### DIFF
--- a/osquery/core/shutdown.h
+++ b/osquery/core/shutdown.h
@@ -23,6 +23,14 @@ namespace osquery {
 int getShutdownExitCode();
 
 /**
+ * @brief Reset the shutdown state to false.
+ *
+ * This is for internal and testing purposes.
+ * This allows for another state transition from waiting to shutdown.
+ */
+void resetShutdown();
+
+/**
  * @brief Set the requested exit code.
  *
  * Use requestShutdown to request shutdown in most cases.


### PR DESCRIPTION
See https://github.com/osquery/osquery/pull/7372 as this is a companion.

This changes the capability of the shutdown APIs so that they can be called multiple times. And that code can "reset" the request to shutdown.

This is helpful when using the SDK and within an extension that both wants to test this state machine and make decisions based on osqueryd's shutdown thrift API.