### PR TITLE
Restore macOS `kernel_panics` table on modern macOS

### DIFF
--- a/osquery/tables/system/darwin/kernel_panics.cpp
+++ b/osquery/tables/system/darwin/kernel_panics.cpp
@@ -52,7 +52,7 @@ const std::map<std::string, std::string> kKernelPanicKeys = {
 
 void readKernelPanic(const std::string& panicLogFilePath, QueryData& results) {
   Row r;
-  r["registers"] = "";  // register context no longer reported since at least 10.14
+  r["registers"] = ""; // registers no longer reported since at least 10.14
   r["path"] = panicLogFilePath;
   std::string rawFileContent;
   std::vector<std::string> lines;
@@ -109,7 +109,7 @@ void readKernelPanic(const std::string& panicLogFilePath, QueryData& results) {
       VLOG(1) << "Could not parse any key:value pair from the panic log line";
       continue;
     }
-    
+
     // For macOS 10.14 and earlier, crudely parse the timestamp:
     auto timeTokens = osquery::split(toks[0], " ");
     if (timeTokens.size() >= 1 && kDays.count(timeTokens[0]) > 0) {

--- a/osquery/tables/system/darwin/kernel_panics.cpp
+++ b/osquery/tables/system/darwin/kernel_panics.cpp
@@ -11,23 +11,34 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/regex.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+//we might not be linking with these Boost components:
+//#include <boost/iostreams/device/array.hpp>
+//#include <boost/iostreams/stream.hpp>
 
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/tables/system/system_utils.h>
 #include <osquery/utils/conversions/split.h>
+#include <osquery/logger/logger.h>
 
 namespace fs = boost::filesystem;
 namespace alg = boost::algorithm;
+namespace pt = boost::property_tree;
 
 namespace osquery {
 namespace tables {
 
-/// Location of the kernel panic crash logs in OS X
+/// Location of the kernel panic crash logs in macOS
 const std::string kDiagnosticReportsPath = "/Library/Logs/DiagnosticReports";
 
-/// List of all register values we wish to catch
-const std::set<std::string> kKernelRegisters = {
+// macOS 11 moved the old panic log file from 10.15 into a JSON string value
+const std::string kPanicStringKey = "macOSPanicString";  // as of macOS 12
+// const std::string kPanicStringkey = "panicString"; // in macOS 11, apparently
+
+/// List of all x86-64 register values we wish to catch
+const std::set<std::string> kX86KernelRegisters = {
     "CR0",
     "RAX",
     "RSP",
@@ -40,42 +51,72 @@ const std::set<std::string> kKernelRegisters = {
 const std::set<std::string> kDays = {
     "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
-/// Map of the values we currently parse out of the log file
+/// Map of some of the values we parse out of the log file
 const std::map<std::string, std::string> kKernelPanicKeys = {
-    {"dependency", "dependencies"},
-    {"BSD process name corresponding to current thread", "name"},
+    {"dependency", "dependencies"},  // macOS 12: no longer present in the file
+    {"BSD process name corresponding to current thread", "name"},  // <= 10.15
     {"System model name", "system_model"},
     {"System uptime in nanoseconds", "uptime"},
 };
 
-void readKernelPanic(const std::string& appLog, QueryData& results) {
+void readKernelPanic(const std::string& panicLogFilePath, QueryData& results) {
   Row r;
-  r["path"] = appLog;
-  std::string content;
+  r["path"] = panicLogFilePath;
+  std::string rawFileContent;
 
-  if (!readFile(appLog, content).ok()) {
+  if (!readFile(panicLogFilePath, rawFileContent).ok()) {
+    VLOG(1) << "Could not read the panic log at " << panicLogFilePath;
     return;
   }
 
-  boost::regex rxSpaces("\\s+");
-  auto lines = osquery::split(content, "\n");
+  auto lines = osquery::split(rawFileContent, "\n");  // actual newlines
+  
+  // if (macOS major version >= 11) {
+    // Legacy format panic log content is now in a JSON-style container.
+    // Perform some additional unwrapping:
+    try {
+      pt::ptree panicLogHeader, panicLogContent;
+      std::istringstream issHeader( lines[0] );
+      pt::read_json(issHeader, panicLogHeader);
+      r["time"] = panicLogHeader.get<std::string>("timestamp", "");
+        
+      std::istringstream issContent( lines[1] );
+      pt::read_json(issContent, panicLogContent);
+        
+      std::string panicStringBlob = panicLogContent.get<std::string>(kPanicStringKey, "");
+      //VLOG(1) << "Debug: panicStringBlob after JSON get_value: \n" << panicStringBlob;
+    
+      lines = osquery::split(panicStringBlob, "\n");  // embedded newlines
+    }
+    catch (const pt::json_parser::json_parser_error& e) {
+       VLOG(1) << "Could not parse JSON from " << panicLogFilePath << ": " << e.what();
+    }
+  // }  // end if-new-macOS
+    
   for (auto it = lines.begin(); it != lines.end(); it++) {
     auto line = *it;
     boost::trim(line);
 
+    // Before macOS 11, most lines of the panic log were "KEY : VALUE" even if VALUE contained the ":" character too
     auto toks = osquery::split(line, ":");
     if (toks.size() == 0) {
+      VLOG(1) << "Could not parse any key:value pair from the panic log line";
       continue;
     }
 
+    // From here on, toks[0] is the kay of a key:value pair, toks[1] the value
     auto timeTokens = osquery::split(toks[0], " ");
+    
     if (timeTokens.size() >= 1 && kDays.count(timeTokens[0]) > 0) {
       r["time"] = line;
     }
 
-    if (kKernelRegisters.count(toks[0]) > 0) {
+    boost::regex rxSpaces("\\s+");
+
+    if (kX86KernelRegisters.count(toks[0]) > 0) {
       auto registerTokens = osquery::split(line, ",");
       if (registerTokens.size() == 0) {
+        VLOG(1) << "Could not parse the registers from the panic log at " << panicLogFilePath;
         continue;
       }
 
@@ -92,12 +133,15 @@ void readKernelPanic(const std::string& appLog, QueryData& results) {
                                                      : " " + std::move(regLine);
         }
       }
-    } else if (boost::starts_with(toks[0], "last loaded kext at") &&
+    } else if (boost::starts_with(toks[0], "last loaded kext at") &&  // macOS 10.15
                toks.size() == 2) {
       r["last_loaded"] = boost::regex_replace(toks[1], rxSpaces, " ");
     } else if (boost::starts_with(toks[0], "last unloaded kext at") &&
                toks.size() == 2) {
       r["last_unloaded"] = boost::regex_replace(toks[1], rxSpaces, " ");
+    } else if (boost::starts_with(toks[0], "last started kext at") &&  // macOS 12 equivalent
+               toks.size() == 2) {
+        r["last_loaded"] = boost::regex_replace(toks[1], rxSpaces, " ");
     } else if (boost::starts_with(toks[0], "Backtrace") &&
                std::next(it) != lines.end()) {
       r["frame_backtrace"] = *(std::next(it));
@@ -110,8 +154,15 @@ void readKernelPanic(const std::string& appLog, QueryData& results) {
     } else if (boost::starts_with(toks[0], "Kernel version") &&
                std::next(it) != lines.end()) {
       r["kernel_version"] = *(std::next(it));
-    } else if (kKernelPanicKeys.count(toks[0]) != 0 && toks.size() == 2) {
+    } else if (boost::starts_with(toks[0], "Process name corresponding to current thread") &&
+               std::next(it) != lines.end()) {
+      r["name"] = boost::regex_replace(toks[1], rxSpaces, " ");
+    }
+    else if (kKernelPanicKeys.count(toks[0]) != 0 && toks.size() == 2) {
+      // all of the other strings defined at the top of this file
       r[kKernelPanicKeys.at(toks[0])] = toks[1];
+    } else {
+      //VLOG(1) << "Debug: nothing parsed from this line of the panic log.";
     }
   }
   results.push_back(r);


### PR DESCRIPTION
Fixes #7215 by unwrapping a light layer of undocumented obfuscation (JSON) that Apple added to their semi-structured plaintext kernel panic log files up through macOS 10.15. Some columns don't appear to exist anymore, or might just be missing from my crash dump: `dependencies`, `last_unloaded`, etc.

- [x] attempt to read the `regsiters` column, but unfortunately the data is not there anymore (at least since macOS 10.14)
- [x] same for `module_backtrace` column, but unfortunately the data is not there anymore (at least since macOS 10.14)
- [x] test on M1 Mac
- [x] test on macOS 10.15
- [x] test on macOS 10.14
- [x] ~test on macOS 11.x~ (skipped, since the format in 10.15.6 and 12.3.1 are exactly the same)
- [x] clean up and clang-format

Example of table working to parse a crash dump:

```
mmyers@mmyerss-Mac build % ./osquery/osqueryi
Using a virtual database. Need help, type '.help'
osquery> .mode line
osquery> select * from kernel_panics;
            path = /Library/Logs/DiagnosticReports/Kernel-2022-05-05-173858.panic
            time = 2022-05-05 17:38:58.00 -0700
       registers = 
 frame_backtrace = 0xffffffe0735e3210 : 0xffffff8019c83e2d
module_backtrace = 
    dependencies = 
            name = dtrace
      os_version = 21E258
  kernel_version = Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64
    system_model = VMware7,1 (Mac-5F9802EFE386AA28)
          uptime = 779382986226
     last_loaded = |IOAVB!F 1040.6 (addr 0xffffff7fb2b2f000, size 77824)
   last_unloaded = 
```