### PR TITLE
test: Fix flaky test_daemon_sigint

### DIFF
--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -148,8 +148,12 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
     def test_daemon_sigint(self):
         pidfile_path = test_base.CONFIG["options"]["pidfile"]
 
-        Path(pidfile_path).touch()
-        self.assertTrue(os.path.exists(pidfile_path))
+        # Ensure there are no leftovers from previous tests
+        try:
+            os.remove(pidfile_path)
+        except:
+            pass
+
         self.daemon_sigint_test_helper(pidfile_path)
 
         try:


### PR DESCRIPTION
The test is supposed to verify the correct and clean shutdown when osquery receives a SIGINT.
The clean shutdown though, is only possible when the signal handler is installed, which might not happen immediately,
so there might be a window where if the test sends a SIGINT it will immediately interrupt the osquery process with exit code -2, due to the signal, making the test fail.

Originally the test was waiting for the pidfile to be created by the process, because at that point the signal handler was installed. But a regression was introduced and the pidfile path was created by the test itself before starting osquery,
causing the wait to not work properly.

This restores that logic by removing the creation of that path in the test.
We also ensure that there's no pidfile created by another test.

Fixes #7718 