### PR TITLE
Fix SchedulerTests.test_scheduler_drift_accumulation flakyness

### DIFF
--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -9,13 +9,13 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/config/config.h>
+#include <osquery/core/shutdown.h>
 #include <osquery/core/system.h>
 #include <osquery/database/database.h>
+#include <osquery/dispatcher/scheduler.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry.h>
-
-#include <osquery/config/config.h>
-#include <osquery/dispatcher/scheduler.h>
 #include <osquery/sql/sqlite_util.h>
 #include <osquery/utils/system/time.h>
 
@@ -38,6 +38,7 @@ class SchedulerTests : public testing::Test {
   void TearDown() override {
     FLAGS_disable_logging = logging_;
     Config::get().reset();
+    resetShutdown();
   }
 
  private:


### PR DESCRIPTION
The test was not resetting the shutdown status,
which gets set everytime the scheduler does all the steps
it was requested to do.
Due to a recent change the scheduler was correctly
not executing queries anymore if the shutdown was requested.

This often caused very low execution time
and the test expecting at least 1ms drift was failing.

Fixes #7612 