### PR TITLE
Fix crash due to interaction between distributed and config plugin

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -45,14 +45,19 @@ const std::string kQueries = "queries";
 const std::string kEvents = "events";
 const std::string kCarves = "carves";
 const std::string kLogs = "logs";
+const std::string kDistributedQueries = "distributed";
 
 const std::string kDbEpochSuffix = "epoch";
 const std::string kDbCounterSuffix = "counter";
 
 const std::string kDbVersionKey = "results_version";
 
-const std::vector<std::string> kDomains = {
-    kPersistentSettings, kQueries, kEvents, kLogs, kCarves};
+const std::vector<std::string> kDomains = {kPersistentSettings,
+                                           kQueries,
+                                           kEvents,
+                                           kLogs,
+                                           kCarves,
+                                           kDistributedQueries};
 
 std::atomic<bool> kDBAllowOpen(false);
 std::atomic<bool> kDBInitialized(false);

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -52,6 +52,8 @@ extern const std::string kCarves;
 /// The key for the DB version
 extern const std::string kDbVersionKey;
 
+extern const std::string kDistributedQueries;
+
 /// The running version of our database schema
 const int kDbCurrentVersion = 2;
 

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -14,9 +14,9 @@
 #include <osquery/database/database.h>
 #include <osquery/distributed/distributed.h>
 
-#include <osquery/utils/system/time.h>
 #include <osquery/dispatcher/distributed_runner.h>
 #include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/system/time.h>
 
 namespace osquery {
 
@@ -34,9 +34,7 @@ void DistributedRunner::start() {
   auto dist = Distributed();
   while (!interrupted()) {
     dist.pullUpdates();
-    if (dist.getPendingQueryCount() > 0) {
-      dist.runQueries();
-    }
+    dist.runQueries();
 
     std::string accelerate_checkins_expire_str = "-1";
     Status status = getDatabaseValue(kPersistentSettings,

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -222,8 +222,8 @@ class Distributed {
   /// Retrieve queued queries from a remote server
   Status pullUpdates();
 
-  /// Get the number of queries which are waiting to be executed
-  size_t getPendingQueryCount();
+  /// Get the queries which are waiting to be executed
+  std::vector<std::string> getPendingQueries();
 
   /// Get the number of results which are waiting to be flushed
   size_t getCompletedCount();
@@ -250,11 +250,11 @@ class Distributed {
   Status acceptWork(const std::string& work);
 
   /**
-   * @brief Pop a request object off of the queries_ member
+   * @brief Pop a request off of the database for the query in the argument
    *
    * @return a DistributedQueryRequest object which needs to be executed
    */
-  DistributedQueryRequest popRequest();
+  DistributedQueryRequest popRequest(std::string query);
 
   /**
    * @brief Queue a result to be batch sent to the server

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -197,13 +197,16 @@ TEST_F(DistributedTests, test_workflow) {
   ASSERT_TRUE(s.ok()) << s.getMessage();
   EXPECT_EQ(s.toString(), "OK");
 
-  EXPECT_EQ(dist.getPendingQueryCount(), 2U);
+  auto queries = dist.getPendingQueries();
+
+  EXPECT_EQ(queries.size(), 2U);
   EXPECT_EQ(dist.results_.size(), 0U);
   s = dist.runQueries();
   ASSERT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
 
-  EXPECT_EQ(dist.getPendingQueryCount(), 0U);
+  queries = dist.getPendingQueries();
+  EXPECT_EQ(queries.size(), 0U);
   EXPECT_EQ(dist.results_.size(), 0U);
 }
 } // namespace osquery


### PR DESCRIPTION
Move the distributed plugin RocksDB metadata to a different domain
which is not used or touched by the config plugin.

Also do not acquire the pending queries multiple times just to count
them. Acquire them once, use the obtained vector to count them
and then use them to proceed executing the queries.
