### PR TITLE
Improve scheduled query denylisting and scheduler shutdown

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -48,7 +48,13 @@ function(generateOsqueryCoreInit)
 
   generateIncludeNamespace(osquery_core_init "osquery/core" "FILE_ONLY" ${public_header_files})
 
-  add_test(NAME osquery_core_tests_watcherpermissionstests-test COMMAND osquery_core_tests_watcherpermissionstests-test)
+  # TODO: This test should actually run as root, but it's currently broken when using that user
+  if(DEFINED PLATFORM_POSIX)
+    add_test(NAME osquery_core_tests_permissionstests-test COMMAND osquery_core_tests_permissionstests-test)
+  endif()
+
+  add_test(NAME osquery_core_tests_watchertests-test COMMAND osquery_core_tests_watchertests-test)
+
 endfunction()
 
 function(generateOsqueryCore)

--- a/osquery/core/system.h
+++ b/osquery/core/system.h
@@ -141,6 +141,9 @@ class Initializer : private boost::noncopyable {
   /// This pauses the watchdog process until the watcher thread stops.
   void waitForWatcher() const;
 
+  static void resourceLimitHit();
+  static bool isResourceLimitHit();
+
  private:
   /// Set and wait for an active plugin optionally broadcasted.
   void initActivePlugin(const std::string& type, const std::string& name) const;
@@ -156,6 +159,8 @@ class Initializer : private boost::noncopyable {
 
   /// Is this a worker process
   static bool isWorker_;
+
+  static std::atomic<bool> resource_limit_hit_;
 };
 
 /**

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -9,7 +9,13 @@ function(osqueryCoreTestsMain)
   generateOsqueryCoreTestsFlagstestsTest()
   generateOsqueryCoreTestsSystemtestsTest()
   generateOsqueryCoreTestsTablestestsTest()
-  generateOsqueryCoreTestsWatcherpermissionstestsTest()
+
+  # TODO: This test should actually run as root, but it's currently broken when using that user
+  if(DEFINED PLATFORM_POSIX)
+    generateOsqueryCoreTestsPermissionstestsTest()
+  endif()
+
+  generateOsqueryCoreTestsWatchertestsTest()
   generateOsqueryCoreTestsQuerytestsTest()
   generateOsqueryCoreTestsProcesstestsTest()
 
@@ -63,19 +69,35 @@ function(generateOsqueryCoreTestsTablestestsTest)
   )
 endfunction()
 
-function(generateOsqueryCoreTestsWatcherpermissionstestsTest)
+function(generateOsqueryCoreTestsPermissionstestsTest)
 
+  set(source_files
+    posix/permissions_tests.cpp
+  )
+
+  add_osquery_executable(osquery_core_tests_permissionstests-test ${source_files})
+
+  target_link_libraries(osquery_core_tests_permissionstests-test PRIVATE
+    osquery_cxx_settings
+    osquery_core
+    osquery_extensions
+    osquery_extensions_implthrift
+    osquery_process
+    osquery_registry
+    tests_helper
+    osquery_utils_info
+    thirdparty_googletest
+  )
+endfunction()
+
+function(generateOsqueryCoreTestsWatchertestsTest)
   set(source_files
     watcher_tests.cpp
   )
 
-  if(DEFINED PLATFORM_POSIX)
-    list(APPEND source_files posix/permissions_tests.cpp)
-  endif()
+  add_osquery_executable(osquery_core_tests_watchertests-test ${source_files})
 
-  add_osquery_executable(osquery_core_tests_watcherpermissionstests-test ${source_files})
-
-  target_link_libraries(osquery_core_tests_watcherpermissionstests-test PRIVATE
+  target_link_libraries(osquery_core_tests_watchertests-test PRIVATE
     osquery_cxx_settings
     osquery_core
     osquery_extensions

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -57,11 +57,49 @@ class MockWatcherRunner : public WatcherRunner {
   /// The state machine requested the 'worker' to stop.
   MOCK_CONST_METHOD2(stopChild, void(const PlatformProcess& child, bool force));
 
+  /// The state machine warned the 'worker' that a resource limit has been hit
+  MOCK_CONST_METHOD1(warnWorkerResourceLimitHit,
+                     void(const PlatformProcess& child));
+
   /// The state machine is inspecting the 'worker' health and performance.
   MOCK_CONST_METHOD1(isChildSane, Status(const PlatformProcess& child));
 
  private:
   FRIEND_TEST(WatcherTests, test_watcher);
+};
+
+class MockWatcherRunnerUnhealthy : public WatcherRunner {
+ public:
+  MockWatcherRunnerUnhealthy(int argc,
+                             char** argv,
+                             bool use_worker,
+                             const std::shared_ptr<Watcher>& watcher)
+      : WatcherRunner(argc, argv, use_worker, watcher) {}
+
+  /// The state machine requested the 'worker' to stop.
+  MOCK_METHOD(void,
+              stopChild,
+              (const PlatformProcess& child, bool force),
+              (const, override));
+
+  /// The state machine warned the 'worker' that a resource limit has been hit
+  MOCK_METHOD(void,
+              warnWorkerResourceLimitHit,
+              (const PlatformProcess& child),
+              (const, override));
+
+  void setProcessRow(QueryData qd) {
+    qd_ = std::move(qd);
+  }
+
+  /// The tests do not have access to the processes table.
+  QueryData getProcessRow(pid_t pid) const override {
+    return qd_;
+  }
+
+ private:
+  QueryData qd_;
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy);
 };
 
 /**
@@ -96,6 +134,7 @@ class FakePlatformProcess : public PlatformProcess {
   FRIEND_TEST(WatcherTests, test_watcherrunner_watch);
   FRIEND_TEST(WatcherTests, test_watcherrunner_stop);
   FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy);
 };
 
 TEST_F(WatcherTests, test_watcherrunner_watch) {
@@ -114,6 +153,7 @@ TEST_F(WatcherTests, test_watcherrunner_watch) {
 
   // The above expectation returns a sane child state.
   // This ::watch iteration should NOT attempt to stop the worker.
+  EXPECT_CALL(runner, warnWorkerResourceLimitHit(_)).Times(0);
   EXPECT_CALL(runner, stopChild(_, _)).Times(0);
 
   // When triggering a watch, set the assumed process status.
@@ -131,6 +171,7 @@ TEST_F(WatcherTests, test_watcherrunner_stop) {
   auto fake_test_process = FakePlatformProcess(test_process->nativeHandle());
 
   EXPECT_CALL(runner, isChildSane(_)).Times(0);
+  EXPECT_CALL(runner, warnWorkerResourceLimitHit(_)).Times(0);
   EXPECT_CALL(runner, stopChild(_, _)).Times(0);
 
   // Now set the process status to an error state.
@@ -238,6 +279,9 @@ class FakeWatcherRunner : public WatcherRunner {
   void stopChild(const PlatformProcess& child,
                  bool resource_limit_hit) const override {}
 
+  void warnWorkerResourceLimitHit(const PlatformProcess& child) const override {
+  }
+
  private:
   QueryData qd_;
 };
@@ -340,5 +384,46 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
 
   FLAGS_watchdog_delay = delay;
   watcher->workerStartTime(start_time);
+}
+
+TEST_F(WatcherTests, test_watcherrunner_unhealthy) {
+  auto watcher = std::make_shared<Watcher>();
+  MockWatcherRunnerUnhealthy runner(0, nullptr, true, watcher);
+
+  auto test_process = PlatformProcess::getCurrentProcess();
+  auto fake_test_process = FakePlatformProcess(test_process->nativeHandle());
+  fake_test_process.setStatus(PROCESS_STILL_ALIVE, 0);
+
+  // Set up a fake test process and place it into an healthy state.
+  Row r;
+  r["parent"] = INTEGER(test_process->pid());
+  r["user_time"] = INTEGER(100);
+  r["system_time"] = INTEGER(100);
+  r["resident_size"] = INTEGER(100);
+  r["total_size"] = INTEGER(100);
+  runner.setProcessRow({r});
+
+  // Check the fake process sanity, which records the state at t=0.
+  EXPECT_TRUE(runner.isChildSane(fake_test_process));
+
+  // Update the fake process resident memory, make it unhealthy.
+  r["resident_size"] = INTEGER(1024 * 1024 * 1024);
+  r["total_size"] = INTEGER(1024 * 1024 * 1024);
+  runner.setProcessRow({std::move(r)});
+
+  // Set the worker start time.
+  watcher->workerStartTime(getUnixTime() - 1);
+
+  auto org_delay = FLAGS_watchdog_delay;
+  FLAGS_watchdog_delay = 0;
+
+  /* Verify that the worker is warned about hitting a resource limit
+     and that is asked to be stopped */
+  EXPECT_CALL(runner, warnWorkerResourceLimitHit(_)).Times(1);
+  EXPECT_CALL(runner, stopChild(_, _)).Times(1);
+
+  ASSERT_FALSE(runner.watch(fake_test_process));
+
+  FLAGS_watchdog_delay = org_delay;
 }
 } // namespace osquery

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -395,6 +395,7 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
             << ") stopping: " << status.getMessage();
       systemLog(error.str());
       LOG(WARNING) << error.str();
