### PR TITLE
Add `firmware_type` column to `platform_info` table on Windows.

### DIFF
--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -52,8 +52,10 @@ std::string getFirmwareType() {
     // the registry keys
     HKEY state_reg_key;
     auto success =
-        RegCreateKeyA(HKEY_LOCAL_MACHINE,
+        RegOpenKeyExA(HKEY_LOCAL_MACHINE,
                       "SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State",
+                      0,
+                      KEY_READ,
                       &state_reg_key);
 
     if (success != 0 && state_reg_key != INVALID_HANDLE_VALUE) {

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -69,12 +69,12 @@ std::string getFirmwareType() {
   }
 
   if (firmware_type == FirmwareType::Bios) {
-    return "Bios";
+    return "bios";
   } else if (firmware_type == FirmwareType::Uefi) {
-    return "Uefi";
+    return "uefi";
   }
 
-  return "Unknown";
+  return "unknown";
 }
 
 QueryData genPlatformInfo(QueryContext& context) {

--- a/specs/platform_info.table
+++ b/specs/platform_info.table
@@ -10,4 +10,7 @@ schema([
     Column("volume_size", INTEGER, "(Optional) size of firmware volume"),
     Column("extra", TEXT, "Platform-specific additional information"),
 ])
+extended_schema(WINDOWS, [
+    Column("firmware_type", TEXT, "The type of firmware (Uefi, Bios, Unknown).")
+])
 implementation("system@genPlatformInfo")


### PR DESCRIPTION
Tested on Windows 11 and Windows 7 VM's. Adds a column with the value for the firmware type of the system, with possible output values of:
- `Uefi`
- `Bios`
- `Unknown`