### PR TITLE
Fix deadlock when logging happens during a database reset

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -598,12 +598,6 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
         1, "Memory limits exceeded: " + std::to_string(change.footprint));
   }
 
-  // The worker is sane, no action needed.
-  // Attempt to flush status logs to the well-behaved worker.
-  if (use_worker_ && child.pid() == watcher_->getWorker().pid()) {
-    relayStatusLogs();
-  }
-
   return Status(0);
 }
 

--- a/osquery/logger/data_logger.h
+++ b/osquery/logger/data_logger.h
@@ -124,6 +124,15 @@ Status logSnapshotQuery(const QueryLogItem& item);
  */
 void relayStatusLogs(LoggerRelayMode relay_mode = LoggerRelayMode::Sync);
 
+/**
+ * @brief Waits for the relay thread to finish
+ *
+ * Waits for the new relay thread launched by the relayStatusLogs function,
+ * called previously on the current thread, to finish.
+ * Must not be called in a path that can be called by Google Log.
+ */
+void waitLogRelay();
+
 /// Inspect the number of internal-buffered status log lines.
 size_t queuedStatuses();
 


### PR DESCRIPTION
A deadlock could happen if a log relay thread
was trying to serialize logs into the database
when a database reset was being attempted.

Since the log relay thread is started by the same thread that executes the database reset, the scheduler thread, ensure that the log relay thread has finished its work before doing a database reset on the next scheduler loop.

Also ensure that when the scheduler is finishing its work, to permit osquery to exit, we wait on the log relaying thread if it's still running to prevent race conditions
and possible crashes on shutdown.

Finally remove the relayStatusLog call from the watcher process, it's a no-op since there's no logger plugin active.

# To reproduce
Since the database reset doesn't happen at every scheduler step, but every `schedule_reload` seconds, and by default that is 3600, reducing it to a lower value increases the chances to encounter the issue.
The starting of the relay thread doesn't too happen at every step, but every 3, so one has to wait when the two somehow align, so that at the previous step a relay thread is started, that at the next step a database reset happens, and the relay thread is still running.

When testing, to increase the chances for this to happen I've inserted a sleep when the reset database logic takes the exclusive lock on the database reset mutex (it would be below this line):
https://github.com/osquery/osquery/blob/027307903d38161fedd7e5996d0b08adb666df82/osquery/database/database.cpp#L134

Moreover this causes the scheduler loop to take more than the normally allotted time for a step (1 second), so multiple steps happen one after the other, increase the overlap chance.

osquery is launched with:
```
sudo osquery/osqueryd --allow_unsafe --enroll_tls_endpoint=/enroll --tls_client_cert=test_configs/test_client.pem --tls_client_key=test_configs/test_client.key --tls_server_certs=test_configs/test_server_ca.pem --enroll_secret_path=test_configs/test_enroll_secret.txt --tls_hostname=localhost:8080 --logger_plugin=tls --verbose --schedule_reload=5
```

and the test TLS server with:
```
tools/tests/test_http_server.py --tls --persist --verbose --ca test_configs/test_server_ca.pem --cert test_configs/test_server.pem --key test_configs/test_server.key --test-configs-dir test_configs 8080
```