### PR TITLE
Fix a crash when Yara uses its own strutils functions

### DIFF
--- a/libraries/cmake/source/yara/patches/strutils.cpp
+++ b/libraries/cmake/source/yara/patches/strutils.cpp
@@ -24,13 +24,38 @@ namespace yara_strutils {
 
 extern "C" {
 
-size_t (*yara_strutils_strlcpy)(char* , const char* , size_t ){&yara_strutils::strlcpy};
-uint64_t (*yara_strutils_xtoi)(const char*){&yara_strutils::xtoi};
-int (*yara_strutils_strnlen_w)(const char*){&yara_strutils::strnlen_w};
-size_t (*yara_strutils_strlcpy_w)(char*, const char*, size_t){&yara_strutils::strlcpy_w};
-int (*yara_strutils_strcmp_w)(const char*, const char*){&yara_strutils::strcmp_w};
-size_t (*yara_strutils_strlcat)(char*, const char*, size_t){&yara_strutils::strlcat};
-void *(*yara_strutils_memmem)(const void*, size_t, const void*, size_t){&yara_strutils::memmem};
-int (*yara_strutils_isalnum)(const uint8_t*){&yara_strutils::yr_isalnum};
+size_t yara_strutils_strlcpy(char* dst, const char* src, size_t size) {
+  return yara_strutils::strlcpy(dst, src, size);
+}
 
+uint64_t yara_strutils_xtoi(const char* hexstr) {
+  return yara_strutils::xtoi(hexstr);
+}
+
+int yara_strutils_strnlen_w(const char* w_str) {
+  return yara_strutils::strnlen_w(w_str);
+}
+
+size_t yara_strutils_strlcpy_w(char* dst, const char* w_src, size_t n) {
+  return yara_strutils::strlcpy_w(dst, w_src, n);
+}
+
+int yara_strutils_strcmp_w(const char* w_str, const char* str) {
+  return yara_strutils::strcmp_w(w_str, str);
+}
+
+size_t yara_strutils_strlcat(char* dst, const char* src, size_t size) {
+  return yara_strutils::strlcat(dst, src, size);
+}
+
+void* yara_strutils_memmem(const void* haystack,
+                           size_t haystack_size,
+                           const void* needle,
+                           size_t needle_size) {
+  return yara_strutils::memmem(haystack, haystack_size, needle, needle_size);
+}
+
+int yara_strutils_isalnum(const uint8_t* s) {
+  return yara_strutils::yr_isalnum(s);
+}
 }

--- a/osquery/tables/yara/tests/yara_tests.cpp
+++ b/osquery/tables/yara/tests/yara_tests.cpp
@@ -22,6 +22,7 @@ namespace osquery {
 
 const std::string alwaysTrue = "rule always_true { condition: true }";
 const std::string alwaysFalse = "rule always_false { condition: false }";
+const std::string invalidRule = "rule invalid { Not a valid rule }";
 
 class YARATest : public testing::Test {
  protected:
@@ -32,7 +33,12 @@ class YARATest : public testing::Test {
   Row scanFile(const std::string& ruleContent) {
     YR_RULES* rules = nullptr;
     int result = yr_initialize();
-    EXPECT_TRUE(result == ERROR_SUCCESS);
+    bool init_succeeded = result == ERROR_SUCCESS;
+    EXPECT_TRUE(init_succeeded);
+
+    if (!init_succeeded) {
+      return {};
+    }
 
     const auto rule_file = fs::temp_directory_path() /
                            fs::unique_path("osquery.tests.yara.%%%%.%%%%.sig");
@@ -40,6 +46,10 @@ class YARATest : public testing::Test {
 
     Status status = compileSingleFile(rule_file.string(), &rules);
     EXPECT_TRUE(status.ok()) << status.what();
+
+    if (!status.ok()) {
+      return {};
+    }
 
     Row r;
     r["count"] = "0";
@@ -70,10 +80,19 @@ class YARATest : public testing::Test {
   Row scanString(const std::string& rule_defs) {
     YR_RULES* rules = nullptr;
     int result = yr_initialize();
-    EXPECT_TRUE(result == ERROR_SUCCESS);
+    bool init_succeeded = result == ERROR_SUCCESS;
+    EXPECT_TRUE(init_succeeded);
+
+    if (!init_succeeded) {
+      return {};
+    }
 
     Status status = compileFromString(rule_defs, &rules);
     EXPECT_TRUE(status.ok()) << status.what();
+
+    if (!status.ok()) {
+      return {};
+    }
 
     Row r;
     r["count"] = "0";
@@ -150,7 +169,12 @@ TEST_F(YARATest, test_rule_compilation_failures) {
      like strlcpy are incorrectly called, causing a segfault;
      strlcpy is used to copy the error message. */
   YR_RULES* rules = nullptr;
-  Status status = compileSingleFile("/tmp", &rules);
+  Status status = compileSingleFile(fs::temp_directory_path().string(), &rules);
+  EXPECT_FALSE(status.ok());
+
+  /* Same as above, but this will cause a crash also on Windows
+     (due to the syntax error), if there are issues with those functions. */
+  status = compileFromString(invalidRule, &rules);
   EXPECT_FALSE(status.ok());
 
   // Simple test to verify that the API handles non existing files cleanly

--- a/osquery/tables/yara/tests/yara_tests.cpp
+++ b/osquery/tables/yara/tests/yara_tests.cpp
@@ -142,4 +142,20 @@ TEST_F(YARATest, test_match_string_false) {
   EXPECT_TRUE(r["count"] == "0");
 }
 
+TEST_F(YARATest, test_rule_compilation_failures) {
+  int result = yr_initialize();
+  EXPECT_TRUE(result == ERROR_SUCCESS);
+
+  /* This comes from a regression where Yara internal functions
+     like strlcpy are incorrectly called, causing a segfault;
+     strlcpy is used to copy the error message. */
+  YR_RULES* rules = nullptr;
+  Status status = compileSingleFile("/tmp", &rules);
+  EXPECT_FALSE(status.ok());
+
+  // Simple test to verify that the API handles non existing files cleanly
+  status = compileSingleFile("/tmp/this_path_doesnt_exists", &rules);
+  EXPECT_FALSE(status.ok());
+}
+
 } // namespace osquery


### PR DESCRIPTION
Define real wrapper functions instead of function pointers
to the various strutils functions.

Yara was incorrectly attempting to call some internal functions
as normal functions instead of function pointers,
causing the execution to jump to data instead of an instruction.
This would in turn cause a crash.

The reason is that to avoid collisions of functions like strlcpy,
which Yara needs and provides its own definition,
in all the caller contexts we rename the calls to those to yara_strutils_\<funcname\>.
We then define a global variable with the same name
and type of a function pointer.
The problem is that the various callers still include headers
with the definition of strlcpy (renamed to the new name)
which is not a function pointer, but a function.
The compiler therefore doesn't resolve the function pointer
and calls the address where the global variable has stored the function address.

Add a test that triggers the issue.

Fix line endings.
