### PR TITLE
Fix and document discovery queries behavior on distributed queries and add tests

### DIFF
--- a/docs/wiki/development/unit-tests.md
+++ b/docs/wiki/development/unit-tests.md
@@ -45,7 +45,7 @@ The above code is very simple. If you're unfamiliar with the syntax/concepts of 
 Each component of osquery you're working on has its own "CMakeLists.txt" file. For example, the _tables_ component (folder) has its own "CMakeLists.txt" file at [osquery/tables/CMakeLists.txt](https://github.com/osquery/osquery/blob/master/osquery/tables/CMakeLists.txt). The file that we're going to be modifying today is [osquery/CMakeLists.txt](https://github.com/osquery/osquery/tree/master/osquery/CMakeLists.txt). Edit that file to include the following content:
 
 ```CMake
-ADD_OSQUERY_TEST(example_test example_test.cpp)
+add_osquery_executable(example_test example_test.cpp)
 ```
 
 After you specify the test sources, add whatever libraries you have to link against and properly set the compiler flags, make sure you call `ADD_TEST` with your unit test. This registers it with CTest (CMake's test runner).

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -269,6 +269,9 @@ Status Distributed::acceptWork(const std::string& work) {
   }
 
   std::set<std::string> queries_to_run;
+
+  auto hasDiscoveryQueries = false;
+
   // Check for and run discovery queries first
   if (doc.doc().HasMember("discovery")) {
     const auto& queries = doc.doc()["discovery"];
@@ -285,6 +288,7 @@ Status Distributed::acceptWork(const std::string& work) {
         if (query.empty() || name.empty()) {
           return Status(1, "Distributed discovery query is not a string");
         }
+        hasDiscoveryQueries = true;
 
         SQL sql(query);
         if (!sql.getStatus().ok()) {
@@ -313,7 +317,7 @@ Status Distributed::acceptWork(const std::string& work) {
           return Status(1, "Distributed query is not a string");
         }
 
-        if (queries_to_run.empty() || queries_to_run.count(name)) {
+        if (!hasDiscoveryQueries || queries_to_run.count(name)) {
           setDatabaseValue(kDistributedQueries, name, query);
         }
       }

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -274,6 +274,11 @@ class Distributed {
    * Given a response from a distributed plugin, parse the results and enqueue
    * them in the internal state of the class
    *
+   * If the response contains one or more "discovery" queries, then only queries
+   * with the following criteria will be enqueued:
+   *  - The query has a corresponding "discovery" query.
+   *  - The corresponding "discovery" query returns one or more results.
+   *
    * @param work is the string from DistributedPlugin::getQueries
    * @return a Status indicating the success or failure of the operation
    */
@@ -340,5 +345,8 @@ class Distributed {
   FRIEND_TEST(DistributedTests, test_workflow);
   FRIEND_TEST(DistributedTests, test_run_queries_with_denylisted_query);
   FRIEND_TEST(DistributedTests, test_check_and_set_as_running);
+  FRIEND_TEST(DistributedTests, test_accept_work_basic);
+  FRIEND_TEST(DistributedTests, test_accept_work_with_discovery);
+  FRIEND_TEST(DistributedTests, test_accept_work_with_discovery_all_fail);
 };
 } // namespace osquery

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -274,10 +274,13 @@ class Distributed {
    * Given a response from a distributed plugin, parse the results and enqueue
    * them in the internal state of the class
    *
-   * If the response contains one or more "discovery" queries, then only queries
-   * with the following criteria will be enqueued:
-   *  - The query has a corresponding "discovery" query.
-   *  - The corresponding "discovery" query returns one or more results.
+   * Following is the behavior with respect to "discovery" queries in "work":
+   *  - If a query in "queries" has no corresponding query in "discovery",
+   *    then the distributed query is enqueued.
+   *  - If a discovery query in "discovery" returns one or more results,
+   *    then its corresponding distributed query in "queries" is enqueued.
+   *  - If a discovery query in "discovery" returns no results, then its
+   *    corresponding distributed query in "queries" is not enqueued.
    *
    * @param work is the string from DistributedPlugin::getQueries
    * @return a Status indicating the success or failure of the operation

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -198,15 +198,15 @@ TEST_F(DistributedTests, test_workflow) {
   auto dist = Distributed();
   auto s = dist.pullUpdates();
   ASSERT_TRUE(s.ok()) << s.getMessage();
-  EXPECT_EQ(s.toString(), "OK");
+  EXPECT_EQ(s.getMessage(), "OK");
 
   auto queries = dist.getPendingQueries();
 
   EXPECT_EQ(queries.size(), 2U);
   EXPECT_EQ(dist.results_.size(), 0U);
   s = dist.runQueries();
-  ASSERT_TRUE(s.ok());
-  EXPECT_EQ(s.toString(), "OK");
+  ASSERT_TRUE(s.ok()) << s.getMessage();
+  EXPECT_EQ(s.getMessage(), "OK");
 
   queries = dist.getPendingQueries();
   EXPECT_EQ(queries.size(), 0U);
@@ -341,5 +341,93 @@ TEST_F(DistributedTests, test_run_queries_with_denylisted_query) {
       getDatabaseValue(kDistributedRunningQueries, denylistedQueryKey, ts2);
   ASSERT_FALSE(status.ok()); // NotFound
   ASSERT_TRUE(ts2.empty());
+}
+
+TEST_F(DistributedTests, test_accept_work_basic) {
+  auto dist = Distributed();
+
+  const std::string work = R"json(
+{
+  "queries": {
+    "q1": "SELECT * FROM system_info;",
+    "q2": "SELECT * FROM osquery_info;"
+  }
+}
+)json";
+  auto s = dist.acceptWork(work);
+  ASSERT_TRUE(s.ok()) << s.getMessage();
+  const auto queries = dist.getPendingQueries();
+  ASSERT_EQ(queries.size(), 2);
+  for (const auto& queryName : queries) {
+    ASSERT_FALSE(queryName.compare("q1") && queryName.compare("q2"))
+        << queryName;
+    std::string actualQuery;
+    s = getDatabaseValue(kDistributedQueries, queryName, actualQuery);
+    ASSERT_TRUE(s.ok()) << s.getMessage();
+    std::string expectedQuery;
+    if (queryName.compare("q1") == 0) {
+      expectedQuery = "SELECT * FROM system_info;";
+    } else { // q2
+      expectedQuery = "SELECT * FROM osquery_info;";
+    }
+    EXPECT_EQ(actualQuery, expectedQuery);
+  }
+}
+
+TEST_F(DistributedTests, test_accept_work_with_discovery) {
+  auto dist = Distributed();
+
+  const std::string work = R"json(
+{
+  "queries": {
+    "q1": "SELECT * FROM system_info;",
+    "q2": "SELECT * FROM time;",
+    "q3": "SELECT * FROM osquery_info;"
+  },
+  "discovery": {
+    "q1": "SELECT 1;",
+    "q2": "SELECT 1 WHERE false;"
+  }
+}
+)json";
+  auto s = dist.acceptWork(work);
+  ASSERT_TRUE(s.ok()) << s.getMessage();
+
+  // Query q1 has a discovery query with > 0 results.
+  // Query q2 has a discovery query with 0 results, thus it won't be executed.
+  // Query q3 does not have a discovery query, thus it won't be executed.
+  const auto queries = dist.getPendingQueries();
+  ASSERT_EQ(queries.size(), 1);
+  auto queryName = queries[0];
+  EXPECT_EQ(queryName, "q1");
+  std::string actualQuery;
+  s = getDatabaseValue(kDistributedQueries, queryName, actualQuery);
+  ASSERT_TRUE(s.ok()) << s.getMessage();
+  EXPECT_EQ(actualQuery, "SELECT * FROM system_info;");
+}
+
+// Tests https://github.com/osquery/osquery/issues/5260.
+TEST_F(DistributedTests, test_accept_work_with_discovery_all_fail) {
+  auto dist = Distributed();
+
+  const std::string work = R"json(
+{
+  "queries": {
+    "q1": "SELECT * FROM system_info;",
+    "q2": "SELECT * FROM osquery_info;"
+  },
+  "discovery": {
+    "q1": "SELECT 1 WHERE false;",
+    "q2": "SELECT 1 WHERE false;"
+  }
+}
+)json";
+  auto s = dist.acceptWork(work);
+  ASSERT_TRUE(s.ok()) << s.getMessage();
+
+  // Both queries q1 and q2 have a discovery query with 0 results,
+  // thus they won't be executed.
+  const auto queries = dist.getPendingQueries();
+  ASSERT_EQ(queries.size(), 0);
 }
 } // namespace osquery


### PR DESCRIPTION
This PR fixes and attempts to document the discovery queries behavior in distributed queries.

The main change:
If a distributed query does not have its corresponding discovery query, then it will always be executed.
(Currently on `master` this is not the case, if there's at least one discovery query then all those distributed queries that do not have one defined are not executed at all.)

This PR also fixes #5260 and #7793 and adds some tests to `Distributed.acceptWork`.