### PR TITLE
Fix regressions in `profile.py --leaks`

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -84,13 +84,13 @@ def check_leaks_darwin(shell, query, count=1):
         if args.verbose:
             print(stdout)
         try:
-            for line in stdout.split("\n"):
-                if line.find("total leaked bytes") >= 0:
-                    leak_checks = line.split(":")[1].strip()
+            for line in stdout.split(b"\n"):
+                if line.find(b"total leaked bytes") >= 0:
+                    leak_checks = line.split(b":")[1].strip()
         except:
             print("Encountered exception while running leaks:")
-            print(stdout)
-    return {"definitely": leak_checks}
+            print("stdout")
+    return {"definitely": leak_checks.decode("utf-8")}
 
 
 def check_leaks(shell, query, count=1, supp_file=None):

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -89,7 +89,7 @@ def check_leaks_darwin(shell, query, count=1):
                     leak_checks = line.split(b":")[1].strip()
         except:
             print("Encountered exception while running leaks:")
-            print("stdout")
+            print(stdout)
     return {"definitely": leak_checks.decode("utf-8")}
 
 

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -280,9 +280,8 @@ if __name__ == "__main__":
         help="Run the profile for N rounds and use the average."
     )
     group.add_argument(
-        "--shell", metavar="PATH", default="./build/%s/osquery/osqueryi" % (
-            utils.platform()),
-        help="Path to osqueryi shell (./build/<sys>/osquery/osqueryi)."
+        "--shell", metavar="PATH", default="./build/osquery/osqueryi",
+        help="Path to osqueryi shell (./build/osquery/osqueryi)."
     )
     group.add_argument(
         "--force", action="store_true", default=False,


### PR DESCRIPTION
This PR fixes two issues I encountered when I recently `./tools/analysis/profile.py --leaks` in my `osquery` development folder.

### Issue 1: In Python3 `Popen` no longer treats pipes as standard strings
The most pressing issue is that when this Python script runs the `leaks` binary under the hood, it attempts to do string manipulation on `stdout`. This is allowed in Python2, but in Python3, stdout is now a `bytes` object. This PR updates the calls so they are compatible.

### Issue 2: The default `--shell` was not accurate
When executing the tool without arguments, the script was looking for an osqueryi binary in `./build/<platform>/osquery/osqueryi` but in practice, builds seem to actually now be located at `./build/osquery/osqueryi`. I've updated the default accordingly.

After making these two changes, I get the expected output from the tool:

```
☁  osquery [jem_fix_leaks] ⚡  ./tools/analysis/profile.py --leaks
Analyzing leaks in query: SELECT * FROM os_version;
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: SELECT * FROM startup_items;
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: SELECT * FROM platform_info;
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: SELECT * FROM etc_hosts;
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: SELECT * FROM uptime;
```

These fixes should make it easier for folks to use these tools going forward when they follow the docs explicitly.