### PR TITLE
fix std::bad_alloc on pci_devices on Apple Silicon macs

### DIFF
--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -63,5 +63,5 @@ QueryData genPCIDevices(QueryContext& context) {
   IOObjectRelease(it);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -19,13 +19,17 @@ void genPCIDevice(const io_service_t& device, QueryData& results) {
 
   // Get the device details
   CFMutableDictionaryRef details;
-  IORegistryEntryCreateCFProperties(
+  auto ret = IORegistryEntryCreateCFProperties(
       device, &details, kCFAllocatorDefault, kNilOptions);
-
+  if (ret != KERN_SUCCESS) {
+    return;
+  }
   r["pci_slot"] = getIOKitProperty(details, "pcidebug");
 
   auto compatible = getIOKitProperty(details, "compatible");
+
   auto properties = IOKitPCIProperties(compatible);
+
   r["vendor_id"] = properties.vendor_id;
   r["model_id"] = properties.model_id;
   r["pci_class"] = properties.pci_class;

--- a/osquery/utils/conversions/darwin/iokit.cpp
+++ b/osquery/utils/conversions/darwin/iokit.cpp
@@ -45,8 +45,11 @@ IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
 
   std::vector<std::string> vendor;
   boost::split(vendor, properties[prop_index++], boost::is_any_of(","));
+
   vendor_id = vendor[0].substr(3);
+  if (vendor.size() > 1) {
   model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
+  }
 
   if (properties[prop_index].find("pciclass") == 0) {
     // There is a class definition.

--- a/osquery/utils/conversions/darwin/iokit.cpp
+++ b/osquery/utils/conversions/darwin/iokit.cpp
@@ -45,10 +45,11 @@ IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
 
   std::vector<std::string> vendor;
   boost::split(vendor, properties[prop_index++], boost::is_any_of(","));
-
-  vendor_id = vendor[0].substr(3);
-  if (vendor.size() > 1) {
-    model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
+  if (!vendor.empty()) {
+    vendor_id = vendor[0].substr(3);
+    if (vendor.size() > 1) {
+      model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
+    }
   }
 
   if (properties[prop_index].find("pciclass") == 0) {

--- a/osquery/utils/conversions/darwin/iokit.cpp
+++ b/osquery/utils/conversions/darwin/iokit.cpp
@@ -15,10 +15,10 @@
 
 #include <osquery/utils/conversions/tryto.h>
 
-#include "iokit.h"
-#include "cfstring.h"
-#include "cfnumber.h"
 #include "cfdata.h"
+#include "cfnumber.h"
+#include "cfstring.h"
+#include "iokit.h"
 
 namespace osquery {
 
@@ -48,7 +48,7 @@ IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
 
   vendor_id = vendor[0].substr(3);
   if (vendor.size() > 1) {
-  model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
+    model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
   }
 
   if (properties[prop_index].find("pciclass") == 0) {


### PR DESCRIPTION
Sometimes querying `pci_devices` on Apple Silicon macs would result in `std::bad_alloc`. 
The way to trigger this would be `select * from pci_devices` in quick succession (about 10ish times). This was because we were not doing bounds check on a vector