### PR TITLE
Improving `listDirectoriesInDirectory` by using `std::fs`

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -457,13 +457,17 @@ Status listDirectoriesInDirectory(const fs::path& path,
 
   if (recursive) {
     for (const auto& entry : fs::recursive_directory_iterator(path)) {
-      if (fs::is_directory(entry)) {
+      if (fs::is_symlink(entry)) {
+        results.push_back(entry.path().string());
+      } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());
       }
     }
   } else {
     for (const auto& entry : fs::directory_iterator(path)) {
-      if (fs::is_directory(entry)) {
+      if (fs::is_symlink(entry)) {
+        results.push_back(entry.path().string());
+      } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());
       }
     }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -451,8 +451,25 @@ Status listFilesInDirectory(const fs::path& path,
 Status listDirectoriesInDirectory(const fs::path& path,
                                   std::vector<std::string>& results,
                                   bool recursive) {
-  return listInAbsoluteDirectory(
-      (path / ((recursive) ? "**" : "*")), results, GLOB_FOLDERS);
+  if (path.empty() || !pathExists(path)) {
+    return Status(1, "Target directory is invalid");
+  }
+
+  if (recursive) {
+    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+      if (fs::is_directory(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  } else {
+    for (const auto& entry : fs::directory_iterator(path)) {
+      if (fs::is_directory(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  }
+
+  return Status::success();
 }
 
 Status isDirectory(const fs::path& path) {

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -869,6 +869,7 @@ TEST_F(FilesystemTests, test_directory_listing_with_nested_dirs_and_symlinks) {
   deleteDirectoryContent(test_root_work_dirs);
 }
 
+#ifdef OSQUERY_WINDOWS
 TEST_F(FilesystemTests, test_directory_listing_with_recursive_junction) {
   // This test verifies that a recursive directory junction can be handled by
   // listDirectoriesInDirectory logic
@@ -897,6 +898,7 @@ TEST_F(FilesystemTests, test_directory_listing_with_recursive_junction) {
 
   deleteDirectoryContent(test_root_raw);
 }
+#endif
 
 TEST_F(FilesystemTests, test_directory_listing_with_legacy_logic) {
   // This test verifies that symlinks and nested directories are properly

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -113,8 +113,14 @@ void genSiteDirectories(const std::string& site,
                         Logger& logger) {
   std::vector<std::string> directories;
 
-  if (!stdListDirectoriesInDirectory(site, directories, true).ok()) {
-    return;
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    if (!stdListDirectoriesInDirectory(site, directories, true).ok()) {
+      return;
+    }
+  } else {
+    if (!listDirectoriesInDirectory(site, directories, true).ok()) {
+      return;
+    }
   }
 
   for (const auto& directory : directories) {

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -84,11 +84,36 @@ void genPackage(const std::string& path, Row& r, Logger& logger) {
   }
 }
 
+Status stdListDirectoriesInDirectory(const fs::path& path,
+                                     std::vector<std::string>& results,
+                                     bool recursive) {
+  if (path.empty() || !pathExists(path)) {
+    return Status(1, "Target directory is invalid");
+  }
+
+  if (recursive) {
+    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+      if (fs::is_directory(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  } else {
+    for (const auto& entry : fs::directory_iterator(path)) {
+      if (fs::is_directory(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  }
+
+  return Status::success();
+}
+
 void genSiteDirectories(const std::string& site,
                         QueryData& results,
                         Logger& logger) {
   std::vector<std::string> directories;
-  if (!listDirectoriesInDirectory(site, directories, true).ok()) {
+
+  if (!stdListDirectoriesInDirectory(site, directories, true).ok()) {
     return;
   }
 

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -84,43 +84,13 @@ void genPackage(const std::string& path, Row& r, Logger& logger) {
   }
 }
 
-Status stdListDirectoriesInDirectory(const fs::path& path,
-                                     std::vector<std::string>& results,
-                                     bool recursive) {
-  if (path.empty() || !pathExists(path)) {
-    return Status(1, "Target directory is invalid");
-  }
-
-  if (recursive) {
-    for (const auto& entry : fs::recursive_directory_iterator(path)) {
-      if (fs::is_directory(entry)) {
-        results.push_back(entry.path().string());
-      }
-    }
-  } else {
-    for (const auto& entry : fs::directory_iterator(path)) {
-      if (fs::is_directory(entry)) {
-        results.push_back(entry.path().string());
-      }
-    }
-  }
-
-  return Status::success();
-}
-
 void genSiteDirectories(const std::string& site,
                         QueryData& results,
                         Logger& logger) {
   std::vector<std::string> directories;
 
-  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
-    if (!stdListDirectoriesInDirectory(site, directories, true).ok()) {
-      return;
-    }
-  } else {
-    if (!listDirectoriesInDirectory(site, directories, true).ok()) {
-      return;
-    }
+  if (!listDirectoriesInDirectory(site, directories, true).ok()) {
+    return;
   }
 
   for (const auto& directory : directories) {


### PR DESCRIPTION
This relates to #[6679 ](https://github.com/osquery/osquery/issues/6679) and Fleet PR #[8243](https://github.com/fleetdm/fleet/issues/8243)

There was a 10x performance increase when using this logic (see osqueryi_custom.exe results below)

```
PS C:\tools\osquery> Measure-Command { .\osqueryi_5.8.2.exe "select COUNT(*) from python_packages;" | Out-Default }
+----------+
| COUNT(*) |
+----------+
| 228      |
+----------+
TotalSeconds      : 19.1131021
TotalMilliseconds : 19113.1021



PS C:\tools\osquery> Measure-Command { .\osqueryi_custom.exe "select COUNT(*) from python_packages;" | Out-Default }
+----------+
| COUNT(*) |
+----------+
| 228      |
+----------+
TotalSeconds      : 1.907992
TotalMilliseconds : 1907.992
```