### PR TITLE
profile.py: Log # of queries loaded and raise an error if 0 are loaded

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -354,8 +354,11 @@ if __name__ == "__main__":
     if len(queries) == 0:
         print("0 queries were loaded from %s" % query_source)
         exit(1)
+    elif len(queries) == 1:
+        print("%d query loaded from %s\n" % (len(queries), query_source))
+    else:
+        print("%d queries loaded from %s\n" % (len(queries), query_source))
 
-    print("%d queries loaded from %s\n" % (len(queries), query_source))
     if args.leaks:
         results = profile_leaks(
             args.shell, queries, count=args.count,

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -329,7 +329,10 @@ if __name__ == "__main__":
         exit(1)
 
     queries = {}
+    query_source = "<none provided>"
+
     if args.config is not None:
+        query_source = args.config
         if not os.path.exists(args.config):
             print("Cannot find --config: %s" % (args.config))
             exit(1)
@@ -340,12 +343,19 @@ if __name__ == "__main__":
                 queries.update(utils.queries_from_config(os.path.join(
                     args.config + ".d", config_file)))
     elif args.query is not None:
+        query_source = "--query"
         queries["manual"] = args.query
     elif args.force:
         queries["force"] = True
     else:
+        query_source = args.tables
         queries = utils.queries_from_tables(args.tables, args.restrict)
 
+    if len(queries) == 0:
+        print("0 queries were loaded from %s" % query_source)
+        exit(1)
+
+    print("%d queries loaded from %s\n" % (len(queries), query_source))
     if args.leaks:
         results = profile_leaks(
             args.shell, queries, count=args.count,

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -80,6 +80,11 @@ def queries_from_config(config_path):
         print("Cannot open/parse config: %s" % str(e))
         exit(1)
     queries = {}
+
+    if "schedule" not in config and "packs" not in config:
+        print("%s parsed as JSON, but does not contain a 'schedule' or 'packs' stanza. Is it really an osquery configuration file?" % config_path)
+        exit(1)
+
     if "schedule" in config:
         for name, details in config["schedule"].items():
             queries[name] = details["query"]


### PR DESCRIPTION
This adds some diagnostic log and error messages to profile.py so that people can debug why profile.py is quietly exiting. In my case, it was because I was passing an osquery pack file to `--config`. 

## Old Behavior

Invalid config:

```
$ ./profile.py --shell /usr/bin/osqueryi --config pack.conf
```

Notice the lack of any output or error code.

Valid config:

```
$ ./profile.py --shell /usr/bin/osqueryi --config osquery.conf
Profiling query: SELECT hostname, cpu_brand, physical_memory FROM system_info;
```

## New Behavior

Invalid config:

```
$ ./profile.py --shell /usr/bin/osqueryi --config pack.conf                       pack.conf parsed as JSON, but does not contain a 'schedule' or 'packs' stanza. Is it really an osquery configuration file?
```

Valid config:

```
$ ./profile.py --shell /usr/bin/osqueryi --config osquery.conf
1 query loaded from /etc/osquery/osquery.conf

Profiling query: SELECT hostname, cpu_brand, physical_memory FROM system_info;
```