### PR TITLE
Fix linking of thirdparty_sleuthkit

### DIFF
--- a/libraries/cmake/source/sleuthkit/CMakeLists.txt
+++ b/libraries/cmake/source/sleuthkit/CMakeLists.txt
@@ -263,7 +263,7 @@ function(sleuthkitMain)
   )
 
   # fs library
-  add_library(thirdparty_sleuthkit_fs_cpp OBJECT
+  add_library(thirdparty_sleuthkit_fs_cpp
     "${library_root}/tsk/fs/apfs_compat.cpp"
     "${library_root}/tsk/fs/apfs.cpp"
     "${library_root}/tsk/fs/apfs_fs.cpp"
@@ -277,6 +277,7 @@ function(sleuthkitMain)
   target_link_libraries(thirdparty_sleuthkit_fs_cpp PRIVATE
     thirdparty_sleuthkit_settings
     thirdparty_cxx_settings
+    thirdparty_sleuthkit_auto
   )
 
   add_library(thirdparty_sleuthkit_fs


### PR DESCRIPTION
The thirdparty_sleuthkit_fs_cpp object library actually depends
on thirdparty_sleuthkit_auto but we are not explicitly specifying
that depedency.
Sometimes it works, sometimes it doesn't (like on oss-fuzz).

Add the correct dependency and also change thirdparty_sleuthkit_fs_cpp
to be a STATIC library, because linking to thirdparty_sleuthkit_auto
causes a circular dependency (which is also present upstream),
and CMake can only deal with that if every library involved is STATIC.
