### PR TITLE
`processes`: Stabilize the `start_time` column value on macOS and Linux

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -269,6 +269,7 @@ function(generateOsqueryTablesSystemSystemtable)
   if(DEFINED PLATFORM_LINUX)
     target_link_libraries(osquery_tables_system_systemtable PUBLIC
       osquery_utils_linux
+      osquery_utils_system_boottime
       thirdparty_libdevmapper
       thirdparty_libcryptsetup
       thirdparty_librpm

--- a/osquery/utils/system/CMakeLists.txt
+++ b/osquery/utils/system/CMakeLists.txt
@@ -28,6 +28,10 @@ function(osqueryUtilsSystemMain)
   generateOsqueryUtilsSystem()
   generateOsqueryUtilsSystemUptime()
 
+  if(DEFINED PLATFORM_LINUX)
+    generateOsqueryUtilsSystemBoottime()
+  endif()
+
   if(DEFINED PLATFORM_WINDOWS)
     generateOsqueryUtilsSystemUsersGroups()
   endif()
@@ -246,6 +250,30 @@ function(generateOsqueryUtilsSystemUptime)
   )
 
   generateIncludeNamespace(osquery_utils_system_uptime "osquery/utils/system" "FILE_ONLY" ${public_header_files})
+endfunction()
+
+function(generateOsqueryUtilsSystemBoottime)
+
+  if(DEFINED PLATFORM_LINUX)
+    set(source_files
+      linux/boottime.cpp
+    )
+  endif()
+
+  add_osquery_library(osquery_utils_system_boottime EXCLUDE_FROM_ALL
+    ${source_files}
+  )
+
+  target_link_libraries(osquery_utils_system_boottime PUBLIC
+    osquery_cxx_settings
+    osquery_filesystem
+  )
+
+  set(public_header_files
+    boottime.h
+  )
+
+  generateIncludeNamespace(osquery_utils_system_boottime "osquery/utils/system" "FILE_ONLY" ${public_header_files})
 endfunction()
 
 function(generateOsqueryUtilsSystemUsersGroups)

--- a/osquery/utils/system/boottime.h
+++ b/osquery/utils/system/boottime.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <cstdint>
+
+#include <osquery/filesystem/filesystem.h>
+
+namespace osquery {
+std::uint64_t getBootTime();
+} // namespace osquery

--- a/osquery/utils/system/linux/boottime.cpp
+++ b/osquery/utils/system/linux/boottime.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/system/boottime.h>
+
+namespace osquery {
+std::uint64_t getBootTime() {
+  std::string content;
+  auto status = readFile("/proc/stat", content);
+
+  if (!status.ok()) {
+    return 0;
+  }
+
+  auto btime_start = content.find("btime");
+
+  if (btime_start == std::string::npos) {
+    return 0;
+  }
+
+  btime_start += 6;
+
+  auto btime_end = content.find("\n", btime_start);
+
+  if (btime_end == std::string::npos) {
+    return 0;
+  }
+
+  auto btime = content.substr(btime_start, btime_end - btime_start);
+
+  auto btime_res = tryTo<std::uint64_t>(btime);
+
+  if (btime_res.isError()) {
+    return 0;
+  }
+
+  return btime_res.take();
+}
+} // namespace osquery


### PR DESCRIPTION
- Linux: instead of using the uptime and having to extrapolate the boot time and then calculate the start time, which causes multiple clock reads and therefore an inherent imprecision in the final result, we read directly the boot time from procfs once and keep it in memory for the whole process duration.

- macOS: instead of extrapolating the process age and then use that to calculate the start time, which is again done through two different clock reads, read the already correct start time from another API. This also fixes a bug with system sleep, since the start time retrieved by the previous APIs was a relative value that didn't include system sleep.

Fixes #7556, #6911