### PR TITLE
Update the "new release" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Blueprint.md
+++ b/.github/ISSUE_TEMPLATE/Blueprint.md
@@ -1,6 +1,10 @@
 ---
 name: Blueprint
 about: You're planning on implementing a change
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Thank you for contributing to osquery! -->

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,6 +1,10 @@
 ---
 name: Bug Report
 about: Something is not working as expected
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Thank you for contributing to osquery! -->
@@ -33,4 +37,3 @@ osqueryi --line "SELECT version from osquery_info;"
 ### What did you expect to see?
 
 ### What did you see instead?
-

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,6 +1,10 @@
 ---
 name: Feature Request
 about: You want the team to implement a new feature
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Thank you for contributing to osquery! -->

--- a/.github/ISSUE_TEMPLATE/Free_Form.md
+++ b/.github/ISSUE_TEMPLATE/Free_Form.md
@@ -1,6 +1,10 @@
 ---
 name: Task
 about: A generic task or TODO item
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Thank you for contributing to osquery! -->
@@ -11,4 +15,3 @@ about: A generic task or TODO item
 Before you submit, are you sure there isn't a better template for you?
 This is mostly used by the core maintainer team to keep track of tasks.
 -->
-

--- a/.github/ISSUE_TEMPLATE/New_Release.md
+++ b/.github/ISSUE_TEMPLATE/New_Release.md
@@ -1,6 +1,10 @@
 ---
 name: New Release
 about: Checklist of Release actions
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Please only use this issue-type if you are creating a new release. -->
@@ -12,13 +16,13 @@ about: Checklist of Release actions
 ## Before creating a GitHub tag
 
 - [ ] Review the [milestones](https://github.com/osquery/osquery/milestones), move unfinished issues to the next release, close the milestone.
-- [ ] Update the `CHANGELOG.md`, review and merge the change.
-- [ ] Assure that testable packages are available for the `#core` channel on Slack.
-- [ ] Ask for a volunteer to make a GitHub tag.
-- [ ] Assure that the ChangeLog shows up in the [tag release notes](https://github.com/osquery/osquery/tags).
+- [ ] Ask for a Technical Steering Committee member to make a GitHub tag.
+- [ ] Assure that testable packages are available on the Releases page, and announce to the `#core` channel on Slack.
 
 ## After creating a GitHub tag
 
+- [ ] If the `CHANGELOG.md` hasn't already been updated, update it in a new Pull Request, review and merge it. It should reflect everything done up to the tagged version commit.
+- [ ] Assure that the ChangeLog shows up in the [tag release notes](https://github.com/osquery/osquery/tags).
 - [ ] Create packages and upload to S3 (for download use only).
 - [ ] Update the website with the new release and schema.
 - [ ] Publish the website changes.

--- a/.github/ISSUE_TEMPLATE/New_Release.md
+++ b/.github/ISSUE_TEMPLATE/New_Release.md
@@ -24,7 +24,9 @@ assignees: ''
 
 - [ ] If the `CHANGELOG.md` hasn't already been updated, update it in a new Pull Request, review and merge it. It should reflect everything done up to the tagged version commit.
 - [ ] Assure that the ChangeLog shows up in the [tag release notes](https://github.com/osquery/osquery/tags).
-- [ ] Create packages and upload to S3 (for download use only).
+
+## Promoting to Stable
+- [ ] Use [code signing workflow](https://github.com/osquery/osquery-codesign/actions/workflows/release-generator.yml) to build packages and upload to S3
 - [ ] Update the website with the new release and schema.
 - [ ] Publish the website changes.
 - [ ] Publish the new packages into the hosted repos.

--- a/.github/ISSUE_TEMPLATE/New_Release.md
+++ b/.github/ISSUE_TEMPLATE/New_Release.md
@@ -17,6 +17,7 @@ assignees: ''
 
 - [ ] Review the [milestones](https://github.com/osquery/osquery/milestones), move unfinished issues to the next release, close the milestone.
 - [ ] Ask for a Technical Steering Committee member to make a GitHub tag.
+- [ ] Trigger [code signing workflow](https://github.com/osquery/osquery-codesign/actions/workflows/release-generator.yml)
 - [ ] Assure that testable packages are available on the Releases page, and announce to the `#core` channel on Slack.
 
 ## After creating a GitHub tag

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,6 +1,10 @@
 ---
 name: Question
 about: You have a question about osquery
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Thank you for your interest in osquery! -->


### PR DESCRIPTION
This PR just updates the "New Release" issue template, specifically because we no longer post new tagged release binaries to Slack. They become available on the Releases page as build artifacts.

That change was mine. Then GitHub has updated the other templates with some additional hidden fields.