### PR TITLE
cve: Ignore libgcrypt cves

### DIFF
--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -163,7 +163,12 @@
     "vendor": "gnupg",
     "version": "1.8.1",
     "commit": "80fd8615048c3897b91a315cca22ab139b056ccd",
-    "ignored-cves": []
+    "ignored-cves": [
+      "CVE-2018-0495",
+      "CVE-2018-6829",
+      "CVE-2021-33560",
+      "CVE-2021-40528"
+    ]
   },
   "libgpg-error": {
     "product": "libgpg-error",


### PR DESCRIPTION
Ignore CVE-2018-0495, CVE-2018-6829, CVE-2021-33560, and CVE-2021-40528, since they do not affect osquery.

Fixes #7845
Fixes #7846 
Fixes #7847 
Fixes #7848 
