### PR TITLE
ci: Workaround in the aarch64 runner to avoid out of space

### DIFF
--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -325,6 +325,11 @@ jobs:
           --target install \
           -j ${{ steps.build_job_count.outputs.VALUE }}
 
+        # Do some targeted cleanups to get additional free space before installing dependencies,
+        # we are unfortunately out of space otherwise.
+        find . -name "*.a" -exec rm {} \;
+        find . -name "*.o" -exec rm {} \;
+
     # Since we need to run CMake to create the packages with osquery-packaging, the
     # configuration will fail unless the C and C++ compilers are found
     - name: Install packaging dependencies


### PR DESCRIPTION
Due to some new libraries being added to the build, we hit the disk space limit on the aarch64 runner; this adds a workaround to cleanup some build artifacts that are not needed after a certain point, which helps give some breathing space.

You can see a job failing here: https://github.com/osquery/osquery/actions/runs/4183644659/jobs/7248309929

And a build where I was testing this workaround: https://github.com/osquery/osquery/actions/runs/4185682265

Adding 30MB of a single static library caused ~4GB of additional disk space taken by tests.

See this comment for further explanation: https://github.com/osquery/osquery/issues/6397#issuecomment-1431724082