### PR TITLE
Change where the macOS Info.plist is generated

### DIFF
--- a/cmake/install_directives.cmake
+++ b/cmake/install_directives.cmake
@@ -257,7 +257,7 @@ function(generateInstallDirectives)
       FILES
         "tools/deployment/macos_packaging/osquery.entitlements"
         "tools/deployment/macos_packaging/embedded.provisionprofile"
-        "tools/deployment/macos_packaging/Info.plist"
+        "${CMAKE_BINARY_DIR}/tools/deployment/macos_packaging/Info.plist"
         "tools/deployment/macos_packaging/PkgInfo"
 
       DESTINATION
@@ -349,7 +349,7 @@ function(generateInstallDirectives)
     install(
       FILES
         "tools/deployment/macos_packaging/embedded.provisionprofile"
-        "tools/deployment/macos_packaging/Info.plist"
+        "${CMAKE_BINARY_DIR}/tools/deployment/macos_packaging/Info.plist"
         "tools/deployment/macos_packaging/PkgInfo"
 
       DESTINATION

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -219,7 +219,7 @@ function(add_osquery_executable)
 
     configure_file(
       "${CMAKE_SOURCE_DIR}/tools/deployment/macos_packaging/Info.plist.in"
-      "${CMAKE_SOURCE_DIR}/tools/deployment/macos_packaging/Info.plist"
+      "${CMAKE_BINARY_DIR}/tools/deployment/macos_packaging/Info.plist"
     )
   endif()
 


### PR DESCRIPTION
Generated files should not end up in the source folder,
but the build folder.
Change the generation destination and the install logic accordingly.

To test, configure as usual (I'm using `Ninja` here, with `Make` would be the same), the file will end up in
```
<build folder>/tools/deployment/macos_packaging
```

Then build:
```
DESTDIR=/tmp/osquery ninja install
```

Result:
```
[617/618] Install the project...
-- Install configuration: "RelWithDebInfo"
-- Installing: /tmp/osquery/control/osquery.entitlements
-- Installing: /tmp/osquery/control/embedded.provisionprofile
-- Installing: /tmp/osquery/control/Info.plist <----
[...]
-- Installing: /tmp/osquery/opt/osquery/osquery.app/Contents/MacOS/osqueryd
-- Installing: /tmp/osquery/opt/osquery/osquery.app/Contents/embedded.provisionprofile
-- Installing: /tmp/osquery/opt/osquery/osquery.app/Contents/Info.plist <----
-- Installing: /tmp/osquery/opt/osquery/osquery.app/Contents/PkgInfo
-- Installing: /tmp/osquery/opt/osquery/osquery.app/Contents/Resources/osqueryctl
```
