### PR TITLE
codegen: Include extended schema platforms in website json

### DIFF
--- a/specs/platform_info.table
+++ b/specs/platform_info.table
@@ -7,10 +7,10 @@ schema([
     Column("revision", TEXT, "BIOS major and minor revision"),
     Column("extra", TEXT, "Platform-specific additional information"),
 ])
-extended_schema(lambda: DARWIN() or WINDOWS(), [
+extended_schema(DARWIN + WINDOWS, [
     Column("firmware_type", TEXT, "The type of firmware (Uefi, Bios, Unknown).")
 ])
-extended_schema(lambda: LINUX() or DARWIN(),[
+extended_schema(LINUX + DARWIN,[
     Column("address", TEXT, "Relative address of firmware mapping"),
     Column("size", TEXT, "Size in bytes of firmware"),
     Column("volume_size", INTEGER, "(Optional) size of firmware volume")

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -94,24 +94,11 @@ TABLE_ATTRIBUTES = {
 }
 
 
-def WINDOWS():
-    return PLATFORM in ['windows', 'win32', 'cygwin']
-
-
-def LINUX():
-    return PLATFORM in ['linux']
-
-
-def POSIX():
-    return PLATFORM in ['linux', 'darwin', 'freebsd']
-
-
-def DARWIN():
-    return PLATFORM in ['darwin']
-
-
-def FREEBSD():
-    return PLATFORM in ['freebsd']
+WINDOWS = ['windows', 'win32', 'cygwin']
+LINUX = ['linux']
+POSIX = ['linux', 'darwin', 'freebsd']
+DARWIN = ['darwin']
+FREEBSD = ['freebsd']
 
 
 def to_camel_case(snake_case):
@@ -314,11 +301,12 @@ class Column(object):
     documentation generation and reference.
     """
 
-    def __init__(self, name, col_type, description="", aliases=[], **kwargs):
+    def __init__(self, name, col_type, description="", aliases=[], platforms=[], **kwargs):
         self.name = name
         self.type = col_type
         self.description = description
         self.aliases = aliases
+        self.platforms = platforms
         self.options = kwargs
 
 
@@ -359,7 +347,7 @@ def schema(schema_list):
     table.schema = schema_list
 
 
-def extended_schema(check, schema_list):
+def extended_schema(platforms, schema_list):
     """
     define a comparator and a list of Columns objects.
     """
@@ -367,7 +355,8 @@ def extended_schema(check, schema_list):
     for it in schema_list:
         if isinstance(it, Column):
             logging.debug("  - column: %s (%s)" % (it.name, it.type))
-            if not check():
+            it.platforms = platforms
+            if not PLATFORM in platforms:
                 it.options['hidden'] = True
             table.schema.append(it)
 

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -107,19 +107,11 @@ def generate_table_metadata(specs_dir, full_path):
             c["description"] = col.description
             c["type"] = col.type.affinity.replace("_TYPE", "").lower()
 
-            hidden = False
-            required = False
-            index = False
-            for option in col.options:
-                if option == "hidden":
-                    hidden = True
-                elif option == "required":
-                    required = True
-                elif option == "index":
-                    index == True
-            c["hidden"] = hidden
-            c["required"] = required
-            c["index"] = index
+            c["hidden"] = col.options.get("hidden", False)
+            c["required"] = col.options.get("required", False)
+            c["index"] = col.options.get("index", False)
+            if col.platforms != []:
+                c["platforms"] = col.platforms
 
             t["columns"].append(c)
     return t


### PR DESCRIPTION
At Fleet we would like to be able to include platforms on extended schema updates in our web interface (see fleetdm/fleet#7236). This PR changes how the platforms field works in extended_schema and includes them in the output of `genwebsitejson.py`