### PR TITLE
Improvements to osquery AWS logic

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -631,3 +631,17 @@ Comma separated list of tables to disable. By default no tables are disabled.
 `--enable_tables=table1,table2`
 
 Comma separated list of tables to enable. By default every table is enabled. If a specific table is set in both `--enable_tables` and `--disable_tables`, disabling take precedence. If `--enable_tables` is defined and `--disable_tables` is not set, every table but the one defined in `--enable_tables` become disabled.
+
+## AWS
+
+`--aws_imdsv2_request_attempts=3`
+
+How many attempts to do at requesting an IMDSv2 token. Such a token is retrieved from an AWS metadata service that might not always be accessible, and it's used by plugins like the loggers `AWS Kinesis`, `AWS Firehose` or the EC2 tables.
+
+`--aws_imdsv2_request_interval=3`
+
+Base seconds to wait between attempts at requesting an IMDSv2 token. Scales quadratically with the number of attempts.
+
+`--aws_disable_imdsv1_fallback=false`
+
+Whether to disable support for IMDSv1 and fail if an IMDSv2 token could not be retrieved

--- a/osquery/tables/cloud/aws/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/aws/ec2_instance_tags.cpp
@@ -25,9 +25,18 @@ namespace model = Aws::EC2::Model;
 
 QueryData genEc2InstanceTags(QueryContext& context) {
   QueryData results;
-  std::string instance_id, region;
-  getInstanceIDAndRegion(instance_id, region);
+
+  auto opt_instance_info = getInstanceIDAndRegion();
+
+  if (!opt_instance_info.has_value()) {
+    LOG(WARNING) << "Failed to retrieve region and instance id";
+    return results;
+  }
+
+  const auto& [instance_id, region] = *opt_instance_info;
+
   if (instance_id.empty() || region.empty()) {
+    LOG(WARNING) << "Instance id and region are empty, returning no results";
     return results;
   }
 


### PR DESCRIPTION
- Introduce the flag aws_imdsv2_request_attempts
  to specify how many attempts should be done
  to retrieve an IMDSv2 token to do a secure request.

- Introduce the flag aws_imdsv2_request_interval
  to specify the base seconds to wait between attempts,
  which scales quadratically with the number of attempts.

- Introduce the flag aws_disable_imdsv1_fallback
  which disables IMDSv1 as a fallback if the IMDSv2 token
  fails to be retrieved.

- Remove the automatic check to see if osquery
  is running on an EC2 instance.

- Improve the retrieval of instance id and region.
  If the retrieval keeps failing, don't cache empty values,
  keep retrying on next requests until it has success,
  then cache the values.

- Improve error message when STS credentials fail to be retrieved.
  The hardcoded error was hiding the true reason for the failure.