### PR TITLE
Set counter consistently so zero always indicates all records

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -279,7 +279,7 @@ To aid with this, osquery maintains an `epoch` marker along with each scheduled 
 
 ### Schedule counter
 
-When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial `added` records. `counter` can be used to identify if the added records are all records from initial query of if they are new records. For initial query results that includes all records counter will be **"0"**. For subsequent query executions counter will be incremented by **1**. When `epoch` changes, counter will be reset back to `0`.
+When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial `added` records. `counter` can be used to identify if the added records are all records from initial query or if they are new records. For initial query results that include all records counter will be **"0"**, while initial results without all records (like event tables) will start at **"1"**. For subsequent query executions counter will be incremented by **1**. When `epoch` changes, counter will be reset back to the initial query state.
 
 ### Numerics
 

--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -172,17 +172,16 @@ class Query {
    * @brief Get the query invocation counter.
    *
    * This method returns query invocation counter. If the query is returning all
-   * records, the counter resets to 0. If the query is a new query, but not
-   * returning all records, the counter resets to 1. Otherwise the counter
-   * associated with the query is retrieved from the database and incremented
-   * by 1.
+   * records, the counter resets to 0. If the counter is resetting, but not
+   * returning all records, it resets to 1. Otherwise the counter associated
+   * with the query is retrieved from the database and incremented by 1.
    *
    * @param all_records Whether or not the query is including all records
-   * @param new_query Whether or not the query is new.
+   * @param is_reset Whether or not the query counter is reset.
    *
    * @return the query invocation counter.
    */
-  uint64_t getQueryCounter(bool all_records, bool new_query) const;
+  uint64_t getQueryCounter(bool all_records, bool is_reset) const;
 
   /**
    * @brief Check if a given scheduled query exists in the database.

--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -192,11 +192,11 @@ class Query {
   bool isQueryNameInDatabase() const;
 
   /**
-   * @brief Check if a query (not query name) is 'new' or altered.
+   * @brief Check if a query's SQL (not query name) is 'new' or altered.
    *
-   * @return true if the scheduled query has not been altered.
+   * @return true if the scheduled query has been altered.
    */
-  bool isNewQuery() const;
+  bool isNewQuerySql() const;
 
   /// Determines if this is a first run or new query.
   void getQueryStatus(uint64_t epoch,

--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -171,17 +171,19 @@ class Query {
   /**
    * @brief Get the query invocation counter.
    *
-   * This method returns query invocation counter. If the query is returning all
-   * records, the counter resets to 0. If the counter is resetting, but not
-   * returning all records, it resets to 1. Otherwise the counter associated
-   * with the query is retrieved from the database and incremented by 1.
+   * This method returns query invocation counter. If the counter is resetting
+   * and returning all records, the counter resets to 0. If the counter is
+   * resetting, but not returning all records, it resets to 1. Otherwise the
+   * counter associated with the query is retrieved from the database and
+   * incremented by 1.
    *
-   * @param all_records Whether or not the query is including all records
    * @param is_reset Whether or not the query counter is reset.
+   * @param reset_has_all_records Whether or not a reset would include all
+   * records
    *
    * @return the query invocation counter.
    */
-  uint64_t getQueryCounter(bool all_records, bool is_reset) const;
+  uint64_t getQueryCounter(bool is_reset, bool reset_has_all_records) const;
 
   /**
    * @brief Check if a given scheduled query exists in the database.
@@ -203,25 +205,9 @@ class Query {
                       bool& new_query) const;
 
   /// Increment and return the query counter.
-  Status incrementCounter(bool all_records,
-                          bool new_query,
+  Status incrementCounter(bool is_reset,
+                          bool reset_has_all_records,
                           uint64_t& counter) const;
-
-  /**
-   * @brief Add a new set of results to the persistent storage.
-   *
-   * Given the results of the execution of a scheduled query, add the results
-   * to the database using addNewResults.
-   *
-   * @param qd the QueryDataTyped object, which has the results of the query.
-   * @param epoch the epoch associated with QueryData
-   * @param counter [output] the output that holds the query execution counter.
-   *
-   * @return the success or failure of the operation.
-   */
-  Status addNewResults(QueryDataTyped qd,
-                       uint64_t epoch,
-                       uint64_t& counter) const;
 
   /**
    * @brief Add a new set of results to the persistent storage and get back
@@ -235,15 +221,13 @@ class Query {
    * @param epoch the epoch associated with QueryData
    * @param counter the output that holds the query execution counter.
    * @param dr an output to a DiffResults object populated based on last run.
-   * @param calculate_diff default true to populate dr.
    *
    * @return the success or failure of the operation.
    */
   Status addNewResults(QueryDataTyped qd,
                        uint64_t epoch,
                        uint64_t& counter,
-                       DiffResults& dr,
-                       bool calculate_diff = true) const;
+                       DiffResults& dr) const;
 
   /// A version of adding new results for events-based queries.
   Status addNewEvents(QueryDataTyped current_qd,

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -197,14 +197,14 @@ TEST_F(QueryTests, test_query_name_updated) {
   QueryDataSet previous_qd;
   auto query = getOsqueryScheduledQuery();
   auto cf = Query("will_update_query", query);
-  EXPECT_TRUE(cf.isNewQuery());
-  EXPECT_TRUE(cf.isNewQuery());
+  EXPECT_TRUE(cf.isNewQuerySql());
+  EXPECT_TRUE(cf.isNewQuerySql());
 
   DiffResults dr;
   uint64_t counter = 128;
   auto results = getTestDBExpectedResults();
   cf.addNewResults(results, 0, counter, dr);
-  EXPECT_FALSE(cf.isNewQuery());
+  EXPECT_FALSE(cf.isNewQuerySql());
   EXPECT_EQ(counter, 0UL);
   EXPECT_FALSE(dr.hasNoResults());
 
@@ -212,9 +212,9 @@ TEST_F(QueryTests, test_query_name_updated) {
   counter = 128;
   auto cf2 = Query("will_update_query", query);
   EXPECT_TRUE(cf2.isQueryNameInDatabase());
-  EXPECT_TRUE(cf2.isNewQuery());
+  EXPECT_TRUE(cf2.isNewQuerySql());
   cf2.addNewResults(results, 0, counter, dr);
-  EXPECT_FALSE(cf2.isNewQuery());
+  EXPECT_FALSE(cf2.isNewQuerySql());
   EXPECT_EQ(counter, 1UL);
   EXPECT_TRUE(dr.hasNoResults());
 }

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -75,11 +75,11 @@ TEST_F(QueryTests, test_get_query_status) {
   auto cf = Query("query_status", query);
 
   // We have never seen this query before (it has no results yet either).
-  bool new_epoch = false;
-  bool new_query = false;
-  cf.getQueryStatus(100, new_epoch, new_query);
-  EXPECT_TRUE(new_epoch);
-  EXPECT_TRUE(new_query);
+  bool new_query_epoch = false;
+  bool new_query_sql = false;
+  cf.getQueryStatus(100, new_query_epoch, new_query_sql);
+  EXPECT_TRUE(new_query_epoch);
+  EXPECT_TRUE(new_query_sql);
 
   // Add results for this query (this action is not under test).
   uint64_t counter = 0;
@@ -87,31 +87,31 @@ TEST_F(QueryTests, test_get_query_status) {
   ASSERT_TRUE(status.ok());
 
   // The query has results and the query text has not changed.
-  new_epoch = false;
-  new_query = false;
-  cf.getQueryStatus(100, new_epoch, new_query);
-  EXPECT_FALSE(new_epoch);
-  EXPECT_FALSE(new_query);
+  new_query_epoch = false;
+  new_query_sql = false;
+  cf.getQueryStatus(100, new_query_epoch, new_query_sql);
+  EXPECT_FALSE(new_query_epoch);
+  EXPECT_FALSE(new_query_sql);
 
   // The epoch changed so the previous results are invalid.
-  new_epoch = false;
-  new_query = false;
-  cf.getQueryStatus(101, new_epoch, new_query);
-  EXPECT_TRUE(new_epoch);
-  EXPECT_FALSE(new_query);
+  new_query_epoch = false;
+  new_query_sql = false;
+  cf.getQueryStatus(101, new_query_epoch, new_query_sql);
+  EXPECT_TRUE(new_query_epoch);
+  EXPECT_FALSE(new_query_sql);
 
   // Add results for the new epoch (this action is not under test).
   status = cf.addNewResults(getTestDBExpectedResults(), 101, counter);
   ASSERT_TRUE(status.ok());
 
   // The epoch is the same but the query text has changed.
-  new_epoch = false;
-  new_query = false;
+  new_query_epoch = false;
+  new_query_sql = false;
   query.query += " LIMIT 1";
   auto cf2 = Query("query_status", query);
-  cf2.getQueryStatus(101, new_epoch, new_query);
-  EXPECT_FALSE(new_epoch);
-  EXPECT_TRUE(new_query);
+  cf2.getQueryStatus(101, new_query_epoch, new_query_sql);
+  EXPECT_FALSE(new_query_epoch);
+  EXPECT_TRUE(new_query_sql);
 }
 
 TEST_F(QueryTests, test_add_and_get_current_results) {

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -206,6 +206,7 @@ TEST_F(QueryTests, test_query_name_updated) {
   cf.addNewResults(results, 0, counter, dr);
   EXPECT_FALSE(cf.isNewQuery());
   EXPECT_EQ(counter, 0UL);
+  EXPECT_FALSE(dr.hasNoResults());
 
   query.query += " LIMIT 1";
   counter = 128;
@@ -214,7 +215,8 @@ TEST_F(QueryTests, test_query_name_updated) {
   EXPECT_TRUE(cf2.isNewQuery());
   cf2.addNewResults(results, 0, counter, dr);
   EXPECT_FALSE(cf2.isNewQuery());
-  EXPECT_EQ(counter, 0UL);
+  EXPECT_EQ(counter, 1UL);
+  EXPECT_TRUE(dr.hasNoResults());
 }
 
 TEST_F(QueryTests, test_get_stored_query_names) {


### PR DESCRIPTION
This change sets the counter to zero only when all records are being logged as part of an initial run or new epoch. 

Previously in some cases, the counter would be zero for a differential log (specifically events tables or if the query changed). For these cases, the counter is now reset to 1 instead. This change also does a small refactor to ensure the epoch in the database is updated for events tables, so that it will be set accurately if the same query is later changed to run over a non-evented table.

More context and motivation for this change is in https://github.com/osquery/osquery/issues/7799