### PR TITLE
Add `utc` flag back for compatibility

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -97,6 +97,14 @@ FLAG(string,
      "",
      "Field used to specify the host_identifier when set to \"specified\"");
 
+// Deprecated, unused. Exists for backwards compatibility with existing config
+// files.
+HIDDEN_FLAG(
+    bool,
+    utc,
+    true,
+    "Deprecated utc flag. From https://github.com/osquery/osquery/pull/7276");
+
 namespace {
 
 const std::vector<std::string> kPlaceholderHardwareUUIDList{


### PR DESCRIPTION
In #7276 we removed the functionality of the `--utc` flag. Unfortunately, we also removed the flag. This causes osquery to break on older configurations.

While I'm generally game for some breaking changes, this presents something of a coupling issue. If one wanted utc timestamps, but needed an osquery config to work across multiple versions, there's no way to do it. So, this adds the flag back as a `HIDDEN_FLAG`. (Not sure we have a better pattern for this)

