### PR TITLE
Fix for shortcut files

### DIFF
--- a/osquery/tables/system/windows/shortcut_files.cpp
+++ b/osquery/tables/system/windows/shortcut_files.cpp
@@ -211,6 +211,11 @@ QueryData genShortcutFiles(QueryContext& context) {
       continue;
     }
     const int lnk_data = 152;
+    auto check_size = checkShortcutDataSize(lnk_hex.size(), lnk_data);
+    if (check_size.isError()) {
+      LOG(INFO) << check_size.getError();
+      continue;
+    }
     std::string data_string = lnk_hex.substr(lnk_data);
     std::string lnk_path = lnk;
     parseShortcutFiles(results, data, data_string, lnk_path);

--- a/osquery/utils/windows/shelllnk.cpp
+++ b/osquery/utils/windows/shelllnk.cpp
@@ -18,7 +18,8 @@
 #include <boost/algorithm/hex.hpp>
 
 namespace osquery {
-ExpectedSize checkShortcutDataSize(const size_t& shortdata_size, const int& size) {
+ExpectedSize checkShortcutDataSize(const size_t& shortdata_size,
+                                   const int& size) {
   if (size > shortdata_size) {
     return ExpectedSize::failure(ConversionError::InvalidArgument,
                                  "Invalid shortcut data size");

--- a/osquery/utils/windows/shelllnk.h
+++ b/osquery/utils/windows/shelllnk.h
@@ -145,6 +145,7 @@ ExtraDataTracker parseExtraDataTracker(const std::string& data);
  *
  * @returns Status of shortcut data size
  */
-ExpectedSize checkShortcutDataSize(const size_t& shortdata_size, const int& size);
+ExpectedSize checkShortcutDataSize(const size_t& shortdata_size,
+                                   const int& size);
 
 } // namespace osquery

--- a/osquery/utils/windows/shelllnk.h
+++ b/osquery/utils/windows/shelllnk.h
@@ -9,13 +9,14 @@
 
 #pragma once
 
+#include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/system/system.h>
 
 #include <string>
 #include <vector>
 
 namespace osquery {
-
+using ExpectedSize = Expected<bool, ConversionError>;
 struct LinkFlags {
   bool has_target_id_list;
   bool has_link_info;
@@ -138,4 +139,12 @@ DataStringInfo parseDataString(const std::string& data,
  * @returns The shortcut extra data tracker structure
  */
 ExtraDataTracker parseExtraDataTracker(const std::string& data);
+
+/**
+ * @brief Windows helper function to check shortcut data size
+ *
+ * @returns Status of shortcut data size
+ */
+ExpectedSize checkShortcutDataSize(const size_t& shortdata_size, const int& size);
+
 } // namespace osquery


### PR DESCRIPTION
This PR fixes the bug reported at #7380. It adds a comparison check before extracting the data from the shortcut file.
I added additional comparison checks in the the shortcut file parsing functions to try to account for any additional corrupted data scenarios.

I tested the fix with the provided file at #7380, in additional I manually modified/corrupted several other shortcut files and no errors were produced instead the table returns a log message about invalid data size .
Definitely interested in any feedback or suggestions for improvement. Thanks!