### PR TITLE
Remove `binary` column from `firefox_addons` table

### DIFF
--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -60,7 +60,6 @@ const std::map<std::string, std::string> kFirefoxAddonKeys = {
     {"visible", "visible"},
     {"active", "active"},
     {"applyBackgroundUpdates", "autoupdate"},
-    {"hasBinaryComponents", "native"},
     {"location", "location"},
     {"path", "path"},
 };

--- a/specs/firefox_addons.table
+++ b/specs/firefox_addons.table
@@ -16,8 +16,6 @@ schema([
       "1 If the addon is application-disabled else 0"),
     Column("autoupdate", INTEGER,
       "1 If the addon applies background updates else 0"),
-    Column("native", INTEGER,
-      "1 If the addon includes binary components else 0"),
     Column("location", TEXT, "Global, profile location"),
     Column("path", TEXT, "Path to plugin bundle"),
     ForeignKey(column="uid", table="users"),
@@ -25,7 +23,7 @@ schema([
 attributes(user_data=True)
 implementation("applications/browser_firefox@genFirefoxAddons")
 examples([
-    "select * from users join firefox_addons using (uid)",
+    "SELECT * FROM users CROSS JOIN firefox_addons USING (uid)",
 ])
 fuzz_paths([
     "/Library/Application Support/Firefox/Profiles/",


### PR DESCRIPTION
This functionality seems to have been [removed from Firefox since 2015](https://blog.mozilla.org/addons/2015/05/04/dropping-support-for-binary-components/). In our testing we never saw this have a nonzero value.