### PR TITLE
Describe user-context-related caveat for screenlock table

### DIFF
--- a/specs/darwin/screenlock.table
+++ b/specs/darwin/screenlock.table
@@ -1,5 +1,5 @@
 table_name("screenlock")
-description("macOS screenlock status for the current logged in user context.")
+description("macOS screenlock status. Note: only fetches results for osquery's current logged-in user context. The user must also have recently logged in.")
 schema([
     Column("enabled", INTEGER, "1 If a password is required after sleep or the screensaver begins; else 0"),
     Column("grace_period", INTEGER, "The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake"),


### PR DESCRIPTION
### Problem
Since Apple locked down the screenlock data, Kollide and osquery implemented a workaround (https://www.kolide.com/blog/how-kolide-built-its-macos-screenlock-check). The screenlock table is only for the current user context, but the table spec did not add the user_data=True attribute to reflect it. This PR adds that attribute.