### PR TITLE
Fix thrift server shutting down when dropping privileges

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -516,7 +516,8 @@ bool DropPrivileges::dropTo(uid_t uid, gid_t gid) {
     original_groups_ = (gid_t*)malloc(group_size_ * sizeof(gid_t));
     group_size_ = getgroups(group_size_, original_groups_);
   }
-  setgroups(1, &gid);
+
+  syscall(SYS_setgroups, 1, &gid);
 
   if (!setThreadEffective(uid, gid)) {
     (void)setegid(getgid());
@@ -532,7 +533,7 @@ bool DropPrivileges::dropTo(uid_t uid, gid_t gid) {
 
 void DropPrivileges::restoreGroups() {
   if (group_size_ > 0) {
-    setgroups(group_size_, original_groups_);
+    syscall(SYS_setgroups, group_size_, original_groups_);
     group_size_ = 0;
     free(original_groups_);
   }


### PR DESCRIPTION
This is a regression from last time we updated Thrift
and seems to affect only Linux.

Thrift had a patch to ignore the EINTR error
when waiting for connections.
This is because on Linux when dropping privileges
we call libc APIs to change user and groups
that require all threads to change credentials too.
The mechanism uses signals,
which interrupt other syscalls (like a poll) with EINTR.

Thrift has some limited retries for the EINTR case,
but it's pretty easy to hit.

Instead of patching Thrift it's possible to call
the underlying syscalls to change user and group
for a single thread, because the signaling mechanism
is implemented by the libc library only.
This was already partially done but missing
on a couple more function calls.

Fixes #7586
Fixes #7602 
