### PR TITLE
Shimcache: Only check CurrentControlSet

### DIFF
--- a/osquery/tables/system/windows/shimcache.cpp
+++ b/osquery/tables/system/windows/shimcache.cpp
@@ -31,8 +31,9 @@ const std::string kWin10CreatorStart = "34";
 const std::string kWin8110ShimcacheDelimiter = "31307473";
 
 // Shimcache can be in multiple ControlSets (ControlSet001, ControlSet002, etc)
+// We are only going to check CurrentControlSet, which is symlinked to the active ControlSet
 const std::string kShimcacheControlset =
-    "HKEY_LOCAL_MACHINE\\SYSTEM\\%ControlSet%\\Control\\Session "
+    "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session "
     "Manager\\AppCompatCache";
 
 struct ShimcacheData {

--- a/osquery/tables/system/windows/shimcache.cpp
+++ b/osquery/tables/system/windows/shimcache.cpp
@@ -31,7 +31,9 @@ const std::string kWin10CreatorStart = "34";
 const std::string kWin8110ShimcacheDelimiter = "31307473";
 
 // Shimcache can be in multiple ControlSets (ControlSet001, ControlSet002, etc)
-// We are only going to check CurrentControlSet, which is symlinked to the active ControlSet
+// We are only going to check CurrentControlSet, which is symlinked to the
+// active ControlSet
+
 const std::string kShimcacheControlset =
     "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session "
     "Manager\\AppCompatCache";


### PR DESCRIPTION
Per Slack discussion, change shimcache table to only pull from `CurrentControlSet`. This will fix the duplicates.

Closes: https://github.com/osquery/osquery/issues/7831