### PR TITLE
macOS: add `translated` column to `processes` table to indicate whether the process is running under rosetta

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -326,6 +326,7 @@ void genProcArch(QueryContext& context, int pid, ProcessesRow& r) {
 
     if (sysctl(mib, 4, &kinfo, &size, nullptr, 0) != 0 ||
         size < sizeof(kinfo)) {
+      r.translated_col = -1;
       return;
     }
 

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -314,6 +314,28 @@ void genProcArch(QueryContext& context, int pid, ProcessesRow& r) {
     r.cpu_type_col = -1;
     r.cpu_subtype_col = -1;
   }
+
+  if (archinfo.p_cputype == CPU_TYPE_X86_64) {
+    r.kind_col = "intel";
+  }
+
+  if (archinfo.p_cputype == CPU_TYPE_ARM64) {
+    r.kind_col = "apple silicon";
+
+    struct kinfo_proc kinfo{};
+    int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+    size_t size = sizeof(kinfo);
+
+    if (sysctl(mib, 4, &kinfo, &size, nullptr, 0) != 0 || size < sizeof(kinfo)) {
+      return;
+    }
+
+    // proc_bsdinfo also has pbi_flags, but that seems to be not always populated
+    // kinfo_proc works better to get at the process flags
+    if (kinfo.kp_proc.p_flag & P_TRANSLATED) {
+      r.kind_col = "intel";
+    }
+  }
 }
 
 bool parseProcCmdline(std::string& args, size_t len) {
@@ -506,7 +528,7 @@ TableRows genProcesses(QueryContext& context) {
 
     genProcUniquePid(context, pid, *r);
 
-    genProcArch(context, pid, *r);
+    genProcArch(context, pid,*r);
 
     std::unique_ptr<TableRow> tr(r);
     results.push_back(std::move(tr));

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -293,9 +293,12 @@ void genProcUniquePid(QueryContext& context, int pid, ProcessesRow& r) {
 void genProcArch(QueryContext& context, int pid, ProcessesRow& r) {
   if (!context.isAnyColumnUsed(ProcessesRow::CPU_TYPE |
                                ProcessesRow::CPU_SUBTYPE |
-                               ProcessesRow::KIND)) {
+                               ProcessesRow::TRANSLATED)) {
     return;
   }
+
+  // default the translated column to 0
+  r.translated_col = 0;
 
   struct proc_archinfo {
     cpu_type_t p_cputype;
@@ -316,13 +319,7 @@ void genProcArch(QueryContext& context, int pid, ProcessesRow& r) {
     r.cpu_subtype_col = -1;
   }
 
-  if (archinfo.p_cputype == CPU_TYPE_X86_64) {
-    r.kind_col = "intel";
-  }
-
   if (archinfo.p_cputype == CPU_TYPE_ARM64) {
-    r.kind_col = "apple";
-
     struct kinfo_proc kinfo {};
     int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
     size_t size = sizeof(kinfo);
@@ -334,8 +331,9 @@ void genProcArch(QueryContext& context, int pid, ProcessesRow& r) {
 
     // proc_bsdinfo also has pbi_flags, but that seems to be not always
     // populated, instead kinfo_proc works better to get at the process flags
+    // and check whether P_TRANSLATED is one of the flags
     if (kinfo.kp_proc.p_flag & P_TRANSLATED) {
-      r.kind_col = "intel";
+      r.translated_col = 1;
     }
   }
 }

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -44,7 +44,7 @@ extended_schema(DARWIN, [
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
-    Column("arch", TEXT, "Indicates the architecture of the process, apple or intel."),
+    Column("translated", INTEGER, "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -44,7 +44,7 @@ extended_schema(DARWIN, [
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
-    Column("translated", INTEGER, "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0."),
+    Column("translated", INTEGER, "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -44,7 +44,7 @@ extended_schema(DARWIN, [
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
-    Column("kind", TEXT, "Running under rosetta or not."),
+    Column("kind", TEXT, "Indicates the architecture of the process, apple or intel."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -44,7 +44,7 @@ extended_schema(DARWIN, [
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
-    Column("kind", TEXT, "Indicates the architecture of the process, apple or intel."),
+    Column("arch", TEXT, "Indicates the architecture of the process, apple or intel."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -44,6 +44,7 @@ extended_schema(DARWIN, [
     Column("uppid", BIGINT, "The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system."),
     Column("cpu_type", INTEGER, "Indicates the specific processor designed for installation."),
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
+    Column("kind", TEXT, "Running under rosetta or not."),
 ])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")

--- a/tests/integration/tables/processes.cpp
+++ b/tests/integration/tables/processes.cpp
@@ -103,6 +103,7 @@ TEST_F(ProcessesTest, test_sanity) {
     row_map.emplace("uppid", IntType);
     row_map.emplace("cpu_type", IntType);
     row_map.emplace("cpu_subtype", IntType);
+    row_map.emplace("kind", NormalType);
   }
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/processes.cpp
+++ b/tests/integration/tables/processes.cpp
@@ -103,7 +103,7 @@ TEST_F(ProcessesTest, test_sanity) {
     row_map.emplace("uppid", IntType);
     row_map.emplace("cpu_type", IntType);
     row_map.emplace("cpu_subtype", IntType);
-    row_map.emplace("kind", NormalType);
+    row_map.emplace("translated", IntType);
   }
   validate_rows(data, row_map);
 }


### PR DESCRIPTION
Implements a `kind` column to `processes` table on macOS. This checks if the process is translated (running under rosetta) on apple silicon macs.

(Not sold on the `kind` column name, happy to hear any suggestions)


```
osquery> select * from processes where kind = 'apple' limit 1;
               pid = 1
              name = launchd
              path = /sbin/launchd
           cmdline = /sbin/launchd
             state = R
               cwd = /
...
          cpu_type = 16777228
       cpu_subtype = -2147483646
              kind = apple
```
```
osquery> select * from processes where kind = 'intel' limit 1;
               pid = 2710
              name = CarbonComponentScannerXPC
              path = /System/Library/Frameworks/AudioToolbox.framework/XPCServices/CarbonComponentScannerXPC.xpc/Contents/MacOS/CarbonComponentScannerXPC
           cmdline = /System/Library/Frameworks/AudioToolbox.framework/XPCServices/CarbonComponentScannerXPC.xpc/Contents/MacOS/CarbonComponentScannerXPC
             state = R
               cwd = /
...
          cpu_type = 16777228
       cpu_subtype = 2
              kind = intel              
```  

```
osquery> select count(*) from processes;
count(*) = 634
osquery> select count(*) from processes where kind = 'apple';
count(*) = 629
osquery> select count(*) from processes where kind = 'intel';
count(*) = 5
```            