### PR TITLE
packs: Update reverse shell query pack to check for a valid remote_port

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -547,7 +547,8 @@
         LEFT OUTER JOIN process_open_files \
         ON processes.pid = process_open_files.pid \
         WHERE (name='sh' OR name='bash') \
-        AND process_open_files.pid IS NULL;",
+        AND process_open_files.pid IS NULL \
+        AND process_open_sockets.remote_port > 0;",
       "interval" : "3600",
       "version" : "2.8.0",
       "description" : "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",


### PR DESCRIPTION
Hi,
I would like to make a minor improvement to avoid false positives for `Behavioral_Reverse_Shell` query in osx-attacks pack. Certain build processes are spawned by IDEs such as Xcode which do not have any open files, but have an open socket that is not a network socket which results in remote_port being 0 and remote_address empty. 

In this PR, I basically add a check for `process_open_sockets.remote_port > 0` to avoid all possible false positives which do not indicate a reverse shell. We can confirm it's safe considering port `0` is [reserved](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml) and cannot be used for network sockets.