### PR TITLE
add language around arm/M1 in affected tables

### DIFF
--- a/specs/darwin/battery.table
+++ b/specs/darwin/battery.table
@@ -1,5 +1,5 @@
 table_name("battery")
-description("Provides information about the internal battery of a Macbook.")
+description("Provides information about the internal battery of a Macbook. Warning: behaves differently on Intel vs. Apple Silicon.")
 schema([
     Column("manufacturer", TEXT, "The battery manufacturer's name"),
     Column("manufacture_date", INTEGER, "The date the battery was manufactured UNIX Epoch"),

--- a/specs/darwin/fan_speed_sensors.table
+++ b/specs/darwin/fan_speed_sensors.table
@@ -1,5 +1,5 @@
 table_name("fan_speed_sensors")
-description("Fan speeds. Warning: inconsistent data from Apple Silicon.")
+description("Fan speeds. Warning: behaves differently on Intel vs. Apple Silicon.")
 schema([
     Column("fan", TEXT, "Fan number"),
     Column("name", TEXT, "Fan name"),

--- a/specs/darwin/fan_speed_sensors.table
+++ b/specs/darwin/fan_speed_sensors.table
@@ -1,5 +1,5 @@
 table_name("fan_speed_sensors")
-description("Fan speeds.")
+description("Fan speeds. Warning: inconsistent data from Apple Silicon.")
 schema([
     Column("fan", TEXT, "Fan number"),
     Column("name", TEXT, "Fan name"),

--- a/specs/darwin/temperature_sensors.table
+++ b/specs/darwin/temperature_sensors.table
@@ -1,5 +1,5 @@
 table_name("temperature_sensors")
-description("Machine's temperature sensors. Warning: inconsistent data from Apple Silicon.")
+description("Machine's temperature sensors. Warning: behaves differently on Intel vs. Apple Silicon.")
 schema([
     Column("key", TEXT, "The SMC key on macOS", index=True),
     Column("name", TEXT, "Name of temperature source"),

--- a/specs/darwin/temperature_sensors.table
+++ b/specs/darwin/temperature_sensors.table
@@ -1,5 +1,5 @@
 table_name("temperature_sensors")
-description("Machine's temperature sensors.")
+description("Machine's temperature sensors. Warning: inconsistent data from Apple Silicon.")
 schema([
     Column("key", TEXT, "The SMC key on macOS", index=True),
     Column("name", TEXT, "Name of temperature source"),

--- a/specs/kernel_info.table
+++ b/specs/kernel_info.table
@@ -1,5 +1,5 @@
 table_name("kernel_info")
-description("Basic active kernel information. Not available on ARM architectures.")
+description("Basic active kernel information. Not available on Apple Silicon.")
 schema([
   Column("version", TEXT, "Kernel version"),
   Column("arguments", TEXT, "Kernel arguments"),

--- a/specs/kernel_info.table
+++ b/specs/kernel_info.table
@@ -1,5 +1,5 @@
 table_name("kernel_info")
-description("Basic active kernel information.")
+description("Basic active kernel information. Not available on ARM architectures.")
 schema([
   Column("version", TEXT, "Kernel version"),
   Column("arguments", TEXT, "Kernel arguments"),

--- a/specs/platform_info.table
+++ b/specs/platform_info.table
@@ -1,5 +1,5 @@
 table_name("platform_info")
-description("Information about EFI/UEFI/ROM and platform/boot.")
+description("Information about EFI/UEFI/ROM and platform/boot. Not available on ARM architectures.")
 schema([
     Column("vendor", TEXT, "Platform code vendor"),
     Column("version", TEXT, "Platform code version"),

--- a/specs/platform_info.table
+++ b/specs/platform_info.table
@@ -1,5 +1,5 @@
 table_name("platform_info")
-description("Information about EFI/UEFI/ROM and platform/boot. Not available on ARM architectures.")
+description("Information about EFI/UEFI/ROM and platform/boot. Not available on Apple Silicon.")
 schema([
     Column("vendor", TEXT, "Platform code vendor"),
     Column("version", TEXT, "Platform code version"),

--- a/specs/posix/acpi_tables.table
+++ b/specs/posix/acpi_tables.table
@@ -1,5 +1,5 @@
 table_name("acpi_tables")
-description("Firmware ACPI functional table common metadata and content.")
+description("Firmware ACPI functional table common metadata and content. Not available on ARM architectures.")
 schema([
     Column("name", TEXT, "ACPI table name"),
     Column("size", INTEGER, "Size of compiled table data"),

--- a/specs/posix/acpi_tables.table
+++ b/specs/posix/acpi_tables.table
@@ -1,5 +1,5 @@
 table_name("acpi_tables")
-description("Firmware ACPI functional table common metadata and content. Not available on ARM architectures.")
+description("Firmware ACPI functional table common metadata and content. Not available on Apple Silicon.")
 schema([
     Column("name", TEXT, "ACPI table name"),
     Column("size", INTEGER, "Size of compiled table data"),

--- a/specs/posix/memory_array_mapped_addresses.table
+++ b/specs/posix/memory_array_mapped_addresses.table
@@ -1,5 +1,5 @@
 table_name("memory_array_mapped_addresses")
-description("Data associated for address mapping of physical memory arrays. Not available on ARM architectures.")
+description("Data associated for address mapping of physical memory arrays. Not available on Apple Silicon.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("memory_array_handle", TEXT,

--- a/specs/posix/memory_array_mapped_addresses.table
+++ b/specs/posix/memory_array_mapped_addresses.table
@@ -1,5 +1,5 @@
 table_name("memory_array_mapped_addresses")
-description("Data associated for address mapping of physical memory arrays.")
+description("Data associated for address mapping of physical memory arrays. Not available on ARM architectures.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("memory_array_handle", TEXT,

--- a/specs/posix/memory_arrays.table
+++ b/specs/posix/memory_arrays.table
@@ -1,5 +1,5 @@
 table_name("memory_arrays")
-description("Data associated with collection of memory devices that operate to form a memory address. Not available on ARM architectures.")
+description("Data associated with collection of memory devices that operate to form a memory address. Not available on Apple Silicon.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the array"),
     Column("location",  TEXT, "Physical location of the memory array"),

--- a/specs/posix/memory_arrays.table
+++ b/specs/posix/memory_arrays.table
@@ -1,5 +1,5 @@
 table_name("memory_arrays")
-description("Data associated with collection of memory devices that operate to form a memory address.")
+description("Data associated with collection of memory devices that operate to form a memory address. Not available on ARM architectures.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the array"),
     Column("location",  TEXT, "Physical location of the memory array"),

--- a/specs/posix/memory_device_mapped_addresses.table
+++ b/specs/posix/memory_device_mapped_addresses.table
@@ -1,5 +1,5 @@
 table_name("memory_device_mapped_addresses")
-description("Data associated for address mapping of physical memory devices.")
+description("Data associated for address mapping of physical memory devices. Not available on ARM architectures.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("memory_device_handle", TEXT,

--- a/specs/posix/memory_device_mapped_addresses.table
+++ b/specs/posix/memory_device_mapped_addresses.table
@@ -1,5 +1,5 @@
 table_name("memory_device_mapped_addresses")
-description("Data associated for address mapping of physical memory devices. Not available on ARM architectures.")
+description("Data associated for address mapping of physical memory devices. Not available on Apple Silicon.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("memory_device_handle", TEXT,

--- a/specs/posix/memory_devices.table
+++ b/specs/posix/memory_devices.table
@@ -1,5 +1,5 @@
 table_name("memory_devices")
-description("Physical memory device (type 17) information retrieved from SMBIOS. Not available on ARM architectures.")
+description("Physical memory device (type 17) information retrieved from SMBIOS. Not available on Apple Silicon.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure in SMBIOS"),
     Column("array_handle",  TEXT, "The memory array that the device is attached to"),

--- a/specs/posix/memory_devices.table
+++ b/specs/posix/memory_devices.table
@@ -1,5 +1,5 @@
 table_name("memory_devices")
-description("Physical memory device (type 17) information retrieved from SMBIOS.")
+description("Physical memory device (type 17) information retrieved from SMBIOS. Not available on ARM architectures.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure in SMBIOS"),
     Column("array_handle",  TEXT, "The memory array that the device is attached to"),

--- a/specs/posix/memory_error_info.table
+++ b/specs/posix/memory_error_info.table
@@ -1,5 +1,5 @@
 table_name("memory_error_info")
-description("Data associated with errors of a physical memory array. Not available on ARM architectures.")
+description("Data associated with errors of a physical memory array. Not available on Apple Silicon.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("error_type",  TEXT,

--- a/specs/posix/memory_error_info.table
+++ b/specs/posix/memory_error_info.table
@@ -1,5 +1,5 @@
 table_name("memory_error_info")
-description("Data associated with errors of a physical memory array.")
+description("Data associated with errors of a physical memory array. Not available on ARM architectures.")
 schema([
     Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
     Column("error_type",  TEXT,

--- a/specs/posix/oem_strings.table
+++ b/specs/posix/oem_strings.table
@@ -1,5 +1,5 @@
 table_name("oem_strings")
-description("OEM defined strings retrieved from SMBIOS.")
+description("OEM defined strings retrieved from SMBIOS. Not available on ARM architectures.")
 schema([
     Column("handle", TEXT, "Handle, or instance number, associated with the Type 11 structure"),
     Column("number", INTEGER, "The string index of the structure"),

--- a/specs/posix/oem_strings.table
+++ b/specs/posix/oem_strings.table
@@ -1,5 +1,5 @@
 table_name("oem_strings")
-description("OEM defined strings retrieved from SMBIOS. Not available on ARM architectures.")
+description("OEM defined strings retrieved from SMBIOS. Not available on Apple Silicon.")
 schema([
     Column("handle", TEXT, "Handle, or instance number, associated with the Type 11 structure"),
     Column("number", INTEGER, "The string index of the structure"),

--- a/specs/posix/smbios_tables.table
+++ b/specs/posix/smbios_tables.table
@@ -1,5 +1,5 @@
 table_name("smbios_tables")
-description("BIOS (DMI) structure common details and content. Not available on ARM architectures.")
+description("BIOS (DMI) structure common details and content. Not available on Apple Silicon.")
 schema([
     Column("number", INTEGER, "Table entry number"),
     Column("type", INTEGER, "Table entry type"),

--- a/specs/posix/smbios_tables.table
+++ b/specs/posix/smbios_tables.table
@@ -1,5 +1,5 @@
 table_name("smbios_tables")
-description("BIOS (DMI) structure common details and content.")
+description("BIOS (DMI) structure common details and content. Not available on ARM architectures.")
 schema([
     Column("number", INTEGER, "Table entry number"),
     Column("type", INTEGER, "Table entry type"),


### PR DESCRIPTION
### Problem
Some tables have been affected by the move to ARM architecture, esp. Apple's M-series chips. They will mysteriously return nothing or will return nonsense data. While we are figuring out how to fully solve/ adapt to these issues, I was thinking in the short run we ought to document which ones are affected to help potentially confused users. 

This PR proposes some language to add to the descriptions of affected tables. But I'm totally open to rewording/reframing or different approach! 

The tables that return info on Intel but not ARM (that I know of) are:
- acpi_tables
- memory_array_mapped_addresses
- memory_arrays
- memory_devices
- memory_device_mapped_addresses
- memory_error_info
- oem_strings
- smbios_tables
- kernel_info
- platform_info

Tables that are returning weird data (that I know of) are:
- fan_speed_sensors
- temperature_sensors
- battery

### Related
- https://github.com/osquery/osquery-site/issues/249
- https://github.com/osquery/osquery/issues/7627
- https://github.com/osquery/osquery/issues/7588
- https://github.com/osquery/osquery/issues/7481
- https://github.com/osquery/osquery/issues/6800