### PR TITLE
Support logging empty result set in batch format for initial runs

### DIFF
--- a/osquery/core/query.h
+++ b/osquery/core/query.h
@@ -35,6 +35,9 @@ class Status;
  */
 struct QueryLogItem {
  public:
+  /// Indicates if results are in snapshot form instead of differential
+  bool isSnapshot;
+
   /// Differential results from the query.
   DiffResults results;
 

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -265,25 +265,29 @@ TEST_F(LoggerTests, test_logger_variations) {
 TEST_F(LoggerTests, test_logger_snapshots) {
   // A snapshot query should not include removed items.
   QueryLogItem item;
+  item.isSnapshot = true;
   item.name = "test_query";
   item.identifier = "unknown_test_host";
   item.time = 0;
   item.calendar_time = "no_time";
 
   // Add a fake set of results.
-  item.results.added.push_back({{"test_column", "test_value"}});
-  logSnapshotQuery(item);
+  item.snapshot_results.push_back({{"test_column", "test_value"}});
+  auto status = logSnapshotQuery(item);
+  EXPECT_TRUE(status.ok());
 
   // Expect the plugin to optionally handle snapshot logging.
   EXPECT_EQ(1U, LoggerTests::snapshot_rows_added);
 
   // Expect a single event, event though there were two added.
-  item.results.added.push_back({{"test_column", "test_value"}});
-  logSnapshotQuery(item);
+  item.snapshot_results.push_back({{"test_column", "test_value"}});
+  status = logSnapshotQuery(item);
+  EXPECT_TRUE(status.ok());
   EXPECT_EQ(2U, LoggerTests::snapshot_rows_added);
 
   FLAGS_logger_snapshot_event_type = true;
-  logSnapshotQuery(item);
+  status = logSnapshotQuery(item);
+  EXPECT_TRUE(status.ok());
   EXPECT_EQ(4U, LoggerTests::snapshot_rows_added);
   FLAGS_logger_snapshot_event_type = false;
 }
@@ -350,6 +354,7 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   item.calendar_time = "no_time";
   item.epoch = 0L;
   item.counter = 0L;
+  item.isSnapshot = false;
   item.results.added.push_back({{"test_column", "test_value"}});
   logQueryLogItem(item);
   EXPECT_EQ(1U, LoggerTests::log_lines.size());
@@ -386,6 +391,7 @@ TEST_F(LoggerTests, test_logger_numeric_flag) {
   item.calendar_time = "no_time";
   item.epoch = 0L;
   item.counter = 0L;
+  item.isSnapshot = false;
   item.results.added.push_back({{"test_double_column", 2.000}});
   FLAGS_logger_numerics = true;
   logQueryLogItem(item);

--- a/osquery/sql/tests/sql_test_utils.cpp
+++ b/osquery/sql/tests/sql_test_utils.cpp
@@ -144,6 +144,7 @@ std::pair<JSON, QueryLogItem> getSerializedQueryLogItem() {
   QueryLogItem i;
   JSON doc = JSON::newObject();
   auto dr = getSerializedDiffResults();
+  i.isSnapshot = false;
   i.results = std::move(dr.second);
   i.name = "foobar";
   i.calendar_time = "Mon Aug 25 12:10:57 2014";

--- a/plugins/config/parsers/tests/decorators_tests.cpp
+++ b/plugins/config/parsers/tests/decorators_tests.cpp
@@ -94,6 +94,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   QueryLogItem item;
   item.epoch = 0L;
   item.counter = 0L;
+  item.isSnapshot = true;
   getDecorations(item.decorations);
   ASSERT_EQ(item.decorations.size(), 2U);
   EXPECT_EQ(item.decorations.at("internal_60_test"), "test");

--- a/plugins/logger/tests/filesystem_logger_tests.cpp
+++ b/plugins/logger/tests/filesystem_logger_tests.cpp
@@ -149,6 +149,7 @@ TEST_F(FilesystemLoggerTests, test_log_status) {
 
 TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   QueryLogItem item;
+  item.isSnapshot = true;
   item.name = "test";
   item.identifier = "test";
   item.time = 0;


### PR DESCRIPTION
This change adds logging of an empty result set in batch format for an initial run (or new epoch) if there are no results. Previously the no results case was ignored and not logged even on an initial run / new epoch.

This makes the initial run / new epoch for differential queries more consistent with the snapshot query behavior, and it ensures there is always a "counter=0" log entry for each epoch in batch format. It makes it possible for users to differentiate between a query not running and the query not producing any results.

More context is in https://github.com/osquery/osquery/issues/7799

### Backward Compatibility
This should not lead to significantly more log events than before, as it is adding at most one log per epoch change.

There's a risk that implementations won't handle having both "added" and "removed" lists be empty correctly, but this risk seems low enough as it's already valid/expected for either of these lists to be empty independently. Osquery documentation never promises not to emit an empty entry like this, and its meaning seems reasonably expected/clear.
