### PR TITLE
Temporarily disable memory_devices integration test

### DIFF
--- a/tests/integration/tables/memory_devices.cpp
+++ b/tests/integration/tables/memory_devices.cpp
@@ -26,7 +26,7 @@ TEST_F(memoryDevices, test_sanity) {
   // 1. Query data
   auto const data = execute_query("select * from memory_devices");
   // 2. Check size before validation
-  ASSERT_GT(data.size(), 0ul);
+  // ASSERT_GT(data.size(), 0ul);
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map


### PR DESCRIPTION
This will fix CI for linux aarch64. The test must be changed to perform
proper validation, rather than a naive assumption that a memory device
row will always be present. The validation will require more updates
to the table code, so this is the temporary fix.
