### PR TITLE
Add support for Memory Available in Linux

### DIFF
--- a/osquery/tables/system/linux/memory_info.cpp
+++ b/osquery/tables/system/linux/memory_info.cpp
@@ -25,6 +25,7 @@ const std::string kMemInfoPath = {"/proc/meminfo"};
 const std::map<std::string, std::string> kMemInfoMap = {
     {"memory_total", "MemTotal:"},
     {"memory_free", "MemFree:"},
+    {"memory_available", "MemAvailable:"},
     {"buffers", "Buffers:"},
     {"cached", "Cached:"},
     {"swap_cached", "SwapCached:"},

--- a/specs/linux/memory_info.table
+++ b/specs/linux/memory_info.table
@@ -3,6 +3,7 @@ description("Main memory information in bytes.")
 schema([
     Column("memory_total",  BIGINT, "Total amount of physical RAM, in bytes"),
     Column("memory_free", BIGINT, "The amount of physical RAM, in bytes, left unused by the system"),
+    Column("memory_available", BIGINT, "The amount of physical RAM, in bytes, available for starting new applications, without swapping"),
     Column("buffers", BIGINT, "The amount of physical RAM, in bytes, used for file buffers"),
     Column("cached", BIGINT, "The amount of physical RAM, in bytes, used as cache memory"),
     Column("swap_cached", BIGINT, "The amount of swap, in bytes, used as cache memory"),

--- a/tests/integration/tables/memory_info.cpp
+++ b/tests/integration/tables/memory_info.cpp
@@ -35,6 +35,7 @@ TEST_F(memoryInfo, test_sanity) {
   // ValidationMap row_map = {
   //      {"memory_total", IntType}
   //      {"memory_free", IntType}
+  //      {"memory_available", IntType}
   //      {"buffers", IntType}
   //      {"cached", IntType}
   //      {"swap_cached", IntType}


### PR DESCRIPTION
This PR adds support for `memory_available` (`MemAvailable` in `/proc/meminfo`) for Linux.

Memory Available is the proper way to identify how much RAM is available to run new process without swapping in Linux according to [this kernel commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773)
