### PR TITLE
`cpu_info`: Port the table to macOS x86 and Apple Silicon

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -258,6 +258,7 @@ function(setupBuildFlags)
         APPLE=1
         DARWIN=1
         BSD=1
+        OSQUERY_DARWIN=1
         OSQUERY_BUILD_PLATFORM="darwin"
         OSQUERY_BUILD_DISTRO="10.14"
       )

--- a/libraries/cmake/source/libmagic/CMakeLists.txt
+++ b/libraries/cmake/source/libmagic/CMakeLists.txt
@@ -52,9 +52,14 @@ function(libmagicMain)
   target_compile_definitions(thirdparty_libmagic PRIVATE
     ${compile_definition_list}
     buffer_init=libmagic_buffer_init
-    strlcat=libmagic_strlcat
-    strlcpy=libmagic_strlcpy
   )
+
+  if(DEFINED PLATFORM_LINUX)
+    target_compile_definitions(thirdparty_libmagic PRIVATE
+      strlcat=libmagic_strlcat
+      strlcpy=libmagic_strlcpy
+    )
+  endif()
 
   target_link_libraries(thirdparty_libmagic PUBLIC
     thirdparty_zlib

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -28,14 +28,13 @@ struct DeviceTracker : private boost::noncopyable {
   io_object_t notification{0};
 };
 
-
 void IOKitEventPublisher::restart() {
   static std::vector<const std::string*> device_classes = {
       &kIOUSBDeviceClassName_,
       &kIOPCIDeviceClassName_,
       &kIOPlatformExpertDeviceClassName_,
       &kIOACPIPlatformDeviceClassName_,
-      &kIOPlatformDeviceClassname_,
+      &kIOPlatformDeviceClassName_,
   };
 
   if (run_loop_ == nullptr) {
@@ -264,4 +263,4 @@ void IOKitEventPublisher::tearDown() {
   // Do not keep a reference to the run loop.
   run_loop_ = nullptr;
 }
-}
+} // namespace osquery

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -112,6 +112,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/battery.mm
       darwin/block_devices.cpp
       darwin/certificates.mm
+      darwin/cpu_info.cpp
       darwin/cpu_time.cpp
       darwin/crashes.cpp
       darwin/cups_destinations.cpp

--- a/osquery/tables/system/darwin/cpu_info.cpp
+++ b/osquery/tables/system/darwin/cpu_info.cpp
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <array>
+#include <iostream>
+#include <memory>
+
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/darwin/smbios_utils.h>
+#include <osquery/utils/conversions/darwin/cfdata.h>
+#include <osquery/utils/conversions/darwin/cfnumber.h>
+#include <osquery/utils/conversions/darwin/cfstring.h>
+#include <osquery/utils/conversions/darwin/iokit.h>
+#include <osquery/utils/darwin/iokit_helpers.h>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+const char* kPowerManagerDevice = "pmgr";
+const char* kCpusDevice = "cpus";
+const char* kPCoresVoltageStates = "voltage-states5-sram";
+const char* kPCoresCount = "p-core-count";
+const char* kECoresCount = "e-core-count";
+} // namespace
+
+QueryData genIntelCpuInfo(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    VLOG(1) << "Failed to discover SMBIOS entry point";
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           uint8_t* textAddrs,
+                           size_t size) {
+    genSMBIOSProcessor(index, hdr, address, textAddrs, size, results);
+  });
+
+  // Decorate table
+  std::int32_t device_id = 0;
+  for (auto& row : results) {
+    auto current_processor_id = row.find("processor_type");
+    if (current_processor_id == row.end()) {
+      continue;
+    }
+
+    // `device_id` column is not part of the SMBios table.
+    auto friendly_name =
+        kSMBIOSProcessorTypeFriendlyName.find(current_processor_id->second);
+    if (friendly_name != kSMBIOSProcessorTypeFriendlyName.end()) {
+      row["device_id"] = friendly_name->second + std::to_string(device_id++);
+    }
+  }
+
+  return results;
+}
+
+std::optional<std::uint32_t> getAarch64MaxCPUFreq() {
+  auto matching = IOServiceMatching(kAppleARMIODeviceClassName_.data());
+  if (matching == nullptr) {
+    VLOG(1) << "No matching " << kAppleARMIODeviceClassName_;
+    // No devices matched AppleARMIODevice.
+    return std::nullopt;
+  }
+
+  io_iterator_t device_it;
+
+  auto kr =
+      IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &device_it);
+
+  if (kr != KERN_SUCCESS) {
+    VLOG(1) << "Failed to get matching " << kAppleARMIODeviceClassName_;
+    return std::nullopt;
+  }
+
+  UniqueIoIterator device_it_ptr(device_it);
+  UniqueIoService device_ptr;
+
+  std::uint32_t max_freq = 0;
+
+  while ((device_ptr = UniqueIoService(IOIteratorNext(device_it_ptr.get())))
+             .get()) {
+    io_name_t buf;
+    kr = IORegistryEntryGetName(device_ptr.get(), buf);
+
+    if (kr != KERN_SUCCESS) {
+      VLOG(1) << "Failed to get one of the " << kAppleARMIODeviceClassName_
+              << " name";
+      continue;
+    }
+
+    std::string name(buf);
+
+    if (name != kPowerManagerDevice) {
+      continue;
+    }
+
+    CFMutableDictionaryRef properties;
+    kr = IORegistryEntryCreateCFProperties(
+        device_ptr.get(), &properties, kCFAllocatorDefault, kNilOptions);
+
+    if (kr != KERN_SUCCESS) {
+      LOG(ERROR) << "Failed to create and retrieve the power manager "
+                    "properties dictionary";
+      return std::nullopt;
+    }
+
+    UniqueCFMutableDictionaryRef properties_ptr(properties);
+
+    // voltage-states5-sram contains the performance cores available frequencies
+    auto cfkey = UniqueCFStringRef(CFStringCreateWithCString(
+        kCFAllocatorDefault, kPCoresVoltageStates, kCFStringEncodingUTF8));
+    auto p_cores_freq_property = static_cast<CFDataRef>(
+        CFDictionaryGetValue(properties_ptr.get(), cfkey.get()));
+
+    if (p_cores_freq_property == nullptr) {
+      VLOG(1) << "Failed to retrieve the power manager property "
+              << kPCoresVoltageStates;
+      return std::nullopt;
+    }
+
+    auto p_cores_freq_type = CFGetTypeID(p_cores_freq_property);
+    if (p_cores_freq_type != CFDataGetTypeID()) {
+      VLOG(1) << "Unsupported data type for the " << kPCoresVoltageStates
+              << " property";
+      return std::nullopt;
+    }
+
+    std::size_t length = CFDataGetLength(p_cores_freq_property);
+
+    // The frequencies are in hz, saved in an array
+    // as little endian 4 byte integers
+    for (std::size_t i = 0; i < length - 3; i += 4) {
+      std::uint32_t cur_freq = 0;
+      CFDataGetBytes(p_cores_freq_property,
+                     CFRangeMake(i, sizeof(uint32_t)),
+                     reinterpret_cast<UInt8*>(&cur_freq));
+
+      if (max_freq < cur_freq) {
+        max_freq = cur_freq;
+      }
+    }
+  }
+
+  return max_freq;
+}
+
+std::optional<std::pair<std::string, std::string>> getHybridCoresNumber() {
+  auto matching = IOServiceMatching(kIOPlatformDeviceClassName_.data());
+  if (matching == nullptr) {
+    VLOG(1) << "No matching " << kIOPlatformDeviceClassName_;
+    // No devices matched IOPlatformDevice.
+    return std::nullopt;
+  }
+
+  io_iterator_t device_it;
+  auto kr =
+      IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &device_it);
+
+  if (kr != KERN_SUCCESS) {
+    VLOG(1) << "Failed to get matching " << kIOPlatformDeviceClassName_;
+    return std::nullopt;
+  }
+
+  UniqueIoIterator device_it_ptr(device_it);
+  UniqueIoService device_ptr;
+
+  std::pair<std::string, std::string> hybrid_cores_counts{};
+
+  while ((device_ptr = UniqueIoService(IOIteratorNext(device_it))).get()) {
+    io_name_t buf;
+    kr = IORegistryEntryGetName(device_ptr.get(), buf);
+
+    if (kr != KERN_SUCCESS) {
+      VLOG(1) << "Failed to get one of the " << kIOPlatformDeviceClassName_
+              << " name";
+      continue;
+    }
+
+    std::string name(buf);
+
+    if (name != kCpusDevice) {
+      continue;
+    }
+
+    CFMutableDictionaryRef properties;
+    kr = IORegistryEntryCreateCFProperties(
+        device_ptr.get(), &properties, kCFAllocatorDefault, kNilOptions);
+
+    if (kr != KERN_SUCCESS) {
+      LOG(ERROR) << "Failed to create and retrieve the power manager "
+                    "properties dictionary";
+      return std::nullopt;
+    }
+
+    UniqueCFMutableDictionaryRef properties_ptr(properties);
+
+    auto e_core_count_key = UniqueCFStringRef(CFStringCreateWithCString(
+        kCFAllocatorDefault, kECoresCount, kCFStringEncodingUTF8));
+    auto p_core_count_key = UniqueCFStringRef(CFStringCreateWithCString(
+        kCFAllocatorDefault, kPCoresCount, kCFStringEncodingUTF8));
+
+    auto e_core_count_property = static_cast<CFDataRef>(
+        CFDictionaryGetValue(properties_ptr.get(), e_core_count_key.get()));
+    auto p_core_count_property = static_cast<CFDataRef>(
+        CFDictionaryGetValue(properties_ptr.get(), p_core_count_key.get()));
+
+    if (e_core_count_property == nullptr || p_core_count_property == nullptr) {
+      return std::nullopt;
+    }
+
+    auto e_core_count_type = CFGetTypeID(e_core_count_property);
+    if (e_core_count_type != CFDataGetTypeID()) {
+      VLOG(1) << "Unsupported data type for the " << kECoresCount
+              << " property. Found: " << e_core_count_type;
+      return std::nullopt;
+    }
+
+    auto p_core_count_type = CFGetTypeID(p_core_count_property);
+    if (p_core_count_type != CFDataGetTypeID()) {
+      VLOG(1) << "Unsupported data type for the " << kPCoresCount
+              << " property. Found: " << p_core_count_type;
+      return std::nullopt;
+    }
+
+    auto data_to_uint32_string = [](CFDataRef data) -> std::string {
+      std::uint32_t value;
+      CFDataGetBytes(data, CFRangeMake(0, sizeof(uint32_t)), (UInt8*)&value);
+      return std::to_string(value);
+    };
+
+    hybrid_cores_counts.first = data_to_uint32_string(e_core_count_property);
+    hybrid_cores_counts.second = data_to_uint32_string(p_core_count_property);
+
+    return hybrid_cores_counts;
+  }
+
+  return std::nullopt;
+}
+
+QueryData genAarch64CpuInfo(QueryContext& context) {
+  QueryData rows;
+  Row r;
+
+  // Hardcoded for now, we only support a single CPU
+  r["device_id"] = "CPU0";
+
+  std::array<char, 256> brand_string;
+
+  // Leave space for a null-terminator
+  size_t len = sizeof(brand_string) - 1;
+  auto res =
+      sysctlbyname("machdep.cpu.brand_string", &brand_string, &len, nullptr, 0);
+
+  if (res == 0) {
+    r["model"] = TEXT(brand_string.data());
+  }
+  r["manufacturer"] = "Apple";
+  r["processor_type"] = INTEGER(3); // 3 = Central Processor
+  r["address_width"] = INTEGER(64);
+
+  std::uint32_t sysctl_value = 0;
+  len = sizeof(sysctl_value);
+  res = sysctlbyname("machdep.cpu.core_count", &sysctl_value, &len, nullptr, 0);
+
+  if (res == 0) {
+    r["number_of_cores"] = INTEGER(sysctl_value);
+  }
+
+  len = sizeof(sysctl_value);
+  res = sysctlbyname("hw.logicalcpu", &sysctl_value, &len, nullptr, 0);
+
+  if (res == 0) {
+    r["logical_processors"] = INTEGER(sysctl_value);
+  }
+
+  auto opt_max_freq = getAarch64MaxCPUFreq();
+  if (opt_max_freq.has_value()) {
+    r["max_clock_speed"] = INTEGER(*opt_max_freq / (1000 * 1000));
+  }
+
+  auto opt_hybrid_cores_number = getHybridCoresNumber();
+
+  if (opt_hybrid_cores_number.has_value()) {
+    const auto& [ecores_number, pcores_number] = *opt_hybrid_cores_number;
+    r["number_of_efficiency_cores"] = INTEGER(ecores_number);
+    r["number_of_performance_cores"] = INTEGER(pcores_number);
+  }
+
+  rows.emplace_back(std::move(r));
+
+  return rows;
+}
+
+QueryData genCpuInfo(QueryContext& context) {
+#ifdef __aarch64__
+  return genAarch64CpuInfo(context);
+#else
+  return genIntelCpuInfo(context);
+#endif
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/smbios_utils.h
+++ b/osquery/tables/system/darwin/smbios_utils.h
@@ -41,5 +41,5 @@ class DarwinSMBIOSParser : public SMBIOSParser {
  private:
   uint8_t* smbios_data_{nullptr};
 };
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/cpu_info.cpp
+++ b/osquery/tables/system/linux/cpu_info.cpp
@@ -19,9 +19,6 @@
 namespace osquery {
 namespace tables {
 
-static const std::map<std::string, std::string> ProcessorTypeToFriendlyName = {
-    {"3", "CPU"}, {"4", "MATH"}, {"5", "DSP"}, {"6", "GPU"}};
-
 QueryData genCpuInfo(QueryContext& context) {
   QueryData results;
   LinuxSMBIOSParser parser;
@@ -39,18 +36,18 @@ QueryData genCpuInfo(QueryContext& context) {
   }));
 
   // Decorate table
-  uint8_t deviceId = 0;
+  std::int32_t device_id = 0;
   for (auto& row : results) {
-    auto currentProcessorId = row.find("processor_type");
-    if (currentProcessorId == row.end()) {
+    auto current_processor_id = row.find("processor_type");
+    if (current_processor_id == row.end()) {
       continue;
     }
 
     // `device_id` column is not part of the SMBios table.
-    auto friendlyName =
-        ProcessorTypeToFriendlyName.find(currentProcessorId->second);
-    if (friendlyName != ProcessorTypeToFriendlyName.end()) {
-      row["device_id"] = friendlyName->second + std::to_string(deviceId++);
+    auto friendly_name =
+        kSMBIOSProcessorTypeFriendlyName.find(current_processor_id->second);
+    if (friendly_name != kSMBIOSProcessorTypeFriendlyName.end()) {
+      row["device_id"] = friendly_name->second + std::to_string(device_id++);
     }
   }
 

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -17,6 +17,7 @@
 namespace osquery {
 namespace tables {
 
+// All the kSMBIOS* mappings have been taken from the SMBIOS spec PDF
 const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions = {
     {0, "BIOS Information"},
     {1, "System Information"},

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -187,6 +187,9 @@ const std::map<uint8_t, std::string> kSMBIOSMemoryErrorOperationTable = {
     {0x05, "Partial write"},
 };
 
+const std::map<std::string, std::string> kSMBIOSProcessorTypeFriendlyName = {
+    {"3", "CPU"}, {"4", "MATH"}, {"5", "DSP"}, {"6", "GPU"}};
+
 template <class T>
 static inline std::string toHexStr(T num, int width = 4) {
   std::stringstream ss;

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <osquery/core/tables.h>
 
 namespace osquery {
@@ -48,6 +50,9 @@ extern const std::map<uint8_t, std::string> kSMBIOSMemoryErrorOperationTable;
 
 /// Get friendly names for each SMBIOS table/section type.
 extern const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions;
+
+extern const std::map<std::string, std::string>
+    kSMBIOSProcessorTypeFriendlyName;
 
 constexpr uint8_t kSMBIOSTypeBIOS = 0;
 constexpr uint8_t kSMBIOSTypeSystem = 1;

--- a/osquery/utils/CMakeLists.txt
+++ b/osquery/utils/CMakeLists.txt
@@ -95,6 +95,7 @@ function(generateOsqueryUtils)
   if(DEFINED PLATFORM_MACOS)
     set(platform_public_header_files
       darwin/plist.h
+      darwin/iokit_helpers.h
     )
 
     generateIncludeNamespace(osquery_utils "osquery/utils" "FULL_PATH" ${platform_public_header_files})

--- a/osquery/utils/conversions/darwin/iokit.cpp
+++ b/osquery/utils/conversions/darwin/iokit.cpp
@@ -26,7 +26,8 @@ const std::string kIOUSBDeviceClassName_ = "IOUSBDevice";
 const std::string kIOPCIDeviceClassName_ = "IOPCIDevice";
 const std::string kIOPlatformExpertDeviceClassName_ = "IOPlatformExpertDevice";
 const std::string kIOACPIPlatformDeviceClassName_ = "IOACPIPlatformDevice";
-const std::string kIOPlatformDeviceClassname_ = "IOPlatformDevice";
+const std::string kIOPlatformDeviceClassName_ = "IOPlatformDevice";
+const std::string kAppleARMIODeviceClassName_ = "AppleARMIODevice";
 
 IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
   std::vector<std::string> properties;

--- a/osquery/utils/conversions/darwin/iokit.h
+++ b/osquery/utils/conversions/darwin/iokit.h
@@ -18,7 +18,8 @@ extern const std::string kIOUSBDeviceClassName_;
 extern const std::string kIOPCIDeviceClassName_;
 extern const std::string kIOPlatformExpertDeviceClassName_;
 extern const std::string kIOACPIPlatformDeviceClassName_;
-extern const std::string kIOPlatformDeviceClassname_;
+extern const std::string kIOPlatformDeviceClassName_;
+extern const std::string kAppleARMIODeviceClassName_;
 
 struct IOKitPCIProperties {
   std::string vendor_id;

--- a/osquery/utils/darwin/iokit_helpers.h
+++ b/osquery/utils/darwin/iokit_helpers.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include <IOKit/IOKitLib.h>
+
+namespace osquery {
+template <typename Type>
+struct ObjectDeleter final {
+  static_assert(std::is_same_v<io_object_t, Type>,
+                "Type is not compatible with an io_object_t");
+
+  using pointer = Type;
+
+  void operator()(pointer p) {
+    if (p == 0) {
+      return;
+    }
+
+    IOObjectRelease(p);
+  }
+};
+
+template <typename Type>
+struct TypeDeleter final {
+  using pointer = Type;
+
+  void operator()(pointer p) {
+    CFRelease(p);
+  }
+};
+
+using UniqueIoRegistryEntry =
+    std::unique_ptr<io_registry_entry_t, ObjectDeleter<io_registry_entry_t>>;
+using UniqueIoIterator =
+    std::unique_ptr<io_iterator_t, ObjectDeleter<io_iterator_t>>;
+using UniqueIoService =
+    std::unique_ptr<io_service_t, ObjectDeleter<io_service_t>>;
+
+using UniqueCFStringRef =
+    std::unique_ptr<CFStringRef, TypeDeleter<CFStringRef>>;
+using UniqueCFTypeRef = std::unique_ptr<CFTypeRef, TypeDeleter<CFTypeRef>>;
+using UniqueCFMutableDictionaryRef =
+    std::unique_ptr<CFMutableDictionaryRef,
+                    TypeDeleter<CFMutableDictionaryRef>>;
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -84,6 +84,7 @@ function(generateNativeTables)
   set(platform_dependent_spec_files
     "arp_cache.table:linux,macos,windows"
     "atom_packages.table:linux,macos,windows"
+    "cpu_info.table:linux,macos,windows"
     "darwin/account_policy_data.table:macos"
     "darwin/ad_config.table:macos"
     "darwin/alf.table:macos"
@@ -190,7 +191,6 @@ function(generateNativeTables)
     "linux/systemd_units.table:linux"
     "linux/yum_sources.table:linux"
     "linwin/intel_me_info.table:linux,windows"
-    "linwin/cpu_info.table:linux,windows"
     "kernel_info.table:linux,macos,windows"
     "posix/extended_attributes.table:linux,macos"
     "posix/acpi_tables.table:linux,macos"

--- a/specs/cpu_info.table
+++ b/specs/cpu_info.table
@@ -17,4 +17,8 @@ schema([
 extended_schema(WINDOWS, [
     Column("availability", TEXT, "The availability and status of the CPU.")
 ])
+extended_schema(DARWIN, [
+    Column("number_of_efficiency_cores", INTEGER, "The number of efficiency cores of the CPU. Only available on Apple Silicon"),
+    Column("number_of_performance_cores", INTEGER, "The number of performance cores of the CPU. Only available on Apple Silicon")
+])
 implementation("cpu_info@genCpuInfo")

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -38,6 +38,7 @@ function(generateTestsIntegrationTablesTestsTest)
     chrome_extensions.cpp
     curl.cpp
     curl_certificate.cpp
+    cpu_info.cpp
     etc_hosts.cpp
     etc_protocols.cpp
     etc_services.cpp
@@ -281,7 +282,6 @@ function(generateTestsIntegrationTablesTestsTest)
       windows_firewall_rules.cpp
       chassis_info.cpp
       chocolatey_packages.cpp
-      cpu_info.cpp
       default_environment.cpp
       disk_info.cpp
       drivers.cpp
@@ -358,6 +358,7 @@ function(generateTestsIntegrationTablesTestsTest)
     set(root_test_name_list
       "memoryDevices.test_sanity"
       "Secureboot.test_sanity"
+      "cpuInfo.test_sanity"
     )
 
     set(gtest_filter "")
@@ -388,8 +389,8 @@ function(generateTestsIntegrationTablesTestsTest)
       )
 
       set_tests_properties(
-          tests_integration_tables_root-test
-          PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
+        tests_integration_tables_root-test
+        PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
       )
     endif()
 


### PR DESCRIPTION
- Add two new columns "number_of_efficiency_cores",
  and "number_of_performance_cores".
  This is Apple Silicon only for now,
  but in the future it could be extracted for Linux x86
  and Windows x86 with newer Intel CPUs.

- Do some minor cleanups to reuse common SMBIOS utils.

- Enable the cpu_info integration test for Linux and macOS