### PR TITLE
adds windows_search table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -221,6 +221,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/windows_crashes.cpp
       windows/windows_eventlog.cpp
       windows/windows_optional_features.cpp
+      windows/windows_search.cpp
       windows/windows_security_products.cpp
       windows/windows_security_center.cpp
       windows/windows_update_history.cpp

--- a/osquery/tables/system/windows/windows_search.cpp
+++ b/osquery/tables/system/windows/windows_search.cpp
@@ -1,0 +1,254 @@
+// osquery/tables/system/windows/windows_search.cpp
+
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <windows.h>
+#include <atldbcli.h>
+#include <sstream>
+#include <vector>
+#include <comutil.h>
+#include <strsafe.h>
+#include <codecvt>
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/windows/strings.h>
+
+#pragma comment(lib, "comsuppw.lib")
+
+namespace osquery {
+namespace tables {
+
+void writeDate(double date, std::wstringstream& wss)
+{
+    SYSTEMTIME sysTime;
+    BOOL ok = VariantTimeToSystemTime(date, &sysTime);
+    if (ok)
+    {
+        SYSTEMTIME localTime;
+        ok = SystemTimeToTzSpecificLocalTime(NULL, &sysTime, &localTime);
+        if (ok)
+        {
+            WCHAR szBuffer[100];
+            ok = GetDateFormat(LOCALE_USER_DEFAULT, 0, &localTime, NULL, szBuffer, ARRAYSIZE(szBuffer) / sizeof(WCHAR));
+            if (ok)
+            {
+                wss << szBuffer;
+                ok = GetTimeFormat(LOCALE_USER_DEFAULT, 0, &localTime, NULL, szBuffer, ARRAYSIZE(szBuffer) / sizeof(WCHAR));
+                if (ok)
+                {
+                    wss << szBuffer;
+                }
+            }
+        }
+    }
+    if (!ok)
+    {
+        wss << "could not write date " << date;
+    }
+}
+
+// This helper function can print some propvariants and handles BSTR vectors
+void writePropVariant(REFPROPVARIANT variant, std::wstringstream& wss)
+{
+    if (variant.vt == (VT_ARRAY | VT_BSTR) && variant.parray->cDims == 1)
+    {
+        BSTR* pBStr;
+        HRESULT hr = SafeArrayAccessData(variant.parray, reinterpret_cast<void**>(&pBStr));
+        if (SUCCEEDED(hr))
+        {
+            for (unsigned int i = 0; i < variant.parray->rgsabound[0].cElements; i++)
+            {
+                if (i == 0)
+                {
+                    wss << "[";
+                }
+                else
+                {
+                    wss << ";";
+                }
+                wss << pBStr[i];
+            }
+            wss << "]";
+            SafeArrayUnaccessData(variant.parray);
+        }
+        else
+        {
+            wss << "could not write vector";
+        }
+    }
+    else
+    {
+        switch (variant.vt)
+        {
+        case VT_LPWSTR: wss << variant.pwszVal; break;
+        case VT_BSTR: wss << variant.bstrVal; break;
+        case VT_I1: wss << variant.cVal; break;
+        case VT_UI2: wss << variant.uiVal; break;
+        case VT_I2: wss << variant.iVal; break;
+        case VT_UI4: wss << variant.ulVal; break;
+        case VT_I4: wss << variant.lVal; break;
+        case VT_UI8: wss << variant.uhVal.HighPart << variant.uhVal.LowPart; break;
+        case VT_I8: wss << variant.hVal.HighPart << variant.hVal.LowPart; break;
+        case VT_DATE: writeDate(variant.date, wss); break;
+        default:
+            wss << "unhandled variant type " << variant.vt;
+            break;
+        }
+    }
+}
+
+std::string ccomandColumnStringValue(CCommand<CDynamicAccessor, CRowset>& cCommand, DBORDINAL columnIndex) {
+    DBTYPE type;
+    cCommand.GetColumnType(columnIndex, &type);
+
+    std::wstringstream wss;
+
+    DBSTATUS status;
+    cCommand.GetStatus(columnIndex, &status);
+    if (status == DBSTATUS_S_ISNULL)
+    {
+        wss << "NULL";
+    }
+    else if (status == DBSTATUS_S_OK || status == DBSTATUS_S_TRUNCATED)
+    {
+        DBTYPE type;
+        cCommand.GetColumnType(columnIndex, &type);
+        switch (type)
+        {
+        case DBTYPE_VARIANT:
+            writePropVariant(*(static_cast<PROPVARIANT*>(cCommand.GetValue(columnIndex))), wss);
+            break;
+        case DBTYPE_WSTR:
+        {
+            DBLENGTH cbLen;
+            cCommand.GetLength(columnIndex, &cbLen);
+            WCHAR szBuffer[2048];
+            StringCchCopyN(szBuffer, ARRAYSIZE(szBuffer), static_cast<WCHAR*>(cCommand.GetValue(columnIndex)), cbLen / sizeof(WCHAR));
+            wss << szBuffer;
+        }
+        break;
+        case DBTYPE_I1:
+            wss << *static_cast<UCHAR*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_UI2:
+            wss << *static_cast<USHORT*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_I2:
+            wss << *static_cast<SHORT*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_UI4:
+            wss << *static_cast<DWORD*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_I4:
+            wss << *static_cast<INT*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_UI8:
+            wss << *static_cast<ULONGLONG*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_I8:
+            wss << *static_cast<LONGLONG*>(cCommand.GetValue(columnIndex));
+            break;
+        case DBTYPE_DATE:
+            writeDate(*static_cast<DATE*>(cCommand.GetValue(columnIndex)), wss);
+            break;
+        default:
+            wss << "unhandled database type " << type;
+            break;
+        }
+    }
+    else
+    {
+        wss << "error reading column";
+    }
+
+    std::wstring wideStr = wss.str();
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+    return converter.to_bytes(wideStr);
+}
+
+std::vector<std::map<std::string, std::string>> executeWindowsSearchQuery(CSession& cSession, const std::string& query) {
+    HRESULT hr;
+    std::vector<std::map<std::string, std::string>> results;
+
+    CCommand<CDynamicAccessor, CRowset> cCommand;
+    hr = cCommand.Open(cSession, query.c_str());
+
+    if (!SUCCEEDED(hr)) {
+        LOG(ERROR) << "error executing query";
+        return results;
+    }
+
+    for (hr = cCommand.MoveFirst(); S_OK == hr; hr = cCommand.MoveNext()) {
+        std::map<std::string, std::string> row;
+
+        for (DBORDINAL i = 1; i <= cCommand.GetColumnCount(); i++) {
+            auto columnName = cCommand.GetColumnName(i);
+            std::string columnNameStr = wstringToString(columnName);
+
+            // Add the column name and value to the row map.
+            row[columnNameStr] = ccomandColumnStringValue(cCommand, i);
+        }
+
+        results.push_back(row);
+    }
+
+    cCommand.Close();
+    return results;
+}
+
+
+QueryData genWindowsSearch(QueryContext& context) {
+    QueryData results;
+
+    HRESULT hr = CoInitialize(NULL);
+
+    CDataSource cDataSource;
+    hr = cDataSource.OpenFromInitializationString(L"provider=Search.CollatorDSO.1;EXTENDED PROPERTIES=\"Application=Windows\"");
+
+    if (!SUCCEEDED(hr)) {
+        LOG(ERROR) << "error initializing CDataSource";
+        return results;
+    }
+
+    CSession cSession;
+    hr = cSession.Open(cDataSource);
+
+    if (!SUCCEEDED(hr)) {
+        LOG(ERROR) << "error opening CSession";
+        return results;
+    }
+
+    auto queries = context.constraints["query"].getAll(EQUALS);
+
+    for (const auto& query : queries) {
+        auto queryResults = executeWindowsSearchQuery(cSession, query);
+
+        for (size_t i = 0; i < queryResults.size(); i++) {
+            for (const auto &[key, value] : queryResults[i]) {
+                Row r;
+                r["entity"] = INTEGER(i);
+                r["attribute"] = key;
+                r["value"] = value;
+                r["query"] = query;
+                results.push_back(r);
+            }
+        }
+    }
+
+    cSession.Close();
+    cDataSource.Close();
+    CoUninitialize();
+    return results;
+}
+
+} // namespace tables
+} // namespace osquery
+

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -304,6 +304,7 @@ function(generateNativeTables)
     "windows/prefetch.table:windows"
     "windows/tpm_info.table:windows"
     "windows/security_profile_info.table:windows"
