### PR TITLE
Silence warnings for more builtin Chrome and Brave extensions

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -109,6 +109,10 @@ const std::vector<std::string> kBuiltInExtPathList{
     "resources/edge_feedback/manifest.json",
     "resources/microsoft_voices/manifest.json",
     "resources/edge_pdf/manifest.json",
+    "resources/identity_scope_approval_dialog/manifest.json",
+    "resources/brave_rewards/manifest.json",
+    "resources/brave_webtorrent/manifest.json",
+    "resources/brave_extension/manifest.json",
     "resources/webrtc_internals/manifest.json"};
 
 /// A extension property that needs to be copied


### PR DESCRIPTION
Adds additional Chrome and Brave extensions to list of builtin extensions, which seem to occasionally generate warnings that the manifest.json can't be read:
* [identity_scope_approval_dialog](https://github.com/chromium/chromium/blob/main/chrome/browser/resources/identity_scope_approval_dialog/manifest.json)
* [brave_extension](https://github.com/brave/brave-core/blob/master/components/brave_extension/extension/brave_extension/manifest.json)
* brave_rewards (removed in this [Brave PR](https://github.com/brave/brave-core/pull/15342), but still nice to exclude for older versions)
* [brave_webtorrent](https://github.com/brave/brave-core/blob/master/components/brave_webtorrent/extension/manifest.json)

Not sure how to reliably trigger the error to do testing, but it looks like a safe change to add builtins to this list.