### PR TITLE
libs: Fix libmagic build on macOS

### DIFF
--- a/libraries/cmake/source/libmagic/CMakeLists.txt
+++ b/libraries/cmake/source/libmagic/CMakeLists.txt
@@ -52,9 +52,14 @@ function(libmagicMain)
   target_compile_definitions(thirdparty_libmagic PRIVATE
     ${compile_definition_list}
     buffer_init=libmagic_buffer_init
-    strlcat=libmagic_strlcat
-    strlcpy=libmagic_strlcpy
   )
+
+  if(DEFINED PLATFORM_LINUX)
+    target_compile_definitions(thirdparty_libmagic PRIVATE
+      strlcat=libmagic_strlcat
+      strlcpy=libmagic_strlcpy
+    )
+  endif()
 
   target_link_libraries(thirdparty_libmagic PUBLIC
     thirdparty_zlib


### PR DESCRIPTION
Only rename strlcat and strlcpy on Linux,
otherwise the library will try to use the renamed functions which are not provided by the library anymore.

The compilation did not fail on the CI due to linker magic that drops functions that call those strlcat and strlcpy functions. When compiling with ASAN enabled though the callers are not dropped anymore, causing a linking error. 
