### PR TITLE
Do not access the AWS SDK request content type if missing

### DIFF
--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -458,7 +458,7 @@ Response Client::put(Request& req,
                      std::string const& content_type) {
   req.method(beast_http::verb::put);
   req.body() = body;
-  if (!content_type.empty() && content_type.size() < 512) {
+  if (!content_type.empty()) {
     req.set(beast_http::field::content_type, content_type);
   }
   return sendHTTPRequest(req);
@@ -480,7 +480,7 @@ Response Client::put(Request& req,
                      std::string const& content_type) {
   req.method(beast_http::verb::put);
   req.body() = std::move(body);
-  if (!content_type.empty() && content_type.size() < 512) {
+  if (!content_type.empty()) {
     req.set(beast_http::field::content_type, content_type);
   }
   return sendHTTPRequest(req);

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -235,12 +235,18 @@ std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
     case Aws::Http::HttpMethod::HTTP_GET:
       resp = client.get(req);
       break;
-    case Aws::Http::HttpMethod::HTTP_POST:
-      resp = client.post(req, body, request.GetContentType());
+    case Aws::Http::HttpMethod::HTTP_POST: {
+      std::string content_type =
+          request.HasContentType() ? request.GetContentType() : "";
+      resp = client.post(req, body, content_type);
       break;
-    case Aws::Http::HttpMethod::HTTP_PUT:
-      resp = client.put(req, body, request.GetContentType());
+    }
+    case Aws::Http::HttpMethod::HTTP_PUT: {
+      std::string content_type =
+          request.HasContentType() ? request.GetContentType() : "";
+      resp = client.put(req, body, content_type);
       break;
+    }
     case Aws::Http::HttpMethod::HTTP_HEAD:
       resp = client.head(req);
       break;


### PR DESCRIPTION
The AWS SDK request GetContentType function must not be called if we aren't sure (with HasContentType for instance) that the content type is in the headers,
because it doesn't return an empty type and instead returns something referencing uninitialized memory.

This is a followup to https://github.com/osquery/osquery/pull/7216

Currently the issue was spotted because it was creating problems when pulling STS credentials. The request to the `latest/api/token` endpoint (to take instance credentials to use for the STS credentials request), was sometimes failing with HTTP error code 400 (visible in the AWS logs with `--aws_debug`). osquery would then log this error as HTTP error 403 "Missing Authentication Token", when trying to go forward with the STS credential request.

So the reason for the failure in #7216 was due to the gibberish Content-Type header which sometimes was not accepted by the remote (causing the HTTP 400), or sometimes it was too long.

Below an example of what Wireshark sees:
```
Hypertext Transfer Protocol
    PUT /latest/api/token HTTP/1.1\r\n
        [Expert Info (Chat/Sequence): PUT /latest/api/token HTTP/1.1\r\n]
            [Message: PUT /latest/api/token HTTP/1.1\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Request Method: PUT
        Request URI: /latest/api/token
        Request Version: HTTP/1.1
    host: 169.254.169.254\r\n
    user-agent: aws-sdk-cpp/1.9.116 Linux/5.10.135-122.509.amzn2.x86_64 x86_64 Clang/9.0.1\r\n
    x-aws-ec2-metadata-token-ttl-seconds: 21600\r\n
    Content-Type: \354ue\334\000\254\266H\256\213\202\265\214\352y0\032\017\374\317\177\r\n
    Content-Length: 0\r\n
        [Content length: 0]
    \r\n
    [Full request URI: http://169.254.169.254/latest/api/token]
    [HTTP request 1/1]
```

Fixes https://github.com/osquery/osquery/issues/7272