### PR TITLE
 Restore some release checks

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -1154,7 +1154,9 @@ jobs:
 
     - name: Run the tests
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
+      shell: cmd
       run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars${{ matrix.bitness }}.bat"
         ctest --build-nocmake -C Release -V
 
     - name: Run the install target

--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -15,8 +15,26 @@ endfunction()
 
 function(addPythonTest)
   set(oneValueArgs NAME SCRIPT)
-  set(multiValueArgs EXTRA_ARGS)
+  set(multiValueArgs EXTRA_ARGS ARGS)
   cmake_parse_arguments(PARSE_ARGV 0 osquery_test "" "${oneValueArgs}" "${multiValueArgs}")
+
+  if(DEFINED osquery_test_EXTRA_ARGS AND DEFINED osquery_test_ARGS)
+    message(FATAL_ERROR "Only one of ARGS and EXTRA_ARGS can be used to declare a python test")
+  endif()
+
+  set(test_args
+    --verbose
+    --build "${CMAKE_BINARY_DIR}"
+    --test-configs-dir "${TEST_CONFIGS_DIR}"
+  )
+
+  if(DEFINED osquery_test_EXTRA_ARGS)
+    list(APPEND test_args
+      ${osquery_test_EXTRA_ARGS}
+    )
+  elseif(DEFINED osquery_test_ARGS)
+    set(test_args ${osquery_test_ARGS})
+  endif()
 
   get_filename_component(script_name "${osquery_test_SCRIPT}" NAME)
 
