### PR TITLE
ignore spec/example.table when generating documentation

### DIFF
--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -138,6 +138,11 @@ def main(argc, argv):
 
     for subdir, dirs, files in os.walk(specs_dir):
         for filename in files:
+            # Skip the example spec in the spec/ dir.
+            # There is no actual example table in osquery so it should not be generated into the docs.
+            if filename.startswith("example.table"):
+                continue
+
             if filename.endswith(".table"):
                 full_path = os.path.join(subdir, filename)
                 metadata = generate_table_metadata(specs_dir, full_path)


### PR DESCRIPTION
### Problem
The `spec/example.table` file is being generated into a table in the schema documentation but this table does not exist. When someone tries to query the example table, they will get a no such table error. This is because the example spec is really intended as a template for contributors when they submit their own table. It is not intended for production users. 

This PR makes sure that the example.table spec is ignored when generating the documentation JSON.