### PR TITLE
Ensure `python_packages` checks new homebrew paths

### DIFF
--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -34,6 +34,8 @@ const size_t kNumFields = 2;
 const std::set<std::string> kPythonPath = {
     "/usr/local/lib/python%/dist-packages",
     "/usr/local/lib/python%/site-packages",
+    "/opt/homebrew/lib/python%/dist-packages",
+    "/opt/homebrew/lib/python%/site-packages",
     "/usr/lib/python%/dist-packages",
     "/usr/lib/python%/site-packages",
     "/Library/Python/%/site-packages",


### PR DESCRIPTION
Somewhat recently, the homebrew project changed the default installation path for its packages on Macs with Apple Silicon (see https://github.com/osquery/osquery/pull/7117).

This PR updates the `python_packages` to look for packages in this new folder (it was already looking in the intel-based homebrew directory).