### PR TITLE
Improve config parsing and osqueryfuzz-config performance

### DIFF
--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -564,7 +564,6 @@ class ConfigParserPlugin : public Plugin {
     return data_;
   }
 
- protected:
   /// Allow the config to request parser state resets.
   virtual void reset();
 

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -27,7 +27,7 @@ std::string lexical_cast<std::string, bool>(const bool& b) {
   ss << std::boolalpha << b;
   return ss.str();
 }
-}
+} // namespace boost
 
 namespace flags = GFLAGS_NAMESPACE;
 
@@ -228,5 +228,9 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
     }
     fprintf(stdout, "  %s\n", getDescription(flag.second->name).c_str());
   }
+}
+
+void Flag::resetCustomFlags() {
+  instance().custom_.clear();
 }
 } // namespace osquery

--- a/osquery/core/flags.h
+++ b/osquery/core/flags.h
@@ -138,6 +138,14 @@ class Flag : private boost::noncopyable {
                          bool external = false,
                          bool cli = false);
 
+  /**
+   * @brief Clear up the custom flags
+   * Currently used by the fuzzer targets to prevent
+   * the map size to increase indefinitely
+   *
+   */
+  static void resetCustomFlags();
+
  private:
   /// The container of all shell, CLI, and normal flags.
   std::map<std::string, FlagDetail> flags_;

--- a/osquery/main/harnesses/fuzz_config.cpp
+++ b/osquery/main/harnesses/fuzz_config.cpp
@@ -7,17 +7,48 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/config/config.h>
+#include <malloc.h>
 
+#include <chrono>
+
+#include <osquery/config/config.h>
+#include <osquery/core/flags.h>
 #include <osquery/main/harnesses/fuzz_utils.h>
+#include <osquery/registry/registry_factory.h>
+
+std::chrono::system_clock::time_point sample_start;
+osquery::PluginRef option_plugin;
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
-  return osquery::osqueryFuzzerInitialize(argc, argv);
+  sample_start = std::chrono::system_clock::now();
+  auto result = osquery::osqueryFuzzerInitialize(argc, argv);
+
+  option_plugin =
+      osquery::RegistryFactory::get().plugin("config_parser", "options");
+
+  if (option_plugin == nullptr) {
+    throw std::runtime_error("Options plugin not registered");
+  }
+
+  return result;
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string q((const char*)data, size);
   osquery::Config::get().update({{"fuzz", q}});
+
+  auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::system_clock::now() - sample_start)
+                     .count();
+
+  if (elapsed >= 5) {
+    auto config_parser_plugin =
+        std::dynamic_pointer_cast<osquery::ConfigParserPlugin>(option_plugin);
+    config_parser_plugin->reset();
+    osquery::Flag::instance().resetCustomFlags();
+    malloc_trim(0);
+    sample_start = std::chrono::system_clock::now();
+  }
 
   return 0;
 }


### PR DESCRIPTION
- Speed up config parsing in stripConfigComments by using string_view
  to avoid unnecessary and slow string copies

- Speed up osqueryfuzz-config by periodically resetting
  the custom flags map

- Lower the chances of an OOM by periodically resetting
  the options config parser state, since it grows incrementally
  each time it parses new options. Also call malloc_trim.

Related to #7634 
