### PR TITLE
libs: update Thrift to 0.17

### DIFF
--- a/libraries/cmake/README.md
+++ b/libraries/cmake/README.md
@@ -111,24 +111,45 @@ sudo ln -sfn /usr/local/bin/git /usr/bin/git
 
 #### Upgrading Python
 
-The version of `Python` on CentOS 6 is too old to complete osquery's CMake configuration steps. We can install Python 3 from source as well.
+The version of `Python` on CentOS 6 is too old to complete osquery's CMake configuration steps. We can install Python
+3.6 as follows:
 
-```sh
-sudo yum -y install gcc openssl-devel bzip2-devel
-wget https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz
-tar xzf Python-3.6.6.tgz
-cd Python-3.6.6
-./configure --enable-optimizations
-sudo make altinstall
-sudo ln -sfn /usr/local/bin/python3.6 /usr/bin/python3
-curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
-sudo python3 get-pip.py
+First, enable the SCL package repository:
+
+```bash
+yum install centos-release-scl
+```
+
+Update the repository file: `/etc/yum.repos.d/CentOS-SCLo-scl.repo`
+
+```text
+[centos-sclo-sclo]
+name=CentOS-6 - SCLo sclo
+baseurl=https://vault.centos.org/centos/6.10/sclo/x86_64/rh
+# baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
+# mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+```
+
+Now we can install Python:
+
+```bash
+yum install rh-python36-python
+```
+
+Enable Python 3.6:
+
+```bash
+scl enable rh-python36 bash
 ```
 
 #### Additional pre-requisites
 
 ```sh
-sudo yum install ninja-build clang
+sudo yum install epel-release
+sudo yum install ninja-build make automake autoconf
 ```
 
 #### osquery-toolchain

