### PR TITLE
libs: Update popt to 1.19

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -40,7 +40,7 @@ concurrency:
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
   PACKAGING_COMMIT: 4caa2c54f0d893c1efa47932571046bbce156c52
-  SUBMODULE_CACHE_VERSION: 1
+  SUBMODULE_CACHE_VERSION: 2
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -30,7 +30,7 @@ on:
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
   PACKAGING_COMMIT: 4caa2c54f0d893c1efa47932571046bbce156c52
-  SUBMODULE_CACHE_VERSION: 1
+  SUBMODULE_CACHE_VERSION: 2
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	url = https://github.com/rpm-software-management/rpm
 [submodule "libraries/cmake/source/popt/src"]
 	path = libraries/cmake/source/popt/src
-	url = https://github.com/osquery/third-party-popt
+	url = https://github.com/rpm-software-management/popt.git
 [submodule "libraries/cmake/source/libdpkg/src"]
 	path = libraries/cmake/source/libdpkg/src
 	url = https://github.com/osquery/third-party-libdpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ function(importLibraries)
     "Linux,Darwin,Windows:libxml2"
     "Linux,Darwin,Windows:linenoise-ng"
     "Linux,Darwin,Windows:lzma"
-    "Linux,Darwin:popt"
+    "Linux:popt"
     "Linux,Darwin,Windows:rapidjson"
     "Linux,Darwin,Windows:rocksdb"
     "Linux,Darwin,Windows:sleuthkit"

--- a/libraries/cmake/source/popt/CMakeLists.txt
+++ b/libraries/cmake/source/popt/CMakeLists.txt
@@ -9,11 +9,11 @@ function(poptMain)
   set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
   add_library(thirdparty_popt
-    "${library_root}/popt.c"
-    "${library_root}/poptparse.c"
-    "${library_root}/poptconfig.c"
-    "${library_root}/popthelp.c"
-    "${library_root}/poptint.c"
+    "${library_root}/src/popt.c"
+    "${library_root}/src/poptparse.c"
+    "${library_root}/src/poptconfig.c"
+    "${library_root}/src/popthelp.c"
+    "${library_root}/src/poptint.c"
   )
 
   target_link_libraries(thirdparty_popt PRIVATE
@@ -21,27 +21,17 @@ function(poptMain)
   )
 
   target_compile_definitions(thirdparty_popt PRIVATE
-    _GNU_SOURCE
     HAVE_CONFIG_H
-    _REENTRANT  
+    POPT_SYSCONFDIR=\"/usr/local/etc\"
   )
 
-  if(DEFINED PLATFORM_LINUX)
-    target_include_directories(thirdparty_popt PRIVATE
-      "${CMAKE_CURRENT_SOURCE_DIR}/config/linux"
-    )
-  elseif(DEFINED PLATFORM_MACOS)
-    target_include_directories(thirdparty_popt PRIVATE
-      "${CMAKE_CURRENT_SOURCE_DIR}/config/macos"
-    )
-  endif()
-
   target_include_directories(thirdparty_popt PRIVATE
-    "${library_root}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/config/linux/${TARGET_PROCESSOR}"
+    "${library_root}/src"
   )
 
   target_include_directories(thirdparty_popt SYSTEM INTERFACE
-    "${library_root}"
+    "${library_root}/src"
   )
 endfunction()
 

--- a/libraries/cmake/source/popt/README.md
+++ b/libraries/cmake/source/popt/README.md
@@ -1,33 +1,40 @@
-# lzma
+# popt
 
 ## Linux
 
-Using Ubuntu 14.04 (glibc 2.12)
+Patch the configure.ac file to use the gettext version 0.17 on the system; also remove the unsupported usage of `AM_GNU_GETTEXT_REQUIRE_VERSION`
 
 ```sh
-ldd --version
-ldd (GNU libc) 2.12.2
+sed -i 's/0\.19\.8/0\.17/g' configure.ac
+sed -i '/AM_GNU_GETTEXT_REQUIRE_VERSION/d' configure.ac
 ```
 
 Generated with the following commands:
 
 ```sh
-export PATH=/usr/local/osquery-toolchain/usr/bin:$PATH
-export CFLAGS="--sysroot /usr/local/osquery-toolchain"
+export TOOLCHAIN=/usr/local/osquery-toolchain
+export PKG_CONFIG_LIBDIR=${TOOLCHAIN}/usr/lib/pkgconfig
+export PKG_CONFIG_PATH=
+export PKG_CONFIG_SYSROOT_DIR=${TOOLCHAIN}
+export CFLAGS="--sysroot ${TOOLCHAIN}"
 export CXXFLAGS="${CFLAGS}"
 export LDFLAGS="${CFLAGS}"
-export CC=clang
+export CC="${TOOLCHAIN}/usr/bin/clang"
 
 ./autogen.sh
-./configure --disable-scripts --disable-doc --enable-static
+./configure --disable-shared --enable-static
 ```
