### PR TITLE
Add osquery version to macOS app bundle Info.plist

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -214,6 +214,15 @@ function(add_osquery_executable)
 
   add_executable(${osquery_exe_name} ${osquery_exe_args})
 
+  if(DEFINED PLATFORM_MACOS)
+    getCleanedOsqueryVersion("OSQUERY_PLIST_VERSION")
+
+    configure_file(
+      "${CMAKE_SOURCE_DIR}/tools/deployment/macos_packaging/Info.plist.in"
+      "${CMAKE_SOURCE_DIR}/tools/deployment/macos_packaging/Info.plist"
+    )
+  endif()
+
   if(DEFINED PLATFORM_WINDOWS)
     set(OSQUERY_MANIFEST_TARGET_NAME "${osquery_exe_name}")
 

--- a/tools/deployment/macos_packaging/Info.plist
+++ b/tools/deployment/macos_packaging/Info.plist
@@ -2,15 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleExecutable</key>
-    <string>osqueryd</string>
-    <key>CFBundleIdentifier</key>
-    <string>io.osquery.agent</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>osqueryd</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
+	<key>CFBundleExecutable</key>
+	<string>osqueryd</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.osquery.agent</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>osqueryd</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
 </dict>
 </plist>

--- a/tools/deployment/macos_packaging/Info.plist.in
+++ b/tools/deployment/macos_packaging/Info.plist.in
@@ -12,5 +12,9 @@
 	<string>osqueryd</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${OSQUERY_PLIST_VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${OSQUERY_PLIST_VERSION}</string>
 </dict>
 </plist>


### PR DESCRIPTION
My attempt at adding a version to the app bundle.

Fixes #7312 and takes [#7383](https://github.com/osquery/osquery/pull/7383#discussion_r750714364) into consideration.

Uses the existing `getCleanedOsqueryVersion` [function](https://github.com/osquery/osquery/blob/9ecb3f0a77566e7cbc9683b1277a78b25efe1483/cmake/utilities.cmake#L396-L405) that results in a semver-like version string, which conforms to the required format of three period-separated integers, such as 3.2.9.

References
[CFBundleVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion)
[CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)