### PR TITLE
cve: Ignore libdpkg CVE-2022-1664

### DIFF
--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -156,7 +156,7 @@
     "vendor": "debian",
     "version": "1.21.7",
     "commit": "e61f582015a9c67bbb3791cb93a864cfeb9c7151",
-    "ignored-cves": []
+    "ignored-cves": ["CVE-2022-1664"]
   },
   "libgcrypt": {
     "product": "libgcrypt",


### PR DESCRIPTION
The cve is not affecting osquery.

Fixes #7844 
