### PR TITLE
analysis.py: Add --pack flag to load queries from a pack file

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -262,6 +262,10 @@ if __name__ == "__main__":
         help="Use scheduled queries from a config."
     )
     group.add_argument(
+        "--pack", metavar="PACK", default=None,
+        help="Use queries from an osquery pack."
+    )
+    group.add_argument(
         "--query", metavar="STRING", default=None,
         help="Profile a single query."
     )
@@ -339,6 +343,8 @@ if __name__ == "__main__":
             for config_file in os.listdir(args.config + ".d"):
                 queries.update(utils.queries_from_config(os.path.join(
                     args.config + ".d", config_file)))
+    elif args.pack is not None:
+        queries = utils.queries_from_pack(args.pack)
     elif args.query is not None:
         queries["manual"] = args.query
     elif args.force:

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -100,6 +100,28 @@ def queries_from_config(config_path):
     return queries
 
 
+def queries_from_pack(pack_path):
+    pack = {}
+    rmcomment = re.compile('\/\*[\*A-Za-z0-9\n\s\.\{\}\'\/\\\:]+\*\/|\s+\/\/.*|^\/\/.*|\x5c\x5c\x0a')
+    try:
+        with open(pack_path, "r") as fh:
+            content = fh.read()
+            content = rmcomment.sub('',content)
+            pack = json.loads(content)
+    except Exception as e:
+        print("Cannot open/parse pack: %s" % str(e))
+        exit(1)
+
+    if "queries" not in pack:
+        print("%s parsed as JSON, but does not contain a 'queries' stanza. Is it really an osquery pack?" % config_path)
+        exit(1)
+
+    queries = {}
+    for k, v in pack["queries"].items():
+        queries[k] = v["query"]
+    return queries
+
+
 def queries_from_tables(path, restrict):
     """Construct select all queries from all tables."""
     # Let the caller limit the tables


### PR DESCRIPTION
This adds a `--pack` flag so that `analysis.py` can pull queries from an osquery pack file.

For example:

```shell
./profile.py --shell /usr/bin/osqueryi --pack pack.conf
Profiling query: SELECT file.path, file.type, file.size, file.mtime, file.uid, file.ctime, file.gid, hash.sha256, magic.data FROM file LEFT JOIN hash ON file.path = hash.path LEFT JOIN users u ON file.uid = u.uid LEFT JOIN magic ON file.path = magic.path WHERE ( file.directory LIKE '/Users/%/Downloads/%' OR file.directory LIKE '/home/%/%' OR file.directory LIKE '/home/%/' OR file.directory LIKE '/home/%/.%' OR file.directory LIKE '/home/%/Downloads/%' OR file.directory LIKE '/tmp/%' OR file.directory LIKE '/tmp/' OR file.directory LIKE '/Users/%/%' OR file.directory LIKE '/Users/%/' OR file.directory LIKE '/Users/%/.%' OR file.directory LIKE '/var/tmp/%' OR file.directory LIKE '/var/tmp/' ) AND file.directory NOT LIKE "%/../%" AND file.directory NOT LIKE "%/./%" AND filename LIKE "%-%-%.json" AND size BETWEEN 2311 AND 2385 AND NOT INSTR(filename, CONCAT (u.username, "-")) == 1 AND NOT INSTR( filename, REPLACE(LOWER(TRIM(description)), " ", "-") ) == 1;
```