### PR TITLE
Replace OS X with macOS in table specs

### DIFF
--- a/specs/darwin/account_policy_data.table
+++ b/specs/darwin/account_policy_data.table
@@ -1,5 +1,5 @@
 table_name("account_policy_data")
-description("Additional OS X user account data from the AccountPolicy section of OpenDirectory.")
+description("Additional macOS user account data from the AccountPolicy section of OpenDirectory.")
 schema([
     Column("uid", BIGINT, "User ID"),
     Column("creation_time", DOUBLE, "When the account was first created"),

--- a/specs/darwin/ad_config.table
+++ b/specs/darwin/ad_config.table
@@ -1,7 +1,7 @@
 table_name("ad_config")
-description("OS X Active Directory configuration.")
+description("macOS Active Directory configuration.")
 schema([
-    Column("name", TEXT, "The OS X-specific configuration name"),
+    Column("name", TEXT, "The macOS-specific configuration name"),
     Column("domain", TEXT, "Active Directory trust domain"),
     Column("option", TEXT, "Canonical name of option"),
     Column("value", TEXT, "Variable typed option value"),

--- a/specs/darwin/alf.table
+++ b/specs/darwin/alf.table
@@ -1,5 +1,5 @@
 table_name("alf")
-description("OS X application layer firewall (ALF) service details.")
+description("macOS application layer firewall (ALF) service details.")
 schema([
     Column("allow_signed_enabled", INTEGER, "1 If allow signed mode is enabled else 0"),
     Column("firewall_unload", INTEGER, "1 If firewall unloading enabled else 0"),

--- a/specs/darwin/alf_exceptions.table
+++ b/specs/darwin/alf_exceptions.table
@@ -1,5 +1,5 @@
 table_name("alf_exceptions")
-description("OS X application layer firewall (ALF) service exceptions.")
+description("macOS application layer firewall (ALF) service exceptions.")
 schema([
     Column("path", TEXT, "Path to the executable that is excepted"),
     Column("state", INTEGER, "Firewall exception state"),

--- a/specs/darwin/app_schemes.table
+++ b/specs/darwin/app_schemes.table
@@ -1,12 +1,12 @@
 table_name("app_schemes")
-description("OS X application schemes and handlers (e.g., http, file, mailto).")
+description("macOS application schemes and handlers (e.g., http, file, mailto).")
 schema([
     Column("scheme", TEXT, "Name of the scheme/protocol"),
     Column("handler", TEXT, "Application label for the handler"),
     Column("enabled", INTEGER, "1 if this handler is the OS default, else 0"),
     Column("external", INTEGER,
-        "1 if this handler does NOT exist on OS X by default, else 0"),
+        "1 if this handler does NOT exist on macOS by default, else 0"),
     Column("protected", INTEGER,
-        "1 if this handler is protected (reserved) by OS X, else 0"),
+        "1 if this handler is protected (reserved) by macOS, else 0"),
 ])
 implementation("apps@genAppSchemes")

--- a/specs/darwin/apps.table
+++ b/specs/darwin/apps.table
@@ -1,5 +1,5 @@
 table_name("apps")
-description("OS X applications installed in known search paths (e.g., /Applications).")
+description("macOS applications installed in known search paths (e.g., /Applications).")
 schema([
     Column("name", TEXT, "Name of the Name.app folder"),
     Column("path", TEXT, "Absolute and full Name.app path", index=True),
@@ -21,7 +21,7 @@ schema([
     Column("display_name", TEXT, "Info properties CFBundleDisplayName label"),
     Column("info_string", TEXT, "Info properties CFBundleGetInfoString label"),
     Column("minimum_system_version", TEXT,
-        "Minimum version of OS X required for the app to run"),
+        "Minimum version of macOS required for the app to run"),
     Column("category", TEXT,
         "The UTI that categorizes the app for the App Store"),
     Column("applescript_enabled", TEXT,

--- a/specs/darwin/authorization_mechanisms.table
+++ b/specs/darwin/authorization_mechanisms.table
@@ -1,5 +1,5 @@
 table_name("authorization_mechanisms")
-description("OS X Authorization mechanisms database.")
+description("macOS Authorization mechanisms database.")
 schema([
     Column("label", TEXT, "Label of the authorization right", index=True),
     Column("plugin", TEXT, "Authorization plugin name"),

--- a/specs/darwin/authorizations.table
+++ b/specs/darwin/authorizations.table
@@ -1,5 +1,5 @@
 table_name("authorizations")
-description("OS X Authorization rights database.")
+description("macOS Authorization rights database.")
 schema([
     Column("label", TEXT, "Item name, usually in reverse domain format",
       index=True),

--- a/specs/darwin/gatekeeper.table
+++ b/specs/darwin/gatekeeper.table
@@ -1,5 +1,5 @@
 table_name("gatekeeper")
-description("OS X Gatekeeper Details.")
+description("macOS Gatekeeper Details.")
 schema([
     Column("assessments_enabled", INTEGER, "1 If a Gatekeeper is enabled else 0"),
     Column("dev_id_enabled", INTEGER, "1 If a Gatekeeper allows execution from identified developers else 0"),

--- a/specs/darwin/kernel_extensions.table
+++ b/specs/darwin/kernel_extensions.table
@@ -1,5 +1,5 @@
 table_name("kernel_extensions")
-description("OS X's kernel extensions, both loaded and within the load search path.")
+description("macOS's kernel extensions, both loaded and within the load search path.")
 schema([
     Column("idx", INTEGER, "Extension load tag or index"),
     Column("refs", INTEGER, "Reference count"),

--- a/specs/darwin/package_bom.table
+++ b/specs/darwin/package_bom.table
@@ -1,5 +1,5 @@
 table_name("package_bom")
-description("OS X package bill of materials (BOM) file list.")
+description("macOS package bill of materials (BOM) file list.")
 schema([
     Column("filepath", TEXT, "Package file or directory"),
     Column("uid", INTEGER, "Expected user of file or directory"),

--- a/specs/darwin/package_install_history.table
+++ b/specs/darwin/package_install_history.table
@@ -1,5 +1,5 @@
 table_name("package_install_history")
-description("OS X package install history.")
+description("macOS package install history.")
 schema([
     Column("package_id", TEXT, "Label packageIdentifiers"),
     Column("time", INTEGER, "Label date as UNIX timestamp"),

--- a/specs/darwin/package_receipts.table
+++ b/specs/darwin/package_receipts.table
@@ -1,5 +1,5 @@
 table_name("package_receipts", aliases=["packages"])
-description("OS X package receipt details.")
+description("macOS package receipt details.")
 schema([
     Column("package_id", TEXT, "Package domain identifier"),
     Column("package_filename", TEXT, "Filename of original .pkg file",

--- a/specs/darwin/power_sensors.table
+++ b/specs/darwin/power_sensors.table
@@ -1,7 +1,7 @@
 table_name("power_sensors")
 description("Machine power (currents, voltages, wattages, etc) sensors.")
 schema([
-    Column("key", TEXT, "The SMC key on OS X", index=True),
+    Column("key", TEXT, "The SMC key on macOS", index=True),
     Column("category", TEXT, "The sensor category: currents, voltage, wattage"),
     Column("name", TEXT, "Name of power source"),
     Column("value", TEXT, "Power in Watts"),

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -1,5 +1,5 @@
 table_name("preferences")
-description("OS X defaults and managed preferences.")
+description("macOS defaults and managed preferences.")
 schema([
     Column("domain", TEXT, "Application ID usually in com.name.product format",
       index=True),

--- a/specs/darwin/quicklook_cache.table
+++ b/specs/darwin/quicklook_cache.table
@@ -1,5 +1,5 @@
 table_name("quicklook_cache")
-description("Files and thumbnails within OS X's Quicklook Cache.")
+description("Files and thumbnails within macOS's Quicklook Cache.")
 schema([
     Column("path", TEXT, "Path of file"),
     Column("rowid", INTEGER, "Quicklook file rowid key"),

--- a/specs/darwin/sandboxes.table
+++ b/specs/darwin/sandboxes.table
@@ -1,5 +1,5 @@
 table_name("sandboxes")
-description("OS X application sandboxes container details.")
+description("macOS application sandboxes container details.")
 schema([
     Column("label", TEXT, "UTI-format bundle or label ID"),
     Column("user", TEXT, "Sandbox owner"),

--- a/specs/darwin/sharing_preferences.table
+++ b/specs/darwin/sharing_preferences.table
@@ -1,5 +1,5 @@
 table_name("sharing_preferences", aliases=["alf_services"])
-description("OS X Sharing preferences.")
+description("macOS Sharing preferences.")
 schema([
 Column("screen_sharing", INTEGER, "1 If screen sharing is enabled else 0"),
 Column("file_sharing", INTEGER, "1 If file sharing is enabled else 0"),

--- a/specs/darwin/temperature_sensors.table
+++ b/specs/darwin/temperature_sensors.table
@@ -1,7 +1,7 @@
 table_name("temperature_sensors")
 description("Machine's temperature sensors.")
 schema([
-    Column("key", TEXT, "The SMC key on OS X", index=True),
+    Column("key", TEXT, "The SMC key on macOS", index=True),
     Column("name", TEXT, "Name of temperature source"),
     Column("celsius", DOUBLE, "Temperature in Celsius"),
     Column("fahrenheit", DOUBLE, "Temperature in Fahrenheit"),

--- a/specs/darwin/wifi_status.table
+++ b/specs/darwin/wifi_status.table
@@ -1,5 +1,5 @@
 table_name("wifi_status")
-description("OS X current WiFi status.")
+description("macOS current WiFi status.")
 schema([
     Column("interface", TEXT, "Name of the interface"),
     Column("ssid", TEXT, "SSID octets of the network"),

--- a/specs/example.table
+++ b/specs/example.table
@@ -24,7 +24,7 @@ schema([
     Column("id", INTEGER, "An index of some sort", index=True),
 
     # Some tables operate using default configurations or OS settings.
-    # OS X has default paths for .app executions, but .apps exist otherwise.
+    # macOS has default paths for .app executions, but .apps exist otherwise.
     # Tables may generate additional or different data when using some columns.
     # Set the "additional" argument if searching a non-default path.
     Column("path", TEXT, "Path of example", additional=True),


### PR DESCRIPTION
Simple non-code change:

Replace all occurrences of `OS X` with `macOS` in the table specs. This will bring the website schema and other things in line with the current Mac OS name (since we're now running Mac OS XII).