### PR TITLE
Add example for hostname form in curl_certificate table

### DIFF
--- a/specs/curl_certificate.table
+++ b/specs/curl_certificate.table
@@ -1,7 +1,7 @@
 table_name("curl_certificate")
 description("Inspect TLS certificates by connecting to input hostnames.")
 schema([
-    Column("hostname", TEXT, "Hostname (domain[:port]) to CURL", required=True),
+    Column("hostname", TEXT, "Hostname (domain[:port]) to CURL e.g osquery.io", required=True),
     Column("common_name", TEXT, "Common name of company issued to"),
     Column("organization", TEXT, "Organization issued to"),
     Column("organization_unit", TEXT, "Organization unit issued to"),


### PR DESCRIPTION
This makes it obvious the "form" of the hostname(which doesn't allow the protocol - http:/https to be included)

