### PR TITLE
Removing unnecessary macOS version check

### DIFF
--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -34,28 +34,11 @@ namespace tables {
 std::set<std::string> kCheckedArches{
     "", "i386", "ppc", "arm", "x86_64", "arm64"};
 
-int getOSMinorVersion() {
-  auto qd = SQL::selectAllFrom("os_version");
-  if (qd.size() != 1) {
-    return -1;
-  }
-
-  return tryTo<int>(qd.front().at("minor")).takeOr(-1);
-}
-
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on
 // the OS version.
 Status getVerifyFlags(SecCSFlags& flags, bool hashResources) {
-  static const auto minorVersion = getOSMinorVersion();
-  if (minorVersion == -1) {
-    return Status(-1, "Couldn't determine OS X version");
-  }
-
   flags = kSecCSStrictValidate | kSecCSCheckAllArchitectures |
           kSecCSCheckNestedCode;
-  if (minorVersion > 8) {
-    flags |= kSecCSCheckNestedCode;
-  }
 
   if (!hashResources) {
     flags |= kSecCSDoNotValidateResources;


### PR DESCRIPTION
Resolves #7321

Due to [this commit](https://github.com/osquery/osquery/commit/e1676c9ef584b426ca402f41d1ceadfede79b1d9#diff-73482bd04aaa0be86cca133932cedb490d2cfa1ade51dc2269b289b6aecf24b2R54-R55), the `kSecCSCheckNestedCode` flag is always included, therefore, there is no longer a need to check OS version to optionally include this flag.
