### PR TITLE
Initialize users and groups services on all tests that need them

### DIFF
--- a/osquery/core/windows/global_users_groups_cache.h
+++ b/osquery/core/windows/global_users_groups_cache.h
@@ -13,16 +13,6 @@
 #include <osquery/system/usersgroups/windows/users_groups_cache.h>
 
 namespace osquery {
-
-namespace tables {
-class SystemsTablesTests;
-}
-
-namespace table_tests {
-class UsersTest;
-class groups;
-class UserGroups;
-} // namespace table_tests
 class GlobalUsersGroupsCache {
  public:
   /// Waits for the users cache to be initialized by the respective service
@@ -41,9 +31,7 @@ class GlobalUsersGroupsCache {
   static std::shared_ptr<GroupsCache> global_groups_cache_;
 
   friend class Initializer;
-  friend class osquery::tables::SystemsTablesTests;
-  friend class osquery::table_tests::UsersTest;
-  friend class osquery::table_tests::groups;
-  friend class osquery::table_tests::UserGroups;
+  friend void initUsersAndGroupsServices(bool, bool);
+  friend void deinitUsersAndGroupsServices(bool, bool);
 };
 } // namespace osquery

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -19,17 +19,16 @@
 #include <osquery/core/system.h>
 #include <osquery/core/tables.h>
 #include <osquery/database/database.h>
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry_factory.h>
 #include <osquery/sql/sql.h>
+#include <osquery/tests/test_util.h>
+#include <osquery/utils/info/platform_type.h>
 #ifdef OSQUERY_WINDOWS
-#include <osquery/core/windows/global_users_groups_cache.h>
-#include <osquery/system/usersgroups/windows/groups_service.h>
-#include <osquery/system/usersgroups/windows/users_service.h>
 #include <osquery/utils/conversions/windows/strings.h>
 #endif
-#include <osquery/utils/info/platform_type.h>
 
 namespace osquery {
 namespace tables {
@@ -44,28 +43,14 @@ class SystemsTablesTests : public testing::Test {
 
 #ifdef OSQUERY_WINDOWS
   static void SetUpTestSuite() {
-    // For the users and groups table we need to start services
-    // to fill up the caches
-    std::promise<void> users_cache_promise;
-    std::promise<void> groups_cache_promise;
-    GlobalUsersGroupsCache::global_users_cache_future_ =
-        users_cache_promise.get_future();
-    GlobalUsersGroupsCache::global_groups_cache_future_ =
-        groups_cache_promise.get_future();
-
-    Dispatcher::addService(std::make_shared<UsersService>(
-        std::move(users_cache_promise),
-        GlobalUsersGroupsCache::global_users_cache_));
-    Dispatcher::addService(std::make_shared<GroupsService>(
-        std::move(groups_cache_promise),
-        GlobalUsersGroupsCache::global_groups_cache_));
+    initUsersAndGroupsServices(true, true);
   }
 
   static void TearDownTestSuite() {
     Dispatcher::stopServices();
     Dispatcher::joinServices();
-    GlobalUsersGroupsCache::global_users_cache_->clear();
-    GlobalUsersGroupsCache::global_groups_cache_->clear();
+    deinitUsersAndGroupsServices(true, true);
+    Dispatcher::instance().resetStopping();
   }
 #endif
 };

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -8,7 +8,6 @@
 function(testsIntegrationTablesMain)
   generateTestsIntegrationTablesIntegrationtestshelper()
   generateTestsIntegrationTablesTestsTest()
-
 endfunction()
 
 function(generateTestsIntegrationTablesIntegrationtestshelper)
@@ -25,6 +24,7 @@ function(generateTestsIntegrationTablesIntegrationtestshelper)
     osquery_database
     osquery_sql
     osquery_utils
+    tests_helper
     thirdparty_boost
     thirdparty_googletest_headers
   )
@@ -144,7 +144,7 @@ function(generateTestsIntegrationTablesTestsTest)
     endif()
   endif()
 
-  if(OSQUERY_BUILD_AWS AND (DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_WINDOWS))
+  if(OSQUERY_BUILD_AWS AND(DEFINED PLATFORM_LINUX OR DEFINED PLATFORM_WINDOWS))
     list(APPEND source_files
       ec2_instance_metadata.cpp
       ec2_instance_tags.cpp
@@ -335,7 +335,6 @@ function(generateTestsIntegrationTablesTestsTest)
     )
 
     list(APPEND source_files ${platform_source_files})
-
   endif()
 
   add_osquery_executable(tests_integration_tables-test ${source_files})
@@ -357,10 +356,9 @@ function(generateTestsIntegrationTablesTestsTest)
 
   add_test(NAME tests_integration_tables-test COMMAND tests_integration_tables-test)
   set_tests_properties(
-        tests_integration_tables-test
-        PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
+    tests_integration_tables-test
+    PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
   )
-
 endfunction()
 
 testsIntegrationTablesMain()

--- a/tests/integration/tables/certificates.cpp
+++ b/tests/integration/tables/certificates.cpp
@@ -10,8 +10,9 @@
 // Sanity check integration test for certificates
 // Spec file: specs/macwin/certificates.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
-
+#include <osquery/tests/test_util.h>
 #include <osquery/utils/info/platform_type.h>
 
 namespace osquery {
@@ -22,6 +23,19 @@ class certificates : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
   }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(certificates, test_sanity) {

--- a/tests/integration/tables/chrome_extensions.cpp
+++ b/tests/integration/tables/chrome_extensions.cpp
@@ -10,7 +10,9 @@
 // Sanity check integration test for chrome_extensions
 // Spec file: specs/chrome_extensions.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 
 namespace osquery {
 namespace table_tests {
@@ -20,6 +22,19 @@ class chromeExtensions : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
   }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(chromeExtensions, test_sanity) {

--- a/tests/integration/tables/firefox_addons.cpp
+++ b/tests/integration/tables/firefox_addons.cpp
@@ -10,7 +10,9 @@
 // Sanity check integration test for firefox_addons
 // Spec file: specs/firefox_addons.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 
 namespace osquery {
 namespace table_tests {
@@ -20,6 +22,19 @@ class firefoxAddons : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
   }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(firefoxAddons, test_sanity) {

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -10,12 +10,10 @@
 // Sanity check integration test for groups
 // Spec file: specs/groups.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 #include <osquery/utils/info/platform_type.h>
-#ifdef OSQUERY_WINDOWS
-#include <osquery/core/windows/global_users_groups_cache.h>
-#include <osquery/system/usersgroups/windows/groups_service.h>
-#endif
 
 namespace osquery {
 namespace table_tests {
@@ -28,21 +26,13 @@ class groups : public testing::Test {
 
 #ifdef OSQUERY_WINDOWS
   static void SetUpTestSuite() {
-    // For the groups table we need to start services
-    // to fill up the caches
-    std::promise<void> groups_cache_promise;
-    GlobalUsersGroupsCache::global_groups_cache_future_ =
-        groups_cache_promise.get_future();
-
-    Dispatcher::addService(std::make_shared<GroupsService>(
-        std::move(groups_cache_promise),
-        GlobalUsersGroupsCache::global_groups_cache_));
+    initUsersAndGroupsServices(false, true);
   }
 
   static void TearDownTestSuite() {
     Dispatcher::stopServices();
     Dispatcher::joinServices();
-    GlobalUsersGroupsCache::global_groups_cache_->clear();
+    deinitUsersAndGroupsServices(false, true);
     Dispatcher::instance().resetStopping();
   }
 #endif

--- a/tests/integration/tables/ssh_configs.cpp
+++ b/tests/integration/tables/ssh_configs.cpp
@@ -10,7 +10,9 @@
 // Sanity check integration test for ssh_configs
 // Spec file: specs/posix/ssh_configs.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 
 namespace osquery {
 namespace table_tests {
@@ -20,6 +22,19 @@ class sshConfigs : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
   }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(sshConfigs, test_sanity) {

--- a/tests/integration/tables/user_ssh_keys.cpp
+++ b/tests/integration/tables/user_ssh_keys.cpp
@@ -10,7 +10,9 @@
 // Sanity check integration test for user_ssh_keys
 // Spec file: specs/posix/user_ssh_keys.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 
 namespace osquery {
 namespace table_tests {
@@ -20,6 +22,19 @@ class userSshKeys : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
   }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(userSshKeys, test_sanity) {

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -12,13 +12,10 @@
 
 #include <string>
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 #include <osquery/utils/info/platform_type.h>
-
-#ifdef OSQUERY_WINDOWS
-#include <osquery/core/windows/global_users_groups_cache.h>
-#include <osquery/system/usersgroups/windows/users_service.h>
-#endif
 
 namespace osquery {
 namespace table_tests {
@@ -31,21 +28,13 @@ class UsersTest : public testing::Test {
 
 #ifdef OSQUERY_WINDOWS
   static void SetUpTestSuite() {
-    // For the users table we need to start services
-    // to fill up the caches
-    std::promise<void> users_cache_promise;
-    GlobalUsersGroupsCache::global_users_cache_future_ =
-        users_cache_promise.get_future();
-
-    Dispatcher::addService(std::make_shared<UsersService>(
-        std::move(users_cache_promise),
-        GlobalUsersGroupsCache::global_users_cache_));
+    initUsersAndGroupsServices(true, false);
   }
 
   static void TearDownTestSuite() {
     Dispatcher::stopServices();
     Dispatcher::joinServices();
-    GlobalUsersGroupsCache::global_users_cache_->clear();
+    deinitUsersAndGroupsServices(true, false);
     Dispatcher::instance().resetStopping();
   }
 #endif

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -71,4 +71,9 @@ ScheduledQuery getOsqueryScheduledQuery();
 // Helper function to generate all rows from a generator-based table.
 TableRows genRows(EventSubscriberPlugin* sub);
 
+#ifdef OSQUERY_WINDOWS
+void initUsersAndGroupsServices(bool init_users, bool init_groups);
+void deinitUsersAndGroupsServices(bool deinit_users, bool deinit_groups);
+#endif
+
 } // namespace osquery


### PR DESCRIPTION
Some of the tests making queries on tables that were
indirectly making use of the users and groups cached information
were sometimes failing because the needed services were not started.
This starts the appropriate services and makes sure to reset
the futures needed to access the cache, so that all the tests
that do not initialize the services on their own will fail,
instead of relying on a previous initialization.