### PR TITLE
Fix DebPackages.test_sanity test

### DIFF
--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -30,7 +30,7 @@ TEST_F(DebPackages, test_sanity) {
     ValidationMap row_map = {{"name", NonEmptyString},
                              {"version", NonEmptyString},
                              {"source", NormalType},
-                             {"size", IntType},
+                             {"size", IntOrEmpty},
                              {"arch", NonEmptyString},
                              {"revision", NormalType},
                              {"status", NonEmptyString},


### PR DESCRIPTION
The size column of the deb_packages table can be empty
if the Installed-Size field of the package is unknown.

Fixes #7568 
