### PR TITLE
process_open_sockets.state documented as available on all supported p…

### DIFF
--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -11,8 +11,6 @@ schema([
     Column("local_port", INTEGER, "Socket local port"),
     Column("remote_port", INTEGER, "Socket remote port"),
     Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
-])
-extended_schema(lambda: LINUX() or DARWIN() or WINDOWS(), [
     Column("state", TEXT, "TCP socket state"),
 ])
 extended_schema(LINUX, [


### PR DESCRIPTION
### Background

Previously, we were documenting `process_open_sockets.state` to be windows, linux, or darwin only in the extended schema. Since we got rid of Free BSD as a supported platform, this column is now effectively available on all platforms, so this PR removes that extended_schema. 