### PR TITLE
yum_sources: Include the mirrorlist URL in the table output

### DIFF
--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -43,7 +43,7 @@ void parseYumConf(std::istream& source,
       // Option
       if ("baseurl" == it2.first || "enabled" == it2.first ||
           "gpgcheck" == it2.first || "name" == it2.first ||
-          "gpgkey" == it2.first) {
+          "gpgkey" == it2.first || "mirrorlist" == it2.first) {
         r[it2.first] = it2.second.data();
       }
     }

--- a/osquery/tables/system/tests/posix/yum_sources_tests.cpp
+++ b/osquery/tables/system/tests/posix/yum_sources_tests.cpp
@@ -46,6 +46,7 @@ baseurl=http://my.repo.url/1/v2/3
 enabled=1
 name=My personal repo
 reposdir=/ignored/path
+mirrorlist=http://url.to.mirror.list
 
 [math]
 baseurl=http://some.math.repo.url
@@ -53,6 +54,7 @@ enabled=0
 name=Mathematic library repo
 gpgcheck=0
 gpgkey=ftp://repokeys/mykey
+mirrorlist=http://url.to.mirror.list
 )STRLIT");
 
   parseYumConf(stream2, results, repos_dir);
@@ -60,12 +62,14 @@ gpgkey=ftp://repokeys/mykey
   ASSERT_EQ(results.size(), (unsigned long)2);
 
   ASSERT_EQ(results.at(0).at("baseurl"), "http://my.repo.url/1/v2/3");
+  ASSERT_EQ(results.at(0).at("mirrorlist"), "http://url.to.mirror.list");
   ASSERT_EQ(results.at(0).at("enabled"), "1");
   ASSERT_EQ(results.at(0).at("name"), "My personal repo");
   ASSERT_EQ(results.at(0).find("gpgcheck"), results.at(0).end());
   ASSERT_EQ(results.at(0).find("gpgkey"), results.at(0).end());
 
   ASSERT_EQ(results.at(1).at("baseurl"), "http://some.math.repo.url");
+  ASSERT_EQ(results.at(1).at("mirrorlist"), "http://url.to.mirror.list");
   ASSERT_EQ(results.at(1).at("enabled"), "0");
   ASSERT_EQ(results.at(1).at("name"), "Mathematic library repo");
   ASSERT_EQ(results.at(1).at("gpgcheck"), "0");

--- a/specs/posix/yum_sources.table
+++ b/specs/posix/yum_sources.table
@@ -3,6 +3,7 @@ description("Current list of Yum repositories or software channels.")
 schema([
     Column("name", TEXT, "Repository name"),
     Column("baseurl", TEXT, "Repository base URL"),
+    Column("mirrorlist", TEXT, "Mirrorlist URL"),
     Column("enabled", TEXT, "Whether the repository is used"),
     Column("gpgcheck", TEXT, "Whether packages are GPG checked"),
     Column("gpgkey", TEXT, "URL to GPG key"),


### PR DESCRIPTION
This PR adds a new mirrorlist column to the yum_sources table.