### PR TITLE
CHANGELOG 5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 Osquery 5.2.1 brings native Apple Silicon (M1) support to the macOS
 platform. It also represents a comprehensive review and update of our
-third-party dependancies. To support this work, the developer docs
+third-party dependencies. To support this work, the developer docs
 have been updated, as have several parts of the build system
 
 This release represents commits from 9 contributors! Thank you all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Representing commits from 9 contributors! Thank you all.
 ### Table Changes
 
 - Update `time` table to reflect UTC values ([#7276](https://github.com/osquery/osquery/pull/7276))
-- Hide the deprecate `antispyware` column in `windows_security_center` ([#7411](https://github.com/osquery/osquery/pull/7411))
+- Hide the deprecated `antispyware` column in `windows_security_center` ([#7411](https://github.com/osquery/osquery/pull/7411))
 
 ### Under the Hood improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # osquery Changelog
 
+
+<a name="5.2.1"></a>
+## [5.2.1](https://github.com/osquery/osquery/releases/tag/5.2.1)
+
+[Git Commits](https://github.com/osquery/osquery/compare/5.1.0...5.2.1)
+
+Osquery 5.2.1 brings native m1 support to the macOS platform. 
+
+Representing commits from 9 contributors! Thank you all.
+
+### New Features
+
+- Apple Silicon support ([#7330](https://github.com/osquery/osquery/pull/7330))
+
+### Table Changes
+
+- Update `time` table to reflect UTC values ([#7276](https://github.com/osquery/osquery/pull/7276))
+- Hide the deprecate `antispyware` column in `windows_security_center` ([#7411](https://github.com/osquery/osquery/pull/7411))
+
+### Under the Hood improvements
+
+
+### Bug Fixes
+
+
+- Update the ATC table `path` column check to be case insensitive ([#7442](https://github.com/osquery/osquery/pull/7442))
+- Fix a crash when Yara uses its own strutils functions ([#7439](https://github.com/osquery/osquery/pull/7439))
+
+### Documentation
+
+- Fix typos in documentation ([#7443](https://github.com/osquery/osquery/pull/7443), [#7412](https://github.com/osquery/osquery/pull/7412))
+- CHANGELOG 5.1.0 ([#7406](https://github.com/osquery/osquery/pull/7406))
+
+### Build
+
+- Update sqlite to version 3.37.0 ([#7426](https://github.com/osquery/osquery/pull/7426))
+- Fix linking of thirdparty_sleuthkit ([#7425](https://github.com/osquery/osquery/pull/7425))
+- Fix how we disable tables in the fuzzer init method ([#7419](https://github.com/osquery/osquery/pull/7419))
+- Prevent running discovery queries when fuzzing ([#7418](https://github.com/osquery/osquery/pull/7418))
+
 <a name="5.1.0"></a>
 ## [5.1.0](https://github.com/osquery/osquery/releases/tag/5.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,27 @@ This release represents commits from 24 contributors! Thank you all.
 - Removing unnecessary macOS version check ([#7451](https://github.com/osquery/osquery/pull/7451))
 - Fix submodule cache for macOS CI runner ([#7456](https://github.com/osquery/osquery/pull/7456))
 - Add osquery version to macOS app bundle Info.plist ([#7452](https://github.com/osquery/osquery/pull/7452))
-
+- libs: Update OpenSSL to verion 1.1.1l ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update augeas to version 1.12.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update aws-sdk to version 1.9.116 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update boost to version 1.77 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update gflags to 2.2.2 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update glog to version 0.5.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update googletest to version 1.11.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update libarchive to version 3.5.2 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update libcap to version 1.2.59 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update libmagic to version 5.40 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update librdkafka to version 1.8.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update libxml2 to version 2.9.12 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update linenoise-ng to the latest commit ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update lzma to version 5.2.5 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update rocksdb to version 6.22.1 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update sleuthkit to version 4.11.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update ssdeep-cpp to the latest commit (d8705da) ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update thrift to version 0.15.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update yara to version 4.1.3 ([#7330](https://github.com/osquery/osquery/pull/7330))
+- libs: Update zstd to version 1.4.0 ([#7330](https://github.com/osquery/osquery/pull/7330))
+	
 <a name="5.1.0"></a>
 ## [5.1.0](https://github.com/osquery/osquery/releases/tag/5.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,38 @@
 # osquery Changelog
 
+<a name="5.2.2"></a>
+## [5.2.2](https://github.com/osquery/osquery/releases/tag/5.2.2)
 
-<a name="5.2.1"></a>
-## [5.2.1](https://github.com/osquery/osquery/releases/tag/5.2.1)
+[Git Commits](https://github.com/osquery/osquery/compare/5.1.0...5.2.2)
 
-[Git Commits](https://github.com/osquery/osquery/compare/5.1.0...5.2.1)
-
-Osquery 5.2.1 brings native Apple Silicon (M1) support to the macOS
+Osquery 5.2.2 brings native Apple Silicon (M1) support to the macOS
 platform. It also represents a comprehensive review and update of our
 third-party dependencies. To support this work, the developer docs
 have been updated, as have several parts of the build system
 
-This release represents commits from 9 contributors! Thank you all.
+This release represents commits from 24 contributors! Thank you all.
 
 ### New Features
 
 - Apple Silicon support ([#7330](https://github.com/osquery/osquery/pull/7330))
 
+### Deprecation Notices
+
+- The `cpuid` table is x86 only. See [#7462](https://github.com/osquery/osquery/issues/7462)
+- The `smart_drive_info` table has been deprecated, and is not included in the m1 builds. See [#7464](https://github.com/osquery/osquery/issues/7464)
+- The `lldp_neighbors` table has been deprecated, and is not included in the m1 builds. See [#7463](https://github.com/osquery/osquery/issues/7463)
+
 ### Table Changes
 
-- Update `time` table to reflect UTC values ([#7276](https://github.com/osquery/osquery/pull/7276))
+- Update `time` table to always reflect UTC values ([#7276](https://github.com/osquery/osquery/pull/7276), [#7460](https://github.com/osquery/osquery/pull/7460), [#7437](https://github.com/osquery/osquery/pull/7437))
 - Hide the deprecated `antispyware` column in `windows_security_center` ([#7411](https://github.com/osquery/osquery/pull/7411))
+- Add `windows_firewall_rules` table for windows ([#7403](https://github.com/osquery/osquery/pull/7403))
 
 ### Bug Fixes
 
 - Update the ATC table `path` column check to be case insensitive ([#7442](https://github.com/osquery/osquery/pull/7442))
 - Fix a crash introduced by 5.2.0 when Yara uses its own strutils functions ([#7439](https://github.com/osquery/osquery/pull/7439))
+- Fix `user_time` and `system_time` unit in processes table on M1 ([#7473](https://github.com/osquery/osquery/pull/7473))
 
 ### Documentation
 
@@ -38,6 +45,10 @@ This release represents commits from 9 contributors! Thank you all.
 - Fix linking of thirdparty_sleuthkit ([#7425](https://github.com/osquery/osquery/pull/7425))
 - Fix how we disable tables in the fuzzer init method ([#7419](https://github.com/osquery/osquery/pull/7419))
 - Prevent running discovery queries when fuzzing ([#7418](https://github.com/osquery/osquery/pull/7418))
+- Add BOOST_USE_ASAN define when enabling Asan ([#7469](https://github.com/osquery/osquery/pull/7469))
+- Removing unnecessary macOS version check ([#7451](https://github.com/osquery/osquery/pull/7451))
+- Fix submodule cache for macOS CI runner ([#7456](https://github.com/osquery/osquery/pull/7456))
+- Add osquery version to macOS app bundle Info.plist ([#7452](https://github.com/osquery/osquery/pull/7452))
 
 <a name="5.1.0"></a>
 ## [5.1.0](https://github.com/osquery/osquery/releases/tag/5.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 [Git Commits](https://github.com/osquery/osquery/compare/5.1.0...5.2.1)
 
-Osquery 5.2.1 brings native m1 support to the macOS platform. 
+Osquery 5.2.1 brings native Apple Silicon (M1) support to the macOS
+platform. It also represents a comprehensive review and update of our
+third-party dependancies. To support this work, the developer docs
+have been updated, as have several parts of the build system
 
-Representing commits from 9 contributors! Thank you all.
+This release represents commits from 9 contributors! Thank you all.
 
 ### New Features
 
@@ -19,14 +22,10 @@ Representing commits from 9 contributors! Thank you all.
 - Update `time` table to reflect UTC values ([#7276](https://github.com/osquery/osquery/pull/7276))
 - Hide the deprecated `antispyware` column in `windows_security_center` ([#7411](https://github.com/osquery/osquery/pull/7411))
 
-### Under the Hood improvements
-
-
 ### Bug Fixes
 
-
 - Update the ATC table `path` column check to be case insensitive ([#7442](https://github.com/osquery/osquery/pull/7442))
-- Fix a crash when Yara uses its own strutils functions ([#7439](https://github.com/osquery/osquery/pull/7439))
+- Fix a crash introduced by 5.2.0 when Yara uses its own strutils functions ([#7439](https://github.com/osquery/osquery/pull/7439))
 
 ### Documentation
 


### PR DESCRIPTION
Combined changelog for 5.2.0 and 5.2.1. I _think_ it's reasonable to not ship the 5.2.0 changes?
