### PR TITLE
Fix file carve table under debug builds.

### DIFF
--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -53,8 +53,10 @@ void enumerateCarves(QueryData& results, const std::string& new_guid) {
       r["time"] = INTEGER(tree.doc()["time"].GetUint64());
     }
 
-    if (tree.doc().HasMember("size")) {
+    if (tree.doc()["size"].IsInt()) {
       r["size"] = INTEGER(tree.doc()["size"].GetInt());
+    } else if (tree.doc()["size"].IsString()) {
+      r["size"] = INTEGER(tree.doc()["size"].GetString());
     }
 
     stringToRow("sha256", r, tree);


### PR DESCRIPTION
The type assertion will fail after the initial update to the size
since the calculated size is written as a string. This checks
the type before loading.

Fixes #7756

<!-- Thank you for contributing to osquery! -->


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
