### PR TITLE
Make TLS status logging configurable

### DIFF
--- a/plugins/logger/tls_logger.cpp
+++ b/plugins/logger/tls_logger.cpp
@@ -46,6 +46,8 @@ FLAG(uint64,
      1 * 1024 * 1024,
      "Max size in bytes allowed per log line");
 
+FLAG(bool, tls_disable_status_log, false, "Disable sending status logs");
+
 // The flag name logger_tls_max is deprecated.
 FLAG_ALIAS(google::uint64, logger_tls_max, logger_tls_max_linesize);
 
@@ -96,6 +98,11 @@ void TLSLoggerPlugin::init(const std::string& name,
 
 Status TLSLogForwarder::send(std::vector<std::string>& log_data,
                              const std::string& log_type) {
+  // Skip sending status logs to remote server if disabled
+  if (FLAGS_tls_disable_status_log && log_type == "status") {
+    return Status::success();
+  }
+
   JSON params;
   params.add("node_key", getNodeKey("tls"));
   params.add("log_type", log_type);


### PR DESCRIPTION
The TLS logger plugin sends two types of logs, results log and status log. If `--verbose` option specified the logger will frequently send status logs to remote server, which may cause undesirable bandwidth usage.  Currently the logger plugin dose not provide an option to opt out the status logs sending.

This PR adds a flag option `--tls_disable_status_log` that will prevent status log being sent to the remote server. The default value of this option is false, so no impact to the previous behavior.

Here are the test results from my local

Test query

```json
{
    "schedule": {
       "test_query": {
            "query": "select year from time",
            "interval": 10,
            "snapshot": true
        }
    }
}
```

Without `--tls_disable_status_log`

```shell
./osqueryd --verbose --ephemeral --disable_database \
    --tls_hostname localhost:8088 \
    --tls_server_certs ./tools/tests/configs/test_server_ca.pem \
    --logger_tls_endpoint /logger \
    --logger_plugin tls  \
    --disable_enrollment \
    --config_path ./osquery.conf \
    --host_identifier=specified \
    --specified_identifier=test
```

Result
 
```
-- [DEBUG] Request: {'data': [{'snapshot': [{'year': '2022'}], 'action': 'snapshot', 'name': 'test_query', 'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:13:23 2022 UTC', 'unixTime': 1649222003, 'epoch': 0, 'counter': 0, 'numerics': False}], 'log_type': 'result', 'node_key': ''}
-- [DEBUG] Replying: {'foo': 'bar'}
-- [DEBUG] RealSimpleHandler::post /logger
127.0.0.1 - - [06/Apr/2022 14:13:25] "POST /logger HTTP/1.1" 200 -
-- [DEBUG] Request: {'data': [{'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:13:21 2022 UTC', 'unixTime': '1649222001', 'severity': '0', 'filename': 'tls.cpp', 'line': '253', 'message': 'TLS/HTTPS POST request to URI: https://localhost:8088/logger', 'version': '5.2.2-33-g11b670d6e-dirty'}, {'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:13:23 2022 UTC', 'unixTime': '1649222003', 'severity': '0', 'filename': 'scheduler.cpp', 'line': '119', 'message': 'Executing scheduled query test_query: select year from time', 'version': '5.2.2-33-g11b670d6e-dirty'}], 'log_type': 'status', 'node_key': ''}
-- [DEBUG] Replying: {'foo': 'bar'}
-- [DEBUG] RealSimpleHandler::post /logger
127.0.0.1 - - [06/Apr/2022 14:13:29] "POST /logger HTTP/1.1" 200 -
-- [DEBUG] Request: {'data': [{'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:13:25 2022 UTC', 'unixTime': '1649222005', 'severity': '0', 'filename': 'tls.cpp', 'line': '253', 'message': 'TLS/HTTPS POST request to URI: https://localhost:8088/logger', 'version': '5.2.2-33-g11b670d6e-dirty'}, {'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:13:25 2022 UTC', 'unixTime': '1649222005', 'severity': '0', 'filename': 'tls.cpp', 'line': '253', 'message': 'TLS/HTTPS POST request to URI: https://localhost:8088/logger', 'version': '5.2.2-33-g11b670d6e-dirty'}], 'log_type': 'status', 'node_key': ''}
-- [DEBUG] Replying: {'foo': 'bar'}
```

With `--tls_disable_status_log`

```shell
./osqueryd --verbose --ephemeral --disable_database \
    --tls_hostname localhost:8088 \
    --tls_server_certs ./tools/tests/configs/test_server_ca.pem \
    --logger_tls_endpoint /logger \
    --logger_plugin tls  \
    --disable_enrollment \
    --config_path ./osquery.conf \
    --host_identifier=specified \
    --specified_identifier=test \
    --tls_disable_status_log
```

Result

```
127.0.0.1 - - [06/Apr/2022 14:15:53] "POST /logger HTTP/1.1" 200 -
-- [DEBUG] Request: {'data': [{'snapshot': [{'year': '2022'}], 'action': 'snapshot', 'name': 'test_query', 'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:15:50 2022 UTC', 'unixTime': 1649222150, 'epoch': 0, 'counter': 0, 'numerics': False}], 'log_type': 'result', 'node_key': ''}
-- [DEBUG] Replying: {'foo': 'bar'}
-- [DEBUG] RealSimpleHandler::post /logger
127.0.0.1 - - [06/Apr/2022 14:16:01] "POST /logger HTTP/1.1" 200 -
-- [DEBUG] Request: {'data': [{'snapshot': [{'year': '2022'}], 'action': 'snapshot', 'name': 'test_query', 'hostIdentifier': 'test', 'calendarTime': 'Wed Apr  6 05:16:00 2022 UTC', 'unixTime': 1649222160, 'epoch': 0, 'counter': 0, 'numerics': False}], 'log_type': 'result', 'node_key': ''}
-- [DEBUG] Replying: {'foo': 'bar'}
```