### PR TITLE
Fix watchdog not killing unhealthy worker/extension fast enough

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -120,6 +120,11 @@ at maximum sustained CPU utilization.
 
 A delay in seconds before the watchdog process starts enforcing memory and CPU utilization limits. The default value `60s` allows the daemon to perform resource intense actions, such as forwarding logs, at startup.
 
+`--watchdog_forced_shutdown_delay=4`
+
+Amount of seconds to wait to issue a forced shutdown, after the watchdog has issued a graceful shutdown request to a worker or extension, due to resource limits being hit.
+Note that on Windows this doesn't have any effect currently, since the watchdog issues a TerminateProcess as a "graceful" shutdown, which immediately kills the process.
+
 `--enable_extensions_watchdog=false`
 
 By default the watchdog monitors extensions for improper shutdown, but NOT for performance and utilization issues. Enable this flag if you would like extensions to use the same CPU and memory limits as the osquery worker. This means that your extensions or third-party extensions may be asked to stop and restart during execution.

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -281,7 +281,9 @@ class WatcherRunner : public InternalRunnable {
   /// Signal the worker or extension process to close cleanly.
   /// If enough time has passed, and the process hasn't closed yet,
   /// the process will be killed.
-  /// The force argument is used to skip the clean shutdown part.
+  /// The force argument is used to request a faster timeout
+  /// for the clean shutdown, which is based on the flag
+  /// watchdog_forced_shutdown_delay
   virtual void stopChild(const PlatformProcess& child,
                          bool force = false) const;
 

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -278,8 +278,12 @@ class WatcherRunner : public InternalRunnable {
   /// Fork an extension process.
   virtual void createExtension(const std::string& extension);
 
-  /// If a worker/extension has otherwise gone insane, stop it.
-  virtual void stopChild(const PlatformProcess& child) const;
+  /// Signal the worker or extension process to close cleanly.
+  /// If enough time has passed, and the process hasn't closed yet,
+  /// the process will be killed.
+  /// The force argument is used to skip the clean shutdown part.
+  virtual void stopChild(const PlatformProcess& child,
+                         bool force = false) const;
 
   /// Return the time the watchdog is delayed until (from start of watcher).
   uint64_t delayedTime() const;


### PR DESCRIPTION
Add a new flag "watchdog_forced_shutdown_delay" set to a default of 4 seconds,
which separates the timeouts for a forced shutdown due to a resource
limit being hit by a worker or extension, from the timeouts for a normal shutdown.

This flag can also be set to 0, which skips sending a gracefull kill
and directly goes for a SIGKILL.

This has currently no effect on Windows, since the normal
shutdown would issue a TerminateProcess anyway, which kills a process immediately.

The fix was necessary since the watchdog was using the normal shutdown timeouts to kill
a misbehaving worker or extension; this was not ideal,
especially since the lowest amount of time we could wait for a forced kill was 6 seconds.