### PR TITLE
carves: use full pathnames while creating an archive

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -28,7 +28,7 @@
 #include <osquery/utils/system/system.h>
 #include <osquery/utils/system/time.h>
 
-#include<boost/algorithm/string.hpp>
+#include <boost/algorithm/string.hpp>
 
 namespace fs = boost::filesystem;
 

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -241,6 +241,7 @@ std::set<fs::path> Carver::carveAll() {
     }
 
     PlatformFile dst(dstPath, PF_CREATE_NEW | PF_WRITE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
     if (!dst.isValid()) {
       VLOG(1) << "Destination temporary file is invalid: " << dstPath;
       continue;

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -28,6 +28,8 @@
 #include <osquery/utils/system/system.h>
 #include <osquery/utils/system/time.h>
 
+#include<boost/algorithm/string.hpp>
+
 namespace fs = boost::filesystem;
 
 namespace osquery {
@@ -236,10 +238,7 @@ std::set<fs::path> Carver::carveAll() {
     fs::path dstPath;
     if (srcPath.has_root_name()) {
       auto temp = srcPath.string();
-      auto colon_position = temp.find(':');
-      if (colon_position != std::string::npos) {
-        temp.erase(colon_position);
-      }
+      boost::erase_first(temp, ":");
       dstPath = carveDir_ / fs::path(temp);
     } else {
       dstPath = carveDir_ / srcPath;

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -233,7 +233,17 @@ std::set<fs::path> Carver::carveAll() {
       continue;
     }
 
-    const auto dstPath = carveDir_ / srcPath;
+    fs::path dstPath;
+    if (srcPath.has_root_name()) {
+      auto temp = srcPath.string();
+      auto colon_position = temp.find(':');
+      if (colon_position != std::string::npos) {
+        temp.erase(colon_position);
+      }
+      dstPath = carveDir_ / fs::path(temp);
+    } else {
+      dstPath = carveDir_ / srcPath;
+    }
     if (!fs::exists(dstPath.parent_path())) {
       auto ret = fs::create_directories(dstPath.parent_path());
       if (!ret) {

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -234,14 +234,16 @@ std::set<fs::path> Carver::carveAll() {
     }
 
     const auto dstPath = carveDir_ / srcPath;
-    auto ret = fs::create_directories(dstPath.parent_path());
-    if (!ret) {
-      VLOG(1) << "Failed to create directories for: " << dstPath.parent_path();
-      continue;
+    if (!fs::exists(dstPath.parent_path())) {
+      auto ret = fs::create_directories(dstPath.parent_path());
+      if (!ret) {
+        VLOG(1) << "Failed to create directories for: "
+                << dstPath.parent_path();
+        continue;
+      }
     }
 
     PlatformFile dst(dstPath, PF_CREATE_NEW | PF_WRITE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
     if (!dst.isValid()) {
       VLOG(1) << "Destination temporary file is invalid: " << dstPath;
       continue;

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -162,7 +162,8 @@ Status decompress(const boost::filesystem::path& in,
 }
 
 Status archive(const std::set<boost::filesystem::path>& paths,
-               const boost::filesystem::path& out, std::size_t block_size) {
+               const boost::filesystem::path& out,
+               std::size_t block_size) {
   auto arch = archive_write_new();
   if (arch == nullptr) {
     return Status(1, "Failed to create tar archive");
@@ -177,7 +178,7 @@ Status archive(const std::set<boost::filesystem::path>& paths,
     PlatformFile pFile(f, PF_OPEN_EXISTING | PF_READ);
 
     auto entry = archive_entry_new();
-    archive_entry_set_pathname(entry, f.leaf().string().c_str());
+    archive_entry_set_pathname(entry, f.string().c_str());
     archive_entry_set_size(entry, pFile.size());
     archive_entry_set_filetype(entry, AE_IFREG);
     archive_entry_set_perm(entry, 0644);


### PR DESCRIPTION
Fixes #7679 

Archives will now use full path names:

```
➜  scratch tar -tf helloworld.tar
/tmp/osquery_carve_f5613894-26e9-4c03-b171-411d5240e5b8/tmp/hello world.txt

➜  scratch tar -tf foo.tar
/tmp/osquery_carve_56c6dfe1-72f8-424e-99b5-8c6ff2395ed3/tmp/foo/foo 1/foo_random.data
/tmp/osquery_carve_56c6dfe1-72f8-424e-99b5-8c6ff2395ed3/tmp/foo/foo 2/foo_random.data
/tmp/osquery_carve_56c6dfe1-72f8-424e-99b5-8c6ff2395ed3/tmp/foo/foo 3/foo_random.data
```