### PR TITLE
Record and send statistics for distributed queries

### DIFF
--- a/osquery/distributed/CMakeLists.txt
+++ b/osquery/distributed/CMakeLists.txt
@@ -24,6 +24,8 @@ function(generateOsqueryDistributed)
     osquery_cxx_settings
     osquery_core
     osquery_core_plugins
+    osquery_config
+    osquery_process
     osquery_database
     osquery_logger
     osquery_utils_json

--- a/osquery/distributed/CMakeLists.txt
+++ b/osquery/distributed/CMakeLists.txt
@@ -24,7 +24,6 @@ function(generateOsqueryDistributed)
     osquery_cxx_settings
     osquery_core
     osquery_core_plugins
-    osquery_config
     osquery_process
     osquery_database
     osquery_logger

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -130,12 +130,6 @@ Status Distributed::serializeResults(std::string& json) {
       obj.AddMember("last_executed",
                     static_cast<uint64_t>(perf.last_executed),
                     obj.GetAllocator());
-      obj.AddMember("output_size",
-                    static_cast<uint64_t>(perf.output_size),
-                    obj.GetAllocator());
-      obj.AddMember("wall_time",
-                    static_cast<uint64_t>(perf.wall_time),
-                    obj.GetAllocator());
       obj.AddMember("wall_time_ms",
                     static_cast<uint64_t>(perf.wall_time_ms),
                     obj.GetAllocator());
@@ -439,7 +433,6 @@ void Distributed::recordQueryPerformance(const std::string& name,
     performance_[name] = QueryPerformance();
   }
 
-  // Grab access to the non-const schedule item.
   auto& query = performance_.at(name);
   if (!r1.at("user_time").empty() && !r0.at("user_time").empty()) {
     auto ut1 = tryTo<long long>(r1.at("user_time"));

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -132,7 +132,7 @@ Status Distributed::serializeResults(std::string& json) {
       obj.AddMember("system_time",
                     static_cast<uint64_t>(perf.system_time),
                     obj.GetAllocator());
-      obj.AddMember("last_memory",
+      obj.AddMember("memory",
                     static_cast<uint64_t>(perf.last_memory),
                     obj.GetAllocator());
     };

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -14,6 +14,7 @@
 
 #include <osquery/core/plugins/plugin.h>
 #include <osquery/core/query.h>
+#include <osquery/sql/sql.h>
 #include <osquery/utils/status/status.h>
 
 namespace osquery {
@@ -341,4 +342,6 @@ class Distributed {
   FRIEND_TEST(DistributedTests, test_run_queries_with_denylisted_query);
   FRIEND_TEST(DistributedTests, test_check_and_set_as_running);
 };
+
+SQL monitor_nonnumeric(const std::string& name, const std::string& query);
 } // namespace osquery

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -16,7 +16,6 @@
 #include <osquery/core/query.h>
 #include <osquery/core/sql/query_performance.h>
 #include <osquery/sql/sql.h>
-#include <osquery/utils/mutex.h>
 #include <osquery/utils/status/status.h>
 
 namespace osquery {
@@ -356,9 +355,6 @@ class Distributed {
 
   // ID of the currently executing query
   static std::string currentRequestId_;
-
-  // Mutex for accessing performance_
-  RecursiveMutex performance_mutex_;
 
   // Performance statistics recorded from distributed queries
   std::map<std::string, QueryPerformance> performance_;

--- a/plugins/distributed/CMakeLists.txt
+++ b/plugins/distributed/CMakeLists.txt
@@ -20,6 +20,7 @@ function(generatePluginsDistributedTls)
     osquery_cxx_settings
     osquery_core
     osquery_core_plugins
+    osquery_config
     osquery_database
     osquery_distributed
     osquery_logger


### PR DESCRIPTION
This creates a new top-level `stats` key when writing a distributed query response. This includes the data included in `QueryPerformance` class, indexed by the query ID included in the read endpoint from the server.

This issue is tracked in #7867