--- a/libraries/cmake/README.md
+++ b/libraries/cmake/README.md
@@ -19,7 +19,7 @@ Beyond what previously described, we use a custom toolchain ([osquery-toolchain]
 
 These are the current targeted versions:
 
-### x86
+### x86-64
 
 CentOS 6.10
 
@@ -80,7 +80,58 @@ uname -r
 4.15.0-1099-aws
 ```
 
-### Troubleshooting Linux
+### Troubleshooting CentOS 6 Linux
+
+CentOS 6 reached "End of Life" status in 2020, so continuing to build osquery on it requires some extra preparation steps.
+
+#### Yum Package Repo
+
+The Yum package repo for CentOS 6 is no longer hosted at its default location, so we must configure it.
+
+```sh
+sudo curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+sudo yum update
+```
+
+#### Upgrading git
+
+The version of `git` on CentOS 6 is ~1.7, but osquery requires much newer. We can install it from source.
+
+```sh
+sudo yum remove git
+sudo yum -y install curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc perl-ExtUtils-MakeMaker
+cd /usr/src
+sudo wget https://www.kernel.org/pub/software/scm/git/git-2.39.0.tar.gz
+sudo tar xzf git-2.39.0.tar.gz
+cd git-2.39.0
+sudo make prefix=/usr/local all
+sudo make prefix=/usr/local install
+sudo ln -sfn /usr/local/bin/git /usr/bin/git
+```
+
+#### Upgrading Python
+
+The version of `Python` on CentOS 6 is too old to complete osquery's CMake configuration steps. We can install Python 3 from source as well.
+
+```sh
+sudo yum -y install gcc openssl-devel bzip2-devel
+wget https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz
+tar xzf Python-3.6.6.tgz
+cd Python-3.6.6
+./configure --enable-optimizations
+sudo make altinstall
+sudo ln -sfn /usr/local/bin/python3.6 /usr/bin/python3
+curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
+sudo python3 get-pip.py
+```
+
+#### Additional pre-requisites
+
+```sh
+sudo yum install ninja-build clang
+```
+
+#### osquery-toolchain
 
 There are some issues with the osquery-toolchain 1.1.0 when trying to use it on CentOS 6.10.  
 Binaries like `as`, `ar`, etc need to be symlinked to their llvm counterpart, since the original ones are fully static and contain a glibc version that won't work on that old distribution, and will throw a `FATAL: kernel too old`.  

--- a/libraries/cmake/source/libdpkg/README.md
+++ b/libraries/cmake/source/libdpkg/README.md
@@ -27,7 +27,6 @@ apt update
 apt upgrade -y
 ```
 
-
 ### Install build dependencies (AArch64 only)
 
 ```bash
@@ -122,34 +121,7 @@ make install
 
 ### Install Python 3.6 (x86 only)
 
-Enable the SCL:
-
-```bash
-yum install centos-release-scl
-```
-
-Update the repository file: `/etc/yum.repos.d/CentOS-SCLo-scl.repo`
-
-```
-[centos-sclo-sclo]
-name=CentOS-6 - SCLo sclo
-baseurl=https://vault.centos.org/centos/6.10/sclo/x86_64/rh
-# baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
-# mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
-gpgcheck=1
-enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-```
-
-```bash
-yum install rh-python36-python
-```
-
-Enable Python 3.5
-
-```bash
-scl enable rh-python36 bash
-```
+(Refer to the steps in the top-level `osquery/libraries/cmake/README.md`)
 
 ### Build the osquery dependencies: zlib, liblzma, libbz2 (x86 + AArch64)
 
@@ -160,7 +132,7 @@ scl enable rh-python36 bash
 cmake --build build --target thirdparty_zlib thirdparty_lzma thirdparty_bzip2
 ```
 
-Update the environment
+Update the environment:
 
 ```bash
 export OSQUERY_SOURCE_ROOT=/path/to/osquery/source/directory
@@ -177,9 +149,9 @@ ln -sf "${OSQUERY_BUILD_ROOT}/libs/src/lzma/libthirdparty_lzma.a" "${OSQUERY_BUI
 
 Open the `CMakeLists.txt` files for each library, and take note of the `SYSTEM INTERFACE` include directories:
 
- * zlib: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/zlib/src`
- * bzip2: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/bzip2/src`
- * liblzma: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/lzma/src/src/liblzma/api`
+* zlib: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/zlib/src`
+* bzip2: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/bzip2/src`
+* liblzma: `${OSQUERY_SOURCE_ROOT}/libraries/cmake/source/lzma/src/src/liblzma/api`
 
 ### Build libdpkg
 

--- a/libraries/cmake/source/thrift/README.md
+++ b/libraries/cmake/source/thrift/README.md
@@ -9,8 +9,10 @@ cmake \
   -S . \
   -B b \
   -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTING=OFF \
   -G Ninja \
   -DBoost_USE_STATIC_LIBS=ON \
+  -DBoost_INCLUDE_DIR=/path/to/osquery/libraries/cmake/source/boost/src/libs/config/include/ \
   -DBUILD_SHARED_LIBS=OFF \
   -DWITH_OPENSSL=ON \
   -DWITH_ZLIB=ON \

--- a/libraries/cmake/source/thrift/README.md
+++ b/libraries/cmake/source/thrift/README.md
@@ -46,12 +46,15 @@ cmake \
 
 ### macOS ARM (M1, M2, etc.)
 
+Pre-requisite: `brew install openssl@1.1`
+
 ```sh
 cmake \
   -S . \
   -B b \
   -DBUILD_SHARED_LIBS=OFF \
   -DBoost_USE_STATIC_LIBS=ON \
+  -DBoost_INCLUDE_DIR=../../../../../../cmake/source/boost/src/libs/config/include \
   -DWITH_OPENSSL=ON \
   -DWITH_ZLIB=ON \
   -DBUILD_COMPILER=OFF \
@@ -62,10 +65,10 @@ cmake \
   -DBUILD_KOTLIN=OFF \
   -DBUILD_PYTHON=OFF \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk \
+  -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.sdk \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
   -DCMAKE_OSX_ARCHITECTURES=arm64 \
-  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1s
+  -DOPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1s
 ```
 
 ## Windows

--- a/libraries/cmake/source/thrift/README.md
+++ b/libraries/cmake/source/thrift/README.md
@@ -34,6 +34,7 @@ cmake \
   -DBUILD_JAVA=OFF \
   -DBUILD_JAVASCRIPT=OFF \
   -DBUILD_NODEJS=OFF \
+  -DBUILD_KOTLIN=OFF \
   -DBUILD_PYTHON=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
@@ -57,6 +58,7 @@ cmake \
   -DBUILD_JAVA=OFF \
   -DBUILD_JAVASCRIPT=OFF \
   -DBUILD_NODEJS=OFF \
+  -DBUILD_KOTLIN=OFF \
   -DBUILD_PYTHON=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
@@ -80,6 +82,7 @@ cmake ^
   -DBUILD_JAVA=OFF ^
   -DBUILD_JAVASCRIPT=OFF ^
   -DBUILD_NODEJS=OFF ^
+  -DBUILD_KOTLIN=OFF ^
   -DBUILD_PYTHON=OFF ^
   -DCMAKE_BUILD_TYPE=Release ^
   -G "Visual Studio 16 2019" ^

--- a/libraries/cmake/source/thrift/README.md
+++ b/libraries/cmake/source/thrift/README.md
@@ -27,6 +27,7 @@ cmake \
   -B b \
   -DBUILD_SHARED_LIBS=OFF \
   -DBoost_USE_STATIC_LIBS=ON \
+  -DBoost_INCLUDE_DIR=../../../../../../cmake/source/boost/src/libs/config/include/ \
   -DWITH_OPENSSL=ON \
   -DWITH_ZLIB=ON \
   -DBUILD_COMPILER=OFF \
@@ -37,10 +38,10 @@ cmake \
   -DBUILD_KOTLIN=OFF \
   -DBUILD_PYTHON=OFF \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
+  -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
   -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1k
+  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1s
 ```
 
 ### macOS ARM (M1, M2, etc.)
@@ -61,10 +62,10 @@ cmake \
   -DBUILD_KOTLIN=OFF \
   -DBUILD_PYTHON=OFF \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
+  -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
   -DCMAKE_OSX_ARCHITECTURES=arm64 \
-  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1k
+  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1s
 ```
 
 ## Windows

--- a/libraries/cmake/source/thrift/README.md
+++ b/libraries/cmake/source/thrift/README.md
@@ -29,7 +29,7 @@ cmake \
   -B b \
   -DBUILD_SHARED_LIBS=OFF \
   -DBoost_USE_STATIC_LIBS=ON \
-  -DBoost_INCLUDE_DIR=../../../../../../cmake/source/boost/src/libs/config/include/ \
+  -DBoost_INCLUDE_DIR=path/to/osquery/libraries/cmake/source/boost/src/libs/config/include/ \
   -DWITH_OPENSSL=ON \
   -DWITH_ZLIB=ON \
   -DBUILD_COMPILER=OFF \
@@ -56,7 +56,7 @@ cmake \
   -B b \
   -DBUILD_SHARED_LIBS=OFF \
   -DBoost_USE_STATIC_LIBS=ON \
-  -DBoost_INCLUDE_DIR=../../../../../../cmake/source/boost/src/libs/config/include \
+  -DBoost_INCLUDE_DIR=path/to/osquery/libraries/cmake/source/boost/src/libs/config/include \
   -DWITH_OPENSSL=ON \
   -DWITH_ZLIB=ON \
   -DBUILD_COMPILER=OFF \

--- a/libraries/cmake/source/thrift/config/linux/x86_64/thrift/config.h
+++ b/libraries/cmake/source/thrift/config/linux/x86_64/thrift/config.h
@@ -39,10 +39,10 @@
 /* #undef PACKAGE_URL */
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15.0"
+#define PACKAGE_VERSION "0.17.0"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING " 0.15.0"
+#define PACKAGE_STRING " 0.17.0"
 
 /************************** DEFINES *************************/
 
@@ -132,6 +132,9 @@
 
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <afunix.h> header file. */
+/* #undef HAVE_AF_UNIX_H */
 
 /*************************** FUNCTIONS ***************************/
 

--- a/libraries/cmake/source/thrift/config/macos/aarch64/thrift/config.h
+++ b/libraries/cmake/source/thrift/config/macos/aarch64/thrift/config.h
@@ -39,10 +39,10 @@
 /* #undef PACKAGE_URL */
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15.0"
+#define PACKAGE_VERSION "0.17.0"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING " 0.15.0"
+#define PACKAGE_STRING " 0.17.0"
 
 /************************** DEFINES *************************/
 
@@ -132,6 +132,9 @@
 
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <afunix.h> header file. */
+/* #undef HAVE_AF_UNIX_H */
 
 /*************************** FUNCTIONS ***************************/
 

--- a/libraries/cmake/source/thrift/config/macos/x86_64/thrift/config.h
+++ b/libraries/cmake/source/thrift/config/macos/x86_64/thrift/config.h
@@ -39,10 +39,10 @@
 /* #undef PACKAGE_URL */
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15.0"
+#define PACKAGE_VERSION "0.17.0"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING " 0.15.0"
+#define PACKAGE_STRING " 0.17.0"
 
 /************************** DEFINES *************************/
 
@@ -132,6 +132,9 @@
 
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <afunix.h> header file. */
+/* #undef HAVE_AF_UNIX_H */
 
 /*************************** FUNCTIONS ***************************/
 

--- a/libraries/cmake/source/thrift/config/windows/x86_64/thrift/config.h
+++ b/libraries/cmake/source/thrift/config/windows/x86_64/thrift/config.h
@@ -39,10 +39,10 @@
 /* #undef PACKAGE_URL */
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15.0"
+#define PACKAGE_VERSION "0.17.0"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING " 0.15.0"
+#define PACKAGE_STRING " 0.17.0"
 
 /************************** DEFINES *************************/
 
@@ -131,7 +131,10 @@
 /* #undef HAVE_SCHED_H */
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+/* #undef HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <afunix.h> header file. */
+#define HAVE_AF_UNIX_H 1
 
 /*************************** FUNCTIONS ***************************/
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -265,8 +265,8 @@
   "thrift": {
     "product": "thrift",
     "vendor": "apache",
-    "version": "0.15.0",
-    "commit": "8317ec43ea2425b6f8e24e4dc4f5b2360f717eb4",
+    "version": "0.17.0",
+    "commit": "4d493e867b349f3475203ef9848353b315203c51",
     "ignored-cves": []
   },
   "util-linux": {


### PR DESCRIPTION
Updates the git submodule for the Thrift third-party dependency, currently at 0.15.0, to version 0.17.0.

It also updates the CMake config for each relevant platform:

- [x] Windows
- [x] macOS x86-64
- [x] macOS ARM
- [x] Linux x86-64
- [x] Linux ARM

This is related to #7104 and although we are not responding to any known vulnerabilities in _Apache_ Thrift 0.15.0, it may includes fixes to vulnerabilities known to be in _Facebook_ Thrift, if any.