### PR TITLE
Fix MBCS support on Windows

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <codecvt>
 #include <sstream>
 
 #include <fcntl.h>
@@ -19,6 +20,7 @@
 #endif
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -98,6 +100,15 @@ struct OpenReadableFile : private boost::noncopyable {
   std::unique_ptr<PlatformFile> fd{nullptr};
   bool blocking_io;
 };
+
+void initializeFilesystemAPILocale() {
+#if defined(WIN32)
+  setlocale(LC_ALL, ".UTF-8");
+
+  boost::filesystem::path::imbue(std::locale(
+      std::locale(".UTF-8"), new std::codecvt_utf8_utf16<wchar_t>()));
+#endif
+}
 
 Status readFile(const fs::path& path,
                 size_t size,

--- a/osquery/filesystem/filesystem.h
+++ b/osquery/filesystem/filesystem.h
@@ -42,6 +42,9 @@ const std::string kSQLGlobWildcard{"%"};
 /// Globbing wildcard recursive character (double wildcard).
 const std::string kSQLGlobRecursive{kSQLGlobWildcard + kSQLGlobWildcard};
 
+/// Calls the setlocale() API, only used on Windows
+void initializeFilesystemAPILocale();
+
 /**
  * @brief Read a file from disk.
  *

--- a/osquery/filesystem/mock_file_structure.cpp
+++ b/osquery/filesystem/mock_file_structure.cpp
@@ -8,10 +8,13 @@
  */
 
 #include <osquery/filesystem/filesystem.h>
+#include <osquery/filesystem/mock_file_structure.h>
 
 #include <boost/filesystem/path.hpp>
 
 namespace osquery {
+
+const std::string kTopLevelMockFolderName{"辞書"};
 
 namespace fs = boost::filesystem;
 
@@ -19,11 +22,12 @@ fs::path createMockFileStructure() {
   const auto root_dir =
       fs::temp_directory_path() /
       fs::unique_path("osquery.tests.%%%%.%%%%");
-  fs::create_directories(root_dir / "toplevel/");
-  fs::create_directories(root_dir / "toplevel/secondlevel1");
-  fs::create_directories(root_dir / "toplevel/secondlevel2");
-  fs::create_directories(root_dir / "toplevel/secondlevel3");
-  fs::create_directories(root_dir / "toplevel/secondlevel3/thirdlevel1");
+  fs::create_directories(root_dir / kTopLevelMockFolderName / "/");
+  fs::create_directories(root_dir / kTopLevelMockFolderName / "secondlevel1");
+  fs::create_directories(root_dir / kTopLevelMockFolderName / "secondlevel2");
+  fs::create_directories(root_dir / kTopLevelMockFolderName / "secondlevel3");
+  fs::create_directories(root_dir / kTopLevelMockFolderName /
+                         "secondlevel3/thirdlevel1");
   fs::create_directories(root_dir / "deep11/deep2/deep3/");
   fs::create_directories(root_dir / "deep1/deep2/");
   writeTextFile(root_dir / "root.txt", "root");

--- a/osquery/filesystem/mock_file_structure.h
+++ b/osquery/filesystem/mock_file_structure.h
@@ -9,9 +9,13 @@
 
 #pragma once
 
+#include <string>
+
 #include <boost/filesystem/path.hpp>
 
 namespace osquery {
+
+extern const std::string kTopLevelMockFolderName;
 
 // generate a small directory structure for testing
 boost::filesystem::path createMockFileStructure();

--- a/osquery/filesystem/tests/fileops.cpp
+++ b/osquery/filesystem/tests/fileops.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <osquery/filesystem/fileops.h>
-
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/filesystem/mock_file_structure.h>
 
 #include <osquery/utils/info/platform_type.h>
@@ -29,6 +29,7 @@ class FileOpsTests : public testing::Test {
   fs::path fake_directory_;
 
   void SetUp() override {
+    initializeFilesystemAPILocale();
     fake_directory_ = createMockFileStructure();
   }
 
@@ -675,26 +676,28 @@ TEST_F(FileOpsTests, test_glob) {
   }
 
   {
-    std::vector<fs::path> expected{fake_directory_ / "deep1/",
-                                   fake_directory_ / "deep11/",
-                                   fake_directory_ / "door.txt",
-                                   fake_directory_ / "root.txt",
-                                   fake_directory_ / "root2.txt",
-                                   fake_directory_ / "roto.txt",
-                                   fake_directory_ / "toplevel/"};
+    std::vector<fs::path> expected{
+        fake_directory_ / "deep1/",
+        fake_directory_ / "deep11/",
+        fake_directory_ / "door.txt",
+        fake_directory_ / "root.txt",
+        fake_directory_ / "root2.txt",
+        fake_directory_ / "roto.txt",
+        fake_directory_ / kTopLevelMockFolderName / "/"};
     auto result = platformGlob((fake_directory_ / "*").string());
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{fake_directory_ / "deep1/deep2/",
-                                   fake_directory_ / "deep1/level1.txt",
-                                   fake_directory_ / "deep11/deep2/",
-                                   fake_directory_ / "deep11/level1.txt",
-                                   fake_directory_ / "deep11/not_bash",
-                                   fake_directory_ / "toplevel/secondlevel1/",
-                                   fake_directory_ / "toplevel/secondlevel2/",
-                                   fake_directory_ / "toplevel/secondlevel3/"};
+    std::vector<fs::path> expected{
+        fake_directory_ / "deep1/deep2/",
+        fake_directory_ / "deep1/level1.txt",
+        fake_directory_ / "deep11/deep2/",
+        fake_directory_ / "deep11/level1.txt",
+        fake_directory_ / "deep11/not_bash",
+        fake_directory_ / kTopLevelMockFolderName / "secondlevel1/",
+        fake_directory_ / kTopLevelMockFolderName / "secondlevel2/",
+        fake_directory_ / kTopLevelMockFolderName / "secondlevel3/"};
     auto result = platformGlob((fake_directory_ / "*" / "*").string());
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
@@ -704,7 +707,7 @@ TEST_F(FileOpsTests, test_glob) {
         fake_directory_ / "deep1/deep2/level2.txt",
         fake_directory_ / "deep11/deep2/deep3/",
         fake_directory_ / "deep11/deep2/level2.txt",
-        fake_directory_ / "toplevel/secondlevel3/thirdlevel1/",
+        fake_directory_ / kTopLevelMockFolderName / "secondlevel3/thirdlevel1/",
     };
     auto result = platformGlob((fake_directory_ / "*/*/*").string());
     EXPECT_TRUE(globResultsMatch(result, expected));

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -23,9 +23,7 @@
 #include <osquery/core/system.h>
 #include <osquery/logger/logger.h>
 #include <osquery/process/process.h>
-
 #include <osquery/utils/info/platform_type.h>
-
 #include <osquery/filesystem/mock_file_structure.h>
 
 // Some proc* functions are only compiled when building on linux
@@ -42,6 +40,15 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
+namespace {
+
+const std::vector<std::string> kFileNameList{
+    "辞書.txt",
+    "test_file.txt",
+};
+
+}
+
 DECLARE_uint64(read_max);
 
 class FilesystemTests : public testing::Test {
@@ -50,6 +57,8 @@ class FilesystemTests : public testing::Test {
   fs::path fake_directory_;
 
   void SetUp() override {
+    initializeFilesystemAPILocale();
+
     fake_directory_ = fs::canonical(createMockFileStructure());
     test_working_dir_ =
         fs::temp_directory_path() /
@@ -93,84 +102,94 @@ class FilesystemTests : public testing::Test {
 };
 
 TEST_F(FilesystemTests, test_read_file) {
-  std::ofstream test_file((test_working_dir_ / "fstests-file").string());
-  test_file.write("test123\n", sizeof("test123"));
-  test_file.close();
+  for (const auto& file_name : kFileNameList) {
+    auto file_path = test_working_dir_ / file_name;
 
-  std::string content;
-  auto s = readFile(test_working_dir_ / "fstests-file", content);
+    std::ofstream test_file(file_path.string());
+    test_file.write("test123\n", sizeof("test123"));
+    test_file.close();
 
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(content, "test123" + line_ending_);
+    std::string content;
+    auto s = readFile(file_path, content);
 
-  removePath(test_working_dir_ / "fstests-file");
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(s.toString(), "OK");
+    EXPECT_EQ(content, "test123" + line_ending_);
+
+    removePath(file_path);
+  }
 }
 
 TEST_F(FilesystemTests, test_remove_path) {
-  auto test_dir = test_working_dir_ / "rmdir";
-  fs::create_directories(test_dir);
+  for (const auto& file_name : kFileNameList) {
+    auto test_dir = test_working_dir_ / file_name;
+    fs::create_directories(test_dir);
 
-  auto test_file = test_working_dir_ / "rmdir/rmfile";
-  writeTextFile(test_file, "testcontent");
+    auto test_file = test_working_dir_ / file_name / "rmfile";
+    writeTextFile(test_file, "testcontent");
 
-  ASSERT_TRUE(pathExists(test_file).ok());
+    ASSERT_TRUE(pathExists(test_file).ok());
 
-  // Try to remove the directory.
-  EXPECT_TRUE(removePath(test_dir));
-  EXPECT_FALSE(pathExists(test_file).ok());
-  EXPECT_FALSE(pathExists(test_dir).ok());
+    // Try to remove the directory.
+    EXPECT_TRUE(removePath(test_dir));
+    EXPECT_FALSE(pathExists(test_file).ok());
+    EXPECT_FALSE(pathExists(test_dir).ok());
+  }
 }
 
 TEST_F(FilesystemTests, test_write_file) {
-  auto test_file = test_working_dir_ / "fstests-file2";
-  std::string content(2048, 'A');
+  for (const auto& file_name : kFileNameList) {
+    auto test_file = test_working_dir_ / file_name;
+    std::string content(2048, 'A');
 
-  EXPECT_TRUE(writeTextFile(test_file, content).ok());
-  ASSERT_TRUE(pathExists(test_file).ok());
-  ASSERT_TRUE(isWritable(test_file).ok());
-  ASSERT_TRUE(removePath(test_file).ok());
+    EXPECT_TRUE(writeTextFile(test_file, content).ok());
+    ASSERT_TRUE(pathExists(test_file).ok());
+    ASSERT_TRUE(isWritable(test_file).ok());
+    ASSERT_TRUE(removePath(test_file).ok());
 
-  EXPECT_TRUE(writeTextFile(test_file, content, 0400));
-  ASSERT_TRUE(pathExists(test_file).ok());
+    EXPECT_TRUE(writeTextFile(test_file, content, 0400));
+    ASSERT_TRUE(pathExists(test_file).ok());
 
-  // On POSIX systems, root can still read/write.
-  EXPECT_FALSE(isWritable(test_file).ok());
-  EXPECT_TRUE(isReadable(test_file).ok());
-  ASSERT_TRUE(removePath(test_file).ok());
+    // On POSIX systems, root can still read/write.
+    EXPECT_FALSE(isWritable(test_file).ok());
+    EXPECT_TRUE(isReadable(test_file).ok());
+    ASSERT_TRUE(removePath(test_file).ok());
 
-  EXPECT_TRUE(writeTextFile(test_file, content, 0000));
-  ASSERT_TRUE(pathExists(test_file).ok());
+    EXPECT_TRUE(writeTextFile(test_file, content, 0000));
+    ASSERT_TRUE(pathExists(test_file).ok());
 
-  // On POSIX systems, root can still read/write.
-  EXPECT_FALSE(isWritable(test_file).ok());
-  EXPECT_FALSE(isReadable(test_file).ok());
-  ASSERT_TRUE(removePath(test_file).ok());
+    // On POSIX systems, root can still read/write.
+    EXPECT_FALSE(isWritable(test_file).ok());
+    EXPECT_FALSE(isReadable(test_file).ok());
+    ASSERT_TRUE(removePath(test_file).ok());
+  }
 }
 
 TEST_F(FilesystemTests, test_readwrite_file) {
-  auto test_file = test_working_dir_ / "fstests-file3";
-  size_t filesize = 4096 * 10;
+  for (const auto& file_name : kFileNameList) {
+    auto test_file = test_working_dir_ / file_name;
+    size_t filesize = 4096 * 10;
 
-  std::string in_content(filesize, 'A');
-  EXPECT_TRUE(writeTextFile(test_file, in_content).ok());
-  ASSERT_TRUE(pathExists(test_file).ok());
-  ASSERT_TRUE(isReadable(test_file).ok());
+    std::string in_content(filesize, 'A');
+    EXPECT_TRUE(writeTextFile(test_file, in_content).ok());
+    ASSERT_TRUE(pathExists(test_file).ok());
+    ASSERT_TRUE(isReadable(test_file).ok());
 
-  // Now read the content back.
-  std::string out_content;
-  EXPECT_TRUE(readFile(test_file, out_content).ok());
-  EXPECT_EQ(filesize, out_content.size());
-  EXPECT_EQ(in_content, out_content);
-  removePath(test_file);
+    // Now read the content back.
+    std::string out_content;
+    EXPECT_TRUE(readFile(test_file, out_content).ok());
+    EXPECT_EQ(filesize, out_content.size());
+    EXPECT_EQ(in_content, out_content);
+    removePath(test_file);
 
-  // Now try to write outside of a 4k chunk size.
-  in_content = std::string(filesize + 1, 'A');
-  writeTextFile(test_file, in_content);
-  out_content.clear();
-  readFile(test_file, out_content);
-  EXPECT_EQ(in_content, out_content);
-  removePath(test_file);
+    // Now try to write outside of a 4k chunk size.
+    in_content = std::string(filesize + 1, 'A');
+    writeTextFile(test_file, in_content);
+    out_content.clear();
+    readFile(test_file, out_content);
+    EXPECT_EQ(in_content, out_content);
+    removePath(test_file);
+  }
 }
 
 TEST_F(FilesystemTests, test_read_limit) {
@@ -225,7 +244,7 @@ TEST_F(FilesystemTests, test_list_files_valid_directory) {
 
 TEST_F(FilesystemTests, test_intermediate_globbing_directories) {
   fs::path thirdLevelDir =
-      fs::path(fake_directory_) / "toplevel/%/thirdlevel1";
+      fs::path(fake_directory_) / kTopLevelMockFolderName / "%/thirdlevel1";
   std::vector<std::string> results;
   resolveFilePattern(thirdLevelDir, results);
   EXPECT_EQ(results.size(), 1U);

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -25,6 +25,7 @@
 #include <osquery/utils/config/default_paths.h>
 #include <osquery/utils/system/system.h>
 #include <osquery/core/shutdown.h>
+#include <osquery/filesystem/filesystem.h>
 
 DECLARE_string(flagfile);
 
@@ -343,6 +344,8 @@ void WINAPI ServiceMain(DWORD argc, LPSTR* argv) {
 } // namespace osquery
 
 int main(int argc, char* argv[]) {
+  osquery::initializeFilesystemAPILocale();
+
   SERVICE_TABLE_ENTRYA serviceTable[] = {
       {const_cast<CHAR*>(osquery::kServiceName.c_str()),
        static_cast<LPSERVICE_MAIN_FUNCTIONA>(osquery::ServiceMain)},

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -12,43 +12,81 @@
 
 #include <fstream>
 
+#include <osquery/filesystem/filesystem.h>
 #include <osquery/tests/integration/tables/helper.h>
 #include <osquery/utils/info/platform_type.h>
-
-#include <boost/filesystem.hpp>
 
 namespace osquery {
 namespace table_tests {
 
+namespace {
+
+const std::vector<std::string> kFileNameList{
+    // In order to test MBCS support, here's a japanese word
+    // that *should* mean "dictionary"
+    "辞書.txt"
+
+    "file-table-test.txt",
+};
+
+}
+
 class FileTests : public testing::Test {
  public:
-  boost::filesystem::path filepath;
+  boost::filesystem::path directory;
 
   virtual void SetUp() {
     setUpEnvironment();
-    auto directory =
+    initializeFilesystemAPILocale();
+
+    directory =
         boost::filesystem::temp_directory_path() /
         boost::filesystem::unique_path("test-integration-file-table.%%%%-%%%%");
+
     ASSERT_TRUE(boost::filesystem::create_directory(directory));
-    filepath = directory / boost::filesystem::path("file-table-test.txt");
-    {
-      auto fout = std::ofstream(filepath.native(), std::ios::out);
-      fout.open(filepath.string(), std::ios::out);
-      fout << "test";
+
+    for (const auto& file_name : kFileNameList) {
+      auto filepath = directory / boost::filesystem::path(file_name);
+
+      {
+        auto fout = std::ofstream(filepath.native(), std::ios::out);
+        fout.open(filepath.string(), std::ios::out);
+        fout << "test";
+      }
     }
   }
 
   virtual void TearDown() {
-    boost::filesystem::remove_all(filepath.parent_path());
+    boost::filesystem::remove_all(directory);
   }
 };
 
+boost::optional<std::size_t> getRowIndexForFileName(
+    const QueryData& data, const std::string& file_name) {
+  auto it = std::find_if(data.begin(),
+                         data.end(),
+
+                         [&](const Row& row) -> bool {
+                           if (row.count("filename") == 0) {
+                             return false;
+                           }
+
+                           return row.at("filename") == file_name;
+                         });
+
+  if (it == data.end()) {
+    return boost::none;
+  }
+
+  return std::distance(data.begin(), it);
+}
+
 TEST_F(FileTests, test_sanity) {
   std::string path_constraint =
-      (filepath.parent_path() / boost::filesystem::path("%.txt")).string();
+      (directory / boost::filesystem::path("%.txt")).string();
   QueryData data = execute_query("select * from file where path like \"" +
                                  path_constraint + "\"");
-  EXPECT_EQ(data.size(), 1ul);
+  EXPECT_EQ(data.size(), kFileNameList.size());
 
   ValidationMap row_map = {{"path", FileOnDisk},
                            {"directory", DirectoryOnDisk},
@@ -80,9 +118,27 @@ TEST_F(FileTests, test_sanity) {
   row_map["bsd_flags"] = NormalType;
 #endif
 
-  ASSERT_EQ(data[0]["path"], filepath.string());
-  ASSERT_EQ(data[0]["directory"], filepath.parent_path().string());
-  ASSERT_EQ(data[0]["filename"], filepath.filename().string());
+  for (const auto& test_file_name : kFileNameList) {
+    auto opt_index = getRowIndexForFileName(data, test_file_name);
+    ASSERT_TRUE(opt_index.has_value());
+
+    auto index = opt_index.value();
+    const auto& row = data.at(index);
+
+    auto expected_path = directory.string();
+
+#if WIN32
+    expected_path += "\\";
+#else
+    expected_path += "/";
+#endif
+
+    expected_path += test_file_name;
+
+    ASSERT_EQ(row.at("path"), expected_path);
+    ASSERT_EQ(row.at("directory"), directory.string());
+    ASSERT_EQ(row.at("filename"), test_file_name);
+  }
 
   validate_rows(data, row_map);
 


### PR DESCRIPTION
This PR adds a new function that sets the default locale to utf-8, fixing std::wstring -> std::string conversion issues in boost::filesystem::path and std::filesystem::path.

I have verified that this change should at least fix the following tables: chrome_extensions, hash, file.