### PR TITLE
ci: Update some actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -155,7 +155,7 @@ jobs:
         echo "REL_BINARY=${rel_build_path}" >> $GITHUB_OUTPUT
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -339,7 +339,7 @@ jobs:
         chmod 666 /var/run/docker.sock
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -350,7 +350,7 @@ jobs:
           ccache_${{ matrix.os }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -575,7 +575,7 @@ jobs:
         path: ${{ steps.build_paths.outputs.REL_SOURCE }}
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -586,7 +586,7 @@ jobs:
           ccache_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -597,7 +597,7 @@ jobs:
           gitmodules_${{ matrix.os }}_${{ matrix.architecture }}_${{env.SUBMODULE_CACHE_VERSION}}
 
     - name: Update the cache (downloads)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.DOWNLOADS }}
 
@@ -634,7 +634,7 @@ jobs:
                      thrift==0.11.0 \
                      osquery
 
-        echo ::set-output name=PYTHON_ROOT::${python_root}
+        echo "PYTHON_ROOT=${python_root}" >> $GITHUB_OUTPUT
 
     - name: Install CMake
       shell: bash
@@ -990,7 +990,7 @@ jobs:
         git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}\.git\modules
 
@@ -1001,7 +1001,7 @@ jobs:
           gitmodules_${{ matrix.os }}_${{env.SUBMODULE_CACHE_VERSION}}
 
     - name: Update the cache (downloads)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.DOWNLOADS }}
 
@@ -1160,7 +1160,7 @@ jobs:
         echo "COMPILER_VERSION=$version" >> $env:GITHUB_OUTPUT
 
     - name: Update the cache (sccache)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SCCACHE }}
 

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -93,7 +93,7 @@ jobs:
 
 
 
-  # Starts self-hosted runners. TEST TEST TEST
+  # Starts self-hosted runners.
   start_ec2_runners:
     needs: check_code_style
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}
@@ -251,7 +251,7 @@ jobs:
         chmod 666 /var/run/docker.sock
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -262,7 +262,7 @@ jobs:
           ccache_${{ matrix.cache_key }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 


### PR DESCRIPTION
- actions/cache@v2 is getting deprecated, update to v3

- Drop again the deprecated usage of set-output in favor of the environment variable GITHUB_OUTPUT.

- Update the aws-actions/configure-aws-credentials@v1 to v1-node16, to resolve the deprecations warnings of node 12.

Here the notice for the `configure-aws-credential` action: https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning