### PR TITLE
Try to free some disk space on the arm64 runners

### DIFF
--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -21,10 +21,10 @@ on:
   # Do not run this on pull requests
   push:
     branches:
-      - '*'
+      - '**'
 
     tags:
-      - '*'
+      - '**'
 
 # Please remember to update values for both x86 and aarch64 workflows.
 env:
@@ -180,6 +180,16 @@ jobs:
       id: build_job_count
       run: |
         echo "VALUE=$(($(nproc) + 1))" >> $GITHUB_OUTPUT
+
+
+    # try to gather some info about build space
+    - name: Disk Space Information
+      shell: bash
+      id: disk_space_info
+      run: |
+        df -h
+        du -sh /usr/local/lib/android || true
+        du -sh /usr/share/dotnet || true
 
     # We don't have enough space on the worker to actually generate all
     # the debug symbols (osquery + dependencies), so we have a flag to

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -61,7 +61,7 @@ function(generateOsqueryCoreInit)
     add_test(NAME osquery_core_tests_permissionstests-test COMMAND osquery_core_tests_permissionstests-test)
   endif()
 
-  add_test(NAME osquery_core_tests_watchertests-test COMMAND osquery_core_tests_watchertests-test)
+  add_test(NAME osquery_core_tests_mergedtests-test COMMAND osquery_core_tests_mergedtests-test)
 
 endfunction()
 
@@ -149,10 +149,6 @@ function(generateOsqueryCore)
 
   generateIncludeNamespace(osquery_core "osquery/core" "FULL_PATH" ${public_header_files})
 
-  add_test(NAME osquery_core_tests_flagstests-test COMMAND osquery_core_tests_flagstests-test)
-  add_test(NAME osquery_core_tests_systemtests-test COMMAND osquery_core_tests_systemtests-test)
-  add_test(NAME osquery_core_tests_tablestests-test COMMAND osquery_core_tests_tablestests-test)
-  add_test(NAME osquery_core_tests_querytests-test COMMAND osquery_core_tests_querytests-test)
   add_test(NAME osquery_core_tests_processtests-test COMMAND osquery_core_tests_processtests-test)
 
   if(DEFINED PLATFORM_WINDOWS)

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -6,17 +6,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(osqueryCoreTestsMain)
-  generateOsqueryCoreTestsFlagstestsTest()
-  generateOsqueryCoreTestsSystemtestsTest()
-  generateOsqueryCoreTestsTablestestsTest()
+  generateOsqueryCoreTestsMergedtestsTest()
 
   # TODO: This test should actually run as root, but it's currently broken when using that user
   if(DEFINED PLATFORM_POSIX)
     generateOsqueryCoreTestsPermissionstestsTest()
   endif()
 
-  generateOsqueryCoreTestsWatchertestsTest()
-  generateOsqueryCoreTestsQuerytestsTest()
   generateOsqueryCoreTestsProcesstestsTest()
 
   if(DEFINED PLATFORM_WINDOWS)
@@ -24,51 +20,47 @@ function(osqueryCoreTestsMain)
   endif()
 endfunction()
 
-function(generateOsqueryCoreTestsFlagstestsTest)
-  add_osquery_executable(osquery_core_tests_flagstests-test flags_tests.cpp)
+function(generateOsqueryCoreTestsMergedtestsTest)
+  set(source_files
+    flags_tests.cpp
+    system_test.cpp
+    tables_tests.cpp
+    watcher_tests.cpp
+    query_tests.cpp
+  )
 
