### PR TITLE
cmake: Add an option to enable or disable using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 include(cmake/globals.cmake)
 include(cmake/options.cmake)
+include(cmake/ccache.cmake)
 include(cmake/flags.cmake)
 include("${OSQUERY_INSTALL_DIRECTIVES}")
 
@@ -29,7 +30,6 @@ if(OSQUERY_TOOLCHAIN_SYSROOT AND NOT DEFINED PLATFORM_LINUX)
 endif()
 
 function(main)
-
   findClangFormat()
   findPythonExecutablePath()
   generateSpecialTargets()
@@ -48,7 +48,7 @@ function(main)
     endif()
   elseif(NOT DEFINED PLATFORM_WINDOWS)
     if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
-       NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       message(STATUS "Warning: the selected C or C++ compiler is not clang/clang++. Compilation may fail")
     endif()
   endif()
@@ -63,7 +63,7 @@ function(main)
 
     if(TARGET clang-tidy::clang-tidy)
       set(CMAKE_CXX_CLANG_TIDY
-          "${CLANG-TIDY_EXECUTABLE};${OSQUERY_CLANG_TIDY_CHECKS}"
+        "${CLANG-TIDY_EXECUTABLE};${OSQUERY_CLANG_TIDY_CHECKS}"
       )
     else()
       message(WARNING "clang-tidy: Disabled because it was not found")
@@ -153,6 +153,7 @@ function(importLibraries)
     string(REPLACE "," ";" platform_list "${platform_list}")
 
     list(FIND platform_list "${CMAKE_SYSTEM_NAME}" platform_index)
+
     if(platform_index EQUAL -1)
       continue()
     endif()

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,0 +1,18 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+if(OSQUERY_ENABLE_CCACHE)
+  find_program(ccache_command ccache)
+
+  if(NOT "${ccache_command}" STREQUAL "ccache_command-NOTFOUND")
+    message(STATUS "Found ccache: ${ccache_command}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${ccache_command}" CACHE FILEPATH "")
+    set(CMAKE_C_COMPILER_LAUNCHER "${ccache_command}" CACHE FILEPATH "")
+  else()
+    message(STATUS "Not found: ccache. Install it and put it into the PATH if you want to speed up partial builds.")
+  endif()
+endif()

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -61,30 +61,18 @@ endif()
 # Detect MSVC toolset version
 if(DEFINED PLATFORM_WINDOWS)
   detectMSVCToolsetVersion()
+
   if(NOT detectMSVCToolsetVersion_OUTPUT STREQUAL "")
     message(STATUS "MSVC toolset version: ${detectMSVCToolsetVersion_OUTPUT}")
     set(OSQUERY_MSVC_TOOLSET_VERSION ${detectMSVCToolsetVersion_OUTPUT})
   endif()
 endif()
 
-# Use ccache when available
-if(DEFINED PLATFORM_POSIX)
-  find_program(ccache_command ccache)
-
-  if(NOT "${ccache_command}" STREQUAL "ccache_command-NOTFOUND")
-    message(STATUS "Found ccache: ${ccache_command}")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${ccache_command}" CACHE FILEPATH "")
-    set(CMAKE_C_COMPILER_LAUNCHER "${ccache_command}" CACHE FILEPATH "")
-  else()
-    message(STATUS "Not found: ccache. Install it and put it into the PATH if you want to speed up partial builds.")
-  endif()
-
-endif()
-
 set(TEST_CONFIGS_DIR "${CMAKE_BINARY_DIR}/test_configs")
 
 # Cache variables
 set(PACKAGING_SYSTEM "" CACHE STRING "Packaging system to generate when building packages")
+
 if(DEFINED PLATFORM_WINDOWS)
   set(WIX_ROOT_FOLDER_PATH "" CACHE STRING "Root folder of the WIX installation")
 endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -45,6 +45,7 @@ function(detectOsqueryVersion)
   string(REPLACE "." ";" osquery_version_components "${osquery_version}")
 
   list(LENGTH osquery_version_components osquery_version_components_len)
+
   if(NOT osquery_version_components_len GREATER_EQUAL 3)
     message(FATAL_ERROR "Version should have at least 3 components (semvar).")
   endif()
@@ -71,6 +72,7 @@ option(OSQUERY_NO_DEBUG_SYMBOLS "Whether to build without debug symbols or not, 
 option(OSQUERY_BUILD_TESTS "Whether to enable and build tests or not")
 option(OSQUERY_BUILD_ROOT_TESTS "Whether to enable and build tests that require root access")
 
+# Sanitizers
 option(OSQUERY_ENABLE_ADDRESS_SANITIZER "Whether to enable Address Sanitizer")
 
 if(DEFINED PLATFORM_POSIX)
@@ -114,6 +116,10 @@ option(OSQUERY_ENABLE_FORMAT_ONLY "Configure CMake to format only, not build")
 # Unfortunately, due glog always enabling BUILD_TESTING, we have to force it off, so that tests won't be built
 overwrite_cache_variable("BUILD_TESTING" "BOOL" "OFF")
 
+if(DEFINED PLATFORM_POSIX)
+  option(OSQUERY_ENABLE_CCACHE "Whether to search ccache in the system and use it in the build" ON)
+endif()
+
 set(third_party_source_list "source;formula")
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" CACHE STRING "A list of paths containing CMake module files")
@@ -130,6 +136,7 @@ endif()
 # When building on macOS, make sure we are only building one architecture at a time
 if(PLATFORM_MACOS)
   list(LENGTH CMAKE_OSX_ARCHITECTURES osx_arch_count)
+
   if(osx_arch_count GREATER 1)
     message(FATAL_ERROR "The CMAKE_OSX_ARCHITECTURES setting can only contain one architecture at a time")
   endif()


### PR DESCRIPTION
Add OSQUERY_ENABLE_CCACHE CMake option, default to ON,
to enable or disable using ccache during the build.
