### PR TITLE
Fix username field in managed_policy table

### DIFF
--- a/osquery/tables/system/darwin/managed_policies.cpp
+++ b/osquery/tables/system/darwin/managed_policies.cpp
@@ -25,7 +25,11 @@ void genPolicy(const std::string& path,
                const std::string& username,
                QueryData& results) {
   Row r;
-  r["username"] = fs::path(username).stem().string();
+  auto usernameDir = fs::path(username);
+  if (usernameDir.filename_is_dot()) {
+    usernameDir = usernameDir.parent_path();
+  }
+  r["username"] = usernameDir.stem().string();
   r["domain"] = fs::path(path).stem().string();
   if (r.at("domain") == "complete") {
     // There is a special meta list that aggregates the user/system policy.

--- a/tests/integration/tables/managed_policies.cpp
+++ b/tests/integration/tables/managed_policies.cpp
@@ -26,22 +26,20 @@ TEST_F(managedPolicies, test_sanity) {
   // 1. Query data
   auto const data = execute_query("select * from managed_policies");
   // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
+  ASSERT_GE(data.size(), 0);
   // 3. Build validation map
   // See helper.h for available flags
   // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"domain", NormalType}
-  //      {"uuid", NormalType}
-  //      {"name", NormalType}
-  //      {"value", NormalType}
-  //      {"username", NormalType}
-  //      {"manual", IntType}
-  //}
+  ValidationMap row_map = {
+      {"domain", NormalType},
+      {"uuid", NormalType},
+      {"name", NormalType},
+      {"value", NormalType},
+      {"username", NormalType},
+      {"manual", IntType},
+  };
   // 4. Perform validation
-  // validate_rows(data, row_map);
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
Currently the username field in managed_policy table is always set to "." for a user policy. This changes the field to instead be the actual username (or empty if it is a system policy), which is the expected behavior. 

The issue is that directory paths from `listDirectoriesInDirectory` end in "/"  (see [here](https://github.com/osquery/osquery/blob/cb65b6e9d6b2ca15278da8782fcad8507a16246d/osquery/filesystem/filesystem.cpp#L364)), which causes their filename and stem to be "." due to the Boost behavior described [here](https://www.boost.org/doc/libs/1_68_0/libs/filesystem/doc/reference.html#path-filename)

Tested manually with a managed machine using osqueryi. Also uncommented the table test, though it doesn't actually test anything on a non-managed machine (ie in CI) because the plist files are not present.

 
