### PR TITLE
Update cppcheck to version 2.6.3 and skip analysis for third party code

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:e583eee2a
+      image: osquery/builder18.04:c7a9d706d
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:e583eee2a
+      image: osquery/builder18.04:c7a9d706d
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:e583eee2a
+      image: osquery/builder18.04:c7a9d706d
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:a4961d234
+      image: osquery/builder18.04:e583eee2a
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:a4961d234
+      image: osquery/builder18.04:e583eee2a
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:a4961d234
+      image: osquery/builder18.04:e583eee2a
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:a4961d234
+      image: osquery/builder18.04:e583eee2a
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:a4961d234
+      image: osquery/builder18.04:e583eee2a
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     container:
-      image: osquery/builder18.04:e583eee2a
+      image: osquery/builder18.04:c7a9d706d
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:e583eee2a
+      image: osquery/builder18.04:c7a9d706d
       options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
 
     strategy:

--- a/tests/cppcheck/CMakeLists.txt
+++ b/tests/cppcheck/CMakeLists.txt
@@ -33,12 +33,25 @@ function(cppcheckMain)
 
   string(REPLACE "\n" ", " cppcheck_suppressions_list "${cppcheck_suppressions_list}")
 
+  # These folders will not be analyzed, greatly increasing the analysis speed;
+  # this only works for source files, while included headers will still cause warnings,
+  # which will be covered by the suppression list.
+  set(ignored_folders
+    "-i \"*/libraries/*\""
+    "-i \"*/libs/src/*\""
+    "-i \"*/installed_formulas/*\""
+    "-i \"*/openssl/*\""
+  )
+
   # We don't care if multithreading disables the unusedFunction check, since that would turn off
   # suppressions (and we don't want to waste time analyzing the source modules)
   add_custom_target(
     cppcheck
     COMMAND "${CMAKE_COMMAND}" -E echo "Suppression list: '${cppcheck_suppressions_list}'"
-    COMMAND cppcheck::cppcheck "--suppressions-list=${CMAKE_CURRENT_SOURCE_DIR}/suppressions_list.txt" "--library=${CMAKE_CURRENT_SOURCE_DIR}/libraries/googletest.cfg" ${multithread_options} --enable=all --platform=unix64 "--project=${CMAKE_BINARY_DIR}/compile_commands.json" --quiet
+    COMMAND cppcheck::cppcheck "--suppressions-list=${CMAKE_CURRENT_SOURCE_DIR}/suppressions_list.txt"
+            "--library=${CMAKE_CURRENT_SOURCE_DIR}/libraries/googletest.cfg" ${multithread_options}
+            --enable=all --platform=unix64 --std=c++17 "--project=${CMAKE_BINARY_DIR}/compile_commands.json"
+            ${ignored_folders} -q
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Running Cppcheck ${CPPCHECK_VERSION_STRING}"
     VERBATIM

--- a/tests/cppcheck/CMakeLists.txt
+++ b/tests/cppcheck/CMakeLists.txt
@@ -37,10 +37,10 @@ function(cppcheckMain)
   # this only works for source files, while included headers will still cause warnings,
   # which will be covered by the suppression list.
   set(ignored_folders
-    "-i \"*/libraries/*\""
-    "-i \"*/libs/src/*\""
-    "-i \"*/installed_formulas/*\""
-    "-i \"*/openssl/*\""
+    -i "*/libraries/*"
+    -i "*/libs/src/*"
+    -i "*/installed_formulas/*"
+    -i "*/openssl/*"
   )
 
   # We don't care if multithreading disables the unusedFunction check, since that would turn off

--- a/tests/cppcheck/suppressions_list.txt
+++ b/tests/cppcheck/suppressions_list.txt
@@ -1,2 +1,4 @@
 *:*/libraries/*
-*:*/patched-source/*
+*:*/libs/src/*
+*:*/installed_formulas/*
+*:*/openssl/*


### PR DESCRIPTION
Also improve the analysis performance by skipping analysis
on all third party code.

In practice the `check_source_code` job has gone from ~30m to ~5m.