### PR TITLE
Expand env vars for the windows_crashes table

### DIFF
--- a/osquery/tables/system/windows/windows_crashes.cpp
+++ b/osquery/tables/system/windows/windows_crashes.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <osquery/utils/system/env.h>
 #include <osquery/utils/system/system.h>
 
 #include <Winternl.h>
@@ -625,6 +626,10 @@ QueryData genCrashLogs(QueryContext& context) {
   } else {
     auto tempDumpLoc = getEnvVar("TMP");
     dumpFolderLocation = tempDumpLoc.is_initialized() ? *tempDumpLoc : "";
+  }
+
+  if (const auto expandedPath = expandEnvString(dumpFolderLocation)) {
+    dumpFolderLocation = *expandedPath;
   }
 
   if (!fs::exists(dumpFolderLocation) ||


### PR DESCRIPTION
The `windows_crashes` table locates the directory containing the crash dumps by reading a path string from a registry key. If this path contains environment variables, handling this string as the path may fail to find the directory. This change passes the path string through the (existing) osquery utility function, [expandEnvString](https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/utils/system/env.h#L37) before handling it. E.g., it would change `%TMP%` to `C:\Windows\Temp`.

The added code appears similar to what is in the `services` table: https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/tables/system/windows/services.cpp#L141

(description added by @mike-myers-tob)