+      warnWorkerResourceLimitHit(child);
       stopChild(child, true);
       return false;
     }
@@ -443,6 +444,11 @@ void WatcherRunner::stopChild(const PlatformProcess& child, bool force) const {
                    std::to_string(child_pid) + ").";
     requestShutdown(EXIT_CATASTROPHIC, message);
   }
+}
+
+void WatcherRunner::warnWorkerResourceLimitHit(
+    const PlatformProcess& child) const {
+  child.warnResourceLimitHit();
 }
 
 PerformanceChange getChange(const Row& r, PerformanceState& state) {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -223,6 +223,7 @@ class Watcher : private boost::noncopyable {
  private:
   friend class WatcherRunner;
   FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy);
 };
 
 /**
@@ -287,6 +288,8 @@ class WatcherRunner : public InternalRunnable {
   virtual void stopChild(const PlatformProcess& child,
                          bool force = false) const;
 
+  virtual void warnWorkerResourceLimitHit(const PlatformProcess& child) const;
+
   /// Return the time the watchdog is delayed until (from start of watcher).
   uint64_t delayedTime() const;
 
@@ -323,6 +326,7 @@ class WatcherRunner : public InternalRunnable {
   FRIEND_TEST(WatcherTests, test_watcherrunner_loop_disabled);
   FRIEND_TEST(WatcherTests, test_watcherrunner_watcherhealth);
   FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy);
 };
 
 /// The WatcherWatcher is spawned within the worker and watches the watcher.

--- a/osquery/process/posix/process.cpp
+++ b/osquery/process/posix/process.cpp
@@ -75,6 +75,10 @@ bool PlatformProcess::killGracefully() const {
   return (status == 0);
 }
 
+void PlatformProcess::warnResourceLimitHit() const {
+  ::kill(nativeHandle(), SIGUSR1);
+}
+
 ProcessState PlatformProcess::checkStatus(int& status) const {
   int process_status = 0;
   if (!isValid()) {

--- a/osquery/process/process.h
+++ b/osquery/process/process.h
@@ -111,6 +111,8 @@ class PlatformProcess : private boost::noncopyable {
    */
   bool killGracefully() const;
 
