### PR TITLE
test: Fix platform-info.test_sanity on Windows

### DIFF
--- a/tests/integration/tables/platform_info.cpp
+++ b/tests/integration/tables/platform_info.cpp
@@ -15,10 +15,10 @@
 namespace osquery::table_tests {
 
 class platformInfo : public testing::Test {
-  protected:
-    void SetUp() override {
-      setUpEnvironment();
-    }
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
 };
 
 TEST_F(platformInfo, test_sanity) {
@@ -29,10 +29,13 @@ TEST_F(platformInfo, test_sanity) {
     {"version", NormalType},
     {"extra", NormalType},
     {"date", NormalType},
+    {"revision", NormalType},
+
+#ifndef OSQUERY_WINDOWS
+    {"address", NormalType},
     {"size", IntOrEmpty},
     {"volume_size", NonNegativeInt},
-    {"revision", NormalType},
-    {"address", NormalType},
+#endif
 
 #if defined(__APPLE__) || defined(OSQUERY_WINDOWS)
     {"firmware_type", NonEmptyString},


### PR DESCRIPTION
The address, size, and volume_size columns
have been recently become hidden on Windows, because they don't contain data,
don't test them.

This went through because a PR that was making those columns hidden has been merged just before the PR that was activating the test, and since we don't force that PRs are in sync with master, the PR activating the test was successful (because the columns were still available).