### PR TITLE
Have `--tls_dump` output body to `stderr`

### DIFF
--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -167,7 +167,7 @@ If your `--database_path` is `/var/osquery/osquery.db` then the backup is `/var/
 
 ### Inspecting TLS/HTTPS body request and responses
 
-When using the TLS-related plugins the hidden flag `--tls_dump` can be used with `--verbose`. This flag will print all of the HTTPS body content (usually JSON data) to `stdout`.
+When using the TLS-related plugins the hidden flag `--tls_dump` can be used with `--verbose`. This flag will print all of the HTTPS body content (usually JSON data) to `stderr`.
 
 ### Using event publishers and tables in the shell
 

--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -167,7 +167,7 @@ If your `--database_path` is `/var/osquery/osquery.db` then the backup is `/var/
 
 ### Inspecting TLS/HTTPS body request and responses
 
-When using the TLS-related plugins the hidden flag `--tls_dump` can be used with `--verbose`. This flag will print all of the HTTPS body content (usually JSON data) to `stderr`.
+When using the TLS-related plugins the hidden flag `--tls_dump` can be used with `--verbose`. This flag will print all of the HTTPS body content (usually JSON data) to `stdout`.
 
 ### Using event publishers and tables in the shell
 

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -67,7 +67,10 @@ HIDDEN_FLAG(bool,
             "Allow TLS server certificate trust failures");
 #endif
 
-HIDDEN_FLAG(bool, tls_dump, false, "Print remote requests and responses to stdout");
+HIDDEN_FLAG(bool,
+            tls_dump,
+            false,
+            "Print remote requests and responses to stdout");
 
 /// Undocumented feature to override TLS endpoints.
 HIDDEN_FLAG(bool, tls_node_api, false, "Use node key as TLS endpoints");

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -67,7 +67,7 @@ HIDDEN_FLAG(bool,
             "Allow TLS server certificate trust failures");
 #endif
 
-HIDDEN_FLAG(bool, tls_dump, false, "Print remote requests and responses");
+HIDDEN_FLAG(bool, tls_dump, false, "Print remote requests and responses to stdout");
 
 /// Undocumented feature to override TLS endpoints.
 HIDDEN_FLAG(bool, tls_node_api, false, "Use node key as TLS endpoints");

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -70,7 +70,7 @@ HIDDEN_FLAG(bool,
 HIDDEN_FLAG(bool,
             tls_dump,
             false,
-            "Print remote requests and responses to stdout");
+            "Print remote requests and responses to stderr");
 
 /// Undocumented feature to override TLS endpoints.
 HIDDEN_FLAG(bool, tls_node_api, false, "Use node key as TLS endpoints");
@@ -204,6 +204,10 @@ static auto getClient() {
   return client;
 }
 
+void printRawStderr(const std::string& s) {
+  fprintf(stderr, "%s\n", s.c_str());
+}
+
 Status TLSTransport::sendRequest() {
   if (destination_.find("https://") == std::string::npos) {
     return Status::failure(
@@ -222,7 +226,8 @@ Status TLSTransport::sendRequest() {
 
     const auto& response_body = response_.body();
     if (FLAGS_verbose && FLAGS_tls_dump) {
-      fprintf(stdout, "%s\n", response_body.c_str());
+      // Not using VLOG to avoid logging whole body to logging destination.
+      printRawStderr(response_body);
     }
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
@@ -256,7 +261,8 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
   VLOG(1) << "TLS/HTTPS " << ((verb == HTTP_POST) ? "POST" : "PUT")
           << " request to URI: " << destination_;
   if (FLAGS_verbose && FLAGS_tls_dump) {
-    fprintf(stdout, "%s\n", params.c_str());
+    // Not using VLOG to avoid logging whole body to logging destination.
+    printRawStderr(params);
   }
 
   try {
@@ -271,7 +277,8 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
 
     const auto& response_body = response_.body();
     if (FLAGS_verbose && FLAGS_tls_dump) {
-      fprintf(stdout, "%s\n", response_body.c_str());
+      // Not using VLOG to avoid logging whole body to logging destination.
+      printRawStderr(response_body);
     }
     response_status_ =
         serializer_->deserialize(response_body, response_params_);


### PR DESCRIPTION
This change now matches the documentation:

https://github.com/osquery/osquery/blob/3da346d218115556aa5640226f6ee6e000bf0e07/docs/wiki/deployment/debugging.md?plain=1#L199-L201