### PR TITLE
Remove deprecate `is_running` column from macOS `running_apps` table

### DIFF
--- a/osquery/tables/system/darwin/running_apps.mm
+++ b/osquery/tables/system/darwin/running_apps.mm
@@ -22,23 +22,6 @@ QueryData genRunningApps(QueryContext& context) {
   }
 
   NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
-  // If query contains "where is_active = 1", return app in focus without
-  // iterating through all apps
-  if (context.constraints.count("is_active") > 0 &&
-      context.constraints.at("is_active").exists(EQUALS) &&
-      context.constraints["is_active"].matches<int>(1)) {
-    Row r;
-    NSRunningApplication* appInFocus = [workspace frontmostApplication];
-    context.setIntegerColumnIfUsed(r, "pid", appInFocus.processIdentifier);
-    context.setTextColumnIfUsed(r,
-                                "bundle_identifier",
-                                appInFocus.bundleIdentifier
-                                    ? appInFocus.bundleIdentifier.UTF8String
-                                    : "");
-    context.setIntegerColumnIfUsed(r, "is_active", 1);
-    results.push_back(r);
-    return results;
-  }
 
   NSArray* runningApplications = [workspace runningApplications];
   for (NSRunningApplication* app in runningApplications) {
@@ -48,7 +31,7 @@ QueryData genRunningApps(QueryContext& context) {
         r,
         "bundle_identifier",
         app.bundleIdentifier ? app.bundleIdentifier.UTF8String : "");
-    context.setIntegerColumnIfUsed(r, "is_active", app.isActive ? 1 : 0);
+    context.setIntegerColumnIfUsed(r, "is_active", -1);
     results.push_back(r);
   }
   return results;

--- a/specs/darwin/running_apps.table
+++ b/specs/darwin/running_apps.table
@@ -5,7 +5,7 @@ description("macOS applications currently running on the host system.")
 schema([
     Column("pid", INTEGER, "The pid of the application", index=True),
     Column("bundle_identifier", TEXT, "The bundle identifier of the application"),
-    Column("is_active", INTEGER, "(DEPRECATED) 1 if the application is in focus, 0 otherwise", hidden=True)
+    Column("is_active", INTEGER, "(DEPRECATED)", hidden=True)
 ])
 
 implementation("running_apps@genRunningApps")

--- a/specs/darwin/running_apps.table
+++ b/specs/darwin/running_apps.table
@@ -5,7 +5,7 @@ description("macOS applications currently running on the host system.")
 schema([
     Column("pid", INTEGER, "The pid of the application", index=True),
     Column("bundle_identifier", TEXT, "The bundle identifier of the application"),
-    Column("is_active", INTEGER, "1 if the application is in focus, 0 otherwise", additional=True)
+    Column("is_active", INTEGER, "(DEPRECATED) 1 if the application is in focus, 0 otherwise", hidden=True)
 ])
 
 implementation("running_apps@genRunningApps")

--- a/tests/integration/tables/running_apps.cpp
+++ b/tests/integration/tables/running_apps.cpp
@@ -30,11 +30,7 @@ TEST_F(runningApps, test_sanity) {
   QueryData general_query_data = execute_query("select * from running_apps");
   ASSERT_FALSE(general_query_data.empty());
   validate_rows(general_query_data, row_map);
-
-  QueryData specific_query_data =
-      execute_query("select * from running_apps where is_active = 1");
-  ASSERT_EQ(specific_query_data.size(), 1ul);
-  validate_rows(specific_query_data, row_map);
+  
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/running_apps.cpp
+++ b/tests/integration/tables/running_apps.cpp
@@ -30,7 +30,6 @@ TEST_F(runningApps, test_sanity) {
   QueryData general_query_data = execute_query("select * from running_apps");
   ASSERT_FALSE(general_query_data.empty());
   validate_rows(general_query_data, row_map);
-  
 }
 
 } // namespace table_tests


### PR DESCRIPTION
This column will only return accurate data when on query in `osqueryi`. This means that whenever this table is queried via distributed or scheduled queries, it will return false and inaccurate data.

This is a quirk of the NSWorkspace API on macOS, which needs to be run from the main thread only. I tried looking at the slightly higher cocoa API to replace this, but couldn’t find any.

I am also unaware of very many users of this column, and I think it should be okay to deprecate it.