### PR TITLE
Do not run clang-tidy on third party libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,22 +28,6 @@ if(OSQUERY_TOOLCHAIN_SYSROOT AND NOT DEFINED PLATFORM_LINUX)
   message(FATAL_ERROR "The custom toolchain can only be used with Linux, undefine OSQUERY_TOOLCHAIN_SYSROOT and specify a compiler to use")
 endif()
 
-# clang-tidy needs to be initialized in global scope, before any
-# target is created
-if(OSQUERY_ENABLE_CLANG_TIDY)
-  find_package(clang-tidy)
-  if(TARGET clang-tidy::clang-tidy)
-    foreach(language C CXX)
-      set("CMAKE_${language}_CLANG_TIDY"
-        "${CLANG-TIDY_EXECUTABLE};${OSQUERY_CLANG_TIDY_CHECKS}"
-      )
-    endforeach()
-
-  else()
-    message(WARNING "clang-tidy: Disabled because it was not found")
-  endif()
-endif()
-
 function(main)
 
   findClangFormat()
@@ -71,6 +55,20 @@ function(main)
 
   add_subdirectory("libraries")
   importLibraries()
+
+  # Enable clang-tidy only after having created the third party targets,
+  # so it won't run with those and slow down the build.
+  if(OSQUERY_ENABLE_CLANG_TIDY)
+    find_package(clang-tidy)
+
+    if(TARGET clang-tidy::clang-tidy)
+      set(CMAKE_CXX_CLANG_TIDY
+          "${CLANG-TIDY_EXECUTABLE};${OSQUERY_CLANG_TIDY_CHECKS}"
+      )
+    else()
+      message(WARNING "clang-tidy: Disabled because it was not found")
+    endif()
+  endif()
 
   add_subdirectory("osquery")
   add_subdirectory("plugins")


### PR DESCRIPTION
We don't want to run clang-tidy on third party libraries,
so we set that variable after having declared the third party library
targets. This skips setting the relative target property,
and CMake will build normally.

Setting the CMAKE_CXX_CLANG_TIDY variable in a global scope
is not needed, since all the targets we are interested in
are created in the topmost main() function scope.

Finally, only set the CXX variant of the variable,
since the osquery code doesn't contain C.