### PR TITLE
docker_containers: Don't report finished_at for a container which is still running

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -409,8 +409,11 @@ QueryData genContainers(QueryContext& context) {
           BIGINT(container_details.get_child("State").get<pid_t>("Pid", -1));
       r["started_at"] = container_details.get_child("State").get<std::string>(
           "StartedAt", "");
-      r["finished_at"] = container_details.get_child("State").get<std::string>(
-          "FinishedAt", "");
+      if (r["state"] != "running") {
+        r["finished_at"] =
+            container_details.get_child("State").get<std::string>("FinishedAt",
+                                                                  "");
+      }
       r["privileged"] = container_details.get_child("HostConfig")
                                 .get<bool>("Privileged", false)
                             ? INTEGER(1)

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -413,6 +413,8 @@ QueryData genContainers(QueryContext& context) {
         r["finished_at"] =
             container_details.get_child("State").get<std::string>("FinishedAt",
                                                                   "");
+      } else {
+        r["finished_at"] = "";
       }
       r["privileged"] = container_details.get_child("HostConfig")
                                 .get<bool>("Privileged", false)


### PR DESCRIPTION
Fixes fleetdm/fleet#8007

This patch is quite simple and seems to work on my macOS 12.6 system, though I don't have a macOS 13 system to test.
Reporting any finished_at time makes no sense when a container is running, even if that time isn't 1 CE like it is on macOS 13. Therefore I decided to leave the column empty when the container is running, instead of checking if the date makes sense.