### PR TITLE
Add a list of Osquery fleet managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-
 ## Osquery fleet managers
 
 There are many osquery fleet managers out there. The osquery project does not endorse, recommend, or test these. They are provided as a starting point
+
 | Project                                                 | License     |
 | ------------------------------------------------------- | ----------- |
 | [Fleet](https://github.com/fleetdm/fleet)               | Open Core   |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-
 | Project                                                 | License     |
 | ------------------------------------------------------- | ----------- |
 | [Fleet](https://github.com/fleetdm/fleet)               | Open Core   |
-| [Kolide](https://www.kolide.com)                        | Freemium    |
+| [Kolide](https://www.kolide.com)                        | Commercial    |
 | [OSCTRL](https://github.com/jmpsec/osctrl)              | Open Source |
 | [Zentral](https://github.com/zentralopensource/zentral) | Open Source |
 | [Zercurity](https://github.com/zercurity/zercurity)     | Freemium    |

--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-
 
 ## Osquery fleet managers
 
-| Project                                             | License     |
-| --------------------------------------------------- | ----------- |
-| [Fleet](https://github.com/fleetdm/fleet)           | Open Core  |
-| [Kolide](https://www.kolide.com)                    | Freemium    |
-| [OSCTRL](https://github.com/jmpsec/osctrl)          | Open Source |
-| [Zercurity](https://github.com/zercurity/zercurity) | Freemium    |
+| Project                                                 | License     |
+| ------------------------------------------------------- | ----------- |
+| [Fleet](https://github.com/fleetdm/fleet)               | Open Core   |
+| [Kolide](https://www.kolide.com)                        | Freemium    |
+| [OSCTRL](https://github.com/jmpsec/osctrl)              | Open Source |
+| [Zentral](https://github.com/zentralopensource/zentral) | Open Source |
+| [Zercurity](https://github.com/zercurity/zercurity)     | Freemium    |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-
 
 | Project                                             | License     |
 | --------------------------------------------------- | ----------- |
-| [Fleet](https://github.com/fleetdm/fleet)           | Commercial  |
+| [Fleet](https://github.com/fleetdm/fleet)           | Open Core  |
 | [Kolide](https://www.kolide.com)                    | Freemium    |
 | [OSCTRL](https://github.com/jmpsec/osctrl)          | Open Source |
 | [Zercurity](https://github.com/zercurity/zercurity) | Freemium    |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ guide](https://osquery.readthedocs.io/en/latest/development/building/). Also
 check out our [contributing guide](CONTRIBUTING.md) and join the
 community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
 
+## Osquery fleet managers
+
+| Project                                             | License     |
+| --------------------------------------------------- | ----------- |
+| [Fleet](https://github.com/fleetdm/fleet)           | Commercial  |
+| [Kolide](https://www.kolide.com)                    | Freemium    |
+| [OSCTRL](https://github.com/jmpsec/osctrl)          | Open Source |
+| [Zercurity](https://github.com/zercurity/zercurity) | Freemium    |
+
 ## License
 
 By contributing to osquery you agree that your contributions will be

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-
 
 ## Osquery fleet managers
 
+There are many osquery fleet managers out there. The osquery project does not endorse, recommend, or test these. They are provided as a starting point
 | Project                                                 | License     |
 | ------------------------------------------------------- | ----------- |
 | [Fleet](https://github.com/fleetdm/fleet)               | Open Core   |


### PR DESCRIPTION
Following on from a quick discussion on Slack. I've added a table to show case the available fleet managers for Osquery.
