### PR TITLE
Clear cached constraints and columns in xBestIndex

### DIFF
--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -552,6 +552,8 @@ QueryPlanner::QueryPlanner(const std::string& query,
       tables_.push_back(details[1]);
     }
   }
+
+  instance->clearAffectedTables();
 }
 
 Status QueryPlanner::applyTypes(TableColumns& columns) {

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -716,6 +716,8 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
   auto* pVtab = (VirtualTable*)tab;
   const auto& columns = pVtab->content->columns;
 
+  pVtab->instance->addAffectedTable(pVtab->content);
+
   ConstraintSet constraints;
   // Keep track of the index used for each valid constraint.
   // Expect this index to correspond with argv within xFilter.


### PR DESCRIPTION
Fixes #7400 - When we call xBestIndex set the Affected tables and clear the cached data when using the QueryPlanner class.