### PR TITLE
Update `docker_container_stats` table to include `cached_memory` column

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -911,6 +911,8 @@ QueryData genContainerStats(QueryContext& context) {
           INTEGER(container.get<uint64_t>("precpu_stats.online_cpus", 0));
       r["memory_usage"] =
           BIGINT(container.get<uint64_t>("memory_stats.usage", 0));
+      r["memory_cached"] =
+          BIGINT(container.get<uint64_t>("memory_stats.stats.cache", 0));
       r["memory_max_usage"] =
           BIGINT(container.get<uint64_t>("memory_stats.max_usage", 0));
       r["memory_limit"] =

--- a/specs/posix/docker_container_stats.table
+++ b/specs/posix/docker_container_stats.table
@@ -21,6 +21,7 @@ schema([
     Column("pre_system_cpu_usage", BIGINT, "Last read CPU system usage"),
     Column("pre_online_cpus", INTEGER, "Last read online CPUs"),
     Column("memory_usage", BIGINT, "Memory usage"),
+    Column("memory_cached", BIGINT, "Memory cached"),
     Column("memory_max_usage", BIGINT, "Memory maximum usage"),
     Column("memory_limit", BIGINT, "Memory limit"),
     Column("network_rx_bytes", BIGINT, "Total network bytes read"),

--- a/tests/integration/tables/docker_container_stats.cpp
+++ b/tests/integration/tables/docker_container_stats.cpp
@@ -54,6 +54,7 @@ TEST_F(dockerContainerStats, test_sanity) {
   //      {"pre_system_cpu_usage", IntType}
   //      {"pre_online_cpus", IntType}
   //      {"memory_usage", IntType}
+  //      {"memory_cached", IntType}
   //      {"memory_max_usage", IntType}
   //      {"memory_limit", IntType}
   //      {"network_rx_bytes", IntType}


### PR DESCRIPTION
The docker container memory usage isn't in sync with docker cli which subtracts the cached memory from the used memory. I added a new column to docker_container_stats to get the cached container memory to get more detailed information about container memory usage.