### PR TITLE
Warn about setting CLI_FLAGs in the config

### DIFF
--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -115,6 +115,17 @@ std::string Flag::getDescription(const std::string& name) {
   return "";
 }
 
+bool Flag::isCLIOnlyFlag(const std::string& name) {
+  const auto& flags = instance().flags_;
+  const auto it = instance().flags_.find(name);
+
+  if (it == flags.end()) {
+    return false;
+  }
+
+  return it->second.cli;
+}
+
 Status Flag::updateValue(const std::string& name, const std::string& value) {
   if (instance().flags_.count(name) > 0) {
     flags::SetCommandLineOption(name.c_str(), value.c_str());
@@ -218,4 +229,4 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
     fprintf(stdout, "  %s\n", getDescription(flag.second->name).c_str());
   }
 }
-}
+} // namespace osquery

--- a/osquery/core/flags.h
+++ b/osquery/core/flags.h
@@ -122,6 +122,13 @@ class Flag : private boost::noncopyable {
   static std::string getDescription(const std::string& name);
 
   /*
+   * @brief Checks if the provided flag name corresponds to a CLI only flag
+   *
+   * @param name the flag name
+   */
+  static bool isCLIOnlyFlag(const std::string& name);
+
+  /*
    * @brief Print help-style output to stdout for a given flag set.
    *
    * @param shell Only print shell flags.

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -27,15 +27,15 @@
 
 namespace osquery {
 
-FLAG(string,
-     disable_tables,
-     "",
-     "Comma-delimited list of table names to be disabled");
+CLI_FLAG(string,
+         disable_tables,
+         "",
+         "Comma-delimited list of table names to be disabled");
 
-FLAG(string,
-     enable_tables,
-     "",
-     "Comma-delimited list of table names to be enabled");
+CLI_FLAG(string,
+         enable_tables,
+         "",
+         "Comma-delimited list of table names to be enabled");
 
 FLAG(string, nullvalue, "", "Set string for NULL values, default ''");
 

--- a/plugins/config/parsers/options.cpp
+++ b/plugins/config/parsers/options.cpp
@@ -102,6 +102,13 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
+    if (Flag::isCLIOnlyFlag(name)) {
+      LOG(WARNING) << "Setting the CLI only flag --" << name
+                   << " via config is incorrect and will be deprecated in the "
+                      "next release, please specify the flag in the flagfile "
+                      "or pass it to the process at startup";
+    }
+
     Flag::updateValue(name, value);
     // There is a special case for supported Gflags-reserved switches.
     if (kVerboseOptions.count(name)) {
@@ -116,4 +123,4 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
 }
 
 REGISTER_INTERNAL(OptionsConfigParserPlugin, "config_parser", "options");
-}
+} // namespace osquery


### PR DESCRIPTION
CLI_FLAG should not be set/updated in a config file,
but set once via a flagfile or passed at the process startup.
In the next release the ability to do so will be completely removed.

Also change the disable_tables and enable_tables flags
to CLI_FLAG since changes to them won't be reflected at runtime,
but it's also not desirable to have them change at runtime
for security reasons.

Partially Addresses #6533
