### PR TITLE
Prevent CLI_FLAGs to be set via config

### DIFF
--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -375,6 +375,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ConfigTests, test_config_refresh);
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
   FRIEND_TEST(ConfigTests, test_nondenylist_query);
+  FRIEND_TEST(ConfigTests, test_config_cli_flags);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option_first);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_add_view);

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -796,4 +796,21 @@ TEST_F(ConfigTests, test_config_backup_integrate) {
 
   FLAGS_config_enable_backup = config_enable_backup_saved;
 }
+
+TEST_F(ConfigTests, test_config_cli_flags) {
+  get().reset();
+
+  auto pack_delimiter = Flag::getValue("pack_delimiter");
+  ASSERT_NE(pack_delimiter, ",");
+  get().update({{"options", "{\"options\":{ \"pack_delimiter\": \",\" }}"}});
+  pack_delimiter = Flag::getValue("pack_delimiter");
+  ASSERT_EQ(pack_delimiter, ",");
+
+  Flag::updateValue("disable_watchdog", "true");
+  ASSERT_EQ(Flag::getValue("disable_watchdog"), "true");
+
+  get().update({{"options", "{\"options\":{ \"disable_watchdog\": false }}"}});
+
+  ASSERT_NE(Flag::getValue("disable_watchdog"), "false");
+}
 } // namespace osquery

--- a/plugins/config/parsers/options.cpp
+++ b/plugins/config/parsers/options.cpp
@@ -103,10 +103,10 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
     }
 
     if (Flag::isCLIOnlyFlag(name)) {
-      LOG(WARNING) << "Setting the CLI only flag --" << name
-                   << " via config is incorrect and will be deprecated in the "
-                      "next release, please specify the flag in the flagfile "
-                      "or pass it to the process at startup";
+      LOG(WARNING) << "The CLI only flag --" << name
+                   << " set via config file will be ignored, please use a "
+                      "flagfile or pass it to the process at startup";
+      continue;
     }
 
     Flag::updateValue(name, value);


### PR DESCRIPTION
Also change the `disable_tables` and `enable_tables` flags
to CLI_FLAG since changes to them won't be reflected at runtime,
but it's also not desirable to have them change at runtime
for security reasons.

Fixes #6533 

NOTE: This has a slight spin to the original fix; I didn't want to touch the `Flag::updateValue` API because I think that should be still usable as-is internally and especially for tests, since the real issue comes from the "options" config parser.
