### PR TITLE
ci: Remove Windows 32bit build

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -931,7 +931,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        bitness: [32, 64]
+        bitness: [64]
         os: [windows-2019]
 
     steps:


### PR DESCRIPTION
Windows 32bit is not sold on new PCs since 2020, and also its support ended the same year too.
osquery never released official builds of Windows 32bit, its support was always best effort.

Since its support is causing some delays with updating openssl, and there might be other similar issues in the future, we want to reduce our maintenance burden.