### PR TITLE
Fix and improve Audit message header parsing

### DIFF
--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -29,6 +29,8 @@ namespace osquery {
 /// Netlink status, used by AuditNetlink::acquireHandle()
 enum class NetlinkStatus { ActiveMutable, ActiveImmutable, Disabled, Error };
 
+enum class AuditRecordSubtype { None, AppArmor, SELinux };
+
 /// Contains an audit_rule_data structure
 using AuditRuleDataObject = std::vector<std::uint8_t>;
 
@@ -157,8 +159,12 @@ class AuditdNetlinkParser final : public InternalRunnable {
   explicit AuditdNetlinkParser(AuditdContextRef context);
   virtual void start() override;
 
+  static AuditRecordSubtype ParseAuditRecordSubtype(
+      int record_type, std::string_view message_view);
+
   /// Parses an audit_reply structure into an AuditEventRecord object
   static bool ParseAuditReply(const audit_reply& reply,
+                              AuditRecordSubtype subtype,
                               AuditEventRecord& event_record) noexcept;
 
   /// Adjusts the internal pointers of the audit_reply object

--- a/osquery/tables/events/tests/linux/process_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/process_events_tests.cpp
@@ -32,7 +32,13 @@ bool GenerateAuditEventRecord(AuditEventRecord& event_record,
   reply.len = contents.size();
   reply.message = &contents[0];
 
-  return AuditdNetlinkParser::ParseAuditReply(reply, event_record);
+  std::string_view message_view(reply.message,
+                                static_cast<std::size_t>(reply.len));
+
+  auto subtype =
+      AuditdNetlinkParser::ParseAuditRecordSubtype(reply.type, message_view);
+
+  return AuditdNetlinkParser::ParseAuditReply(reply, subtype, event_record);
 }
 
 void GenerateAuditEvent(std::vector<AuditEventRecord>& record_list,


### PR DESCRIPTION
The logic parsing the Audit message header was a bit too lenient
towards a malformed prefix and so it was possible to cause a crash.
Improve the checks done to avoid crashes.

Also improve how the message "subtype" (seccomp, AppArmor, SELinux)
is detected, avoiding multiple copies of the Audit message string
and avoiding multiple scans.
