### PR TITLE
macOS keychain experiments,  remove `SecKeychainOpen`

### DIFF
--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -23,7 +23,6 @@ namespace tables {
 extern const std::vector<std::string> kSystemKeychainPaths;
 extern const std::vector<std::string> kUserKeychainPaths;
 
-void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
 std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Generate a list of keychain items for a given item type.

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -31,29 +31,6 @@ const std::vector<std::string> kUserKeychainPaths = {
     "/Library/Keychains",
 };
 
-void genKeychains(const std::string& path, CFMutableArrayRef& keychains) {
-  std::vector<std::string> paths;
-
-  // Support both a directory and explicit path search.
-  if (isDirectory(path).ok()) {
-    // Try to list every file in the given keychain search path.
-    if (!listFilesInDirectory(path, paths).ok()) {
-      return;
-    }
-  } else {
-    // The explicit path search comes from a query predicate.
-    paths.push_back(path);
-  }
-
-  for (const auto& keychain_path : paths) {
-    SecKeychainRef keychain = nullptr;
-    auto status = SecKeychainOpen(keychain_path.c_str(), &keychain);
-    if (status == 0 && keychain != nullptr) {
-      CFArrayAppendValue(keychains, keychain);
-    }
-  }
-}
-
 std::string getKeychainPath(const SecKeychainItemRef& item) {
   SecKeychainRef keychain = nullptr;
   std::string path;
@@ -65,7 +42,8 @@ std::string getKeychainPath(const SecKeychainItemRef& item) {
 
   UInt32 path_size = 1024;
   char keychain_path[1024] = {0};
-  status = SecKeychainGetPath(keychain, &path_size, keychain_path);
+  status = SecKeychainGetPath(
+      keychain, &path_size, keychain_path); // seph deprecated
   if (status != errSecSuccess || (path_size > 0 && keychain_path[0] != 0)) {
     path = std::string(keychain_path);
   }
@@ -76,10 +54,6 @@ std::string getKeychainPath(const SecKeychainItemRef& item) {
 
 CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
                                const CFTypeRef& item_type) {
-  auto keychains = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
-  for (const auto& path : paths) {
-    genKeychains(path, keychains);
-  }
 
   CFMutableDictionaryRef query;
   query = CFDictionaryCreateMutable(nullptr,
@@ -90,16 +64,12 @@ CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
   CFDictionaryAddValue(query, kSecReturnRef, kCFBooleanTrue);
   // This can be added to restrict results to x509v3
   // CFDictionaryAddValue(query, kSecAttrCertificateType, 0x03);
-  CFDictionaryAddValue(query, kSecMatchSearchList, keychains);
   CFDictionaryAddValue(query, kSecAttrCanVerify, kCFBooleanTrue);
   CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitAll);
 
   CFArrayRef keychain_certs;
   auto status = SecItemCopyMatching(query, (CFTypeRef*)&keychain_certs);
   CFRelease(query);
-
-  // Release each keychain search path.
-  CFRelease(keychains);
 
   if (status != errSecSuccess) {
     return nullptr;


### PR DESCRIPTION
Playing around with #7780

If I understand our code correctly, we look for keychain files, then pass them to `SecKeychainOpen`. Sadly, `SecKeychainOpen` is deprecated. This is an experiment that removes calls to it.

Perhaps unsurprising, I get a lot fewer certificates. It gets some keychains, but not all of them. There might be a better way.

Stock osquery:
```
osquery> select count(*), path from certificates group by path;
+----------+-----------------------------------------------------------+
| count(*) | path                                                      |
+----------+-----------------------------------------------------------+
| 9        | /Library/Keychains/System.keychain                        |
| 1        | /Library/Keychains/apsd.keychain                          |
| 166      | /System/Library/Keychains/SystemRootCertificates.keychain |
| 120      | /System/Library/Keychains/X509Anchors                     |
| 11       | /Users/seph/Library/Keychains/login.keychain-db           |
+----------+-----------------------------------------------------------+
```

This branch:
```
osquery> select count(*), path from certificates group by path;
+----------+-------------------------------------------------+
| count(*) | path                                            |
+----------+-------------------------------------------------+
| 9        | /Library/Keychains/System.keychain              |
| 11       | /Users/seph/Library/Keychains/login.keychain-db |
+----------+-------------------------------------------------+
```