### PR TITLE
cve: Ignore zstd CVE-2021-24031

### DIFF
--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -295,6 +295,6 @@
     "vendor": "facebook",
     "version": "1.4.0",
     "commit": "83b51e9f886be7c2a4d477b6e7bc6db831791d8d",
-    "ignored-cves": []
+    "ignored-cves": ["CVE-2021-24031"]
   }
 }


### PR DESCRIPTION
osquery is not vulnerable; for the details please look at the issue below.
Fixes #7863
