### PR TITLE
Fix packs to check for platform before including queries

### DIFF
--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -69,6 +69,7 @@ def platform():
 
 
 def queries_from_config(config_path):
+    spec_platform = platform()
     config = {}
     rmcomment = re.compile('\/\*[\*A-Za-z0-9\n\s\.\{\}\'\/\\\:]+\*\/|\s+\/\/.*|^\/\/.*|\x5c\x5c\x0a')
     try:
@@ -100,6 +101,8 @@ def queries_from_config(config_path):
                     packcontent = rmcomment.sub('', packfile)
                     packqueries = json.loads(packcontent)
                     for queryname, query in packqueries["queries"].items():
+                        if "platform" in query and query['platform'] != spec_platform:
+                            continue
                         queries["pack_" + queryname] = query["query"]
 
     return queries


### PR DESCRIPTION
* Issue
  * profile.py hangs on macOS with following packs enabled
    * it-compliance
    * vuln-management
```
sudo -E python3  ./tools/analysis/profile.py --config /var/osquery/osquery.conf --shell /usr/local/bin/osqueryi 
...
 U:3  C:2  M:3  F:0  D:2  pack_keychain_items (1/1): utilization: 58.14 cpu_time: 1.464740256 memory: 33173504 fds: 4 duration: 2.030775785446167 
Profiling query: select * from deb_packages;
 U:3  C:3  M:3  F:3  D:3  pack_deb_packages (1/1): utilization: -1 cpu_time: -1 memory: -1 fds: -1 duration: -1 
Profiling query: select * from apt_sources;
```
  * reason being these queries are for ```"platform":"linux"``` and not meant for ```"darwin"```

* Propose fix
  * for profiling with packs
    * check for platform matching 
    * if not matching, skip the query
