### PR TITLE
docs: Update the list of pages

### DIFF
--- a/docs/wiki/deployment/dependency-security.md
+++ b/docs/wiki/deployment/dependency-security.md
@@ -30,6 +30,10 @@ practically possible, as a convenience or reference for osquery deployment decis
 question about the determined impact of any particular threat to a dependency, please ask in the osquery Slack or in our
 GitHub issues.
 
+**NOTE**: The osquery project has introduced a CI scan to find CVEs in the third party libraries it uses. They will be opened as issues labeled with `cve`, `security`, and `libraries`.  
+For more details on this new system refer to [Managing CVEs](../development/cve-scan.md).
+
+
 ## librpm prior to 4.17.0, CVE-2021-20266
 
 Conclusion: This has the potential to be used to DoS a query of the affected tables (`rpm` tables).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Remote Settings: deployment/remote.md
   - Syslog Consumption: deployment/syslog.md
   - Debugging: deployment/debugging.md
+  - Dependency Security: deployment/dependency-security.md
 - Development:
   - Building osquery: development/building.md
   - Creating New Tables: development/creating-tables.md
@@ -46,3 +47,4 @@ nav:
   - Writing Tests: development/unit-tests.md
   - Adding CLI Arguments: development/options-arguments.md
   - Reading/Writing Files: development/reading-files.md
+  - Managing CVEs: development/cve-scan.md


### PR DESCRIPTION
- Add the pages about the CVEs scan and dependency security

- Update the dependency security page to refer to the new system of tracking CVEs and scanning them.