### PR TITLE
Add denylist mechanism to distributed queries

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -83,7 +83,7 @@ the next section on [logging](../deployment/logging.md), and the below configura
 itself has been running before the scheduled query will be executed. If the
 system is suspended or put to sleep the progression of time "freezes" and
 resumes when the system comes back online. For example a scheduled query with
-an interval of `84600`, or 24 hours, running on a laptop system could take
+an interval of `86400`, or 24 hours, running on a laptop system could take
 a few days before the query executes if the system is suspended at night.
 
 ## Query Packs

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -46,6 +46,7 @@ const std::string kEvents = "events";
 const std::string kCarves = "carves";
 const std::string kLogs = "logs";
 const std::string kDistributedQueries = "distributed";
+const std::string kDistributedRunningQueries = "distributed_running";
 
 const std::string kDbEpochSuffix = "epoch";
 const std::string kDbCounterSuffix = "counter";
@@ -57,7 +58,8 @@ const std::vector<std::string> kDomains = {kPersistentSettings,
                                            kEvents,
                                            kLogs,
                                            kCarves,
-                                           kDistributedQueries};
+                                           kDistributedQueries,
+                                           kDistributedRunningQueries};
 
 std::atomic<bool> kDBAllowOpen(false);
 std::atomic<bool> kDBInitialized(false);
@@ -499,6 +501,7 @@ Status initDatabasePluginForTesting() {
   FLAGS_disable_database = true;
   setDatabaseAllowOpen();
   initDatabasePlugin();
+  resetDatabase();
   return Status::success();
 }
 

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -52,7 +52,11 @@ extern const std::string kCarves;
 /// The key for the DB version
 extern const std::string kDbVersionKey;
 
+/// The "domain" where distributed queries are stored.
 extern const std::string kDistributedQueries;
