### PR TITLE
dns_resolvers: fix typo in the name when spawning in namespace

### DIFF
--- a/osquery/tables/networking/posix/dns_resolvers.cpp
+++ b/osquery/tables/networking/posix/dns_resolvers.cpp
@@ -79,7 +79,7 @@ QueryData genDNSResolversImpl(QueryContext& context, Logger& logger) {
 
 QueryData genDNSResolvers(QueryContext& context) {
   if (hasNamespaceConstraint(context)) {
-    return generateInNamespace(context, "dns_resovlers", genDNSResolversImpl);
+    return generateInNamespace(context, "dns_resolvers", genDNSResolversImpl);
   } else {
     GLOGLogger logger;
     return genDNSResolversImpl(context, logger);


### PR DESCRIPTION
Was [using this file as reference point](https://github.com/osquery/osquery/issues/7808) and observed apparent typo