### PR TITLE
libs: Update libarchive to 3.6.2

### DIFF
--- a/libraries/cmake/source/libarchive/CMakeLists.txt
+++ b/libraries/cmake/source/libarchive/CMakeLists.txt
@@ -163,8 +163,6 @@ function(libarchiveMain)
 
   target_compile_definitions(thirdparty_libarchive PRIVATE
     LIBARCHIVE_STATIC
-    USE_BZIP2_STATIC
-    LIBXML_STATIC
     HAVE_CONFIG_H
   )
 
@@ -174,17 +172,8 @@ function(libarchiveMain)
     )
   endif()
 
-  target_link_libraries(thirdparty_libarchive
-    PRIVATE
-      thirdparty_c_settings
-
-    PUBLIC
-      thirdparty_openssl
-      thirdparty_zlib
-      thirdparty_bzip2
-      thirdparty_lzma
-      thirdparty_libxml2
-      thirdparty_zstd
+  target_link_libraries(thirdparty_libarchive PRIVATE
+    thirdparty_c_settings
   )
 endfunction()
 

--- a/libraries/cmake/source/libarchive/README.md
+++ b/libraries/cmake/source/libarchive/README.md
@@ -48,7 +48,7 @@ cmake \
   -DENABLE_LIBB2=OFF \
   -DENABLE_LZ4=OFF \
   -DENABLE_LZO=OFF \
-  -DENABLE_LibGCC=OFF \
+  -DENABLE_LIBGCC=OFF \
   -DENABLE_MBEDTLS=OFF \
   -DENABLE_NETTLE=OFF \
   -DENABLE_PCREPOSIX=OFF \
@@ -88,7 +88,7 @@ cmake ^
   -DENABLE_LIBB2=OFF ^
   -DENABLE_LZ4=OFF ^
   -DENABLE_LZO=OFF ^
-  -DENABLE_LibGCC=OFF ^
+  -DENABLE_LIBGCC=OFF ^
   -DENABLE_MBEDTLS=OFF ^
   -DENABLE_NETTLE=OFF ^
   -DENABLE_PCREPOSIX=OFF ^
@@ -97,7 +97,14 @@ cmake ^
   -DENABLE_TAR_SHARED=OFF ^
   -DENABLE_TEST=OFF ^
   -DENABLE_WERROR=OFF ^
-  -DENABLE_XATTR=OFF
+  -DENABLE_XATTR=OFF ^
+  -DWINDOWS_VERSION=WIN7 ^
+  -DPOSIX_REGEX_LIB=NONE
 ```
 
-NOTE: If necessary, convert the config.h line endings from CRLF to LF
+NOTE: If necessary, convert the config.h line endings from CRLF to LF.
+The `POSIX_REGEX_LIB=NONE` is a hack, since it tries to find a library only if it's set to some other hardcoded values. For our use the regex library is currently not necessary, because it's only used by a CLI shipped with the libarchive project. Not doing so gives an error during configure time: `libgcc not found.`
+
+## Common
+
+After configuration, copy the config.h from the `b` folder.

--- a/libraries/cmake/source/libarchive/config/linux/aarch64/config.h
+++ b/libraries/cmake/source/libarchive/config/linux/aarch64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.1"
+#define BSDCPIO_VERSION_STRING "3.6.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.1"
+#define BSDTAR_VERSION_STRING "3.6.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.1"
+#define BSDCAT_VERSION_STRING "3.6.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006001"
+#define LIBARCHIVE_VERSION_NUMBER "3006002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.1"
+#define LIBARCHIVE_VERSION_STRING "3.6.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.1"
+#define VERSION "3.6.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/linux/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/linux/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.1"
+#define BSDCPIO_VERSION_STRING "3.6.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.1"
+#define BSDTAR_VERSION_STRING "3.6.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.1"
+#define BSDCAT_VERSION_STRING "3.6.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006001"
+#define LIBARCHIVE_VERSION_NUMBER "3006002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.1"
+#define LIBARCHIVE_VERSION_STRING "3.6.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.1"
+#define VERSION "3.6.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/macos/aarch64/config.h
+++ b/libraries/cmake/source/libarchive/config/macos/aarch64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.1"
+#define BSDCPIO_VERSION_STRING "3.6.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.1"
+#define BSDTAR_VERSION_STRING "3.6.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.1"
+#define BSDCAT_VERSION_STRING "3.6.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006001"
+#define LIBARCHIVE_VERSION_NUMBER "3006002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.1"
+#define LIBARCHIVE_VERSION_STRING "3.6.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.1"
+#define VERSION "3.6.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/macos/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/macos/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.1"
+#define BSDCPIO_VERSION_STRING "3.6.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.1"
+#define BSDTAR_VERSION_STRING "3.6.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.1"
+#define BSDCAT_VERSION_STRING "3.6.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006001"
+#define LIBARCHIVE_VERSION_NUMBER "3006002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.1"
+#define LIBARCHIVE_VERSION_STRING "3.6.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.1"
+#define VERSION "3.6.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/windows/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/windows/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.1"
+#define BSDCPIO_VERSION_STRING "3.6.2"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.1"
+#define BSDTAR_VERSION_STRING "3.6.2"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.1"
+#define BSDCAT_VERSION_STRING "3.6.2"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006001"
+#define LIBARCHIVE_VERSION_NUMBER "3006002"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.1"
+#define LIBARCHIVE_VERSION_STRING "3.6.2"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.1"
+#define VERSION "3.6.2"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -119,8 +119,8 @@
   "libarchive": {
     "product": "libarchive",
     "vendor": "libarchive",
-    "version": "3.6.1",
-    "commit": "6c3301111caa75c76e1b2acb1afb2d71341932ef",
+    "version": "3.6.2",
+    "commit": "ba80276ccc3c941c4918ec6e2460059f0c525c43",
     "ignored-cves": []
   },
   "libaudit": {


### PR DESCRIPTION
This also resolves CVE-2022-36227

Fixes #7841 