+
+/// The "domain" where currently running distributed queries are stored.
+extern const std::string kDistributedRunningQueries;
 
 /// The running version of our database schema
 const int kDbCurrentVersion = 2;

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -35,6 +35,7 @@ void DistributedRunner::start() {
   while (!interrupted()) {
     dist.pullUpdates();
     dist.runQueries();
+    dist.cleanupExpiredRunningQueries();
 
     std::string accelerate_checkins_expire_str = "-1";
     Status status = getDatabaseValue(kPersistentSettings,

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -148,7 +148,7 @@ TEST_F(SchedulerTests, test_config_results_purge) {
   }
 
   // Update the timestamp to have run a week and a day ago.
-  query_time -= (84600 * (7 + 1));
+  query_time -= (86400 * (7 + 1));
   setDatabaseValue(
       kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
 

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -141,6 +141,15 @@ Status deserializeDistributedQueryResult(const rapidjson::Value& obj,
 Status deserializeDistributedQueryResultJSON(const std::string& json,
                                              DistributedQueryResult& r);
 
+/**
+ * @brief Checks whether the timestamp for a denylisted query has expired.
+ *
+ * @param timestamp the input timestamp
+ *
+ * @return Boolean set to true if the timestamp has expired.
+ */
+bool denylistedQueryTimestampExpired(const std::string& timestamp);
+
 class DistributedPlugin : public Plugin {
  public:
   /**
@@ -219,6 +228,9 @@ class Distributed {
   /// Default constructor
   Distributed() {}
 
+  /// Default destructor.
+  virtual ~Distributed() {}
+
   /// Retrieve queued queries from a remote server
   Status pullUpdates();
 
@@ -233,6 +245,9 @@ class Distributed {
 
   /// Process and execute queued queries
   Status runQueries();
+
+  /// Cleanup distributed queries marked as running that have expired.
+  Status cleanupExpiredRunningQueries();
 
   // Getter for ID of currently executing request
   static std::string getCurrentRequestId();
@@ -264,9 +279,31 @@ class Distributed {
   void addResult(const DistributedQueryResult& result);
 
   /**
+   * @brief Checks and sets whether the given query is marked as running.
+   *
+   * If the query is already marked as running, then it will return
+   * true if the current time is within the denylisting period
+   * (see FLAGS_distributed_denylist_duration), false otherwise.
+   * If the query is not marked as running, then it will mark it
+   * as such and return false.
+   *
+   * @param query the SQL query string
+   *
+   * @return whether the distributed query to run is considered denylisted.
+   */
+  bool checkAndSetAsRunning(const std::string& query);
+
+  /**
+   * @brief Sets a query as "not running anymore".
+   *
+   * @param query the SQL query string
+   */
+  void setAsNotRunning(const std::string& query);
+
+  /**
    * @brief Flush all of the collected results to the server
    */
-  Status flushCompleted();
+  virtual Status flushCompleted();
 
   // Setter for ID of currently executing request
   static void setCurrentRequestId(const std::string& cReqId);
@@ -279,5 +316,7 @@ class Distributed {
  private:
   friend class DistributedTests;
   FRIEND_TEST(DistributedTests, test_workflow);
+  FRIEND_TEST(DistributedTests, test_run_queries_with_denylisted_query);
+  FRIEND_TEST(DistributedTests, test_check_and_set_as_running);
 };
 } // namespace osquery

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -318,5 +318,6 @@ class Distributed {
   FRIEND_TEST(DistributedTests, test_workflow);
   FRIEND_TEST(DistributedTests, test_run_queries_with_denylisted_query);
   FRIEND_TEST(DistributedTests, test_check_and_set_as_running);
+  FRIEND_TEST(DistributedTests, test_run_queries_query_too_big);
 };
 } // namespace osquery

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -340,6 +340,5 @@ class Distributed {
   FRIEND_TEST(DistributedTests, test_workflow);
   FRIEND_TEST(DistributedTests, test_run_queries_with_denylisted_query);
   FRIEND_TEST(DistributedTests, test_check_and_set_as_running);
-  FRIEND_TEST(DistributedTests, test_run_queries_query_too_big);
 };
 } // namespace osquery

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -150,6 +150,21 @@ Status deserializeDistributedQueryResultJSON(const std::string& json,
  */
 bool denylistedQueryTimestampExpired(const std::string& timestamp);
 
+/**
+ * @brief Returns the SHA-256 hash of a query string.
+ *
+ * @param query the input query string
+ *
+ * @return String with the SHA256 hex digest.
+ */
+std::string hashQuery(const std::string& query);
+
+/**
+ * @brief Returns the configured duration for denylisting of
+ * distributed queries.
+ */
+uint64_t denylistDuration();
+
 class DistributedPlugin : public Plugin {
  public:
   /**
@@ -299,6 +314,13 @@ class Distributed {
    * @param query the SQL query string
    */
   void setAsNotRunning(const std::string& query);
+
+  /**
+   * @brief Sets a query key as "not running anymore".
+   *
+   * @param query the SQL query hash string
+   */
+  void setKeyAsNotRunning(const std::string& queryKey);
 
   /**
    * @brief Flush all of the collected results to the server

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <osquery/core/core.h>
@@ -22,6 +23,8 @@
 #include "osquery/sql/sqlite_util.h"
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/json/json.h>
+#include <osquery/utils/status/status.h>
+#include <osquery/utils/system/time.h>
 
 namespace osquery {
 
@@ -209,4 +212,126 @@ TEST_F(DistributedTests, test_workflow) {
   EXPECT_EQ(queries.size(), 0U);
   EXPECT_EQ(dist.results_.size(), 0U);
 }
+
+TEST_F(DistributedTests, test_check_and_set_as_running) {
+  auto dist = Distributed();
+
+  const auto denylistedQuery = "SELECT * FROM system_info;";
+  const auto denylisted = dist.checkAndSetAsRunning(denylistedQuery);
+  ASSERT_FALSE(denylisted);
+
+  std::string ts1;
+  auto status =
+      getDatabaseValue(kDistributedRunningQueries, denylistedQuery, ts1);
+  ASSERT_TRUE(status.ok());
+  ASSERT_FALSE(ts1.empty());
+
+  const auto denylisted2 = dist.checkAndSetAsRunning(denylistedQuery);
+  ASSERT_TRUE(denylisted2);
+
+  std::string ts2;
+  status = getDatabaseValue(kDistributedRunningQueries, denylistedQuery, ts2);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(ts1, ts2);
+
+  // Change timestamp of the the denylisted query so that it's now expired.
+  status = setDatabaseValue(kDistributedRunningQueries,
+                            denylistedQuery,
+                            std::to_string(getUnixTime() - 2 * 3600));
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  const auto denylisted3 = dist.checkAndSetAsRunning(denylistedQuery);
+  ASSERT_FALSE(denylisted3);
+
+  // Cleanup should cleanup the expired query.
+  status = dist.cleanupExpiredRunningQueries();
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  std::string ts3;
+  status = getDatabaseValue(kDistributedRunningQueries, denylistedQuery, ts3);
+  ASSERT_FALSE(status.ok()); // NotFound
+  ASSERT_TRUE(ts3.empty());
+}
+
+class DistributedMock : public Distributed {
+ public:
+  DistributedMock() : Distributed() {}
+  MOCK_METHOD0(flushCompleted, Status());
+};
+
+TEST_F(DistributedTests, test_run_queries_with_denylisted_query) {
+  auto dist = DistributedMock();
+  // flushCompleted is mocked to avoid sending results in
+  // Distributed.runQueries.
+  EXPECT_CALL(dist, flushCompleted).Times(2);
+
+  // Simulate a denylisted query by manually marking it as running.
+  const auto denylistedQuery = "SELECT * FROM osquery_info;";
+  const auto denylisted = dist.checkAndSetAsRunning(denylistedQuery);
+  ASSERT_FALSE(denylisted);
+
+  const std::string work = R"json(
+{
+  "queries": {
+    "q1": "SELECT * FROM osquery_info;",
+    "q2": "SELECT * FROM osquery_info WHERE version > '5.3.0';"
+  }
+}
+)json";
+  auto status = dist.acceptWork(work);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  status = dist.runQueries();
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  // Query q1 is denylisted, only query q2 ran.
+  ASSERT_EQ(dist.results_.size(), 2);
+  auto q1Idx = 0, q2Idx = 1;
+  if (dist.results_[0].request.id.compare("q2") == 0) {
+    q1Idx = 1;
+    q2Idx = 0;
+  }
+  EXPECT_FALSE(dist.results_[q1Idx].status.ok());
+  EXPECT_TRUE(dist.results_[q1Idx].results.empty());
+  EXPECT_EQ(dist.results_[q1Idx].status.getMessage(), "Denylisted");
+  EXPECT_EQ(dist.results_[q1Idx].message, "distributed query is denylisted");
+  EXPECT_TRUE(dist.results_[q2Idx].status.ok());
+  EXPECT_FALSE(dist.results_[q2Idx].results.empty());
+
+  // Manually clear results.
+  dist.results_.clear();
+
+  // Cleanup should not yet cleanup the denylisted query.
+  status = dist.cleanupExpiredRunningQueries();
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  std::string ts;
+  status = getDatabaseValue(kDistributedRunningQueries, denylistedQuery, ts);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  ASSERT_FALSE(ts.empty());
+
+  // Change timestamp of the the denylisted query so that it's now expired.
+  status = setDatabaseValue(kDistributedRunningQueries,
+                            denylistedQuery,
+                            std::to_string(getUnixTime() - 2 * 3600));
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+
+  // Query q1 should not by denylisted anymore.
+  auto s = dist.acceptWork(work);
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  status = dist.runQueries();
+  ASSERT_TRUE(status.ok()) << status.getMessage();
+  ASSERT_EQ(dist.results_.size(), 2);
+  EXPECT_TRUE(dist.results_[0].status.ok());
+  EXPECT_TRUE(dist.results_[0].request.id == "q1" ||
+              dist.results_[0].request.id == "q2");
+  EXPECT_TRUE(dist.results_[1].status.ok());
+  EXPECT_TRUE(dist.results_[1].request.id == "q1" ||
+              dist.results_[1].request.id == "q2");
+
+  // Query q1 should not be marked as denylisted anymore.
+  std::string ts2;
+  status = getDatabaseValue(kDistributedRunningQueries, denylistedQuery, ts2);
+  ASSERT_FALSE(status.ok()); // NotFound
+  ASSERT_TRUE(ts2.empty());
+}
+
 } // namespace osquery


### PR DESCRIPTION
Implements proposal #7658.

Am not sure about the default value for denylisting expiration, my guess is we could start with a default value of `1h`.

Apart from the added unit tests I manually tested this with Fleet, by running an expensive live query twice (first time to cause the watcher to kill the worker, second time to verify denylisting):
![Screen Shot 2022-07-06 at 09 00 25](https://user-images.githubusercontent.com/2073526/177547495-c8b26cab-d116-4c4a-a889-abff1d4214b9.png)
