### PR TITLE
Add column to `es_process_events` for process codesigning flags

### DIFF
--- a/osquery/events/darwin/endpointsecurity.h
+++ b/osquery/events/darwin/endpointsecurity.h
@@ -57,7 +57,7 @@ struct EndpointSecurityEventContext : public EventContext {
   std::string team_id;
   std::string cdhash;
   bool platform_binary;
-  bool adhoc_signed;
+  std::string codesigning_flags;
 
   std::string executable;
   std::string username;

--- a/osquery/events/darwin/endpointsecurity.h
+++ b/osquery/events/darwin/endpointsecurity.h
@@ -57,6 +57,7 @@ struct EndpointSecurityEventContext : public EventContext {
   std::string team_id;
   std::string cdhash;
   bool platform_binary;
+  bool adhoc_signed;
 
   std::string executable;
   std::string username;

--- a/osquery/events/darwin/es_utils.cpp
+++ b/osquery/events/darwin/es_utils.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <Kernel/kern/cs_blobs.h>
 #include <iomanip>
 #include <osquery/core/flags.h>
 #include <osquery/events/darwin/endpointsecurity.h>
@@ -64,6 +65,10 @@ std::string getSigningId(const es_process_t* p) {
              : "";
 }
 
+bool getIsAdhocSigned(const es_process_t* p) {
+  return p->codesigning_flags & CS_ADHOC;
+}
+
 std::string getTeamId(const es_process_t* p) {
   return p->team_id.length > 0 && p->team_id.data != nullptr ? p->team_id.data
                                                              : "";
@@ -112,6 +117,7 @@ void getProcessProperties(const es_process_t* p,
   ec->team_id = getTeamId(p);
   ec->cdhash = getCDHash(p);
   ec->platform_binary = p->is_platform_binary;
+  ec->adhoc_signed = getIsAdhocSigned(p);
 
   auto user = getpwuid(ec->uid);
   ec->username = user->pw_name != nullptr ? std::string(user->pw_name) : "";

--- a/osquery/tables/events/darwin/es_process_events.cpp
+++ b/osquery/tables/events/darwin/es_process_events.cpp
@@ -62,7 +62,7 @@ Status ESProcessEventSubscriber::Callback(
   r["signing_id"] = ec->signing_id;
   r["team_id"] = ec->team_id;
   r["cdhash"] = ec->cdhash;
-  r["adhoc_signed"] = (ec->adhoc_signed) ? INTEGER(1) : INTEGER(0);
+  r["codesigning_flags"] = ec->codesigning_flags;
 
   r["cmdline"] = ec->args;
   r["cmdline_count"] = BIGINT(ec->argc);

--- a/osquery/tables/events/darwin/es_process_events.cpp
+++ b/osquery/tables/events/darwin/es_process_events.cpp
@@ -62,6 +62,7 @@ Status ESProcessEventSubscriber::Callback(
   r["signing_id"] = ec->signing_id;
   r["team_id"] = ec->team_id;
   r["cdhash"] = ec->cdhash;
+  r["adhoc_signed"] = (ec->adhoc_signed) ? INTEGER(1) : INTEGER(0);
 
   r["cmdline"] = ec->args;
   r["cmdline_count"] = BIGINT(ec->argc);

--- a/specs/darwin/es_process_events.table
+++ b/specs/darwin/es_process_events.table
@@ -27,7 +27,7 @@ schema([
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("event_type", TEXT, "Type of EndpointSecurity event"),
     Column("eid", TEXT, "Event ID", hidden=True),
-    Column("adhoc_signed", INTEGER, "Indicates if the binary is signed ad-hoc (1) or with a signing identity (0)"),
+    Column("codesigning_flags", TEXT, "Codesigning flags matching one of these options, in a comma separated list: NOT_VALID, ADHOC, NOT_RUNTIME, INSTALLER. See kern/cs_blobs.h in XNU for descriptions."),
 ])
 attributes(event_subscriber=True)
 implementation("events/darwin/es_process_events@es_process_events::genTable")

--- a/specs/darwin/es_process_events.table
+++ b/specs/darwin/es_process_events.table
@@ -27,6 +27,7 @@ schema([
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("event_type", TEXT, "Type of EndpointSecurity event"),
     Column("eid", TEXT, "Event ID", hidden=True),
+    Column("adhoc_signed", INTEGER, "Indicates if the binary is signed ad-hoc (1) or with a signing identity (0)"),
 ])
 attributes(event_subscriber=True)
 implementation("events/darwin/es_process_events@es_process_events::genTable")


### PR DESCRIPTION
Adds column to the macOS es_process_events table to indicate information about codesigning flags for the process. This is useful data to include to detect processes that may be tampered with or more vulnerable to it.

This data is available in the es_process_t struct codesigning_flags field [here](https://developer.apple.com/documentation/endpointsecurity/es_process_t/3334987-codesigning_flags), through the flags in the kernel headers [here](https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/cs_blobs.h).

Only a few flags that are understood and relevant for monitoring are supported - more can be added later if use cases arise. These are:
* `NOT_VALID`: Process is running or exited with [invalid code signature](https://developer.apple.com/documentation/endpointsecurity/es_event_cs_invalidated_t)
* `ADHOC`:  "[ad-hoc](https://developer.apple.com/documentation/security/seccodesignatureflags/1397793-adhoc)", without a code signing identity. Ad-hoc signing binaries do not require having an Apple developer account, so they may be less trustworthy (similar to unsigned binaries, which are already indicated in this table by a missing "cdhash" field).
* `NOT_RUNTIME`: Processes that are not using the [hardened runtime](https://developer.apple.com/documentation/security/hardened_runtime), which enforces key security protections by default
* `INSTALLER`: Processes with a powerful system installer entitlement (can be inherited from parent) that can [bypass SIP filesystem protections](https://www.microsoft.com/en-us/security/blog/2021/10/28/microsoft-finds-new-macos-vulnerability-shrootless-that-could-bypass-system-integrity-protection/)

There didn't seem to be existing test cases to add to, so I tested manually in a VM running macOS 12.5 (through Apple's virtualization framework) to make sure the table had the correct values for a normal signed binary, ad-hoc signed binary, system_installd, non-hardened runtime, and invalid code signature cases.