### PR TITLE
Get raw battery max and current capacity on macOS

### DIFF
--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -169,13 +169,13 @@ BOOL genAdvancedBatteryInfo(Row& r) {
     r["designed_capacity"] = INTEGER(
         [[advancedBatteryInfo objectForKey:@"DesignCapacity"] intValue]);
   }
-  if ([advancedBatteryInfo objectForKey:@kIOPMPSMaxCapacityKey]) {
+  if ([advancedBatteryInfo objectForKey:@"AppleRawMaxCapacity"]) {
     r["max_capacity"] = INTEGER(
-        [[advancedBatteryInfo objectForKey:@kIOPMPSMaxCapacityKey] intValue]);
+        [[advancedBatteryInfo objectForKey:@"AppleRawMaxCapacity"] intValue]);
   }
-  if ([advancedBatteryInfo objectForKey:@kIOPMPSCurrentCapacityKey]) {
+  if ([advancedBatteryInfo objectForKey:@"AppleRawCurrentCapacity"]) {
     r["current_capacity"] = INTEGER([[advancedBatteryInfo
-        objectForKey:@kIOPMPSCurrentCapacityKey] intValue]);
+        objectForKey:@"AppleRawCurrentCapacity"] intValue]);
   }
   if ([advancedBatteryInfo objectForKey:@kIOPMPSAmperageKey]) {
     r["amperage"] = INTEGER(


### PR DESCRIPTION
Apple's x86 laptops report battery status in mAh but its ARM laptops use percent.
This commit uses an undocumented raw capacity field which reports mAh on both x86 and ARM laptops. I've tested on a 2022 M2 MacBook Pro and a 2012 i5 MacBook Pro, both running macOS 12. However, this needs more testing on more systems.

This will partially fix #6800 but will not fix the incorrect health column. I've spent a while trying to figure out how the Battery.prefPane and coconutBattery get correct results but so far I've only found that Battery.prefPane uses `IOPSCopyPowerSourcesByType(1)` then gets the `Battery Service State` field from the first battery, which does not exist for me