### PR TITLE
fix for #7394 where cleanup of some event tables never occures

### DIFF
--- a/osquery/events/eventsubscriberplugin.cpp
+++ b/osquery/events/eventsubscriberplugin.cpp
@@ -178,7 +178,7 @@ Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
           index_entry.end(), event_id_list.begin(), event_id_list.end());
     }
 
-    cleanup_events = (((event_count_ % kEventsCheckpoint) + row_list.size()) >
+    cleanup_events = (((event_count_ % kEventsCheckpoint) + row_list.size()) >=
                       kEventsCheckpoint);
     event_count_ += row_list.size();
   }

--- a/osquery/tables/events/linux/apparmor_events.cpp
+++ b/osquery/tables/events/linux/apparmor_events.cpp
@@ -42,9 +42,7 @@ Status AppArmorEventSubscriber::callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : data) {
-    add(row);
-  }
+  addBatch(data);
 
   return Status();
 }

--- a/osquery/tables/events/linux/seccomp_events.cpp
+++ b/osquery/tables/events/linux/seccomp_events.cpp
@@ -61,9 +61,7 @@ Status SeccompEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : data) {
-    add(row);
-  }
+  addBatch(data);
 
   return Status::success();
 }

--- a/osquery/tables/events/linux/selinux_events.cpp
+++ b/osquery/tables/events/linux/selinux_events.cpp
@@ -43,9 +43,7 @@ Status SELinuxEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : emitted_row_list) {
-    add(row);
-  }
+  addBatch(emitted_row_list);
 
   return Status::success();
 }


### PR DESCRIPTION
Fixes: #7394

- Fixed the expression so the cleanup is triggered correctly.
- Replaced `add()` with `addBatch()` for `selinux_events`, `apparmor_events`, `seccomp_events`

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
