### PR TITLE
cve: Update openssl to 1.1.1t

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "1.1.1q")
-set(OPENSSL_ARCHIVE_SHA256 "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca")
+set(OPENSSL_VERSION "1.1.1t")
+set(OPENSSL_ARCHIVE_SHA256 "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "1.1.1q",
+    "version": "1.1.1t",
     "ignored-cves": [
       "CVE-2007-5536",
       "CVE-2019-0190"


### PR DESCRIPTION
Resolves CVE-2023-0286, CVE-2022-4304,
CVE-2023-0215, CVE-2022-4450

Fixes #7936 