### PR TITLE
Remove the test_daemon_sighup test

### DIFF
--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -114,18 +114,6 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         children = daemon.getChildren()
         self.assertTrue(len(children) > 0)
 
-    def test_daemon_sighup(self):
-        # A hangup signal should not do anything to the daemon.
-        daemon = self._run_daemon({
-            "disable_watchdog": True,
-        })
-        self.assertTrue(daemon.isAlive())
-
-        # Send SIGHUP on posix. Windows does not have SIGHUP so we use SIGTERM
-        sig = signal.SIGHUP if os.name != "nt" else signal.SIGTERM
-        os.kill(daemon.proc.pid, sig)
-        self.assertTrue(daemon.isAlive())
-
     def test_daemon_sigint(self):
         # First check that the pidfile does not exist.
         # The existence will be used to check if the daemon has run.


### PR DESCRIPTION
The osquery logic for SIGHUP has long been removed
and actually that signal does close osquery.

The test was flaky because it wasn't waiting enough time
for the process to receive the signal and close,
so most of the times it seemed that nothing was happening
to the daemon.

Fixes #7192