### PR TITLE
Fix system-info support for Unicode characters on Windows

### DIFF
--- a/osquery/core/system.h
+++ b/osquery/core/system.h
@@ -164,21 +164,6 @@ class Initializer : private boost::noncopyable {
 };
 
 /**
- * @brief Getter for a host's current hostname
- *
- * @return a string representing the host's current hostname
- */
-std::string getHostname();
-
-/**
- * @brief Getter for a host's fully qualified domain name
- *
- * @return a string representation of the hosts fully qualified domain name
- * if the host is joined to a domain, otherwise it simply returns the hostname
- */
-std::string getFqdn();
-
-/**
  * @brief Generate a new generic UUID
  *
  * @return a string containing a random UUID

--- a/osquery/utils/system/CMakeLists.txt
+++ b/osquery/utils/system/CMakeLists.txt
@@ -212,18 +212,21 @@ function(generateOsqueryUtilsSystem)
     thirdparty_googletest_headers
   )
 
+  set(public_header_files
+    system.h
+  )
+
   if(DEFINED PLATFORM_POSIX)
-    set(public_header_files
+    list(APPEND public_header_files
       posix/system.h
     )
-
   elseif(DEFINED PLATFORM_WINDOWS)
-    set(public_header_files
+      list(APPEND public_header_files
       windows/system.h
     )
   endif()
 
-  generateIncludeNamespace(osquery_utils_system_systemutils "osquery/utils/system" "FILE_ONLY" ${public_header_files})
+  generateIncludeNamespace(osquery_utils_system_systemutils "osquery/utils/system" "FULL_PATH" ${public_header_files})
 endfunction()
 
 function(generateOsqueryUtilsSystemUptime)

--- a/osquery/utils/system/posix/system.cpp
+++ b/osquery/utils/system/posix/system.cpp
@@ -8,3 +8,47 @@
  */
 
 #include "system.h"
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <osquery/utils/system/system.h>
+
+#include <boost/algorithm/string.hpp>
+
+namespace osquery {
+std::string getHostname() {
+  /* POSIX states that the maximum amount of bytes for a hostname is 255 bytes
+     though gethostname includes the null terminator too in the size. */
+  std::size_t max_size = 256;
+
+  std::vector<char> hostname(max_size, 0);
+  gethostname(hostname.data(), max_size);
+
+  std::string hostname_string(hostname.data());
+  boost::algorithm::trim(hostname_string);
+  return hostname_string;
+}
+
+std::string getFqdn() {
+  std::string fqdn_string = getHostname();
+
+  struct addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags = AI_CANONNAME;
+
+  struct addrinfo* res = nullptr;
+  if (getaddrinfo(fqdn_string.c_str(), nullptr, &hints, &res) == 0) {
+    if (res->ai_canonname != nullptr) {
+      fqdn_string = res->ai_canonname;
+    }
+  }
+  if (res != nullptr) {
+    freeaddrinfo(res);
+  }
+
+  return fqdn_string;
+}
+} // namespace osquery

--- a/osquery/utils/system/posix/system.h
+++ b/osquery/utils/system/posix/system.h
@@ -13,8 +13,8 @@
 #include <memory>
 #include <string>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/core/noncopyable.hpp>
+#include <boost/filesystem/path.hpp>
 #include <gtest/gtest_prod.h>
 #include <osquery/utils/info/tool_type.h>
 

--- a/osquery/utils/system/system.h
+++ b/osquery/utils/system/system.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <string>
+
+#ifdef OSQUERY_WINDOWS
+#include <osquery/utils/system/windows/system.h>
+#elif OSQUERY_POSIX
+#include <osquery/utils/system/posix/system.h>
+#endif
+
+namespace osquery {
+/**
+ * @brief Getter for a host's current hostname
+ *
+ * @return a string representing the host's current hostname
+ */
+std::string getHostname();
+
+/**
+ * @brief Getter for a host's fully qualified domain name
+ *
+ * @return a string representation of the hosts fully qualified domain name
+ * if the host is joined to a domain, otherwise it simply returns the hostname
+ */
+std::string getFqdn();
+} // namespace osquery

--- a/osquery/utils/system/windows/system.cpp
+++ b/osquery/utils/system/windows/system.cpp
@@ -7,4 +7,32 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/utils/system/system.h>
+#include "system.h"
+
+#include <osquery/utils/conversions/windows/strings.h>
+
+#include <vector>
+
+namespace osquery {
+std::string getHostname() {
+  DWORD size = 0;
+  if (0 == GetComputerNameW(nullptr, &size)) {
+    std::vector<WCHAR> computer_name(size, 0);
+    GetComputerNameW(computer_name.data(), &size);
+    return wstringToString(computer_name.data());
+  }
+
+  return {};
+}
+
+std::string getFqdn() {
+  DWORD size = 0;
+  if (0 == GetComputerNameExW(ComputerNameDnsFullyQualified, nullptr, &size)) {
+    std::vector<WCHAR> fqdn(size, 0);
+    GetComputerNameExW(ComputerNameDnsFullyQualified, fqdn.data(), &size);
+    return wstringToString(fqdn.data());
+  }
+
+  return {};
+}
+} // namespace osquery


### PR DESCRIPTION
- The computer_name and local_hostname columns where incorrectly
  truncating Unicode characters when the computer name contained them.
  Use the WinAPI to get the computer name instead of the POSIX one,
  which correctly supports Unicode.

- Minor cleanup on the getHostname implementation of Linux and macOS too,
  since POSIX guarantees the same max size.

On Windows this can be tested by:
1. Opening a Windows Powershell terminal (not Powershell core)
2. Run the following commands:
```
$computerName = Get-WmiObject Win32_ComputerSystem
$computerName.Rename("TEST-ƒ")
```
3. Reboot, then query `system_info` with osquery pre and post this patch
