### PR TITLE
Fix third party libraries flags leaking to osquery targets

### DIFF
--- a/libraries/cmake/source/dbus/CMakeLists.txt
+++ b/libraries/cmake/source/dbus/CMakeLists.txt
@@ -75,7 +75,6 @@ function(dbusMain)
 
   target_link_libraries(thirdparty_dbus
     PRIVATE
-      c_settings
       thirdparty_c_settings
 
     PUBLIC

--- a/libraries/cmake/source/expat/CMakeLists.txt
+++ b/libraries/cmake/source/expat/CMakeLists.txt
@@ -18,7 +18,6 @@ function(expatMain)
   )
 
   target_link_libraries(thirdparty_expat PRIVATE
-    cxx_settings
     thirdparty_cxx_settings
   )
 

--- a/libraries/cmake/source/rocksdb/CMakeLists.txt
+++ b/libraries/cmake/source/rocksdb/CMakeLists.txt
@@ -426,9 +426,7 @@ function(rocksdbMain)
     endif()
   endif()
 
-  set(library_list
-    thirdparty_cxx_settings
-  )
+  set(library_list)
 
   if(PLATFORM_LINUX)
     find_package(Threads REQUIRED)
@@ -443,8 +441,12 @@ function(rocksdbMain)
     )
   endif()
 
-  target_link_libraries(thirdparty_rocksdb PUBLIC
-    ${library_list}
+  target_link_libraries(thirdparty_rocksdb
+    PRIVATE
+      thirdparty_cxx_settings
+
+    PUBLIC
+      ${library_list}
   )
 
   target_include_directories(thirdparty_rocksdb PRIVATE


### PR DESCRIPTION
RocksDB was incorrectly linking to the thirdparty_cxx_settings target
publicly, leaking its flags (and specifically the one disabling warnings)
to some osquery targets.

Also remove redudant linking of c_settings and cxx_settings in
dbus/expat