### PR TITLE
Lower log level of `executing distributed query`

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -495,6 +495,14 @@ Enable thrift global output.
 
 Maximum returned row value size.
 
+`--schedule_lognames=false`
+
+Log executing scheduled query names at the `INFO` level, and not the `VERBOSE` level
+
+`--distributed_loginfo=false`
+
+Log executing distributed queries at the `INFO` level, and not the `VERBOSE` level
+
 ## Distributed query service flags
 
 `--distributed_plugin=tls`

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -39,6 +39,8 @@ FLAG(bool,
      false,
      "Log the running distributed queries name at INFO level");
 
+DECLARE_bool(verbose);
+
 const std::string kDistributedQueryPrefix{"distributed."};
 
 std::string Distributed::currentRequestId_{""};

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -33,6 +33,11 @@ FLAG(bool,
      true,
      "Disable distributed queries (default true)");
 
+FLAG(bool,
+     distributed_loginfo,
+     false,
+     "Log the running distributed queries name at INFO level");
+
 const std::string kDistributedQueryPrefix{"distributed."};
 
 std::string Distributed::currentRequestId_{""};
@@ -118,8 +123,13 @@ void Distributed::addResult(const DistributedQueryResult& result) {
 Status Distributed::runQueries() {
   while (getPendingQueryCount() > 0) {
     auto request = popRequest();
-    VLOG(1) << "Executing distributed query: " << request.id << ": "
-	    << request.query;
+    if (FLAGS_verbose) {
+      VLOG(1) << "Executing distributed query: " << request.id << ": "
+              << request.query;
+    } else if (FLAGS_distributed_loginfo) {
+      LOG(INFO) << "Executing distributed query: " << request.id << ": "
+                << request.query;
+    }
 
     // Keep track of the currently executing request
     Distributed::setCurrentRequestId(request.id);

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -118,8 +118,8 @@ void Distributed::addResult(const DistributedQueryResult& result) {
 Status Distributed::runQueries() {
   while (getPendingQueryCount() > 0) {
     auto request = popRequest();
-    LOG(INFO) << "Executing distributed query: " << request.id << ": "
-              << request.query;
+    VLOG(1) << "Executing distributed query: " << request.id << ": "
+	    << request.query;
 
     // Keep track of the currently executing request
     Distributed::setCurrentRequestId(request.id);

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <utility>
 
+#include <osquery/core/flags.h>
 #include <osquery/core/plugins/logger.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>


### PR DESCRIPTION
This lowers the default log level of `Executing distributed query` and implements similar functionality to what's described in #6923
