### PR TITLE
Rename `kIOMasterPortDefault` to `kIOMainPortDefault`

### DIFF
--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -93,8 +93,7 @@ void DiskArbitrationEventPublisher::DiskAppearedCallback(DADiskRef disk,
   auto device_path = stringFromCFString((CFStringRef)devicePathKey);
   ec->device_path = device_path;
 
-  auto entry =
-      IORegistryEntryFromPath(kIOMasterPortDefault, device_path.c_str());
+  auto entry = IORegistryEntryFromPath(kIOMainPortDefault, device_path.c_str());
   if (entry == MACH_PORT_NULL) {
     CFRelease(disk_properties);
     return;

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -47,7 +47,7 @@ void IOKitEventPublisher::restart() {
 
   {
     WriteLock lock(mutex_);
-    port_ = IONotificationPortCreate(kIOMasterPortDefault);
+    port_ = IONotificationPortCreate(kIOMainPortDefault);
     // Get a run loop source from the created IOKit notification port.
     auto run_loop_source = IONotificationPortGetRunLoopSource(port_);
     CFRunLoopAddSource(run_loop_, run_loop_source, kCFRunLoopDefaultMode);

--- a/osquery/tables/system/darwin/acpi_tables.cpp
+++ b/osquery/tables/system/darwin/acpi_tables.cpp
@@ -41,7 +41,7 @@ QueryData genACPITables(QueryContext& context) {
     return {};
   }
 
-  auto service = IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+  auto service = IOServiceGetMatchingService(kIOMainPortDefault, matching);
   if (service == 0) {
     return {};
   }

--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -60,7 +60,7 @@ NSDictionary* getIopmBatteryInfo() {
 NSDictionary* getIopmpsBatteryInfo() {
   CFMutableDictionaryRef matching = IOServiceNameMatching("AppleSmartBattery");
   io_service_t entry =
-      IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+      IOServiceGetMatchingService(kIOMainPortDefault, matching);
   matching = nullptr; // Dictionary consumed by IOServiceGetMatchingService
   // From Apple docs:
   // IOService is a subclass of IORegistryEntry, which means any of the

--- a/osquery/tables/system/darwin/block_devices.cpp
+++ b/osquery/tables/system/darwin/block_devices.cpp
@@ -94,7 +94,7 @@ QueryData genBlockDevs(QueryContext& context) {
   }
 
   io_iterator_t it;
-  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
+  auto kr = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &it);
   if (kr != KERN_SUCCESS) {
     return {};
   }

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -58,7 +58,7 @@ const std::set<std::string> kHardcodedDiskUUIDs = {
 
 Status genUnlockIdent(CFDataRef& uuid) {
   auto chosen =
-      IORegistryEntryFromPath(kIOMasterPortDefault, kIODeviceTreeChosenPath_);
+      IORegistryEntryFromPath(kIOMainPortDefault, kIODeviceTreeChosenPath_);
   if (chosen == MACH_PORT_NULL) {
     return Status(1, "Could not open IOKit DeviceTree");
   }
@@ -371,13 +371,12 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
                             bool isAPFS,
                             QueryData& results) {
   auto matching_dict =
-      IOBSDNameMatching(kIOMasterPortDefault, kNilOptions, bsd_name.c_str());
+      IOBSDNameMatching(kIOMainPortDefault, kNilOptions, bsd_name.c_str());
   if (matching_dict == nullptr) {
     return;
   }
 
-  auto service =
-      IOServiceGetMatchingService(kIOMasterPortDefault, matching_dict);
+  auto service = IOServiceGetMatchingService(kIOMainPortDefault, matching_dict);
   if (!service) {
     return;
   }

--- a/osquery/tables/system/darwin/ibridge.cpp
+++ b/osquery/tables/system/darwin/ibridge.cpp
@@ -29,7 +29,7 @@ static const std::unordered_map<uint32_t, std::string> kCoprocessorVersions = {
 
 static inline void genBootUuid(Row& r) {
   auto chosen = IORegistryEntryFromPath(
-      kIOMasterPortDefault, kIODeviceTreePlane kIODeviceChosenPath_);
+      kIOMainPortDefault, kIODeviceTreePlane kIODeviceChosenPath_);
   if (chosen == MACH_PORT_NULL) {
     return;
   }
@@ -52,7 +52,7 @@ static inline void genBootUuid(Row& r) {
 }
 
 static inline void genAppleCoprocessorVersion(Row& r) {
-  auto asoc = IORegistryEntryFromPath(kIOMasterPortDefault,
+  auto asoc = IORegistryEntryFromPath(kIOMainPortDefault,
                                       kIODeviceTreePlane kIODeviceEfiPath_);
   if (asoc == MACH_PORT_NULL) {
     LOG(WARNING) << "Cannot open EFI Device Tree";
@@ -104,7 +104,7 @@ QueryData genIBridgeInfo(QueryContext& context) {
     return results;
   }
 
-  auto service = IOServiceGetMatchingService(kIOMasterPortDefault, eos);
+  auto service = IOServiceGetMatchingService(kIOMainPortDefault, eos);
   CFMutableDictionaryRef properties = nullptr;
   auto kr = IORegistryEntryCreateCFProperties(
       service, &properties, kCFAllocatorDefault, kNilOptions);

--- a/osquery/tables/system/darwin/iokit_registry.cpp
+++ b/osquery/tables/system/darwin/iokit_registry.cpp
@@ -163,7 +163,7 @@ QueryData genDeviceFirmware(QueryContext& context) {
   QueryData qd;
 
   // Start with the services root node.
-  auto service = IORegistryGetRootEntry(kIOMasterPortDefault);
+  auto service = IORegistryGetRootEntry(kIOMainPortDefault);
   genIOKitDeviceChildren(&genIOKitFirmware, service, kIOServicePlane, 0, qd);
   IOObjectRelease(service);
 
@@ -174,7 +174,7 @@ QueryData genIOKitDeviceTree(QueryContext& context) {
   QueryData qd;
 
   // Get the IO registry root node.
-  auto service = IORegistryGetRootEntry(kIOMasterPortDefault);
+  auto service = IORegistryGetRootEntry(kIOMainPortDefault);
   // Begin recursing along the IODeviceTree "plane".
   genIOKitDeviceChildren(&genIOKitDevice, service, kIODeviceTreePlane, 0, qd);
   IOObjectRelease(service);
@@ -186,7 +186,7 @@ QueryData genIOKitRegistry(QueryContext& context) {
   QueryData qd;
 
   // Get the IO registry root node.
-  auto service = IORegistryGetRootEntry(kIOMasterPortDefault);
+  auto service = IORegistryGetRootEntry(kIOMainPortDefault);
   // Begin recursing along the IODeviceTree "plane".
   genIOKitDeviceChildren(&genIOKitDevice, service, kIOServicePlane, 0, qd);
   IOObjectRelease(service);

--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -45,7 +45,7 @@ QueryData genPCIDevices(QueryContext& context) {
   }
 
   io_iterator_t it;
-  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
+  auto kr = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &it);
   if (kr != KERN_SUCCESS) {
     return results;
   }

--- a/osquery/tables/system/darwin/sip_config.cpp
+++ b/osquery/tables/system/darwin/sip_config.cpp
@@ -47,7 +47,7 @@ int csr_get_active_config(csr_config_t* config);
 
 Status genCsrConfigFromNvram(uint32_t& config) {
   auto chosen =
-      IORegistryEntryFromPath(kIOMasterPortDefault, kIODeviceTreeChosenPath_);
+      IORegistryEntryFromPath(kIOMainPortDefault, kIODeviceTreeChosenPath_);
   if (chosen == MACH_PORT_NULL) {
     return Status(1, "Could not open IOKit DeviceTree");
   }

--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -54,7 +54,7 @@ bool DarwinSMBIOSParser::discover() {
     return false;
   }
 
-  auto service = IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+  auto service = IOServiceGetMatchingService(kIOMainPortDefault, matching);
   if (service == 0) {
     return false;
   }
@@ -224,7 +224,7 @@ QueryData genOEMStrings(QueryContext& context) {
 }
 
 QueryData genPlatformInfo(QueryContext& context) {
-  auto rom = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/rom");
+  auto rom = IORegistryEntryFromPath(kIOMainPortDefault, "IODeviceTree:/rom");
   if (rom == 0) {
     return {};
   }

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -72,7 +72,7 @@ static inline void genHostInfo(Row& r) {
 }
 
 static inline void genHardwareInfo(Row& r) {
-  auto root = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/");
+  auto root = IORegistryEntryFromPath(kIOMainPortDefault, "IODeviceTree:/");
   if (root == MACH_PORT_NULL) {
     VLOG(1) << "Cannot get hardware information from IOKit";
     return;
@@ -105,8 +105,7 @@ static inline void genHardwareInfo(Row& r) {
   // Mac ARM / M1 machines have the hardware_model one level deeper, in the
   // IODeviceTree:/product key.
   if (r["hardware_model"].empty()) {
-    root =
-        IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/product");
+    root = IORegistryEntryFromPath(kIOMainPortDefault, "IODeviceTree:/product");
     if (root == MACH_PORT_NULL) {
       VLOG(1) << "Cannot get ARM hardware information from IOKit";
       return;

--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -83,7 +83,7 @@ QueryData genUSBDevices(QueryContext& context) {
   }
 
   io_iterator_t it;
-  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
+  auto kr = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &it);
   if (kr != KERN_SUCCESS) {
     return results;
   }


### PR DESCRIPTION
Testing something locally, I noticed I was getting deprecated warnings. It looks like apple renamed this.
