### PR TITLE
macos: `password_policy` table, use `-1` as sentinel value for `uid` column

### DIFF
--- a/osquery/tables/system/darwin/password_policy.cpp
+++ b/osquery/tables/system/darwin/password_policy.cpp
@@ -44,7 +44,7 @@ void genRowsFromPolicy(const CFDictionaryRef& policies,
   count = CFArrayGetCount((CFArrayRef)content);
   for (CFIndex i = 0; i < count; i++) {
     Row r;
-    r["uid"] = BIGINT(uid);
+    r["uid"] = uid.empty() ? BIGINT(-1) : BIGINT(uid);
     r["policy_content"] = getPropertiesFromDictionary(
         (CFDictionaryRef)CFArrayGetValueAtIndex((CFArrayRef)content, i),
         "policyContent");

--- a/specs/darwin/password_policy.table
+++ b/specs/darwin/password_policy.table
@@ -1,7 +1,7 @@
 table_name("password_policy")
 description("Password Policies for macOS.")
 schema([
-    Column("uid", BIGINT, "User ID for the policy if available", index=True),
+    Column("uid", BIGINT, "User ID for the policy, -1 for policies that are global", index=True),
     Column("policy_identifier", TEXT, "Policy Identifier"),
     Column("policy_content", TEXT, "Policy content"),
     Column("policy_description", TEXT, "Policy description"),


### PR DESCRIPTION
`uid` is now `-1` for global password policies.

Addresses #7688