### PR TITLE
Adds info on how to use GTEST_FILTER on windows

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -175,6 +175,13 @@ To run a single test, in verbose mode:
 ctest -R <test name> -C <RelWithDebInfo|Release|Debug> -V
 ```
 
+A "single" test case often still involves dozens or hundreds of unit tests. To run a single _unit test_, you can pass the [`GTEST_FILTER`](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#running-a-subset-of-the-tests) variable, for example:
+
+```PowerShell
+$Env:GTEST_FILTER='windowsEventLog.*'
+ctest -R tests_integration_tests_tables-test -C RelWithDebInfo -V #runs just the windowsEventLog under the integration tables tests
+```
+
 ### Run tests on Linux and macOS
 
 To run the tests and get just a summary report:


### PR DESCRIPTION
This PR updates the Windows test section under [building osquery](https://osquery.readthedocs.io/en/stable/development/building/) to explain how to use GTEST_FILTER on PowerShell.

Just documentation. It doesn't contain any code changes.