### PR TITLE
[docs] remove utc flag from example config file

### DIFF
--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -31,9 +31,7 @@
 
     // Comma-delimited list of table names to be enabled.
     // This allows osquery to be launched with certain tables only.
-    //"enable_tables": "foo_bar,time",
-
-    "utc": "true"
+    //"enable_tables": "foo_bar,time"
   },
 
   // Define a schedule of queries:

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -4,9 +4,6 @@
     // Select the osquery config plugin.
     "config_plugin": "filesystem",
 
-    // Select the osquery logging plugin.
-    "logger_plugin": "filesystem",
-
     // The log directory stores info, warning, and errors.
     // If the daemon uses the 'filesystem' logging retriever then the log_dir
     // will also contain the query results.
@@ -31,7 +28,10 @@
 
     // Comma-delimited list of table names to be enabled.
     // This allows osquery to be launched with certain tables only.
-    //"enable_tables": "foo_bar,time"
+    //"enable_tables": "foo_bar,time",
+
+    // Select the osquery logging plugin.
+    "logger_plugin": "filesystem"
   },
 
   // Define a schedule of queries:


### PR DESCRIPTION
Remove `utc` flag in example config file, leftover from #7276 