### PR TITLE
clarify browser_plugins table is referencing basically unsupported CNPAPI tech

### DIFF
--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -1,5 +1,5 @@
 table_name("browser_plugins")
-description("All C/NPAPI browser plugin details for the user context. C/NPAPI has been deprecated on all major browsers. To query for plugins on modern browsers, try: `chrome_extensions` `firefox_addons` `safari_extensions`.")
+description("All C/NPAPI browser plugin details for all users. C/NPAPI has been deprecated on all major browsers. To query for plugins on modern browsers, try: `chrome_extensions` `firefox_addons` `safari_extensions`.")
 schema([
     Column("uid", BIGINT, "The local user that owns the plugin",
       index=True),

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -1,5 +1,5 @@
 table_name("browser_plugins")
-description("All C/NPAPI browser plugin details for all users.")
+description("All C/NPAPI browser plugin details for the user context. C/NPAPI has been deprecated on all major browsers. To query for plugins on modern browsers, try: `chrome_extensions` `firefox_addons` `safari_extensions`.")
 schema([
     Column("uid", BIGINT, "The local user that owns the plugin",
       index=True),


### PR DESCRIPTION
### Problem
The naming of the table `browser_plugins` is pretty expansive. As a newbie, I thought I could just query it for everything! Turns out there are browser-specific tables and this table, despite it's name, references tech that is no longer supported across major browsers (https://en.wikipedia.org/wiki/NPAPI#Support). 

This PR adds some language around that to try alleviate the potential confusion and also communicate to the user that the CNPAPI is widely no longer supported. 

### Broader considerations
Maybe this is a first step towards getting rid of this table? 