### PR TITLE
tests: Fix some tests becoming osquery shells

### DIFF
--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -36,7 +36,6 @@ function(generateOsqueryCoreTestsMergedtestsTest)
     osquery_cxx_settings
     osquery_extensions
     osquery_extensions_implthrift
-    osquery_main
     osquery_process
     osquery_registry
     osquery_sql_tests_sqltestutils
@@ -53,7 +52,6 @@ function(generateOsqueryCoreTestsProcesstestsTest)
     osquery_cxx_settings
     osquery_extensions
     osquery_extensions_implthrift
-    osquery_main
     osquery_process
     tests_helper
     thirdparty_googletest


### PR DESCRIPTION
The osquery_main target should never be linked by tests.

Not sure why the CI is happily working, but when executing the `osquery_core_tests_mergedtests_test` it starts an osquery shell, not the test.
The issue in the other test cannot be seen locally, but it's equally incorrect.