### PR TITLE
Change the JSON of the results from an event scheduled query to an array

### DIFF
--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -125,7 +125,7 @@ Status Query::addNewEvents(QueryDataTyped current_qd,
   bool new_query = false;
   getQueryStatus(current_epoch, fresh_results, new_query);
   if (fresh_results) {
-    auto status = setDatabaseValue(kQueries, name_, "{}");
+    auto status = setDatabaseValue(kQueries, name_, "[]");
     if (!status.ok()) {
       return status;
     }
@@ -374,4 +374,4 @@ Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& item,
   return Status::success();
 }
 
-}
+} // namespace osquery


### PR DESCRIPTION
If a scheduled query is against an evented table,
has run at least once and if this query later changes
and it's against a non evented table,
after that query has run, osquery will exit with the error
"Error adding new results to database for query
\<queryname\> JSON object was not an array"

This is because if the query is against an evented table,
osquery always stores an empty JSON object.

When the query changes and is against a non evented table,
there has been a previous run and if the differential is active,
at the next query run, it will take the previous results of the query
deserializing the JSON document and expecting an array,
which is the type used to serialize non evented results.
