### PR TITLE
packs/incident_response: process_memory_map is also applicable to Darwin

### DIFF
--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -229,7 +229,7 @@
       "interval" : "86400",
       "platform" : "posix",
       "version" : "1.4.5",
-      "description" : "Retrieves the memory map per process in the target Linux system.",
+      "description" : "Retrieves the memory map per process in the target Linux or macOS system.",
       "value" : "Ability to compare with known good. Identify mapped regions corresponding with or containing injected code."
     },
     "arp_cache": {

--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -227,7 +227,7 @@
     "process_memory": {
       "query" : "select * from process_memory_map;",
       "interval" : "86400",
-      "platform" : "linux",
+      "platform" : "posix",
       "version" : "1.4.5",
       "description" : "Retrieves the memory map per process in the target Linux system.",
       "value" : "Ability to compare with known good. Identify mapped regions corresponding with or containing injected code."


### PR DESCRIPTION
This PR updates the `process_memory_map` query from `linux` to `posix`, so that it will execute on macOS machines where it is also beneficial.

