### PR TITLE
Add table spec support for `COLLATE NOCASE`

### DIFF
--- a/osquery/core/sql/column.h
+++ b/osquery/core/sql/column.h
@@ -73,6 +73,7 @@ enum class ColumnOptions {
   /// This column should be hidden from '*'' selects.
   HIDDEN = 16,
 
+  // This sets the collating sequence to NOCASE
   COLLATENOCASE = 32,
 };
 

--- a/osquery/core/sql/column.h
+++ b/osquery/core/sql/column.h
@@ -72,6 +72,8 @@ enum class ColumnOptions {
 
   /// This column should be hidden from '*'' selects.
   HIDDEN = 16,
+
+  COLLATENOCASE = 32,
 };
 
 /// Treat column options as a set of flags.

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -269,6 +269,9 @@ std::string columnDefinition(const TableColumns& columns, bool is_extension) {
     if (options & ColumnOptions::HIDDEN) {
       statement += " HIDDEN";
     }
+    if (options & ColumnOptions::COLLATENOCASE) {
+      statement += " COLLATE NOCASE";
+    }
     if (i < columns.size() - 1) {
       statement += ", ";
     }

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -75,6 +75,7 @@ COLUMN_OPTIONS = {
     "required": "REQUIRED",
     "optimized": "OPTIMIZED",
     "hidden": "HIDDEN",
+    "collate_nocase": "COLLATENOCASE",
 }
 
 # Column options that render tables uncacheable.


### PR DESCRIPTION
Some of the data osquery conveys is case insensitive. Correctly working with this data requires either updating column definitions to set the collating sequence, or updating all sql queries to use case insensitive operations. I think it's reasonable for us to handle this correctly under the hood. (This is required background work for #7673)

This adds a column option of the form `collate_nocase=True`. To be honest, I'd prefer `collate="NOCASE"` -- it reads cleaner and has better future proofing. But that looks it would require deeper changes to how the autogeneration stuff works.

I'd love feedback
* `collate_nocase=True` or the larger work for `collate="NOCASE"` ?
* Other thoughts?

