### PR TITLE
mdfind: Reduce table overhead and support quick interruption

### DIFF
--- a/osquery/tables/system/darwin/mdfind.mm
+++ b/osquery/tables/system/darwin/mdfind.mm
@@ -10,6 +10,7 @@
 #include <CoreServices/CoreServices.h>
 
 #include <osquery/core/core.h>
+#include <osquery/core/shutdown.h>
 #include <osquery/core/system.h>
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
@@ -92,7 +93,7 @@ Status waitForSpotlight(const std::vector<NamedQuery>& queries) {
   for (size_t time_started{getUnixTime()};
        (getUnixTime() - time_started) < kMaxQueryWait;) {
     // The queries run asynchronously in the threads CFRunLoop
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, YES);
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, YES);
 
     // Check if all the queries are complete
     all_done = true;
@@ -102,6 +103,16 @@ Status waitForSpotlight(const std::vector<NamedQuery>& queries) {
     // If all the queries are complete, don't spin any longer
     if (all_done) {
       return Status{0};
+    }
+
+    if (osquery::shutdownRequested()) {
+      VLOG(1) << "Interrupting mdfind query due to a shutdown request";
+
+      // Interrupt the queries before exiting
+      for (const auto& query : queries) {
+        MDQueryStop(query.first);
+      }
+      return Status::failure("Shutdown requested");
     }
   }
   if (!all_done) {


### PR DESCRIPTION
- Run the RunLoop for 1 second each time instead of a single pass
  to then check the spotlight queries status,
  since this means that we are checking the queries status and re-running
  the loop thousands of times per second.
  This causes the osquery worker to use a full core for the duration of
  the query and the watchdog to kill it.

- Support quick interruption of a mdfind query if a shutdown is requested
