### PR TITLE
Fix parsing issue when a backslash as the last character on sudoers file line

### DIFF
--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -43,7 +43,7 @@ void genSudoersFile(const std::string& filename,
     return;
   }
 
-  bool isLongLine = false;
+  bool is_long_line = false;
   std::string contents;
   if (!forensicReadFile(filename, contents).ok()) {
     TLOG << "couldn't read sudoers file: " << filename;
@@ -65,8 +65,8 @@ void genSudoersFile(const std::string& filename,
     // if last line contains a backslash as the last character,
     // treat current line as part of previous line and
     // append it to appropriate column.
-    if (isLongLine) {
-      isLongLine = (line.at(line.size() - 1) == '\\');
+    if (is_long_line) {
+      is_long_line = (line.back() == '\\');
       if (results.back()["rule_details"].empty()) {
         results.back()["header"].pop_back();
       } else {
@@ -103,8 +103,8 @@ void genSudoersFile(const std::string& filename,
     }
 
     // Check if a blackslash is the last character on this line.
-    if (!is_include && !is_includedir && line.at(line.size() - 1) == '\\') {
-      isLongLine = true;
+    if (!is_include && !is_includedir && line.back() == '\\') {
+      is_long_line = true;
     }
 
     Row r;

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -63,10 +63,15 @@ void genSudoersFile(const std::string& filename,
     }
 
     // if last line contains a backslash as the last character,
-    // treat current line as part of long line.
+    // treat current line as part of previous line and
+    // append it to appropriate column.
     if (isLongLine) {
       isLongLine = (line.at(line.size() - 1) == '\\');
-      results.back()["rule_details"].pop_back();
+      if (results.back()["rule_details"].empty()) {
+        results.back()["header"].pop_back();
+      } else {
+        results.back()["rule_details"].pop_back();
+      }
       results.back()["rule_details"].append(line);
       continue;
     }

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -67,12 +67,13 @@ void genSudoersFile(const std::string& filename,
     // append it to appropriate column.
     if (is_long_line) {
       is_long_line = (line.back() == '\\');
-      if (results.back()["rule_details"].empty()) {
-        results.back()["header"].pop_back();
+      auto& last_line = results.back();
+      if (last_line["rule_details"].empty()) {
+        last_line["header"].pop_back();
       } else {
-        results.back()["rule_details"].pop_back();
+        last_line["rule_details"].pop_back();
       }
-      results.back()["rule_details"].append(line);
+      last_line["rule_details"].append(line);
       continue;
     }
 


### PR DESCRIPTION
This PR fixes the bug reported at #7421. I handle the case that a line contains a backslash as last character.
The code aggregates multiple lines within  a "rule_details" column. The aggregation logic starts when a line ends with backslash and end when EOF or the next line doesn't end with a backlash.
The code deletes the backslash character in favor of clearness. 
Any feedback is more than welcome, Thanks!