### PR TITLE
Do not catch table or registry exceptions when running tests

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -117,6 +117,8 @@ DECLARE_bool(disable_database);
 DECLARE_bool(disable_events);
 DECLARE_bool(disable_logging);
 DECLARE_bool(enable_numeric_monitoring);
+DECLARE_bool(ignore_table_exceptions);
+DECLARE_bool(ignore_registry_exceptions);
 
 CLI_FLAG(bool, S, false, "Run as a shell process");
 CLI_FLAG(bool, D, false, "Run as a daemon process");
@@ -353,6 +355,14 @@ Initializer::Initializer(int& argc,
     // These values are force-set and ignore the configuration and CLI.
     FLAGS_disable_logging = true;
     FLAGS_disable_watchdog = true;
+  }
+
+  if (Flag::isDefault("ignore_table_exceptions")) {
+    FLAGS_ignore_table_exceptions = true;
+  }
+
+  if (Flag::isDefault("ignore_registry_exceptions")) {
+    FLAGS_ignore_registry_exceptions = true;
   }
 
   // Initialize registries and plugins

--- a/osquery/registry/registry_factory.cpp
+++ b/osquery/registry/registry_factory.cpp
@@ -22,7 +22,14 @@
 
 namespace osquery {
 
-HIDDEN_FLAG(bool, registry_exceptions, false, "Allow plugin exceptions");
+/* NOTE: the default is false, because it's easier to enable it in one place
+   when starting osquery, instead of having each test enable them,
+   so that they are seen and fixed. */
+HIDDEN_FLAG(bool,
+            ignore_registry_exceptions,
+            false,
+            "Ignore exceptions thrown by the registry. osquery and extensions "
+            "default to true.");
 
 RegistryFactory& RegistryFactory::get() {
   static RegistryFactory instance;
@@ -178,14 +185,14 @@ Status RegistryFactory::call(const std::string& registry_name,
   } catch (const std::exception& e) {
     LOG(ERROR) << registry_name << " registry " << item_name
                << " plugin caused exception: " << e.what();
-    if (FLAGS_registry_exceptions) {
+    if (!FLAGS_ignore_registry_exceptions) {
       throw;
     }
     return Status(1, e.what());
   } catch (...) {
     LOG(ERROR) << registry_name << " registry " << item_name
                << " plugin caused unknown exception";
-    if (FLAGS_registry_exceptions) {
+    if (!FLAGS_ignore_registry_exceptions) {
       throw std::runtime_error(registry_name + ": " + item_name + " failed");
     }
     return Status(2, "Unknown exception");

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -21,7 +21,7 @@
 
 namespace osquery {
 
-DECLARE_bool(table_exceptions);
+DECLARE_bool(ignore_table_exceptions);
 
 class VirtualTableTests : public testing::Test {
  public:
@@ -1219,15 +1219,15 @@ TEST_F(VirtualTableTests, test_table_exceptions) {
   attachTableInternal(
       "exceptional", exceptional->columnDefinition(false), dbc, false);
 
-  auto backup_flag = FLAGS_table_exceptions;
-  FLAGS_table_exceptions = false;
+  auto backup_flag = FLAGS_ignore_table_exceptions;
+  FLAGS_ignore_table_exceptions = true;
   {
     QueryData results;
     auto status = queryInternal("SELECT * FROM exceptional", results, dbc);
     EXPECT_FALSE(status.ok());
   }
 
-  FLAGS_table_exceptions = true;
+  FLAGS_ignore_table_exceptions = false;
   {
     EXPECT_THROW(
         {
@@ -1236,7 +1236,7 @@ TEST_F(VirtualTableTests, test_table_exceptions) {
         },
         std::runtime_error);
   }
-  FLAGS_table_exceptions = backup_flag;
+  FLAGS_ignore_table_exceptions = backup_flag;
 }
 
 } // namespace osquery

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -22,7 +22,7 @@
 
 namespace osquery {
 
-DECLARE_bool(registry_exceptions);
+DECLARE_bool(ignore_registry_exceptions);
 
 class FileEventSubscriber;
 
@@ -36,15 +36,15 @@ class FileEventsTableTests : public testing::Test {
     Config::get().reset();
 
     // Promote registry access exceptions when testing tables and SQL.
-    exceptions_ = FLAGS_registry_exceptions;
-    FLAGS_registry_exceptions = true;
+    exceptions_ = FLAGS_ignore_registry_exceptions;
+    FLAGS_ignore_registry_exceptions = false;
 
     // Setup configuration parsers for file paths accesses.
     Registry::get().registry("config_parser")->setUp();
   }
 
   void TearDown() override {
-    FLAGS_registry_exceptions = exceptions_;
+    FLAGS_ignore_registry_exceptions = exceptions_;
   }
 
  protected:

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -643,9 +643,9 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
         self.daemon = self._run_daemon({
             # The set of queries will hammer the daemon process.
             "disable_watchdog": True,
-            # Enable the 'hidden' flag "registry_exceptions" to prevent
+            # Enable the 'hidden' flag "ignore_registry_exceptions" to prevent
             # catching.
-            "registry_exceptions": True,
+            "ignore_registry_exceptions": False,
             "ephemeral": True,
             "disable_extensions": False,
         })


### PR DESCRIPTION
Change the table_exceptions and registry_exceptions flags
to ignore_table_exceptions and ignore_registry_exceptions,
also changing their default to false.
This way all the tests on tables will fail if an exception
is thrown during the querying of a table.

They will be set to true though, when the Initializer
is used to start an osquery or extension instance.

To further expand the reason for the change, catching those exceptions has hidden the issue fixed in PR https://github.com/osquery/osquery/pull/7620 because the tests were not actually failing, although in the CI log one could see that some of the tables were throwing the exceptions.

Changing them to true makes them enabled by default and impossible to forget to enable in a test; for production (osqueryd instance or extensions), we only need to change them to false in one place, if they are not being explicitly set by the user, and that's it.