@@ -25,9 +43,7 @@ function(addPythonTest)
   set(python_test_command
     "${CMAKE_COMMAND}" -E env "PYTHONPATH=${OSQUERY_PYTHON_PATH}"
     "${OSQUERY_PYTHON_EXECUTABLE}" -u ${script_name}
-    --verbose --build "${CMAKE_BINARY_DIR}"
-    --test-configs-dir "${TEST_CONFIGS_DIR}"
-    "${osquery_test_EXTRA_ARGS}"
+    "${test_args}"
   )
 
   add_test(NAME ${osquery_test_NAME}
@@ -49,6 +65,9 @@ function(preparePythonTestsEnvironment)
   # The test test_example_queries requires to use codegen scripts, let's copy them in the binary dir
   generateCopyFileTarget("osquery_tools_codegen_scripts" "${CMAKE_SOURCE_DIR}/tools/codegen" "REGEX" "gen*.py" "${CMAKE_CURRENT_BINARY_DIR}")
 
+  # TODO: Uncomment me when the query packs test is fully fixed
+  # generateCopyFileTarget("osquery_tools_tests_copy_query_packs" "${CMAKE_SOURCE_DIR}/packs" "REGEX" "*.conf" "${TEST_CONFIGS_DIR}/packs")
+
   # Also prepare a proper module path for utils.py
   if(PLATFORM_WINDOWS)
     configure_file("${CMAKE_SOURCE_DIR}/tools/tests/winexpect.py" winexpect.py COPYONLY)
@@ -60,6 +79,9 @@ function(preparePythonTestsEnvironment)
   add_dependencies(osquery_tools_tests_pythontests specs_table_files)
   add_dependencies(osquery_tools_tests_pythontests codegen_gentable_utils_dependency)
   add_dependencies(osquery_tools_tests_pythontests create_osqueryi)
+
+  # TODO: Uncomment me when the query packs test is fully fixed
+  # add_dependencies(osquery_tools_tests_pythontests osquery_tools_tests_copy_query_packs)
 endfunction()
 
 function(generatePythonTests)
@@ -69,6 +91,17 @@ function(generatePythonTests)
   # Tests
   addPythonTest(NAME tools_tests_testosqueryd SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_osqueryd.py")
   addPythonTest(NAME tools_tests_testosqueryi SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_osqueryi.py")
+
+  set(release_test_args
+    "--build_dir=${CMAKE_BINARY_DIR}"
+    "--verbose"
+  )
+
+  addPythonTest(NAME tools_tests_testrelease SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_release.py" ARGS ${release_test_args})
+
+  # TODO: Uncomment me when the query packs test is fully fixed
+  # addPythonTest(NAME tools_tests_testquerypacks SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_query_packs.py")
+
   if(PLATFORM_LINUX)
     addPythonTest(NAME tools_tests_testfschangestable SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_docker_container_fs_changes_table.py")
   endif()

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -638,6 +638,7 @@ def expect(functional, expected, interval=0.01, timeout=4):
 
 class QueryTester(ProcessGenerator, unittest.TestCase):
     def setUp(self):
+        super().setUp()
         self.binary = getLatestOsqueryBinary("osqueryi")
         self.daemon = self._run_daemon({
             # The set of queries will hammer the daemon process.
@@ -646,6 +647,7 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
             # catching.
             "registry_exceptions": True,
             "ephemeral": True,
+            "disable_extensions": False,
         })
         self.assertTrue(self.daemon.isAlive())
 

--- a/tools/tests/test_query_packs.py
+++ b/tools/tests/test_query_packs.py
@@ -1,0 +1,62 @@
+import json
+import random
+import test_base
+import os
+import utils
+
+
+def allowed_platform(qp):
+    if qp in ["all", "any"]:
+        return True
+    if len(qp) == 0:
+        return True
+
+    curr_platform = utils.platform()
+
+    if (curr_platform == "linux" or curr_platform == "darwin") and qp.find(
+        "posix"
+    ) >= 0:
+        return True
+
+    return qp.find(curr_platform) >= 0
+
+
+class QueryPacksTests(test_base.QueryTester):
+    def test_pack_queries(self):
+        packs = {}
+        PACKS_DIR = test_base.TEST_CONFIGS_DIR + "/packs"
+        print(PACKS_DIR)
+        for root, dirs, files in os.walk(PACKS_DIR):
+            for name in files:
+                with open(os.path.join(PACKS_DIR, name), "r") as fh:
+                    content = fh.read()
+                    content = content.replace("\\\n", "")
+                    packs[name] = json.loads(content)
+        for name, pack in packs.items():
+            if "queries" not in pack:
+                continue
+
+            if "platform" in pack and not allowed_platform(pack["platform"]):
+                continue
+
+            print("Executing queries in pack: %s" % name)
+
+            queries = []
+            for query_name, query in pack["queries"].items():
+                qp = query["platform"] if "platform" in query else ""
+                if allowed_platform(qp):
+                    queries.append(query["query"])
+            self._execute_set(queries)
+            print("")
+
+
+if __name__ == "__main__":
+    module = test_base.Tester()
+
+    test_base.CONFIG["options"][
+        "extensions_socket"
+    ] = test_base.TEMP_DIR + "/osquery-%d.em" % (random.randint(1000, 9999))
+
+    # Find and import the thrift-generated python interface
+    test_base.loadThriftFromBuild(test_base.ARGS.build)
+    module.run()

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -7,72 +7,167 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
-import json
-import os
+import argparse
 import subprocess
-import string
 import unittest
+import sys
 
-# osquery-specific testing utils
-import test_base
 from utils import platform
 
 
-def allowed_platform(qp):
-    if qp in ["all", "any"]:
-        return True
-    if len(qp) == 0:
-        return True
-    return qp.find(platform()) >= 0
+linux_expected_libraries = [
+    "linux-vdso.so",
+    "libdl.so",
+    "libresolv.so",
+    "librt.so",
+    "libm.so",
+    "libpthread.so",
+    "libc.so",
+    "ld-linux-x86-64.so",
+]
+
+windows_expected_libraries = [
+    "SHLWAPI.dll",
+    "RPCRT4.dll",
+    "CRYPT32.dll",
+    "Secur32.dll",
+    "bcrypt.dll",
+    "KERNEL32.dll",
+    "WS2_32.dll",
+    "ncrypt.dll",
+    "USERENV.dll",
+    "VERSION.dll",
+    "USER32.dll",
+    "SHELL32.dll",
+    "ole32.dll",
+    "OLEAUT32.dll",
+    "ADVAPI32.dll",
+    "ntdll.dll",
+    "IPHLPAPI.DLL",
+    "NETAPI32.dll",
+    "WTSAPI32.dll",
+    "dbghelp.dll",
+    "dbgeng.dll",
+    "WINTRUST.dll",
+    "SETUPAPI.dll",
+    "wevtapi.dll",
+]
 
 
-class ReleaseTests(test_base.QueryTester):
-    def test_pack_queries(self):
-        packs = {}
-        PACKS_DIR = SOURCE_DIR + "/packs"
-        for root, dirs, files in os.walk(PACKS_DIR):
-            for name in files:
-                with open(os.path.join(PACKS_DIR, name), 'r') as fh:
-                    content = fh.read()
-                    content = string.replace(content, "\\\n", "")
-                    packs[name] = json.loads(content)
-        for name, pack in packs.items():
-            if "queries" not in pack:
-                continue
-            if "platform" in pack and not allowed_platform(pack["platform"]):
-                continue
-            queries = []
-            for query_name, query in pack["queries"].items():
-                qp = query["platform"] if "platform" in query else ""
-                if allowed_platform(qp):
-                    queries.append(query["query"])
-            self._execute_set(queries)
+class ReleaseTests(unittest.TestCase):
+    @unittest.skipUnless(
+        platform() == "linux" or platform() == "darwin",
+        "Test for Darwin and Linux only",
+    )
+    def test_no_nonsystem_link(self):
 
-    def test_no_avx_instructions(self):
-        if platform() == "darwin":
-            tool = "otool -tV"
+        if platform() == "linux":
+            proc = subprocess.call(
+                "ldd %s | awk '{ print $1\" \"$3 }' | grep -Ev '^/lib64|^/lib| /lib|linux-vdso.so.1'"
+                % (BUILD_DIR + "/osquery/osqueryd"),
+                shell=True,
+            )
         else:
-            tool = "objdump -d"
-        proc = subprocess.call(
-            "%s %s | grep vxorps" % (tool, self.binary), shell=True)
-        # Require no AVX instructions
+            proc = subprocess.call(
+                "otool -L %s | awk '{ if (NR > 1) print $1}' | grep -Ev '^/usr/lib|^/System/Library'"
+                % (BUILD_DIR + "/osquery/osqueryd"),
+                shell=True,
+            )
+
+        # Require all libraries to be system libraries.
         self.assertEqual(proc, 1)
 
-    def test_no_local_link(self):
-        if platform() == "darwin":
-            tool = "otool -L"
-        else:
-            tool = "ldd"
-        proc = subprocess.call(
-            "%s %s | grep /usr/local/" % (tool, self.binary), shell=True)
-        # Require no local dynamic dependent links.
-        self.assertEqual(proc, 1)
+    @unittest.skipUnless(
+        platform() == "linux" or platform() == "win32",
+        "Test for Windows and Linux only",
+    )
+    def test_linked_system_libraries(self):
 
-if __name__ == '__main__':
-    SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-    SOURCE_DIR = os.path.abspath(SCRIPT_DIR + "/../../")
+        if platform() == "linux":
+            output_bytes = subprocess.check_output(
+                "ldd %s | awk '{ print $1 }'"
+                % (BUILD_DIR + "/osquery/osqueryd"),
+                shell=True,
+            )
 
-    module = test_base.Tester()
-    # Find and import the thrift-generated python interface
-    test_base.loadThriftFromBuild(test_base.ARGS.build)
-    module.run()
+            self.assertTrue(output_bytes)
+
+            output = output_bytes.decode("utf-8")
+            libraries = list(filter(None, output.split(sep="\n")))
+
+            self.assertGreaterEqual(len(libraries), 0)
+
+            for expected_library in linux_expected_libraries:
+                found_index = -1
+
+                for i, library in enumerate(libraries):
+                    if expected_library in library:
+                        found_index = i
+
+                self.assertGreaterEqual(
+                    found_index,
+                    0,
+                    msg="Missing expected library %s" % expected_library,
+                )
+                libraries.pop(found_index)
+
+            if len(libraries) > 0:
+                self.fail(
+                    "Found these additional unwanted libraries linked:\n%s"
+                    % ("\n".join(libraries))
+                )
+        elif platform() == "win32":
+            output_bytes = subprocess.check_output(
+                "dumpbin /DEPENDENTS %s"
+                % (BUILD_DIR + "/osquery/osqueryd.exe"),
+            )
+
+            self.assertTrue(output_bytes)
+
+            output = output_bytes.decode("utf-8")
+            libraries = [
+                line
+                for line in list(filter(None, output.split(sep="\r\n")))
+                if ".dll" in line.lower()
+            ]
+
+            self.assertGreaterEqual(len(libraries), 0)
+
+            for expected_library in windows_expected_libraries:
+                found_index = -1
+
+                for i, library in enumerate(libraries):
+                    if expected_library.lower() in library.lower().strip():
+                        found_index = i
+
+                self.assertGreaterEqual(
+                    found_index,
+                    0,
+                    msg="Missing expected library %s" % expected_library,
+                )
+                libraries.pop(found_index)
+
+            if len(libraries) > 0:
+                self.fail(
+                    "Found these additional unwanted libraries linked:\n%s"
+                    % ("\n".join(libraries))
+                )
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser()
+
+    arg_parser.add_argument(
+        "--build_dir",
+        required=True,
+        help="Path of the build directory",
+    )
+
+    args, remaining = arg_parser.parse_known_args()
+    global BUILD_DIR
+    BUILD_DIR = args.build_dir
+
+    additional_argv = [sys.argv[0]]
+    additional_argv.extend(remaining)
+
+    unittest.main(argv=additional_argv)


### PR DESCRIPTION
- Permit to better control which arguments are passed
  to python tests

- Verify that there's no dynamic link
  outside standard system libraries folders
  on Linux and Darwin

- Verify that there's no unwanted linked library
  on Linux and Windows

- Split the query pack test in it's own test script,
  since it depends on osquery test framework,
  and still requires some work
  
Related to #5795
Depends on #7557 
