### PR TITLE
Fix for gathering python packages from any user Python installations

### DIFF
--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -208,5 +208,57 @@ TEST_F(RegistryTablesTest, test_get_username_from_key) {
     EXPECT_FALSE(status.ok());
   }
 }
+
+TEST_F(RegistryTablesTest, test_populate_subkeys_valid_key) {
+  Status status;
+  std::set<std::string> validKey = {"HKEY_CURRENT_USER\\AppEvents"};
+
+  status = populateSubkeys(validKey, false);
+  EXPECT_TRUE(status.ok());
+}
+
+TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_key) {
+  Status status;
+  std::set<std::string> badKey = {"HKEY_LOCAL_MACHINE\\Some\\Key"};
+
+  status = populateSubkeys(badKey, false);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_middle_key) {
+  Status status;
+  std::string validKey1 = "HKEY_LOCAL_MACHINE\\SYSTEM\\ResourceManager";
+  std::string validKey2 = "HKEY_USERS\\.DEFAULT\\System";
+  std::string invalidKey = "HKEY_LOCAL_MACHINE\\Some\\Key";
+  const std::set<std::string> origKeys = {
+      validKey1,
+      invalidKey,
+      validKey2,
+  };
+
+  std::set<std::string> keys{origKeys.cbegin(), origKeys.cend()};
+
+  status = populateSubkeys(keys, false);
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(origKeys.size() < keys.size());
+  keys.erase(validKey1);
+  keys.erase(invalidKey);
+  keys.erase(validKey2);
+  EXPECT_TRUE(std::any_of(keys.begin(),
+                         keys.end(),
+                         [&](const std::string& key) {
+                           return boost::starts_with(key, validKey1);
+                         }));
+  EXPECT_TRUE(std::none_of(keys.begin(),
+                         keys.end(),
+                         [&](const std::string& key) {
+                           return boost::starts_with(key, invalidKey);
+                         }));
+  EXPECT_TRUE(std::any_of(keys.begin(),
+                         keys.end(),
+                         [&](const std::string& key) {
+                           return boost::starts_with(key, validKey2);
+                         }));
+}
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -244,21 +244,18 @@ TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_middle_key) {
   keys.erase(validKey1);
   keys.erase(invalidKey);
   keys.erase(validKey2);
-  EXPECT_TRUE(std::any_of(keys.begin(),
-                         keys.end(),
-                         [&](const std::string& key) {
-                           return boost::starts_with(key, validKey1);
-                         }));
-  EXPECT_TRUE(std::none_of(keys.begin(),
-                         keys.end(),
-                         [&](const std::string& key) {
-                           return boost::starts_with(key, invalidKey);
-                         }));
-  EXPECT_TRUE(std::any_of(keys.begin(),
-                         keys.end(),
-                         [&](const std::string& key) {
-                           return boost::starts_with(key, validKey2);
-                         }));
+  EXPECT_TRUE(
+      std::any_of(keys.begin(), keys.end(), [&](const std::string& key) {
+        return boost::starts_with(key, validKey1);
+      }));
+  EXPECT_TRUE(
+      std::none_of(keys.begin(), keys.end(), [&](const std::string& key) {
+        return boost::starts_with(key, invalidKey);
+      }));
+  EXPECT_TRUE(
+      std::any_of(keys.begin(), keys.end(), [&](const std::string& key) {
+        return boost::starts_with(key, validKey2);
+      }));
 }
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -215,14 +215,18 @@ TEST_F(RegistryTablesTest, test_populate_subkeys_valid_key) {
 
   status = populateSubkeys(validKey, false);
   EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(validKey.size() > 1);
 }
 
 TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_key) {
   Status status;
-  std::set<std::string> badKey = {"HKEY_LOCAL_MACHINE\\Some\\Key"};
+  std::string invalidKey = "HKEY_LOCAL_MACHINE\\Some\\Key";
+  std::set<std::string> badKey = {invalidKey};
 
   status = populateSubkeys(badKey, false);
-  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(badKey.size() == 1);
+  EXPECT_TRUE(badKey.count(invalidKey));
 }
 
 TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_middle_key) {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -429,7 +429,7 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
     QueryData regResults;
     auto ret = queryKey(key, regResults);
     if (!ret.ok()) {
-      if(ret.getCode() == ERROR_FILE_NOT_FOUND) {
+      if (ret.getCode() == ERROR_FILE_NOT_FOUND) {
         continue;
       }
 

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -428,6 +428,9 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
   for (const auto& key : rKeys) {
     QueryData regResults;
     auto ret = queryKey(key, regResults);
+    if (!ret.ok() && ret.getCode() == ERROR_FILE_NOT_FOUND) {
+      continue;
+    }
     if (!ret.ok()) {
       return ret;
     }

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -420,7 +420,7 @@ static inline void populateDefaultKeys(std::set<std::string>& rKeys) {
 
 inline Status populateSubkeys(std::set<std::string>& rKeys,
                               bool replaceKeys) {
-  bool isOneSubkeyQueried = false;
+  bool atLeastOneKeyExists = false;
   std::set<std::string> newKeys;
   if (!replaceKeys) {
     newKeys = rKeys;
@@ -436,7 +436,7 @@ inline Status populateSubkeys(std::set<std::string>& rKeys,
 
       return ret;
     }
-    isOneSubkeyQueried = true;
+    atLeastOneKeyExists = true;
     for (const auto& r : regResults) {
       if (r.at("type") == "subkey") {
         newKeys.insert(r.at("path"));
@@ -444,7 +444,7 @@ inline Status populateSubkeys(std::set<std::string>& rKeys,
     }
   }
   rKeys = std::move(newKeys);
-  if (!isOneSubkeyQueried) {
+  if (!atLeastOneKeyExists) {
     return Status(1, "Failed to query registry keys");
   }
 

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -419,7 +419,6 @@ static inline void populateDefaultKeys(std::set<std::string>& rKeys) {
 }
 
 inline Status populateSubkeys(std::set<std::string>& rKeys, bool replaceKeys) {
-  bool atLeastOneKeyExists = false;
   std::set<std::string> newKeys;
   if (!replaceKeys) {
     newKeys = rKeys;
@@ -435,7 +434,6 @@ inline Status populateSubkeys(std::set<std::string>& rKeys, bool replaceKeys) {
 
       return ret;
     }
-    atLeastOneKeyExists = true;
     for (const auto& r : regResults) {
       if (r.at("type") == "subkey") {
         newKeys.insert(r.at("path"));
@@ -443,10 +441,6 @@ inline Status populateSubkeys(std::set<std::string>& rKeys, bool replaceKeys) {
     }
   }
   rKeys = std::move(newKeys);
-  if (!atLeastOneKeyExists) {
-    return Status(1, "Failed to query registry keys");
-  }
-
   return Status::success();
 }
 

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -418,8 +418,7 @@ static inline void populateDefaultKeys(std::set<std::string>& rKeys) {
               std::inserter(rKeys, rKeys.end()));
 }
 
-inline Status populateSubkeys(std::set<std::string>& rKeys,
-                              bool replaceKeys) {
+inline Status populateSubkeys(std::set<std::string>& rKeys, bool replaceKeys) {
   bool atLeastOneKeyExists = false;
   std::set<std::string> newKeys;
   if (!replaceKeys) {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -428,10 +428,11 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
   for (const auto& key : rKeys) {
     QueryData regResults;
     auto ret = queryKey(key, regResults);
-    if (!ret.ok() && ret.getCode() == ERROR_FILE_NOT_FOUND) {
-      continue;
-    }
     if (!ret.ok()) {
+      if(ret.getCode() == ERROR_FILE_NOT_FOUND) {
+        continue;
+      }
+
       return ret;
     }
     for (const auto& r : regResults) {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -418,8 +418,9 @@ static inline void populateDefaultKeys(std::set<std::string>& rKeys) {
               std::inserter(rKeys, rKeys.end()));
 }
 
-static inline Status populateSubkeys(std::set<std::string>& rKeys,
-                                     bool replaceKeys = false) {
+inline Status populateSubkeys(std::set<std::string>& rKeys,
+                              bool replaceKeys) {
+  bool isOneSubkeyQueried = false;
   std::set<std::string> newKeys;
   if (!replaceKeys) {
     newKeys = rKeys;
@@ -435,6 +436,7 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
 
       return ret;
     }
+    isOneSubkeyQueried = true;
     for (const auto& r : regResults) {
       if (r.at("type") == "subkey") {
         newKeys.insert(r.at("path"));
@@ -442,6 +444,10 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
     }
   }
   rKeys = std::move(newKeys);
+  if (!isOneSubkeyQueried) {
+    return Status(1, "Failed to query registry keys");
+  }
+
   return Status::success();
 }
 

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -119,12 +119,13 @@ Status getUsernameFromKey(const std::string& key, std::string& rUsername);
  * @brief Populate a set of registry keys with their subkeys
  *
  * For example, the key HKEY_LOCAL_MACHINE\SAM would produce a set with two keys
- * 'HKEY_LOCAL_MACHINE\SAM' and 'HKEY_LOCAL_MACHINE\SAM\SAM' if (replaceKeys=false).
+ * 'HKEY_LOCAL_MACHINE\SAM' and 'HKEY_LOCAL_MACHINE\SAM\SAM' if
+ * (replaceKeys=false).
  *
  * @param rKeys A set that will be populated with all registry keys might have
  * subkeys
- * @param replaceKeys A boolean that controls whether the result set will be initialized
- * with the rKeys
+ * @param replaceKeys A boolean that controls whether the result set will be
+ * initialized with the rKeys
  * @return Failure if all subkeys do not exist in registry, otherwise
  * success
  */

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -114,5 +114,22 @@ inline void explodeRegistryPath(const std::string& path,
  * success
  */
 Status getUsernameFromKey(const std::string& key, std::string& rUsername);
+
+/*
+ * @brief Populate a set of registry keys with their subkeys
+ *
+ * For example, the key HKEY_LOCAL_MACHINE\SAM would produce a set with two keys
+ * 'HKEY_LOCAL_MACHINE\SAM' and 'HKEY_LOCAL_MACHINE\SAM\SAM' if (replaceKeys=false).
+ *
+ * @param rKeys A set that will be populated with all registry keys might have
+ * subkeys
+ * @param replaceKeys A boolean that controls whether the result set will be initialized
+ * with the rKeys
+ * @return Failure if all subkeys do not exist in registry, otherwise
+ * success
+ */
+inline Status populateSubkeys(std::set<std::string>& rKeys,
+                              bool replaceKeys = false);
+
 } // namespace tables
 } // namespace osquery


### PR DESCRIPTION
This PR fixes the bug reported at #7350.  It adds  a check whether 'queryKey' returns major error(e.g. access denied) or path not found.
The "path not found" error should be handled when writing registry globs like "HKEY_USERS\\%\SOFTWARE\Python\PythonCore\\%\InstallPath" The first glob wildcard is trivial to be found, but the other once depends on whether user installs any Python software within its registry tree.   

I tested the fix with installing latest Python version for local-user only. My Python installation is stored under "C:\Users\Amir\AppData\Local\Programs\Python\Python310\python.exe" it's not a system location( e.g. c:\program files) .
 After my fix the python packages populate to the table.

any feedback is more than welcome, Thanks!