### PR TITLE
libs: Fix system paths used by dbus

### DIFF
--- a/libraries/cmake/source/dbus/README.md
+++ b/libraries/cmake/source/dbus/README.md
@@ -37,7 +37,9 @@ Do not pass `-Ddbus_1_EXPORTS` but `-DBUS_STATIC_BUILD`.
 We do not need to pass `--export-dynamic` (or `-rdynamic`), because the backtrace created by the assert already works;
 we do need to pass `-DDBUS_BUILT_R_DYNAMIC` to get the backtrace though.
 
-Finally copy the following generated files from the build folder:
+Copy the following generated files from the build folder:
 
 `config.h` -> `config/<arch>/config.h`
 `dbus/dbus-arch-deps.h` -> `generated/<arch>/dbus-arch-deps.h`
+
+Finally in the `config.h` file substitute the path prefix `/usr/local/` with `/usr`, except for the paths that contain `/var`; in that case fully remove the `/usr/local` prefix, so that `/var` is at the root. This is needed because Dbus has to access files that on the system, not under some custom prefix.

--- a/libraries/cmake/source/dbus/config/aarch64/config.h
+++ b/libraries/cmake/source/dbus/config/aarch64/config.h
@@ -46,17 +46,17 @@
 /* #undef HAVE_GNUC_VARARGS */
 
 /* #undef DBUS_CONSOLE_AUTH_DIR */
-#define DBUS_DATADIR  "/usr/local/share"
-#define DBUS_BINDIR   "/usr/local/bin"
-#define DBUS_PREFIX "/usr/local"
+#define DBUS_DATADIR  "/usr/share"
+#define DBUS_BINDIR   "/usr/bin"
+#define DBUS_PREFIX "/usr"
 #define DBUS_SYSTEM_CONFIG_FILE  "/dbus-1/system.conf"
 #define DBUS_SESSION_CONFIG_FILE "/dbus-1/session.conf"
 #define DBUS_DAEMON_NAME "dbus-daemon"
-#define DBUS_SYSTEM_BUS_DEFAULT_ADDRESS  "unix:path=/usr/local/var/run/dbus/system_bus_socket"
+#define DBUS_SYSTEM_BUS_DEFAULT_ADDRESS  "unix:path=/var/run/dbus/system_bus_socket"
 #define DBUS_SESSION_BUS_CONNECT_ADDRESS  "autolaunch:"
-#define DBUS_MACHINE_UUID_FILE "/usr/local/var/lib/dbus/machine-id"
-#define DBUS_DAEMONDIR "/usr/local/bin"
-#define DBUS_RUNSTATEDIR "/usr/local/var/run"
+#define DBUS_MACHINE_UUID_FILE "/var/lib/dbus/machine-id"
+#define DBUS_DAEMONDIR "/usr/bin"
+#define DBUS_RUNSTATEDIR "/var/run"
 
 /* #undef DBUS_ENABLE_STATS */
 

--- a/libraries/cmake/source/dbus/config/x86_64/config.h
+++ b/libraries/cmake/source/dbus/config/x86_64/config.h
@@ -46,17 +46,17 @@
 /* #undef HAVE_GNUC_VARARGS */
 
 /* #undef DBUS_CONSOLE_AUTH_DIR */
-#define DBUS_DATADIR  "/usr/local/share"
-#define DBUS_BINDIR   "/usr/local/bin"
-#define DBUS_PREFIX "/usr/local"
+#define DBUS_DATADIR  "/usr/share"
+#define DBUS_BINDIR   "/usr/bin"
+#define DBUS_PREFIX "/usr"
 #define DBUS_SYSTEM_CONFIG_FILE  "/dbus-1/system.conf"
 #define DBUS_SESSION_CONFIG_FILE "/dbus-1/session.conf"
 #define DBUS_DAEMON_NAME "dbus-daemon"
-#define DBUS_SYSTEM_BUS_DEFAULT_ADDRESS  "unix:path=/usr/local/var/run/dbus/system_bus_socket"
+#define DBUS_SYSTEM_BUS_DEFAULT_ADDRESS  "unix:path=/var/run/dbus/system_bus_socket"
 #define DBUS_SESSION_BUS_CONNECT_ADDRESS  "autolaunch:"
-#define DBUS_MACHINE_UUID_FILE "/usr/local/var/lib/dbus/machine-id"
-#define DBUS_DAEMONDIR "/usr/local/bin"
-#define DBUS_RUNSTATEDIR "/usr/local/var/run"
+#define DBUS_MACHINE_UUID_FILE "/var/lib/dbus/machine-id"
+#define DBUS_DAEMONDIR "/usr/bin"
+#define DBUS_RUNSTATEDIR "/var/run"
 
 /* #undef DBUS_ENABLE_STATS */
 


### PR DESCRIPTION
dbus needs to access some paths on the system
to be able to communicate with systemd.
The config file was incorrectly configured.