### PR TITLE
Use additional instead of index for admindir in deb_packages

### DIFF
--- a/specs/linux/deb_packages.table
+++ b/specs/linux/deb_packages.table
@@ -11,7 +11,7 @@ schema([
     Column("maintainer", TEXT, "Package maintainer"),
     Column("section", TEXT, "Package section"),
     Column("priority", TEXT, "Package priority"),
-    Column("admindir", TEXT, "libdpkg admindir. Defaults to /var/lib/dpkg", index=True),
+    Column("admindir", TEXT, "libdpkg admindir. Defaults to /var/lib/dpkg", additional=True),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),


### PR DESCRIPTION
Although both index and additional add the column to the primary key,
index is meant to mark columns that make the row unique.
So the column values should contain unique values.
additional instead marks a column that when provided in a where clause
changes the table behvior, which is more correct in this case,
since the packages will be parsed from a different path than the default.
