### PR TITLE
Add `pid_with_namespace` for `yara` table

### DIFF
--- a/osquery/tables/yara/CMakeLists.txt
+++ b/osquery/tables/yara/CMakeLists.txt
@@ -48,6 +48,7 @@ function(generateOsqueryTablesYaraYaratable)
     osquery_remote_utility
     osquery_utils_config
     osquery_worker_system_linux_memory
+    osquery_tables_system_systemtable
     thirdparty_boost
     thirdparty_yara
   )

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -28,6 +28,8 @@
 #include <osquery/tables/yara/yara_utils.h>
 #include <osquery/utils/status/status.h>
 #include <osquery/worker/system/memory.h>
+#include <osquery/worker/ipc/platform_table_container_ipc.h>
+#include <osquery/worker/logging/glog/glog_logger.h>
 
 #ifdef CONCAT
 #undef CONCAT
@@ -278,7 +280,7 @@ Status getYaraRules(YARAConfigParser parser,
   return Status::success();
 }
 
-QueryData genYara(QueryContext& context) {
+QueryData genYaraImpl(QueryContext& context) {
   QueryData results;
   YaraScanContext scanContext;
 
@@ -417,5 +419,15 @@ QueryData genYara(QueryContext& context) {
 
   return results;
 }
+
+QueryData genYara(QueryContext& context) {
+  if (hasNamespaceConstraint(context)) {
+    return generateInNamespace(context, "dns_resovlers", genYaraImpl);
+  } else {
+    GLOGLogger logger;
+    return genYaraImpl(context, logger);
+  }
+}
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -280,14 +280,14 @@ Status getYaraRules(YARAConfigParser parser,
   return Status::success();
 }
 
-QueryData genYaraImpl(QueryContext& context) {
+QueryData genYaraImpl(QueryContext& context, Logger& logger) {
   QueryData results;
   YaraScanContext scanContext;
 
   // Initialize yara library
   auto init_status = yaraInitialize();
   if (!init_status.ok()) {
-    LOG(WARNING) << init_status.toString();
+    logger.log(google::GLOG_WARNING, init_status.toString());
     return results;
   }
 
@@ -312,7 +312,7 @@ QueryData genYaraImpl(QueryContext& context) {
     auto sigfiles = context.constraints["sigfile"].getAll(EQUALS);
     auto status = getYaraRules(yaraParser, sigfiles, YC_FILE, scanContext);
     if (!status.ok()) {
-      LOG(WARNING) << status.toString();
+      logger.log(google::GLOG_WARNING, status.toString());
       return results;
     }
   }
@@ -323,7 +323,7 @@ QueryData genYaraImpl(QueryContext& context) {
     auto sigrules = context.constraints["sigrule"].getAll(EQUALS);
     auto status = getYaraRules(yaraParser, sigrules, YC_RULE, scanContext);
     if (!status.ok()) {
-      LOG(WARNING) << status.toString();
+      logger.log(google::GLOG_WARNING, status.toString());
       return results;
     }
   }
@@ -332,7 +332,7 @@ QueryData genYaraImpl(QueryContext& context) {
     auto sigurls = context.constraints["sigurl"].getAll(EQUALS);
     auto status = getYaraRules(yaraParser, sigurls, YC_URL, scanContext);
     if (!status.ok()) {
-      LOG(WARNING) << status.toString();
+      logger.log(google::GLOG_WARNING, status.toString());
       return results;
     }
   }
@@ -409,7 +409,7 @@ QueryData genYaraImpl(QueryContext& context) {
   // more than once it will decrease the reference counter and return
   auto fini_status = yaraFinalize();
   if (!fini_status.ok()) {
-    LOG(WARNING) << fini_status.toString();
+    logger.log(google::GLOG_WARNING, fini_status.toString());
   }
 
 #ifdef OSQUERY_LINUX

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -168,6 +168,8 @@ void doYARAScan(YR_RULES* rules,
   row["sig_group"] = SQL_TEXT("");
   row["sigfile"] = SQL_TEXT("");
   row["sigrule"] = SQL_TEXT("");
+  // This is a default value to be set by namespace handler as appropriate
+  row["pid_with_namespace"] = "0";
 
   // This could use target_path instead to be consistent with yara_events.
   row["path"] = path;

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -422,7 +422,7 @@ QueryData genYaraImpl(QueryContext& context, Logger& logger) {
 
 QueryData genYara(QueryContext& context) {
   if (hasNamespaceConstraint(context)) {
-    return generateInNamespace(context, "dns_resovlers", genYaraImpl);
+    return generateInNamespace(context, "yara", genYaraImpl);
   } else {
     GLOGLogger logger;
     return genYaraImpl(context, logger);

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -27,9 +27,9 @@
 #include <osquery/remote/uri.h>
 #include <osquery/tables/yara/yara_utils.h>
 #include <osquery/utils/status/status.h>
-#include <osquery/worker/system/memory.h>
 #include <osquery/worker/ipc/platform_table_container_ipc.h>
 #include <osquery/worker/logging/glog/glog_logger.h>
+#include <osquery/worker/system/memory.h>
 
 #ifdef CONCAT
 #undef CONCAT

--- a/specs/yara/yara.table
+++ b/specs/yara/yara.table
@@ -16,6 +16,9 @@ schema([
     Column("sigurl", TEXT, "Signature url",
         additional=True, hidden=True)
 ])
+extended_schema(LINUX, [
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
+])
 implementation("yara@genYara")
 examples([
   "select * from yara where path = '/etc/passwd'",


### PR DESCRIPTION
Resolves https://github.com/osquery/osquery/issues/7808

[This is almost blindly based on this previous PR.](https://github.com/osquery/osquery/pull/7132/files#diff-e175bdb0223c28709c16e04c1534b0c85c5ebeba1f5dc1ba9dafc9f9d81d3c07)

I don't see a good way to add automated testing for this, but am happy to implement inline with any pattern that can be pointed to. [I did test this code manually and demonstrate that here](https://www.youtube.com/watch?app=desktop&v=RpUf5LtHsvM). I expect the artifact built on the pipeline could be pulled down and substituted in my [test script which is available here.](https://github.com/NickBorgersOnLowSecurityNode/inspect-container-dependencies/blob/main/osquery_on_host.new_version.sh)