### PR TITLE
Fix a UUID typo in the `disk_encryption` table

### DIFF
--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -44,7 +44,7 @@ const std::string kEncryptionStatusNotEncrypted = "not encrypted";
 const std::string kDeviceNamePrefix = "/dev/";
 
 const std::set<std::string> kHardcodedDiskUUIDs = {
-    "EBC6C064-0000-11AA-AA11-00306543ECA",
+    "EBC6C064-0000-11AA-AA11-00306543ECAC",
     "64C0C6EB-0000-11AA-AA11-00306543ECAC",
     "C064EBC6-0000-11AA-AA11-00306543ECAC",
     "ec1c2ad9-b618-4ed6-bd8d-50f361c27507",


### PR DESCRIPTION
There's a constant `kHardcodedDiskUUIDs` that contains UUIDs of disks in macOS. One of them was clearly intended to be `EBC6C064-0000-11AA-AA11-00306543ECAC` indicating `Type: Personal Recovery User` but the last character of the string was truncated in a copy/paste long ago.

We haven't documented the provenance of these UUIDs, but, if you have enabled FileVault, run the command `diskutil apfs listusers /` and it outputs a list of `Cryptographic users` for that volume, which corresponds to the cryptographic keys. Each is identified by a UUID, and one of them is `EBC6C064-0000-11AA-AA11-00306543ECAC`.

Credit to @elopez for the discovery.