+
+Then build with:
+
+```
+make
+```
+
+And keep track of the preprocessor defines used, which will have to be put in our CMakeLists.txt
 
 Then copy
 
 ```sh
 cp ./config.h ../config/linux/config.h
 ```
-
-And remove the environment-specific variable.
-
-- `POPT_SOURCE_PATH`

--- a/libraries/cmake/source/popt/config/linux/aarch64/config.h
+++ b/libraries/cmake/source/popt/config/linux/aarch64/config.h
@@ -3,25 +3,22 @@
 
 /* Define to 1 if translation of program messages to the user's native
    language is requested. */
-/* #undef ENABLE_NLS */
+#define ENABLE_NLS 1
 
 /* Define to 1 if you have the MacOS X function CFLocaleCopyCurrent in the
    CoreFoundation framework. */
-#define HAVE_CFLOCALECOPYCURRENT 1
+/* #undef HAVE_CFLOCALECOPYCURRENT */
 
 /* Define to 1 if you have the MacOS X function CFPreferencesCopyAppValue in
    the CoreFoundation framework. */
-#define HAVE_CFPREFERENCESCOPYAPPVALUE 1
+/* #undef HAVE_CFPREFERENCESCOPYAPPVALUE */
 
 /* Define if the GNU dcgettext() function is already present or preinstalled.
    */
-/* #undef HAVE_DCGETTEXT */
+#define HAVE_DCGETTEXT 1
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
-
-/* Define to 1 if you have the <float.h> header file. */
-#define HAVE_FLOAT_H 1
 
 /* Define to 1 if you have the <fnmatch.h> header file. */
 #define HAVE_FNMATCH_H 1
@@ -30,13 +27,16 @@
 #define HAVE_GETEUID 1
 
 /* Define if the GNU gettext() function is already present or preinstalled. */
-/* #undef HAVE_GETTEXT */
+#define HAVE_GETTEXT 1
 
 /* Define to 1 if you have the `getuid' function. */
 #define HAVE_GETUID 1
 
 /* Define to 1 if you have the <glob.h> header file. */
 #define HAVE_GLOB_H 1
+
+/* Define to 1 if you have the `glob_pattern_p' function. */
+#define HAVE_GLOB_PATTERN_P 1
 
 /* Define if you have the iconv() function and it works. */
 #define HAVE_ICONV 1
@@ -48,22 +48,34 @@
 #define HAVE_LANGINFO_H 1
 
 /* Define to 1 if you have the <libintl.h> header file. */
-/* #undef HAVE_LIBINTL_H */
+#define HAVE_LIBINTL_H 1
+
+/* Define to 1 if you have the `mbsrtowcs' function. */
+#define HAVE_MBSRTOWCS 1
 
 /* Define to 1 if you have the <mcheck.h> header file. */
-/* #undef HAVE_MCHECK_H */
+#define HAVE_MCHECK_H 1
 
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mtrace' function. */
-/* #undef HAVE_MTRACE */
+#define HAVE_MTRACE 1
 
-/* Define to 1 if you have the `setregid' function. */
-#define HAVE_SETREGID 1
+/* Define to 1 if you have the `secure_getenv' function. */
+#define HAVE_SECURE_GETENV 1
+
+/* Define to 1 if you have the `setreuid' function. */
+#define HAVE_SETREUID 1
+
+/* Define to 1 if you have the `setuid' function. */
+#define HAVE_SETUID 1
 
 /* Define to 1 if you have the `srandom' function. */
 #define HAVE_SRANDOM 1
+
+/* Define to 1 if you have the <stdalign.h> header file. */
+#define HAVE_STDALIGN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -105,13 +117,13 @@
 #define PACKAGE "popt"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "popt-devel@rpm5.org"
+#define PACKAGE_BUGREPORT "rpm-maint@lists.rpm.org"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "popt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "popt 1.16"
+#define PACKAGE_STRING "popt 1.19"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "popt"
@@ -120,19 +132,35 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.16"
-
-/* Full path to default POPT configuration directory */
-#define POPT_SYSCONFDIR "NONE/etc"
-
-/* Define to 1 if the C compiler supports function prototypes. */
-#define PROTOTYPES 1
+#define PACKAGE_VERSION "1.19"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
 /* Version number of package */
