### PR TITLE
Change cpu_info test to ensure *at least* one socket is present

### DIFF
--- a/tests/integration/tables/cpu_info.cpp
+++ b/tests/integration/tables/cpu_info.cpp
@@ -24,7 +24,7 @@ class cpuInfo : public testing::Test {
 
 TEST_F(cpuInfo, test_sanity) {
   const QueryData data = execute_query("select * from cpu_info");
-  ASSERT_EQ(data.size(), 1ul);
+  ASSERT_GE(data.size(), 1ul);
   ValidationMap row_map = {{"device_id", NormalType},
                            {"model", NormalType},
                            {"manufacturer", NormalType},


### PR DESCRIPTION
This change allows the test to pass on systems with more than one cpu socket present so it fixes #7488.