### PR TITLE
Fix bug in GetHomeDirectories filesystem function

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -501,7 +501,9 @@ std::set<fs::path> getHomeDirectories() {
 
   auto users = SQL::selectAllFrom("users");
   for (const auto& user : users) {
-    if (user.at("directory").size() > 0) {
+    // First verify the user has a "directory" entry.
+    auto dir_iter = user.find("directory");
+    if (dir_iter != user.end() && user.at("directory").size() > 0) {
       results.insert(user.at("directory"));
     }
   }


### PR DESCRIPTION
The function did not check whether the `user` had a `directory` so for
systems that have a NULL directory for a single user, this function
throws and exception. This checks that the directory exists before
accessing it.