### PR TITLE
New table: windows handles

### DIFF
--- a/osquery/core/windows/ntapi.h
+++ b/osquery/core/windows/ntapi.h
@@ -14,18 +14,29 @@ namespace osquery {
 
 #define NTSTATUS ULONG
 #define STATUS_SUCCESS 0L
-#define STATUS_INFO_LENGTH_MISMATCH 0xc0000004
 
 #define OBJ_CASE_INSENSITIVE 64L
 #define DIRECTORY_QUERY 0x0001
 #define SYMBOLIC_LINK_QUERY 0x0001
 
 typedef enum _SYSTEM_INFORMATION_CLASS {
+  SystemBasicInformation,
   SystemProcessorInformation,
   SystemPerformanceInformation,
   SystemTimeOfDayInformation,
   SystemPathInformation,
-  SystemProcessInformation
+  SystemProcessInformation,
+  SystemCallCountInformation,
+  SystemDeviceInformation,
+  SystemProcessorPerformanceInformation,
+  SystemFlagsInformation,
+  SystemCallTimeInformation,
+  SystemModuleInformation,
+  SystemLocksInformation,
+  SystemStackTraceInformation,
+  SystemPagedPoolInformation,
+  SystemNonPagedPoolInformation,
+  SystemHandleInformation
 } SYSTEM_INFORMATION_CLASS;
 
 typedef enum _OBJECT_INFORMATION_CLASS {
@@ -51,6 +62,11 @@ typedef struct _OBJECT_ATTRIBUTES {
   PVOID SecurityQualityOfService;
 } OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
 
+typedef struct _OBJECT_NAME_INFORMATION {
+  UNICODE_STRING Name;
+} OBJECT_NAME_INFORMATION, *POBJECT_NAME_INFORMATION;
+
+
 typedef NTSTATUS(WINAPI* ZwQueryObject)(HANDLE h,
                                         OBJECT_INFORMATION_CLASS oic,
                                         PVOID ObjectInformation,
@@ -63,30 +79,24 @@ typedef NTSTATUS(WINAPI* ZwQuerySystemInformation)(
     ULONG SystemInformationLength,
     PULONG ReturnLength);
 
-typedef NTSTATUS(NTAPI *NtQuerySystemInformation) (
-	ULONG SystemInformationClass,
-	PVOID SystemInformation,
-	ULONG SystemInformationLength,
-	PULONG ReturnLength
-);
+typedef NTSTATUS(NTAPI* NtQuerySystemInformation)(ULONG SystemInformationClass,
+	                                                PVOID SystemInformation,
+	                                                ULONG SystemInformationLength,
+	                                                PULONG ReturnLength);
 
-typedef NTSTATUS(NTAPI *NtDuplicateObject) (
-	HANDLE SourceProcessHandle,
-	HANDLE SourceHandle,
-	HANDLE TargetProcessHandle,
-	PHANDLE TargetHandle,
-	ACCESS_MASK DesiredAccess,
-	ULONG Attributes,
-	ULONG Options
-);
+typedef NTSTATUS(NTAPI* NtDuplicateObject)(HANDLE SourceProcessHandle,
+	                                         HANDLE SourceHandle,
+	                                         HANDLE TargetProcessHandle,
+	                                         PHANDLE TargetHandle,
+	                                         ACCESS_MASK DesiredAccess,
+	                                         ULONG Attributes,
+	                                         ULONG Options);
 
-typedef NTSTATUS(NTAPI *NtQueryObject)(
-	HANDLE ObjectHandle,
-	ULONG ObjectInformationClass,
-	PVOID ObjectInformation,
-	ULONG ObjectInformationLength,
-	PULONG ReturnLength
-);
+typedef NTSTATUS(NTAPI* NtQueryObject)(HANDLE ObjectHandle,
+                                       ULONG ObjectInformationClass,
+                                       PVOID ObjectInformation,
+                                       ULONG ObjectInformationLength,
+                                       PULONG ReturnLength);
 
 typedef NTSTATUS(WINAPI* NTCLOSE)(HANDLE Handle);
 

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -229,6 +229,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/hvci_status.cpp
       windows/tpm_info.cpp
       windows/prefetch.cpp
+      windows/handles.cpp
     )
   endif()
 

--- a/osquery/tables/system/windows/handles.cpp
+++ b/osquery/tables/system/windows/handles.cpp
@@ -223,7 +223,6 @@ QueryData genHandles(QueryContext &context) {
     PSYSTEM_HANDLE_INFORMATION handleInfo;
     SYSTEM_HANDLE_TABLE_ENTRY_INFO  handle;
 
-
     // HMODULE ntdllModule;
     auto _NtDuplicateObject = reinterpret_cast<NtDuplicateObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtDuplicateObject"));
     auto _NtQueryObject = reinterpret_cast<NtQueryObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQueryObject"));

--- a/osquery/tables/system/windows/handles.cpp
+++ b/osquery/tables/system/windows/handles.cpp
@@ -47,8 +47,8 @@ Status getObjectName(const NtQueryObject &_NtQueryObject, const HANDLE &processD
         objectName = sstream.str();
         return Status::success();
     }
-
-	if (_NtQueryObject(processDupHandle, ObjectNameInformation, &pName, sizeof(pName), &returnLength) != STATUS_SUCCESS){
+    
+    if (_NtQueryObject(processDupHandle, ObjectNameInformation, &pName, sizeof(pName), &returnLength) != STATUS_SUCCESS){
         // TODO: Should probably realloc pName
         return Status::failure("Could not get object name informations");
     }
@@ -146,7 +146,7 @@ Status getFilenameObject(HANDLE handle, std::string &filename)
 
 BOOL getObjectType(const NtQueryObject &_NtQueryObject, const HANDLE &processDupHandle, PUBLIC_OBJECT_TYPE_INFORMATION *objectTypeInfo)
 {
-	return (_NtQueryObject(processDupHandle, ObjectTypeInformation, objectTypeInfo, 0x1000, NULL) == STATUS_SUCCESS);
+    return (_NtQueryObject(processDupHandle, ObjectTypeInformation, objectTypeInfo, 0x1000, NULL) == STATUS_SUCCESS);
 }
 
 Status getHandleInfo(
@@ -157,14 +157,14 @@ Status getHandleInfo(
     std::string objectName;
     PPUBLIC_OBJECT_TYPE_INFORMATION objectTypeInfo;
 
-	if ((objectTypeInfo = (PPUBLIC_OBJECT_TYPE_INFORMATION)malloc(0x1000)) == NULL) {
+    if ((objectTypeInfo = (PPUBLIC_OBJECT_TYPE_INFORMATION)malloc(0x1000)) == NULL) {
         return Status::failure("Could not allocate memory for objectTypeInfo");
     }
 
     // Retrieve the object type
     if (!getObjectType(_NtQueryObject, handle, objectTypeInfo))
     {
-		free(objectTypeInfo);
+        free(objectTypeInfo);
         return Status::failure("Could not get object type informations");
     }
     std::get<0>(objInfo) = wstringToString(objectTypeInfo->TypeName.Buffer);
@@ -204,7 +204,7 @@ Status getSystemHandles(PSYSTEM_HANDLE_INFORMATION &handleInfo) {
 
 	while ((ULONG)(ntstatus = _NtQuerySystemInformation(SystemHandleInformation, handleInfo, handleInfoSize, NULL)) == STATUS_INFO_LENGTH_MISMATCH)
     {
-		if ((handleInfo = (PSYSTEM_HANDLE_INFORMATION)realloc(handleInfo, handleInfoSize *= 2)) == NULL){
+        if ((handleInfo = (PSYSTEM_HANDLE_INFORMATION)realloc(handleInfo, handleInfoSize *= 2)) == NULL){
             return Status(GetLastError(), "Could not re-allocate memory for for handleInfo");
         }
     }

--- a/osquery/tables/system/windows/handles.cpp
+++ b/osquery/tables/system/windows/handles.cpp
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <ctime>
+#include <cstring>
+#include <iostream>
+#include <stdio.h>
+
+#include <windows.h>
+#include <psapi.h>
+#include <tchar.h>
+
+#include "osquery/core/windows/ntapi.h"
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/windows/strings.h>
+
+
+namespace osquery {
+namespace tables {
+
+using obj_name_type_pair = std::pair<std::wstring, std::wstring>;
+
+#define SystemHandleInformation 16
+#define ObjectNameInformation 1
+#define ObjectTypeInformation 2
+
+#define BUFF_SIZE 1000
+#define STATUS_INFO_LENGTH_MISMATCH 0xc0000004
+
+BOOL getObjectName(const NtQueryObject &_NtQueryObject, const HANDLE &processDupHandle, UNICODE_STRING &objectName)
+{
+    PVOID   objectNameInfo;
+    ULONG   returnLength;
+
+    if ((objectNameInfo = malloc(0x1000)) == NULL)
+    {
+        return FALSE;
+    }
+
+	if (_NtQueryObject(processDupHandle, ObjectNameInformation, objectNameInfo, 0x1000, &returnLength) != STATUS_SUCCESS)
+    {
+        // NtQuery failed, surement à cause du manque de buffer, donc on réaloue
+        if ((objectNameInfo = realloc(objectNameInfo, returnLength)) == NULL)
+        {
+            free(objectNameInfo);
+            return FALSE;
+        }
+        // On réessaye de récupérer le nom de l'objet
+        if (_NtQueryObject(processDupHandle, ObjectNameInformation, objectNameInfo, returnLength, NULL) != STATUS_SUCCESS)
+        {
+            free(objectNameInfo);
+            return FALSE;
+        }
+    }
+
+    objectName = *(PUNICODE_STRING)objectNameInfo;
+    free(objectNameInfo);
+    return objectName.Length > 0;
+}
+
+BOOL getFilenameObject(HANDLE handle, std::wstring &filename)
+{
+    // Most of the code was taken from
+    // https://learn.microsoft.com/en-us/windows/win32/memory/obtaining-a-file-name-from-a-file-handle
+    void    *pMem;
+    HANDLE  hFileMap;
+    TCHAR   pszFilename[MAX_PATH + 1];
+    DWORD   dwFileSizeHi = 0;
+    DWORD   dwFileSizeLo = GetFileSize(&handle, &dwFileSizeHi); 
+
+    if( dwFileSizeLo == 0 && dwFileSizeHi == 0 )
+    {
+        std::cout << "Cannot map a file with a length of zero." << std::endl;
+        return FALSE;
+    }
+
+    // Create a file mapping object.
+    hFileMap = CreateFileMapping(handle, 
+                    NULL,
+                    PAGE_READONLY,
+                    0, 
+                    1,
+                    NULL);
+    if (!hFileMap)
+        return FALSE;
+    
+    // Create a file mapping to get the file name.
+    if (!(pMem = MapViewOfFile(hFileMap, FILE_MAP_READ, 0, 0, 1)))
+    {
+        CloseHandle(hFileMap);
+        return FALSE;
+    }
+
+    if (!GetMappedFileName(GetCurrentProcess(), 
+        pMem, 
+        pszFilename,
+        MAX_PATH))
+    {
+        UnmapViewOfFile(pMem);
+        CloseHandle(hFileMap);
+        return FALSE;
+    }
+    // Translate path with device name to drive letters.
+    TCHAR szTemp[BUFF_SIZE];
+    szTemp[0] = '\0';
+
+    if (GetLogicalDriveStrings(BUFF_SIZE - 1, szTemp)) 
+    {
+        TCHAR szName[MAX_PATH];
+        TCHAR szDrive[3] = TEXT(" :");
+        BOOL bFound = FALSE;
+        TCHAR *p = szTemp;
+        do 
+        {
+            // Copy the drive letter to the template string
+            *szDrive = *p;
+
+            // Look up each device name
+            if (QueryDosDevice(szDrive, szName, MAX_PATH))
+            {
+                size_t uNameLen = _tcslen(szName);
+
+                if (uNameLen < MAX_PATH) 
+                {
+                    bFound = _tcsnicmp(pszFilename, szName, uNameLen) == 0
+                        && *(pszFilename + uNameLen) == _T('\\');
+
+                    if (bFound) 
+                    {
+                        filename = szDrive;
+                        filename.append(pszFilename + uNameLen);
+                    }
+                }
+            }
+            // Go to the next NULL character.
+            while (*p++);
+        } while (!bFound && *p); // end of string
+    }
+    else
+    {
+        filename = pszFilename;
+    }
+    UnmapViewOfFile(pMem);
+    CloseHandle(hFileMap);
+    return TRUE;
+}
+
+Status getHandleInfo(
+    const HANDLE  &handle,
+    const NtQueryObject &_NtQueryObject,
+    Row &r)
+{
+    UNICODE_STRING objectName;
+    PPUBLIC_OBJECT_TYPE_INFORMATION objectTypeInfo;
+    PVOID   objectNameInfo;
+    ULONG   returnLength;
+
+	if ((objectTypeInfo = (PPUBLIC_OBJECT_TYPE_INFORMATION)malloc(0x1000)) == NULL){
+        return Status(GetLastError(), "Could not allocate memory for objectTypeInfo");
+    }
+
+
+    r["object_type"] = wstringToString(objectTypeInfo->TypeName.Buffer);
+    if (wcscmp(objectTypeInfo->TypeName.Buffer, L"File") == 0 ) {
+        // si c'est un fichier, on récupère le chemin complet
+        std::wstring filename;
+        if (getFilenameObject(handle, filename)) {
+            r["object_name"] = "totoototoo";
+        }
+        
+    }
+    else if (getObjectName(_NtQueryObject, handle, objectName)) {
+        // r["object_name"] = wstringToString(objectName.Buffer.c_str());
+        if (_NtQueryObject(handle, ObjectTypeInformation, objectTypeInfo, 0x1000, NULL) != STATUS_SUCCESS) {
+            free(objectTypeInfo);
+            return Status(GetLastError(), "Could not get object Type");
+        }
+        if (_NtQueryObject(handle, ObjectNameInformation, objectNameInfo, 0x1000, &returnLength) != STATUS_SUCCESS)
+        {
+            // NtQuery failed, surement à cause du manque de buffer, donc on réaloue
+            if ((objectNameInfo = realloc(objectNameInfo, returnLength)) == NULL)
+            {
+                free(objectNameInfo);
+                return Status(GetLastError(), "Could not realloc objectNameInfo");
+            }
+            // On réessaye de récupérer le nom de l'objet
+            if (_NtQueryObject(handle, ObjectNameInformation, objectNameInfo, returnLength, NULL) != STATUS_SUCCESS)
+            {
+                free(objectNameInfo);
+                return FALSE;
+            }
+        }
+        objectName = *(PUNICODE_STRING)objectNameInfo;
+        r["object_name"] = wstringToString(objectName.Buffer)
+
+
+    }
+    free(objectTypeInfo);
+
+    return Status::success();
+}
+
+Status getSystemHandles(PSYSTEM_HANDLE_INFORMATION &handleInfo) {
+    NTSTATUS ntstatus;
+    ULONG handleInfoSize = 0x1000;
+
+    auto _NtQuerySystemInformation = reinterpret_cast<NtQuerySystemInformation>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQuerySystemInformation"));
+
+    if ((handleInfo = (PSYSTEM_HANDLE_INFORMATION)malloc(handleInfoSize)) == NULL){
+        return Status(GetLastError(), "Could not allocate memory for handleInfo");
+    }
+
+	while ((ULONG)(ntstatus = _NtQuerySystemInformation(SystemHandleInformation, handleInfo, handleInfoSize, NULL)) == STATUS_INFO_LENGTH_MISMATCH)
+    {
+		if ((handleInfo = (PSYSTEM_HANDLE_INFORMATION)realloc(handleInfo, handleInfoSize *= 2)) == NULL){
+            return Status(GetLastError(), "Could not re-allocate memory for for handleInfo");
+        }
+    }
+    if (ntstatus != STATUS_SUCCESS ) {
+        return Status(ntstatus, "Could not get system informations");
+    }
+    return Status::success();
+}
+
+QueryData genHandles(QueryContext &context) {
+    QueryData rows;
+
+    ULONG   i;
+    DWORD   currentPid;
+    HANDLE  processHandle;
+    HANDLE  processDupHandle;
+    PSYSTEM_HANDLE_INFORMATION handleInfo;
+    SYSTEM_HANDLE_TABLE_ENTRY_INFO  handle;
+
+    // HMODULE ntdllModule;
+    auto _NtDuplicateObject = reinterpret_cast<NtDuplicateObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtDuplicateObject"));
+    auto _NtQueryObject = reinterpret_cast<NtQueryObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQueryObject"));
+
+    // if ((ntdllModule = GetModuleHandleA("ntdll.dll")) == NULL) {
+    //     VLOG(1) << L"Unable to get a handle on ntdll.dll";
+    //     return rows;
+    // }
+
+    auto status = getSystemHandles(handleInfo);
+    if (!status.ok()) {
+        VLOG(1) << L"Unable to get system handles: " << status.getCode();
+        return rows;
+    }
+
+    currentPid = GetCurrentProcessId();
+
+    for (i = 0; i < handleInfo->NumberOfHandles; i++)
+    {
+        if (handleInfo->Handles[i].UniqueProcessId == currentPid) {
+            continue;
+        }
+        handle = handleInfo->Handles[i];
+	    if (!(processHandle = OpenProcess(PROCESS_DUP_HANDLE, FALSE, handle.UniqueProcessId))) {
+            continue;
+        }
+        if (_NtDuplicateObject(
+            processHandle,
+            (HANDLE)(intptr_t)handle.HandleValue,
+            GetCurrentProcess(),
+            &processDupHandle,
+            GENERIC_READ,
+            0,
+            0) != STATUS_SUCCESS)
+        {
+            CloseHandle(processHandle);
+            CloseHandle(processDupHandle);
+            continue;
+        }
+        Row r;
+        // obj_name_type_pair objectPair;
+
+        auto status = getHandleInfo(processDupHandle, _NtQueryObject, r);
+        if (!status.ok()) {
+            continue;
+        }
+        // if (objectPair.second.length() != 0 ) {
+            r["pid"] = BIGINT(handleInfo->Handles[i].UniqueProcessId);
+            rows.push_back(r);
+        // }
+
+    }
+
+    return rows;
+}
+
+}
+}

--- a/osquery/tables/system/windows/handles.cpp
+++ b/osquery/tables/system/windows/handles.cpp
@@ -27,7 +27,6 @@ typedef std::tuple<std::string, std::string> ObjectInfoTuple;
 
 #define BUFF_SIZE 1000
 #define IS_CONSOLE_HANDLE(h) (((((ULONG_PTR)h) & 0x10000003) == 0x3) ? TRUE : FALSE)
-// this should probably be in osquery/core/windows/ntapi.h
 #define STATUS_INFO_LENGTH_MISMATCH 0xc0000004
 
 
@@ -69,6 +68,8 @@ Status getFilenameObject(HANDLE handle, std::string &filename)
     TCHAR   pszFilename[MAX_PATH + 1];
     DWORD   dwFileSizeHi = 0;
     DWORD   dwFileSizeLo = GetFileSize(&handle, &dwFileSizeHi); 
+    TCHAR szTemp[BUFF_SIZE];
+    BOOL bFound = FALSE;
 
     if( dwFileSizeLo == 0 && dwFileSizeHi == 0 ) {
         return Status::failure("Cannot map a file with a length of zero.");
@@ -103,9 +104,7 @@ Status getFilenameObject(HANDLE handle, std::string &filename)
     }
 
     // Translate path with device name to drive letters.
-    TCHAR szTemp[BUFF_SIZE];
     szTemp[0] = '\0';
-    BOOL bFound = FALSE;
 
     if (GetLogicalDriveStrings(BUFF_SIZE - 1, szTemp)) 
     {
@@ -224,6 +223,7 @@ QueryData genHandles(QueryContext &context) {
     PSYSTEM_HANDLE_INFORMATION handleInfo;
     SYSTEM_HANDLE_TABLE_ENTRY_INFO  handle;
 
+
     // HMODULE ntdllModule;
     auto _NtDuplicateObject = reinterpret_cast<NtDuplicateObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtDuplicateObject"));
     auto _NtQueryObject = reinterpret_cast<NtQueryObject>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQueryObject"));
@@ -235,7 +235,6 @@ QueryData genHandles(QueryContext &context) {
     }
 
     currentPid = GetCurrentProcessId();
-
     for (i = 0; i < handleInfo->NumberOfHandles; i++)
     {
         if (handleInfo->Handles[i].UniqueProcessId == currentPid) {

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -303,6 +303,7 @@ function(generateNativeTables)
     "windows/prefetch.table:windows"
     "windows/tpm_info.table:windows"
     "windows/security_profile_info.table:windows"
+    "windows/handles.table:windows"
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,windows"
   )

--- a/specs/windows/handles.table
+++ b/specs/windows/handles.table
@@ -1,0 +1,12 @@
+table_name("handles")
+description("Enumerate open handles for any processes on the system.")
+schema([
+    Column("pid", BIGINT, "The process identifier that owns the handle."),
+    Column("object_type", TEXT, "The type of object referenced by the handle."),
+    Column("object_name", TEXT, "The value of the object referenced by the handle."),
+])
+implementation("handles@genHandles")
+attributes(cacheable=True)
+examples([
+  "select * from handles"
+])

--- a/specs/windows/handles.table
+++ b/specs/windows/handles.table
@@ -8,5 +8,7 @@ schema([
 implementation("handles@genHandles")
 attributes(cacheable=True)
 examples([
-  "select * from handles"
+  "select * from handles",
+  "select * from handles where pid = 1234",
+  "select * from handles where pid = 1234 and object_type = 'file'",
 ])


### PR DESCRIPTION
# Overview

This PR implements a new windows virtual table which implements https://github.com/osquery/osquery/issues/4403, https://github.com/osquery/osquery/issues/2754.
This virtual table is an enumeration of windows open handles.

# Why ?

Handles are usefull to find out which programs has a file open, or to see the windows objects (https://learn.microsoft.com/en-us/windows/win32/sysinfo/object-categories) used by a program.

# Implementation


A list of all the open handles on the system is retrieved by using the `NtQuerySystemInformation` API (https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation)
using undocumented but well known structures:
- `SYSTEM_HANDLE_INFORMATION`: [process hacker docs](https://processhacker.sourceforge.io/doc/struct___s_y_s_t_e_m___h_a_n_d_l_e___i_n_f_o_r_m_a_t_i_o_n.html)
- `SYSTEM_HANDLE_TABLE_ENTRY_INFO`: [process hacker docs](https://processhacker.sourceforge.io/doc/struct___s_y_s_t_e_m___h_a_n_d_l_e___t_a_b_l_e___e_n_t_r_y___i_n_f_o.html)


I will be happy to have your feedback on my implementation, as well as feedback on the quality of the code!