### PR TITLE
macOS: fix sanity test for `running_apps` table

### DIFF
--- a/tests/integration/tables/running_apps.cpp
+++ b/tests/integration/tables/running_apps.cpp
@@ -23,9 +23,7 @@ class runningApps : public testing::Test {
 };
 
 TEST_F(runningApps, test_sanity) {
-  ValidationMap row_map = {{"pid", IntType},
-                           {"bundle_identifier", NormalType},
-                           {"is_active", IntType}};
+  ValidationMap row_map = {{"pid", IntType}, {"bundle_identifier", NormalType}};
 
   QueryData general_query_data = execute_query("select * from running_apps");
   ASSERT_FALSE(general_query_data.empty());


### PR DESCRIPTION
fix sanity test for `running_apps` table