### PR TITLE
Create github workflow target to gate mergeability

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1248,6 +1248,8 @@ jobs:
   # This job is here as a github status check -- it allows us to move the dependacy from
   # being on all the jobs to this single one.
   mergable:
+    steps:
+      run: true
     needs:
       - build_macos
       - build_linux

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1249,7 +1249,7 @@ jobs:
   # being on all the jobs to this single one.
   mergable:
     steps:
-      run: true
+      - run: true
     needs:
       - build_macos
       - build_linux

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1248,6 +1248,7 @@ jobs:
   # This job is here as a github status check -- it allows us to move the dependacy from
   # being on all the jobs to this single one.
   mergable:
+    runs-on: ubuntu-latest
     steps:
       - run: true
     needs:

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1253,4 +1253,3 @@ jobs:
       - build_linux
       - build_windows
       - build_universal_macos_artifacts
-    run: true

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1245,9 +1245,9 @@ jobs:
       run: |
         rm -r -Force ${{ steps.build_paths.outputs.BINARY }}
 
-  # This job is here as a github status check -- it allows us to move the dependacy from
+  # This job is here as a github status check -- it allows us to move the dependency from
   # being on all the jobs to this single one.
-  mergable:
+  mergeable:
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1256,3 +1256,4 @@ jobs:
       - build_linux
       - build_windows
       - build_universal_macos_artifacts
+      - check_source_code

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1244,3 +1244,13 @@ jobs:
       shell: powershell
       run: |
         rm -r -Force ${{ steps.build_paths.outputs.BINARY }}
+
+  # This job is here as a github status check -- it allows us to move the dependacy from
+  # being on all the jobs to this single one.
+  mergable:
+    needs:
+      - build_macos
+      - build_linux
+      - build_windows
+      - build_universal_macos_artifacts
+    run: true


### PR DESCRIPTION
## Problem

Managing the required checks is a github UI action, that feels a bit fragile. When I was recently changing the required status checks I found it very hard to tell if the ones I wanted were configured. 

## Solution

Create a job to gate what's required. The pro is that it makes a single thing to require in the branch protections. The con, is that it might be easier to accidentally change the requirements. But, that would be in the PR. 

Curious what y'all think