### PR TITLE
Update sqlite to version 3.37.0

### DIFF
--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -512,8 +512,8 @@ QueryPlanner::QueryPlanner(const std::string& query,
 
   for (const auto& row : plan) {
     auto details = osquery::split(row.at("detail"));
-    if (details.size() > 2 && details[0] == "SCAN") {
-      tables_.push_back(details[2]);
+    if (details.size() > 1 && details[0] == "SCAN") {
+      tables_.push_back(details[1]);
     }
   }
 }


### PR DESCRIPTION
Also fix the parsing of the "EXPLAIN QUERY PLAN" output,
since the detail column has changed format for the SCAN operation,
from "SCAN TABLE \<uppercase tablename\>" to just "SCAN \<provided tablename\>".