### PR TITLE
Isolate the internal SQLite plugin into a library

### DIFF
--- a/osquery/main/CMakeLists.txt
+++ b/osquery/main/CMakeLists.txt
@@ -52,6 +52,7 @@ function(generateOsqueryMain)
     osquery_registry
     osquery_remote_enroll_tlsenroll
     osquery_sql
+    osquery_sqlite_plugin
     plugins_config_filesystemconfig
     plugins_config_tlsconfig
     plugins_config_parsers

--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -12,6 +12,7 @@ function(osquerySqlMain)
   endif()
 
   generateOsquerySql()
+  generateOsquerySqlitePlugin()
 endfunction()
 
 function(generateOsquerySql)
@@ -37,8 +38,6 @@ function(generateOsquerySql)
   add_osquery_library(osquery_sql EXCLUDE_FROM_ALL
     ${source_files}
   )
-
-  enableLinkWholeArchive(osquery_sql)
 
   target_link_libraries(osquery_sql PUBLIC
     osquery_cxx_settings
@@ -74,6 +73,23 @@ function(generateOsquerySql)
   add_test(NAME osquery_sql_tests_virtualtabletests-test COMMAND osquery_sql_tests_virtualtabletests-test)
   add_test(NAME osquery_sql_tests_sqliteutilstests-test COMMAND osquery_sql_tests_sqliteutilstests-test)
   add_test(NAME osquery_sql_tests_sqlitehashingstests-test COMMAND osquery_sql_tests_sqlitehashingtests-test)
+endfunction()
+
+function(generateOsquerySqlitePlugin)
+  set(source_files
+    sqlite_plugin.cpp
+  )
+
+  add_osquery_library(osquery_sqlite_plugin EXCLUDE_FROM_ALL
+    ${source_files}
+  )
+
+  enableLinkWholeArchive(osquery_sqlite_plugin)
+
+  target_link_libraries(osquery_sqlite_plugin PUBLIC
+    osquery_cxx_settings
+    osquery_sql
+  )
 endfunction()
 
 osquerySqlMain()

--- a/osquery/sql/sqlite_plugin.cpp
+++ b/osquery/sql/sqlite_plugin.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/plugins/sql.h>
+#include <osquery/registry/registry_factory.h>
+#include <osquery/sql/sqlite_util.h>
+#include <osquery/sql/virtual_table.h>
+
+namespace osquery {
+
+/// The SQLiteSQLPlugin implements the "sql" registry for internal/core.
+class SQLiteSQLPlugin : public SQLPlugin {
+ public:
+  /// Execute SQL and store results.
+  Status query(const std::string& query,
+               QueryData& results,
+               bool use_cache) const override;
+
+  /// Introspect, explain, the suspected types selected in an SQL statement.
+  Status getQueryColumns(const std::string& query,
+                         TableColumns& columns) const override;
+
+  /// Similar to getQueryColumns but return the scanned tables.
+  Status getQueryTables(const std::string& query,
+                        std::vector<std::string>& tables) const override;
+
+  /// Create a SQLite module and attach (CREATE).
+  Status attach(const std::string& name) override;
+
+  /// Detach a virtual table (DROP).
+  Status detach(const std::string& name) override;
+};
+
+/// SQL provider for osquery internal/core.
+REGISTER_INTERNAL(SQLiteSQLPlugin, "sql", "sql");
+
+Status SQLiteSQLPlugin::query(const std::string& query,
+                              QueryData& results,
+                              bool use_cache) const {
+  auto dbc = SQLiteDBManager::get();
+  dbc->useCache(use_cache);
+  auto result = queryInternal(query, results, dbc);
+  dbc->clearAffectedTables();
+  return result;
+}
+
+Status SQLiteSQLPlugin::getQueryColumns(const std::string& query,
+                                        TableColumns& columns) const {
+  auto dbc = SQLiteDBManager::get();
+  return getQueryColumnsInternal(query, columns, dbc);
+}
+
+Status SQLiteSQLPlugin::getQueryTables(const std::string& query,
+                                       std::vector<std::string>& tables) const {
+  auto dbc = SQLiteDBManager::get();
+  QueryPlanner planner(query, dbc);
+  tables = planner.tables();
+  return Status(0);
+}
+
+Status SQLiteSQLPlugin::attach(const std::string& name) {
+  PluginResponse response;
+  auto status =
+      Registry::call("table", name, {{"action", "columns"}}, response);
+  if (!status.ok()) {
+    return status;
+  }
+
+  bool is_extension = true;
+  auto statement = columnDefinition(response, false, is_extension);
+
+  // Attach requests occurring via the plugin/registry APIs must act on the
+  // primary database. To allow this, getConnection can explicitly request the
+  // primary instance and avoid the contention decisions.
+  auto dbc = SQLiteDBManager::getConnection(true);
+
+  // Attach as an extension, allowing read/write tables
+  return attachTableInternal(name, statement, dbc, is_extension);
+}
+
+Status SQLiteSQLPlugin::detach(const std::string& name) {
+  // Detach requests occurring via the plugin/registry APIs must act on the
+  // primary database. To allow this, getConnection can explicitly request the
+  // primary instance and avoid the contention decisions.
+  auto dbc = SQLiteDBManager::getConnection(true);
+  return detachTableInternal(name, dbc);
+}
+} // namespace osquery

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -121,32 +121,6 @@ const std::map<std::string, QueryPlanner::Opcode> kSQLOpcodes = {
 
 RecursiveMutex SQLiteDBInstance::kPrimaryAttachMutex;
 
-/// The SQLiteSQLPlugin implements the "sql" registry for internal/core.
-class SQLiteSQLPlugin : public SQLPlugin {
- public:
-  /// Execute SQL and store results.
-  Status query(const std::string& query,
-               QueryData& results,
-               bool use_cache) const override;
-
-  /// Introspect, explain, the suspected types selected in an SQL statement.
-  Status getQueryColumns(const std::string& query,
-                         TableColumns& columns) const override;
-
-  /// Similar to getQueryColumns but return the scanned tables.
-  Status getQueryTables(const std::string& query,
-                        std::vector<std::string>& tables) const override;
-
-  /// Create a SQLite module and attach (CREATE).
-  Status attach(const std::string& name) override;
-
-  /// Detach a virtual table (DROP).
-  Status detach(const std::string& name) override;
-};
-
-/// SQL provider for osquery internal/core.
-REGISTER_INTERNAL(SQLiteSQLPlugin, "sql", "sql");
-
 std::string getStringForSQLiteReturnCode(int code) {
   if (kSQLiteReturnCodes.find(code) != kSQLiteReturnCodes.end()) {
     return kSQLiteReturnCodes.at(code);
@@ -155,30 +129,6 @@ std::string getStringForSQLiteReturnCode(int code) {
     s << "Error: " << code << " is not a valid SQLite result code";
     return s.str();
   }
-}
-
-Status SQLiteSQLPlugin::query(const std::string& query,
-                              QueryData& results,
-                              bool use_cache) const {
-  auto dbc = SQLiteDBManager::get();
-  dbc->useCache(use_cache);
-  auto result = queryInternal(query, results, dbc);
-  dbc->clearAffectedTables();
-  return result;
-}
-
-Status SQLiteSQLPlugin::getQueryColumns(const std::string& query,
-                                        TableColumns& columns) const {
-  auto dbc = SQLiteDBManager::get();
-  return getQueryColumnsInternal(query, columns, dbc);
-}
-
-Status SQLiteSQLPlugin::getQueryTables(const std::string& query,
-                                       std::vector<std::string>& tables) const {
-  auto dbc = SQLiteDBManager::get();
-  QueryPlanner planner(query, dbc);
-  tables = planner.tables();
-  return Status(0);
 }
 
 SQLInternal::SQLInternal(const std::string& query, bool use_cache) {
@@ -230,34 +180,6 @@ void SQLInternal::escapeResults() {
       boost::apply_visitor(visitor, column.second);
     }
   }
-}
-
-Status SQLiteSQLPlugin::attach(const std::string& name) {
-  PluginResponse response;
-  auto status =
-      Registry::call("table", name, {{"action", "columns"}}, response);
-  if (!status.ok()) {
-    return status;
-  }
-
-  bool is_extension = true;
-  auto statement = columnDefinition(response, false, is_extension);
-
-  // Attach requests occurring via the plugin/registry APIs must act on the
-  // primary database. To allow this, getConnection can explicitly request the
-  // primary instance and avoid the contention decisions.
-  auto dbc = SQLiteDBManager::getConnection(true);
-
-  // Attach as an extension, allowing read/write tables
-  return attachTableInternal(name, statement, dbc, is_extension);
-}
-
-Status SQLiteSQLPlugin::detach(const std::string& name) {
-  // Detach requests occurring via the plugin/registry APIs must act on the
-  // primary database. To allow this, getConnection can explicitly request the
-  // primary instance and avoid the contention decisions.
-  auto dbc = SQLiteDBManager::getConnection(true);
-  return detachTableInternal(name, dbc);
 }
 
 SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, Mutex& mtx)


### PR DESCRIPTION
There is a bug in how osquery is built as an SDK. The `SQLiteSQLPlugin` should not be included in static libraries that extensions and whatnot build. In rare cases this plugin and the external SQLlite plugin will "compete". If this plugin is used in an extension then tables that the extension does not know about will be incorrectly labeled as "not found".

This is a hard-to-exercise scenario. A more complete fix would be to refactor how the plugin is selected and force a different name for the external SQL mode.