+    "windows/windows_search.table:windows"
     "yara/yara_events.table:linux,macos"
     "yara/yara.table:linux,macos,windows"
   )
@@ -314,12 +315,12 @@ function(generateNativeTables)
       "linux/bpf_socket_events.table:linux"
     )
   endif()
-  
+
   if(OSQUERY_BUILD_ETW)
     list(APPEND platform_dependent_spec_files
       "windows/process_etw_events.table:windows"
     )
-  endif()  
+  endif()
 
   if(OSQUERY_BUILD_AWS)
     list(APPEND platform_independent_spec_files

--- a/specs/windows/windows_search.table
+++ b/specs/windows/windows_search.table
@@ -1,0 +1,13 @@
+table_name("windows_search")
+description("Run searches against the windows system index database.")
+schema([
+    Column("entity", TEXT, "index of entity"),
+    Column("attribute", TEXT, "attribute"),
+    Column("value", TEXT, "value"),
+    Column("query", TEXT, "windows search query", required=True),
+])
+implementation("system/windows/windows_search@genWindowsSearch")
+examples([
+    "select * from windows_search where query = 'select top 10 system.itempathdisplay from systemindex where scope = ''file:c:\'''",
+    "select * from windows_search where query = 'select top 10 system.itempathdisplay,system.size from systemindex where scope = ''file:c:\'''",
+])


### PR DESCRIPTION
This PR adds a new table called `windows_search`. This table provides a way to query the windows systemindex via osquery. It works by accepting a `query` constraint and passing the query to a `CCommand`.

```sql
osquery> select * from windows_search where query = 'select top 5 system.itempathdisplay,system.size from systemindex where scope=''file:c:\users\james\pictures\screenshots''';
+--------+------------------------+----------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
| entity | attribute              | value                                                                | query                                                                                                                   |
+--------+------------------------+----------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
| 0      | SYSTEM.ITEMPATHDISPLAY | C:\Users\james\Pictures\Screenshots\Screenshot_20230106_080505.png   | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 0      | SYSTEM.SIZE            | 41170                                                                | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 1      | SYSTEM.ITEMPATHDISPLAY | C:\Users\james\Pictures\Screenshots\Screenshot 2023-04-12 155012.png | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 1      | SYSTEM.SIZE            | 16567                                                                | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 2      | SYSTEM.ITEMPATHDISPLAY | C:\Users\james\Pictures\Screenshots\Screenshot 2023-04-12 154302.png | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 2      | SYSTEM.SIZE            | 17115                                                                | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 3      | SYSTEM.ITEMPATHDISPLAY | C:\Users\james\Pictures\Screenshots\Screenshot 2023-04-13 104149.png | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 3      | SYSTEM.SIZE            | 17979                                                                | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 4      | SYSTEM.ITEMPATHDISPLAY | C:\Users\james\Pictures\Screenshots\desktop.ini                      | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
| 4      | SYSTEM.SIZE            | 190                                                                  | select top 5 system.itempathdisplay,system.size from systemindex where scope='file:c:\users\james\pictures\screenshots' |
+--------+------------------------+----------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------+
```

Big thanks to @marcosd4h for the tips. I borrowed his code to do all the type conversions.

Some possible improvements:

* explore using [windows search advance query syntax](https://learn.microsoft.com/en-us/windows/win32/search/-search-3x-advancedquerysyntax)
* always provide the path as the entity, it's unclear to me if this can be used for searching for items other than files