+  virtual void warnResourceLimitHit() const;
+
   /**
    * @brief Wait or cleanup a process, usually a child process.
    *

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -97,6 +97,10 @@ bool PlatformProcess::killGracefully() const {
   return kill();
 }
 
+void PlatformProcess::warnResourceLimitHit() const {
+  // Not implemented
+}
+
 ProcessState PlatformProcess::checkStatus(int& status) const {
   unsigned long exit_code = 0;
   if (!isValid()) { // see issue #7324


### PR DESCRIPTION
- Add support for handling a SIGUSR1 signal which will be used on posix
  platforms by the watcher to immediately signal the worker that a
  resource limit has been hit. Logic in the worker will prevent to
  remove trace of the fact that a query was running when the limit was
  hit, by avoiding clearing up the name of the executing query from the database.

- Improve on the scheduler shutdown logic; even after receiving
  a shutdown request, the scheduler was first executing
  all the queries in the schedule and only then it was exiting.
  This was potentially causing unnecessary forced kills by the watchdog,
  which would result in denylisting queries that were not causing
  any resource limit to be hit, due to them not finishing in time.
  Check for the need to exit after each query execution instead.

- Separate the permission tests from the watcher tests,
  since the first require root to be run.
  They will still not run as root since they currently fail
  under that user. This will be resolved later.
  
  Partially addresses #7476