### PR TITLE
Fix empty batch result set reporting

### DIFF
--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -138,7 +138,6 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
   QueryLogItem item;
   item.name = name;
   item.identifier = ident;
-  item.counter = 1; // default to 1 to differ from new epoch case (counter=0)
   item.time = osquery::getUnixTime();
   item.epoch = FLAGS_schedule_epoch;
   item.calendar_time = osquery::getAsciiTime();
@@ -158,6 +157,12 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
     }
     return status;
   }
+
+  // Set counter to 1 here to be able to tell if this was a new epoch
+  // (counter=0) in the differential stream. Whenever actually logging
+  // results below, this counter value will have been overwritten in
+  // addNewResults or addNewEvents.
+  item.counter = 1;
 
   // Create a database-backed set of query results.
   auto dbQuery = Query(name, query);

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -138,6 +138,7 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
   QueryLogItem item;
   item.name = name;
   item.identifier = ident;
+  item.counter = 1; // default to 1 to differ from new epoch case (counter=0)
   item.time = osquery::getUnixTime();
   item.epoch = FLAGS_schedule_epoch;
   item.calendar_time = osquery::getAsciiTime();


### PR DESCRIPTION
The PR https://github.com/osquery/osquery/pull/7803 intended to add logging of an empty result set in batch format for an initial run (or new epoch) if there are no results. However, it instead lead to logging an empty result set every time the query executes without results (not just on a new epoch) -- see report in [Slack](https://osquery.slack.com/archives/C08VA3XQU/p1678855376559829). 

This is because the `item.counter` field is only set to its correct value when there are results to report and otherwise defaults to zero in the scheduler. The easiest fix seems like making the default `item.counter` field a non-zero value instead. An alternative idea would be to always set `item.counter` correctly in the query code (or else to go back to the old behavior of ignoring all empty runs).

See comment below for reproducing and testing the fix. Ideally we'd have some kind of automated integration test of the scheduler, but I haven't had time to figure out how to add that.