### PR TITLE
Fix assert fail for unverified WMI request result

### DIFF
--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -38,9 +38,11 @@ QueryData genSystemInfo(QueryContext& context) {
 
   const auto wmiSystemReq =
       WmiRequest::CreateWmiRequest("select * from Win32_ComputerSystem");
+  auto wmiExecutedSuccessful = wmiSystemReq.isValue();
   const auto wmiSystemReqProc =
       WmiRequest::CreateWmiRequest("select * from Win32_Processor");
-  if (wmiSystemReq && wmiSystemReqProc && !wmiSystemReq->results().empty() &&
+  wmiExecutedSuccessful &= wmiSystemReqProc.isValue();
+  if (wmiExecutedSuccessful && !wmiSystemReq->results().empty() &&
       !wmiSystemReqProc->results().empty()) {
     const std::vector<WmiResultItem>& wmiResults = wmiSystemReq->results();
     const std::vector<WmiResultItem>& wmiResultsProc =


### PR DESCRIPTION
In debug mode an **osquery::Expected** class object will asserted in destructor, if it's not checked for results.
When we check multiple **osquery::Expected** objects in single **if**, in case of first one has error, the second one will not be checked and **osquery::Expected** object destructor will assert.
So, every **osquery::Expected** must be checked explicitly