-#define VERSION "1.16"
+#define VERSION "1.19"
 
 /* Enable large inode numbers on Mac OS X 10.5.  */
 #ifndef _DARWIN_USE_64_BIT_INODE
@@ -145,5 +173,12 @@
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
 
-/* Define like PROTOTYPES; this can be used by system headers. */
-#define __PROTOTYPES 1
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */

--- a/libraries/cmake/source/popt/config/linux/x86_64/config.h
+++ b/libraries/cmake/source/popt/config/linux/x86_64/config.h
@@ -20,9 +20,6 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
-/* Define to 1 if you have the <float.h> header file. */
-#define HAVE_FLOAT_H 1
-
 /* Define to 1 if you have the <fnmatch.h> header file. */
 #define HAVE_FNMATCH_H 1
 
@@ -38,6 +35,9 @@
 /* Define to 1 if you have the <glob.h> header file. */
 #define HAVE_GLOB_H 1
 
+/* Define to 1 if you have the `glob_pattern_p' function. */
+#define HAVE_GLOB_PATTERN_P 1
+
 /* Define if you have the iconv() function and it works. */
 #define HAVE_ICONV 1
 
@@ -50,6 +50,9 @@
 /* Define to 1 if you have the <libintl.h> header file. */
 #define HAVE_LIBINTL_H 1
 
+/* Define to 1 if you have the `mbsrtowcs' function. */
+#define HAVE_MBSRTOWCS 1
+
 /* Define to 1 if you have the <mcheck.h> header file. */
 #define HAVE_MCHECK_H 1
 
@@ -59,11 +62,20 @@
 /* Define to 1 if you have the `mtrace' function. */
 #define HAVE_MTRACE 1
 
-/* Define to 1 if you have the `setregid' function. */
-#define HAVE_SETREGID 1
+/* Define to 1 if you have the `secure_getenv' function. */
+/* #undef HAVE_SECURE_GETENV */
+
+/* Define to 1 if you have the `setreuid' function. */
+#define HAVE_SETREUID 1
+
+/* Define to 1 if you have the `setuid' function. */
+#define HAVE_SETUID 1
 
 /* Define to 1 if you have the `srandom' function. */
 #define HAVE_SRANDOM 1
+
+/* Define to 1 if you have the <stdalign.h> header file. */
+#define HAVE_STDALIGN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -106,13 +118,13 @@
 #define PACKAGE "popt"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "popt-devel@rpm5.org"
+#define PACKAGE_BUGREPORT "rpm-maint@lists.rpm.org"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "popt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "popt 1.16"
+#define PACKAGE_STRING "popt 1.19"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "popt"
@@ -121,19 +133,35 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.16"
-
-/* Full path to default POPT configuration directory */
-#define POPT_SYSCONFDIR "NONE/etc"
-
-/* Define to 1 if the C compiler supports function prototypes. */
-#define PROTOTYPES 1
+#define PACKAGE_VERSION "1.19"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
 /* Version number of package */
-#define VERSION "1.16"
+#define VERSION "1.19"
 
 /* Enable large inode numbers on Mac OS X 10.5.  */
 #ifndef _DARWIN_USE_64_BIT_INODE
@@ -146,5 +174,12 @@
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
 
-/* Define like PROTOTYPES; this can be used by system headers. */
-#define __PROTOTYPES 1
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -238,8 +238,8 @@
   "popt": {
     "product": "popt",
     "vendor": "popt_project",
-    "version": "1.16",
-    "commit": "abe4af616ffc0e22e54d691e73a67fabc267cc26",
+    "version": "1.19",
+    "commit": "916e61045d268f7e37ade5ec047eb77e8299e6ad",
     "ignored-cves": []
   },
   "rapidjson": {

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -276,7 +276,6 @@ function(generateOsqueryTablesSystemSystemtable)
       thirdparty_libdevmapper
       thirdparty_libcryptsetup
       thirdparty_librpm
-      thirdparty_popt
       thirdparty_dbus
       thirdparty_libcap
     )


### PR DESCRIPTION
- Change the submodule url to the same used for rpm
- Update popt to the same date as the release of the latest version of rpm/librpm
- Remove macOS configs and unnecessary references
- Correctly generate config for both Linux archs and correct the README

This is mostly needed to properly update librpm later.