-  target_link_libraries(osquery_core_tests_flagstests-test PRIVATE
-    osquery_cxx_settings
+  add_osquery_executable(osquery_core_tests_mergedtests-test ${source_files})
+
+  target_link_libraries(osquery_core_tests_mergedtests-test PRIVATE
     osquery_core
+    osquery_cxx_settings
     osquery_extensions
     osquery_extensions_implthrift
+    osquery_main
+    osquery_process
     osquery_registry
+    osquery_sql_tests_sqltestutils
     osquery_utils_info
     tests_helper
     thirdparty_googletest
   )
 endfunction()
 
-function(generateOsqueryCoreTestsSystemtestsTest)
-  add_osquery_executable(osquery_core_tests_systemtests-test system_test.cpp)
+function(generateOsqueryCoreTestsProcesstestsTest)
+  add_osquery_executable(osquery_core_tests_processtests-test process_tests.cpp)
 
-  target_link_libraries(osquery_core_tests_systemtests-test PRIVATE
+  target_link_libraries(osquery_core_tests_processtests-test PRIVATE
     osquery_cxx_settings
-    osquery_core
     osquery_extensions
     osquery_extensions_implthrift
-    osquery_registry
-    osquery_utils_info
+    osquery_main
+    osquery_process
     tests_helper
     thirdparty_googletest
   )
 endfunction()
 
-function(generateOsqueryCoreTestsTablestestsTest)
-  add_osquery_executable(osquery_core_tests_tablestests-test tables_tests.cpp)
-
-  target_link_libraries(osquery_core_tests_tablestests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_registry
-    tests_helper
-    osquery_utils_info
-    thirdparty_googletest
-  )
-endfunction()
-
+# generateOsqueryCoreTestsPermissionstestsTest is posix only, and cannot be merged
 function(generateOsqueryCoreTestsPermissionstestsTest)
 
   set(source_files
@@ -90,42 +82,7 @@ function(generateOsqueryCoreTestsPermissionstestsTest)
   )
 endfunction()
 
-function(generateOsqueryCoreTestsWatchertestsTest)
-  set(source_files
-    watcher_tests.cpp
-  )
-
-  add_osquery_executable(osquery_core_tests_watchertests-test ${source_files})
-
-  target_link_libraries(osquery_core_tests_watchertests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_process
-    osquery_registry
-    tests_helper
-    osquery_utils_info
-    thirdparty_googletest
-  )
-endfunction()
-
-function(generateOsqueryCoreTestsQuerytestsTest)
-  add_osquery_executable(osquery_core_tests_querytests-test query_tests.cpp)
-
-  target_link_libraries(osquery_core_tests_querytests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_registry
-    osquery_sql_tests_sqltestutils
-    tests_helper
-    osquery_utils_info
-    thirdparty_googletest
-  )
-endfunction()
-
+# generateOsqueryCoreTestsWmitestsTest is windows only, and cannot merge
 function(generateOsqueryCoreTestsWmitestsTest)
   add_osquery_executable(osquery_core_tests_wmitests-test windows/wmi_tests.cpp)
 
@@ -135,20 +92,6 @@ function(generateOsqueryCoreTestsWmitestsTest)
     osquery_core
     osquery_sql_tests_sqltestutils
     osquery_utils_info
-    tests_helper
-    thirdparty_googletest
-  )
-endfunction()
-
-function(generateOsqueryCoreTestsProcesstestsTest)
-  add_osquery_executable(osquery_core_tests_processtests-test process_tests.cpp)
-
-  target_link_libraries(osquery_core_tests_processtests-test PRIVATE
-    osquery_cxx_settings
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_main
-    osquery_process
     tests_helper
     thirdparty_googletest
   )

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -198,13 +198,9 @@ function(generateOsqueryEvents)
 
   generateIncludeNamespace(osquery_events "osquery/events" "FULL_PATH" ${platform_public_header_files})
 
-  add_test(NAME osquery_events_tests_eventsdatabasetests-test COMMAND osquery_events_tests_eventsdatabasetests-test)
 
   if(DEFINED PLATFORM_LINUX)
-    add_test(NAME osquery_events_tests_syslogtests-test COMMAND osquery_events_tests_syslogtests-test)
-    add_test(NAME osquery_events_tests_audittests-test COMMAND osquery_events_tests_audittests-test)
-    add_test(NAME osquery_events_tests_processfileeventstests-test COMMAND osquery_events_tests_processfileeventstests-test)
-    add_test(NAME osquery_events_tests_inotifytests-test COMMAND osquery_events_tests_inotifytests-test)
+    add_test(NAME osquery_events_tests_linuxtests-test COMMAND osquery_events_tests_linuxtests-test)
 
     if(OSQUERY_BUILD_BPF)
       add_test(NAME osquery_events_tests_bpftests-test COMMAND osquery_events_tests_bpftests-test)

--- a/osquery/events/tests/CMakeLists.txt
+++ b/osquery/events/tests/CMakeLists.txt
@@ -7,13 +7,9 @@
 
 function(osqueryEventsTestsMain)
   generateOsqueryEventsTestsTest()
-  generateOsqueryEventsTestsEventsdatabasetestsTest()
 
   if(DEFINED PLATFORM_LINUX)
-    generateOsqueryEventsTestsSyslogtestsTest()
-    generateOsqueryEventsTestsAudittestsTest()
-    generateOsqueryEventsTestsProcessfileeventstestsTest()
-    generateOsqueryEventsTestsInotifytestsTest()
+    generateOsqueryEventsLinuxtestsTest()
 
     if(OSQUERY_BUILD_BPF)
       generateOsqueryEventsTestsBpftestsTest()
@@ -31,77 +27,19 @@ function(osqueryEventsTestsMain)
 endfunction()
 
 function(generateOsqueryEventsTestsTest)
-  add_osquery_executable(osquery_events_tests-test events_tests.cpp)
+  set(source_files
+      events_tests.cpp
+      mockedosquerydatabase.cpp
+      eventsubscriberplugin.cpp
+  )
+
+  add_osquery_executable(osquery_events_tests-test ${source_files})
 
   target_link_libraries(osquery_events_tests-test PRIVATE
-    osquery_cxx_settings
     osquery_config_tests_testutils
     osquery_core
     osquery_core_sql
-    osquery_database
-    osquery_events
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_filesystem
-    osquery_tables_system_systemtable
-    osquery_utils
-    osquery_utils_conversions
-    tests_helper
-    thirdparty_googletest
-  )
-endfunction()
-
-function(generateOsqueryEventsTestsEventsdatabasetestsTest)
-  add_osquery_executable(osquery_events_tests_eventsdatabasetests-test
-    mockedosquerydatabase.cpp
-    eventsubscriberplugin.cpp
-  )
-
-  target_link_libraries(osquery_events_tests_eventsdatabasetests-test PRIVATE
     osquery_cxx_settings
-    osquery_core
-    osquery_core_sql
-    osquery_database
-    osquery_events
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_filesystem
-    osquery_tables_system_systemtable
-    osquery_utils
-    osquery_utils_conversions
-    specs_tables
-    thirdparty_googletest
-  )
-endfunction()
-
-function(generateOsqueryEventsTestsSyslogtestsTest)
-  add_osquery_executable(osquery_events_tests_syslogtests-test linux/syslog_tests.cpp)
-
-  target_link_libraries(osquery_events_tests_syslogtests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_database
-    osquery_events
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_filesystem
-    osquery_utils
-    osquery_utils_conversions
-    tests_helper
-    thirdparty_googletest
-  )
-endfunction()
-
-function(generateOsqueryEventsTestsAudittestsTest)
-  add_osquery_executable(osquery_events_tests_audittests-test
-    linux/audit_tests.cpp
-    linux/socket_events.cpp
-  )
-
-  target_link_libraries(osquery_events_tests_audittests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_core_sql
     osquery_database
     osquery_events
     osquery_extensions
@@ -116,13 +54,21 @@ function(generateOsqueryEventsTestsAudittestsTest)
   )
 endfunction()
 
-function(generateOsqueryEventsTestsProcessfileeventstestsTest)
-  add_osquery_executable(osquery_events_tests_processfileeventstests-test linux/process_file_events_tests.cpp)
+function(generateOsqueryEventsLinuxtestsTest)
+  set(source_files
+      linux/syslog_tests.cpp
+      linux/audit_tests.cpp
+      linux/socket_events.cpp
+      linux/process_file_events_tests.cpp
+      linux/inotify_tests.cpp
+  )
 
-  target_link_libraries(osquery_events_tests_processfileeventstests-test PRIVATE
-    osquery_cxx_settings
+  add_osquery_executable(osquery_events_tests_linuxtests-test ${source_files})
+
+  target_link_libraries(osquery_events_tests_linuxtests-test PRIVATE
     osquery_core
     osquery_core_sql
+    osquery_cxx_settings
     osquery_database
     osquery_events
     osquery_extensions
@@ -132,9 +78,11 @@ function(generateOsqueryEventsTestsProcessfileeventstestsTest)
     osquery_utils
     osquery_utils_conversions
     specs_tables
+    tests_helper
     thirdparty_googletest
   )
 endfunction()
+
 
 function(generateOsqueryEventsTestsBpftestsTest)
   add_osquery_executable(
@@ -159,23 +107,6 @@ function(generateOsqueryEventsTestsBpftestsTest)
   )
 endfunction()
 
-function(generateOsqueryEventsTestsInotifytestsTest)
-  add_osquery_executable(osquery_events_tests_inotifytests-test linux/inotify_tests.cpp)
-
-  target_link_libraries(osquery_events_tests_inotifytests-test PRIVATE
-    osquery_cxx_settings
-    osquery_core
-    osquery_database
-    osquery_events
-    osquery_extensions
-    osquery_extensions_implthrift
-    osquery_filesystem
-    osquery_utils
-    osquery_utils_conversions
-    tests_helper
-    thirdparty_googletest
-  )
-endfunction()
 
 function(generateOsqueryEventsTestsFseventstestsTest)
   add_osquery_executable(osquery_events_tests_fseventstests-test darwin/fsevents_tests.cpp)


### PR DESCRIPTION
#6397 has been more and more of an issue, and is now blocking the 5.8 release. Talking in office hours today, we decided to try collapsing some of the test binaries. It's imperfect, but we think it's the quickest way to get 5.8 out. This is a first pass. This may be reverted later.

This branch is on the main osquery repo, because we need to hit the self hosted runner. 

