### PR TITLE
Improved connection time for broken servers. (#7424)

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -391,8 +391,14 @@ WmiRequest::WmiRequest(const std::string& query, std::wstring nspace) {
     return;
   }
 
-  hr = locator_->ConnectServer(
-      nspace_str, nullptr, nullptr, nullptr, 0, nullptr, nullptr, &services);
+  hr = locator_->ConnectServer(nspace_str,
+                               nullptr,
+                               nullptr,
+                               nullptr,
+                               WBEM_FLAG_CONNECT_USE_MAX_WAIT,
+                               nullptr,
+                               nullptr,
+                               &services);
   SysFreeString(nspace_str);
 
   if (hr != S_OK) {


### PR DESCRIPTION
Previously osquery ceasing to respond indefinitely on connection if the server is broken.
Now the `ConnectServer` call returns in 2 minutes or less to prevent program from ceasing to respond indefinitely.