### PR TITLE
git: Ignore compile_commands.json and pyrightconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,12 @@ tags
 cscope.files
 cscope.out
 
+# CMake generated compile commands
+compile_commands.json
+
+# Pyright type checker config
+pyrightconfig.json
+
 # Ignored components
 /external/*
 !/external/examples


### PR DESCRIPTION
The compile_commands.json file is normally generated in the build folder, but there are tools like `vim` with plugins which automatically picks it up to give completion/intellisense if it's in the source folder.

The pyrightconfig.json is used to configure one of the components of the Python extension in Visual Studio Code; one useful thing to do is to tell it to ignore the libraries folder:
```
{
  "exclude": ["**/libraries/**"]
}
```
otherwise it easily breaks due to the amount of code and different projects causing type checking, completion etc to not work for python files in osquery.
