### PR TITLE
Add core to the type column description of osquery_extensions schema

### DIFF
--- a/specs/utility/osquery_extensions.table
+++ b/specs/utility/osquery_extensions.table
@@ -6,7 +6,7 @@ schema([
     Column("version", TEXT, "Extension's version"),
     Column("sdk_version", TEXT, "osquery SDK version used to build the extension"),
     Column("path", TEXT, "Path of the extension's Thrift connection or library path"),
-    Column("type", TEXT, "SDK extension type: extension or module")
+    Column("type", TEXT, "SDK extension type: core, extension or module")
 ])
 attributes(utility=True)
 implementation("osquery@genOsqueryExtensions")


### PR DESCRIPTION
Though the `type` column of the `osquery_extensions` table says the type can be only `module` or `extension`, it can be of the type `core` as well. This PR makes that clear in the schema definition.