### PR TITLE
Add a new table `kernel keys` to the Linux platform

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -65,6 +65,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/intel_me.cpp
       linux/kernel_info.cpp
       linux/kernel_modules.cpp
+      linux/kernel_keys.cpp
       linux/md_tables.cpp
       linux/memory_info.cpp
       linux/memory_map.cpp

--- a/osquery/tables/system/linux/kernel_keys.cpp
+++ b/osquery/tables/system/linux/kernel_keys.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+#include <fstream>
+
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/split.h>
+
+namespace osquery {
+namespace tables {
+
+static const std::string kProcKeysPath = "/proc/keys";
+
+QueryData genKernelKeys(QueryContext& context) {
+  if (!pathExists(kProcKeysPath).ok()) {
+    VLOG(1) << "Cannot find keyrings file: " << kProcKeysPath;
+    return {};
+  }
+
+  std::string content;
+  auto res = osquery::readFile(kProcKeysPath, content);
+  if (!res.ok()) {
+    VLOG(1) << "Error reading keyrings file: " << kProcKeysPath;
+    return {};
+  }
+
+  QueryData results;
+  for (const auto& key : osquery::split(content, "\n")) {
+    Row r = {};
+    auto details = osquery::split(key, " ");
+    if (details.size() != 10) {
+      // Interesting error case, the key line is not well formed.
+      continue;
+    }
+
+    r["serial_number"] = details[0];
+    r["flags"] = details[1];
+    r["usage"] = details[2];
+    r["timeout"] = details[3];
+    r["permissions"] = details[4];
+    r["uid"] = details[5];
+    r["gid"] = details[6];
+    r["type"] = details[7];
+    r["description"] = details[8] + details[9];
+
+    results.push_back(std::move(r));
+  }
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/kernel_keys.cpp
+++ b/osquery/tables/system/linux/kernel_keys.cpp
@@ -38,7 +38,7 @@ QueryData genKernelKeys(QueryContext& context) {
     Row r = {};
     auto details = osquery::split(key, " ");
     if (details.size() != 10) {
-      // Interesting error case, the key line is not well formed.
+      VLOG(1) << "Malformed key format: " << key;
       continue;
     }
 

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -157,6 +157,7 @@ function(generateNativeTables)
     "linux/apparmor_profiles.table:linux"
     "linux/apt_sources.table:linux"
     "linux/iptables.table:linux"
+    "linux/kernel_keys.table:linux"
     "linux/kernel_modules.table:linux"
     "linux/lxd_instances.table:linux"
     "linux/lxd_instance_config.table:linux"

--- a/specs/linux/kernel_keys.table
+++ b/specs/linux/kernel_keys.table
@@ -1,0 +1,23 @@
+table_name("kernel_keys")
+description("List of security data, authentication keys and encryption keys.")
+schema([
+    Column("serial_number", TEXT, "The serial key of the key."),
+    Column("flags", TEXT, "A set of flags describing the state of the key."),
+    Column("usage", BIGINT, "the number of threads and open file references that"
+                     "refer to this key."),
+    Column("timeout", TEXT, "The amount of time until the key will expire,"
+                     "expressed in human-readable form. The string perm here"
+                     "means that the key is permanent (no timeout).  The"
+                     "string expd means that the key has already expired."),
+    Column("permissions", TEXT, "The key permissions, expressed as four hexadecimal"
+                     "bytes containing, from left to right, the"
+                     "possessor, user, group, and other permissions."),
+    Column("uid", BIGINT, "The user ID of the key owner."),
+    Column("gid", BIGINT, "The group ID of the key."),
+    Column("type", TEXT, "The key type."),
+    Column("description", TEXT, "The key description."),
+])
+implementation("system/kernel_keys@genKernelKeys")
+examples([
+  "select * from kernel_keys"
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -156,6 +156,7 @@ function(generateTestsIntegrationTablesTestsTest)
       iptables.cpp
       kernel_info.cpp
       kernel_modules.cpp
+      kernel_keys.cpp
       md_devices.cpp
       md_drives.cpp
       md_personalities.cpp

--- a/tests/integration/tables/kernel_keys.cpp
+++ b/tests/integration/tables/kernel_keys.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for kernel_modules
+// Spec file: specs/linux/kernel_modules.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class KernelKeys : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(KernelKeys, test_sanity) {
+  QueryData data = execute_query("select * from kernel_keys");
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
This PR adds a new table called kernel_keys for Linux. This table exposes the content of the file /proc/keys,
this file exposes a list of the keys for which the reading thread has view permission, providing various information about each key. 

Fixes #7765 