### PR TITLE
Increase mdfind query timeout to 30 seconds

### DIFF
--- a/osquery/tables/system/darwin/mdfind.mm
+++ b/osquery/tables/system/darwin/mdfind.mm
@@ -22,7 +22,7 @@ namespace tables {
 
 typedef std::pair<MDQueryRef, std::string> NamedQuery;
 
-const size_t kMaxQueryWait = 5;
+const size_t kMaxQueryWait = 30;
 
 void genResults(const std::vector<NamedQuery>& queries, QueryData& results) {
   // The results can update live from macOS so we stop subscribing to updates


### PR DESCRIPTION
The default of 5 seconds is quite low in general,
beyond making the mdfind test flaky.

Fixes #7531 
