### PR TITLE
Eliminate removal of nonblocking flag for "special" files

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -92,14 +92,6 @@ struct OpenReadableFile : private boost::noncopyable {
 
     // Open the file descriptor and allow caller to perform error checking.
     fd = std::make_unique<PlatformFile>(path, mode);
-
-    if (!blocking && fd->isSpecialFile()) {
-      // A special file cannot be read in non-blocking mode, reopen in blocking
-      // mode
-      mode &= ~PF_NONBLOCK;
-      blocking_io = true;
-      fd = std::make_unique<PlatformFile>(path, mode);
-    }
   }
 
  public:

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -150,7 +150,7 @@ Status readFile(const fs::path& path,
   handle.fd->getFileTimes(times);
 
   off_t total_bytes = 0;
-  if (handle.blocking_io) {
+  if (handle.blocking_io || handle.fd->isSpecialFile()) {
     // Reset block size to a sane minimum.
     block_size = (block_size < 4096) ? 4096 : block_size;
     ssize_t part_bytes = 0;

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include <gtest/gtest.h>
 
@@ -30,6 +31,11 @@
 // Some proc* functions are only compiled when building on linux
 #ifdef __linux__
 #include "osquery/filesystem/linux/proc.h"
+#endif
+
+#ifdef WIN32
+#include "winbase.h"
+#include <osquery/utils/conversions/windows/strings.h>
 #endif
 
 namespace fs = boost::filesystem;
@@ -596,6 +602,38 @@ TEST_F(FilesystemTests, test_read_empty_file) {
   std::string content;
   ASSERT_TRUE(readFile(test_file, content));
   ASSERT_TRUE(content.empty());
+}
+
+TEST_F(FilesystemTests, test_read_fifo) {
+  // This test verifies that open and read operations do not hang when using
+  // non-blocking mode for pipes. Pipes are platform dependent, hence the
+  // ifndef. Seems preferable to adding half-baked pipes to each fileops
+  // implementation.
+#ifndef WIN32
+  auto test_file = test_working_dir_ / "fifo";
+  ASSERT_EQ(::mkfifo(test_file.c_str(), S_IRUSR | S_IWUSR), 0);
+
+  // The failure behavior is that this test will just hang forever, so
+  // maybe it should be run in another thread with a timeout.
+  std::string content;
+  ASSERT_TRUE(readFile(test_file, content));
+  ASSERT_TRUE(content.empty());
+  ::unlink(test_file.c_str());
+#else
+  std::wstring pipe_name = stringToWstring("\\.pipe\test_pipe");
+  HANDLE pipe_handle = CreateNamedPipe(pipe_name.c_str(),
+                                       PIPE_ACCESS_DUPLEX,
+                                       PIPE_WAIT,
+                                       PIPE_UNLIMITED_INSTANCES,
+                                       0,
+                                       0,
+                                       1000,
+                                       0);
+  std::string content;
+  ASSERT_FALSE(readFile(pipe_name, content));
+  ASSERT_TRUE(content.empty());
+  CloseHandle(pipe_handle);
+#endif
 }
 
 } // namespace osquery


### PR DESCRIPTION
Currently, when opening or reading a named pipe (or fifo), osquery will block. This is a potential avenue for a denial of service attack.

After some investigation, I believe the comment [here](https://github.com/osquery/osquery/blob/master/osquery/filesystem/filesystem.cpp#L97) is incorrect.

>  // A special file cannot be read in non-blocking mode, reopen in blocking
>       // mode

According to [The Linux Programming Interface](https://www.oreilly.com/library/view/the-linux-programming/9781593272203/) Section 5.9

> Nonblocking mode can be used with devices (e.g., terminals and pseudoterminals), pipes, FIFOs, and sockets. (Because file descriptors for pipes and sockets are not obtained using open(), we must enable this flag using the fcntl() F_SETFL operation described in Section 5.3.)
> O_NONBLOCK is generally ignored for regular files, because the kernel buffer cache ensures that I/O on regular files does not block, as described in Section 13.1. How- ever, O_NONBLOCK does have an effect for regular files when mandatory file locking is employed (Section 55.4).
> 

Given this, the best solution seemed to be to get rid of the check for `fd->isSpecialFile()` and the non-blocking mode will handle not blocking and for fifo's it will just return an error that we can handle.

A test is also added to make sure this change behaves properly on Windows as well.