### PR TITLE
processes: add `cgroup_path` column on Linux

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -346,6 +346,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/apt_sources.h
       linux/md_tables.h
       linux/pci_devices.h
+      linux/processes.h
       linux/smbios_utils.h
     )
 

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -428,6 +428,7 @@ int getOnDisk(const std::string& pid, std::string& path) {
 
 void genProcess(const std::string& pid,
                 long system_boot_time,
+                QueryContext& context,
                 TableRows& results) {
   // Parse the process stat and status.
   SimpleProcStat proc_stat(pid);
@@ -450,7 +451,9 @@ void genProcess(const std::string& pid,
   r["threads"] = proc_stat.threads;
   // Read/parse cmdline arguments.
   r["cmdline"] = readProcCMDLine(pid);
-  r["cgroup_path"] = readProcCgroup(pid);
+  if (context.isColumnUsed("cgroup_path")) {
+    r["cgroup_path"] = readProcCgroup(pid);
+  }
   r["cwd"] = readProcLink("cwd", pid);
   r["root"] = readProcLink("root", pid);
   r["uid"] = proc_stat.real_uid;
@@ -524,7 +527,7 @@ TableRows genProcesses(QueryContext& context) {
 
   auto pidlist = getProcList(context);
   for (const auto& pid : pidlist) {
-    genProcess(pid, system_boot_time, results);
+    genProcess(pid, system_boot_time, context, results);
   }
 
   return results;

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -70,13 +70,13 @@ std::string parseProcCGroup(const std::string& content) {
   // Note that a cgroup name may have colons
   auto first_colon = content.find(':');
   if (first_colon == std::string::npos) {
-    return "";
+    return {};
   }
   auto second_colon = content.find(':', first_colon + 1);
   if (second_colon != std::string::npos && second_colon < end_pos) {
     return content.substr(second_colon + 1, end_pos - second_colon - 1);
   } else {
-    return "";
+    return {};
   }
 }
 
@@ -84,7 +84,9 @@ inline std::string readProcCgroup(const std::string& pid) {
   auto attr = getProcAttr("cgroup", pid);
 
   std::string content;
-  readFile(attr, content);
+  if (!readFile(attr, content).ok()) {
+    return {};
+  };
   return parseProcCGroup(content);
 }
 

--- a/osquery/tables/system/linux/processes.h
+++ b/osquery/tables/system/linux/processes.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+namespace osquery {
+namespace tables {
+std::string parseProcCGroup(const std::string& content);
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ function(generateOsqueryTablesSystemLinuxTests)
     linux/pci_devices_tests.cpp
     linux/pcidb_tests.cpp
     linux/portage_tests.cpp
+    linux/processes_tests.cpp
     linux/rpm_packages_tests.cpp
     linux/selinux_settings_tests.cpp
     linux/yum_sources_tests.cpp

--- a/osquery/tables/system/tests/linux/processes_tests.cpp
+++ b/osquery/tables/system/tests/linux/processes_tests.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+#include <osquery/tables/system/linux/processes.h>
+
+namespace osquery {
+namespace tables {
+
+class CGroupTest : public ::testing::Test {};
+
+TEST_F(CGroupTest, systemd_session) {
+  auto got =
+      parseProcCGroup("0::/user.slice/user-1000.slice/session-6.scope\n");
+  EXPECT_EQ("/user.slice/user-1000.slice/session-6.scope", got);
+}
+
+TEST_F(CGroupTest, no_newline) {
+  auto got = parseProcCGroup("0::/user.slice/user-1000.slice/session-6.scope");
+  EXPECT_EQ("/user.slice/user-1000.slice/session-6.scope", got);
+}
+
+TEST_F(CGroupTest, version_1_single_group) {
+  auto got = parseProcCGroup(
+      "4:cpu,cpuset:/user.slice/user-1000.slice/session-6.scope\n");
+  EXPECT_EQ("/user.slice/user-1000.slice/session-6.scope", got);
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/linux/processes_tests.cpp
+++ b/osquery/tables/system/tests/linux/processes_tests.cpp
@@ -32,5 +32,10 @@ TEST_F(CGroupTest, version_1_single_group) {
   EXPECT_EQ("/user.slice/user-1000.slice/session-6.scope", got);
 }
 
+TEST_F(CGroupTest, invalid) {
+  auto got = parseProcCGroup("0:/user.slice\n");
+  EXPECT_EQ("", got);
+}
+
 } // namespace tables
 } // namespace osquery

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -46,6 +46,9 @@ extended_schema(DARWIN, [
     Column("cpu_subtype", INTEGER, "Indicates the specific processor on which an entry may be used."),
     Column("translated", INTEGER, "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1."),
 ])
+extended_schema(LINUX, [
+    Column("cgroup_path", TEXT, "The full hierarchical path of the process's control group"),
+])
 attributes(cacheable=True, strongly_typed_rows=True)
 implementation("system/processes@genProcesses")
 examples([

--- a/tests/integration/tables/processes.cpp
+++ b/tests/integration/tables/processes.cpp
@@ -105,6 +105,11 @@ TEST_F(ProcessesTest, test_sanity) {
     row_map.emplace("cpu_subtype", IntType);
     row_map.emplace("translated", IntType);
   }
+
+  if (isPlatform(PlatformType::TYPE_LINUX)) {
+    row_map.emplace("cgroup_path", NormalType);
+  }
+
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
This will read the full cgroup path out of /proc for each process in the process table. I've tested this with cgroup v2 (unified hierarchies) but have not yet tested it with cgroup v1 (where each group type has a separate hierarchy). On cgroup v1 it should report the first cgroup it's in but that may not be consistently the same type. Proper cgroup v1 support would require a different schema as each process can be in 13 different hierarchies.

This does involve several string copies but I couldn't find a clean way of doing it with fewer.