### PR TITLE
test: Do not always expect a row from the secureboot table

### DIFF
--- a/tests/integration/tables/secureboot.cpp
+++ b/tests/integration/tables/secureboot.cpp
@@ -47,9 +47,6 @@ TEST_F(Secureboot, test_sanity) {
 
   auto secureboot_data = execute_query("SELECT * FROM secureboot;");
 
-  // There should always be exactly 1 row, regardless:
-  ASSERT_EQ(secureboot_data.size(), 1);
-
   // Values should only ever be integers or empty:
   ValidationMap row_map{
       {"secure_boot", IntOrEmpty},


### PR DESCRIPTION
For instance if the machine is not using UEFI,
or there is any error, the table won't return a row.
