### PR TITLE
Leave min_version empty in xprotect_meta when not specified

### DIFF
--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -208,7 +208,6 @@ QueryData genXProtectMeta(QueryContext& context) {
           r["identifier"] = ext.second.get("CFBundleIdentifier", "");
           r["developer_id"] = ext.second.get("Developer Identifier", "");
           r["type"] = "extension";
-          r["min_version"] = "any";
           results.push_back(std::move(r));
         }
       } else if (it.first == "PlugInBlacklist") {
@@ -234,5 +233,5 @@ QueryData genXProtectMeta(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
This makes the `min_version` column consistent across the various types of entries in the `XProtect.meta.plist` file. Returning `any` was misleading as these values are actually empty in the file.

See discussion in https://github.com/fleetdm/fleet/issues/9545#issuecomment-1411214980.
