### PR TITLE
Update the ATC table `path` column check to be case insensitive

### DIFF
--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -38,10 +38,16 @@ const char* getSystemVFS(bool respect_locking) {
 Status genSqliteTableRow(sqlite3_stmt* stmt,
                          TableRows& qd,
                          const fs::path& sqlite_db) {
+  bool user_defined_path_column = false;
   auto r = make_table_row();
   for (int i = 0; i < sqlite3_column_count(stmt); ++i) {
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);
+
+    if (strcasecmp(column_name.c_str(), "path") == 0) {
+      user_defined_path_column = true;
+    }
+
     switch (column_type) {
     case SQLITE_BLOB:
     case SQLITE_TEXT: {
@@ -63,7 +69,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     }
     }
   }
-  if (r.count("path") > 0) {
+  if (user_defined_path_column) {
     LOG(WARNING) << "ATC Table: Row contains a defined path key, omitting the "
                     "implicit one";
   } else {

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -44,7 +44,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);
 
-    if (boost::iequals(column_name.c_str(), "path")) {
+    if (boost::iequals(column_name, "path")) {
       user_defined_path_column = true;
     }
 

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -44,7 +44,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);
 
-    if (strcasecmp(column_name.c_str(), "path") == 0) {
+    if (boost::iequals(column_name.c_str(), "path")) {
       user_defined_path_column = true;
     }
 

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <boost/algorithm/string.hpp>
+
 #include <osquery/config/config.h>
 #include <osquery/core/system.h>
 #include <osquery/core/tables.h>
@@ -167,7 +169,7 @@ Status ATCConfigParserPlugin::update(const std::string& source,
                    << " is misconfigured (no columns)";
     }
 
-    std::string user_defined_path_column = "";
+    std::string user_defined_path_column;
 
     for (const auto& column : params["columns"].GetArray()) {
       if (!column.IsString()) {
@@ -176,7 +178,7 @@ Status ATCConfigParserPlugin::update(const std::string& source,
         continue;
       }
 
-      if (strcasecmp(std::string(column.GetString()).c_str(), "path") == 0) {
+      if (boost::iequals(std::string(column.GetString()).c_str(), "path")) {
         user_defined_path_column = std::string(column.GetString());
       }
 
@@ -185,9 +187,9 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       columns_value += std::string(column.GetString()) + ",";
     }
 
-    if (user_defined_path_column != "") {
+    if (user_defined_path_column.empty()) {
       LOG(WARNING) << "ATC Table: " << table_name
-                   << " is misconfigured. The configuration include `"
+                   << " is misconfigured. The configuration includes `"
                    << user_defined_path_column
                    << "`. This is a reserved column name";
     } else {

--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -178,8 +178,8 @@ Status ATCConfigParserPlugin::update(const std::string& source,
         continue;
       }
 
-      if (boost::iequals(std::string(column.GetString()).c_str(), "path")) {
-        user_defined_path_column = std::string(column.GetString());
+      if (boost::iequals(column.GetString(), "path")) {
+        user_defined_path_column = column.GetString();
       }
 
       columns.push_back(make_tuple(
@@ -187,7 +187,7 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       columns_value += std::string(column.GetString()) + ",";
     }
 
-    if (user_defined_path_column.empty()) {
+    if (!user_defined_path_column.empty()) {
       LOG(WARNING) << "ATC Table: " << table_name
                    << " is misconfigured. The configuration includes `"
                    << user_defined_path_column


### PR DESCRIPTION
## Problem

In sqlite, column names are case insensitive. But, in #6278 I added logic to _add_ the `path` column to ATC configs. Unfortunately, this logic was not case sensitive, and sometimes try to create a table with sql akin to:

```sql
CREATE TABLE atc_downcase(`path` TEXT, `Anum` TEXT, `Path` TEXT)
```

The double `path` and `Path` are a fatal sql error

## Solution

Refine the `path` checks to be case insensitive.

Fixes #7441

