### PR TITLE
[getInternalOptions|https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/remote/transports/tls.cpp#L146] and [getOptions|https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/remote/transports/tls.cpp#L94] set the server_certificate_file_ file to all http::Client's that use this options variable - and as such the connection fails when the certificate is used to verify the aws kinesis endpoints.  The fix is to initialize the http::Client used in aws_util.cpp with a plain http::Client::Options, with no certificates set.

### DIFF
--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -155,7 +155,9 @@ std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
   uri.SetPath(Aws::Http::URI::URLEncodePath(uri.GetPath()));
   Aws::String url = uri.GetURIString();
 
-  http::Client client(TLSTransport().getInternalOptions());
+  http::Client::Options options;
+  options.timeout(10);
+  http::Client client(options);
   http::Request req(url);
 
   for (const auto& requestHeader : request.GetHeaders()) {


### PR DESCRIPTION
This pull request fixes [issue 7449](https://github.com/osquery/osquery/issues/7449).

The issue occurs because [getInternalOptions](https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/remote/transports/tls.cpp#L146) and [getOptions](https://github.com/osquery/osquery/blob/d2be385d71f401c85872f00d479df8f499164c5a/osquery/remote/transports/tls.cpp#L94) called when initialising the http::Client used in aws_util.cpp sets the openssl_certificate field and so connections to aws kinesis tls endpoints fail certificate verification.

This PR fixes the issue by initializing the http::Client used in aws_util.cpp with a plain http::Client::Options, with no certificates set so it works with kinesis.