### PR TITLE
systemd_units: Add new unit_file_state column

### DIFF
--- a/osquery/tables/system/linux/systemd_units.cpp
+++ b/osquery/tables/system/linux/systemd_units.cpp
@@ -27,7 +27,7 @@ const std::vector<PropertyQueryDesc> kStringPropertyQueryList = {
     {"FragmentPath", "fragment_path", "org.freedesktop.systemd1.Unit"},
     {"SourcePath", "source_path", "org.freedesktop.systemd1.Unit"},
     {"User", "user", "org.freedesktop.systemd1.Service"},
-    {"UnitFileState", "enablement_state", "org.freedesktop.systemd1.Unit"},
+    {"UnitFileState", "unit_file_state", "org.freedesktop.systemd1.Unit"},
 };
 } // namespace
 

--- a/osquery/tables/system/linux/systemd_units.cpp
+++ b/osquery/tables/system/linux/systemd_units.cpp
@@ -27,6 +27,7 @@ const std::vector<PropertyQueryDesc> kStringPropertyQueryList = {
     {"FragmentPath", "fragment_path", "org.freedesktop.systemd1.Unit"},
     {"SourcePath", "source_path", "org.freedesktop.systemd1.Unit"},
     {"User", "user", "org.freedesktop.systemd1.Service"},
+    {"UnitFileState", "enablement_state", "org.freedesktop.systemd1.Unit"},
 };
 } // namespace
 

--- a/specs/linux/systemd_units.table
+++ b/specs/linux/systemd_units.table
@@ -6,6 +6,7 @@ schema([
     Column("load_state", TEXT, "Reflects whether the unit definition was properly loaded"),
     Column("active_state", TEXT, "The high-level unit activation state, i.e. generalization of SUB"),
     Column("sub_state", TEXT, "The low-level unit activation state, values depend on unit type"),
+    Column("enablement_state", TEXT, "Whether the unit file is enabled, e.g. `enabled`, `masked`, `disabled`, etc"),
     Column("following", TEXT, "The name of another unit that this unit follows in state"),
     Column("object_path", TEXT, "The object path for this unit"),
     Column("job_id", BIGINT, "Next queued job id"),

--- a/specs/linux/systemd_units.table
+++ b/specs/linux/systemd_units.table
@@ -6,7 +6,7 @@ schema([
     Column("load_state", TEXT, "Reflects whether the unit definition was properly loaded"),
     Column("active_state", TEXT, "The high-level unit activation state, i.e. generalization of SUB"),
     Column("sub_state", TEXT, "The low-level unit activation state, values depend on unit type"),
-    Column("enablement_state", TEXT, "Whether the unit file is enabled, e.g. `enabled`, `masked`, `disabled`, etc"),
+    Column("unit_file_state", TEXT, "Whether the unit file is enabled, e.g. `enabled`, `masked`, `disabled`, etc"),
     Column("following", TEXT, "The name of another unit that this unit follows in state"),
     Column("object_path", TEXT, "The object path for this unit"),
     Column("job_id", BIGINT, "Next queued job id"),


### PR DESCRIPTION
This adds a new column to the `systemd_units` table to determine if a systemd service is in one of several enabled states, such as `enabled` or `masked`. There is currently no way of determining service is enabled.

This change may be slower than a more complicated change that makes only 2 dbus requests then joins them in osquery, but that would substantially increase code complexity.

Fleet has tracked this in [fleetdm/fleet#8976](https://github.com/fleetdm/fleet/issues/8976)