### PR TITLE
Package uninstall option in windows packaging script

### DIFF
--- a/tools/deployment/windows_packaging/manage-osqueryd.ps1
+++ b/tools/deployment/windows_packaging/manage-osqueryd.ps1
@@ -42,7 +42,7 @@ function Do-Help {
   Write-Host "    -install                  Install the osqueryd service"
   Write-Host "    -startupArgs              Specifies additional arguments for the service (only used with -install)"
   Write-Host "    -uninstall                Uninstall the osqueryd service"
-  Write-Host "    -forceuninstall           It uninstalls the installed osquery package"
+  Write-Host "    -forceuninstall           Uninstall the installed osquery package"
   Write-Host "    -start                    Start the osqueryd service"
   Write-Host "    -stop                     Stop the osqueryd service"
   Write-Host "    -installWelManifest       Installs the Windows Event Log manifest"


### PR DESCRIPTION
This PR adds the `-forceuninstall` option to the manage osqueryd PowerShell script.

This option will use `msiexec` to uninstall osquery if present.

This PR is related to this [bug](https://github.com/fleetdm/fleet/issues/8891).