### PR TITLE
ci: Automatically cancel old PR jobs

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -30,6 +30,12 @@ on:
     branches:
       - '*'
 
+# Cancel old jobs of a PR if a new job is started.
+# Fallback on using the run id if it's not a PR, which is unique, so no job canceling.
+concurrency:
+  group: ${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Please remember to update values for both x86 and aarch64 workflows.
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging


### PR DESCRIPTION
Set the concurrency group for the workflow to
either the PR number or the run id so that in the first case, if there are multiple updates to a PR that start multiple build jobs, only the last job will run and the previous ones will be canceled, to avoid starving the CI.

The fallback is for a build job not started from a PR, the run id is unique, so no canceling will happen.
