### PR TITLE
add linwin to list of supported PLATFORM_DIRS

### DIFF
--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -43,6 +43,7 @@ PLATFORM_DIRS = {
     "darwin": ["darwin"],
     "freebsd": ["freebsd"],
     "kernel": ["darwin"],
+    "linwin": ["linux", "windows"],
     "linux": ["linux"],
     "lldpd": ["linux"],
     "macwin": ["darwin", "windows"],


### PR DESCRIPTION
### Problem

The two tables `intel_me_info` and `secureboot` are being marked as available for all platforms, when it should only be on linux and windows ("linwin"). It is correctly marked as linwin, but the documentation is not generating correctly. 

This is because the `genwebsitejson.py` file does not contemplate linwin, so it just assumes every platform is supported.

This PR adds a linwin key to the PLATFORM_DIRS constant so that it will generate the correct tagging in the JSON.

### For broader consideration
Should we not have that try-catch statement? It allows for silent failures like this, if something happens in the future. I'm happy to make that change, if you think this is a good idea.