### PR TITLE
Fix `process_file_events` subscriber being incorrectly initialized

### DIFF
--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -1062,8 +1062,8 @@ bool AuditSyscallRecordHandler(AuditdFimContext& fim_context,
   }
 
   switch (syscall_context.syscall_number) {
-  // The following syscalls are only handled to duplicate and/or create the fd
-  // map
+    // The following syscalls are only handled to duplicate and/or create the fd
+    // map
 #ifdef __x86_64__
   case __NR_fork:
   case __NR_vfork:
@@ -1160,20 +1160,18 @@ bool AuditSyscallRecordHandler(AuditdFimContext& fim_context,
         fim_context, syscall_context, record);
   }
 
-  default: { return false; }
+  default: {
+    return false;
+  }
   }
 }
 } // namespace
 
-Status ProcessFileEventSubscriber::setUp() {
+Status ProcessFileEventSubscriber::init() {
   if (!FLAGS_audit_allow_fim_events) {
     return Status(1, "Subscriber disabled via configuration");
   }
 
-  return Status(0);
-}
-
-Status ProcessFileEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&ProcessFileEventSubscriber::Callback, sc);
 

--- a/osquery/tables/events/linux/process_file_events.h
+++ b/osquery/tables/events/linux/process_file_events.h
@@ -283,7 +283,6 @@ struct AuditdFimSyscallContext final {
 class ProcessFileEventSubscriber final
     : public EventSubscriber<AuditEventPublisher> {
  public:
-  Status setUp() override;
   Status init() override;
 
   /// Applies the user configuration to the subscriber


### PR DESCRIPTION
The process_file_events subscriber was not finding its data
in the database, so no event was shown.

The setUp() function shouldn't be overridden
by the implementation of the subscriber,
otherwise vital information about the subscriber
and where it should search its data in the database is not setup.
Only init() should be used.
