### PR TITLE
Update `safari_extensions` to handle the current app extensions pattern

### DIFF
--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -417,9 +417,6 @@ inline void genSafariSandboxedExtensions(const QueryContext& context,
     // Traverse app directories to obtain app extension data if present
     SandboxedExtensionsData sandboxed_ext_data;
     for (const auto& app_directory : app_directories) {
-      if (isExtensionAppExcluded(app_directory)) {
-        continue;
-      }
 
       std::vector<std::string> app_internal_dirs;
       if (!listDirectoriesInDirectory(app_directory, app_internal_dirs, true)) {

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -417,7 +417,6 @@ inline void genSafariSandboxedExtensions(const QueryContext& context,
     // Traverse app directories to obtain app extension data if present
     SandboxedExtensionsData sandboxed_ext_data;
     for (const auto& app_directory : app_directories) {
-
       std::vector<std::string> app_internal_dirs;
       if (!listDirectoriesInDirectory(app_directory, app_internal_dirs, true)) {
         continue;

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -362,17 +362,17 @@ inline bool isUserExtension(const fs::path& app_extension_plist,
   // Gather user extension metainformation
   pt::ptree app_extension_ptree;
   pt::ptree web_extension_ptree;
-  getPtreeFromPlist(app_extension_plist, app_extension_ptree);
-  getPtreeFromPlist(web_extension_plist, web_extension_ptree);
 
   // Iterate over the list of user extensions and check if there is a match with
   // extension identifier
+  getPtreeFromPlist(app_extension_plist, app_extension_ptree);
   for (const auto& entry : app_extension_ptree) {
     if (!boost::algorithm::contains(entry.first, ext_data.identifier)) {
       return true;
     }
   }
 
+  getPtreeFromPlist(web_extension_plist, web_extension_ptree);
   for (const auto& entry : web_extension_ptree) {
     if (!boost::algorithm::contains(entry.first, ext_data.identifier)) {
       return true;

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -1,5 +1,5 @@
 table_name("safari_extensions")
-description("Safari browser extension details for all users.")
+description("Safari browser extension details for all users. This table requires Full Disk Access (FDA) permission.")
 schema([
     Column("uid", BIGINT, "The local user that owns the extension",
       index=True),
@@ -20,6 +20,7 @@ schema([
 attributes(user_data=True)
 implementation("applications/browser_plugins@genSafariExtensions")
 examples([
+  "select * from safari_extensions where uid=501",
   "select count(*) from users JOIN safari_extensions using (uid)",
 ])
 fuzz_paths([

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -12,6 +12,8 @@ schema([
     Column("developer_id", TEXT, "Optional developer identifier"),
     Column("description", TEXT, "Optional extension description text"),
     Column("path", TEXT, "Path to extension XAR bundle"),
+    Column("bundle_version", TEXT, "The version of the build that identifies an iteration of the bundle"),
+    Column("copyright", TEXT, "A human-readable copyright notice for the bundle"),
     Column("extension_type", TEXT, "Extension Type: WebOrAppExtension or LegacyExtension"),	
     ForeignKey(column="uid", table="users")
 ])

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -12,6 +12,7 @@ schema([
     Column("developer_id", TEXT, "Optional developer identifier"),
     Column("description", TEXT, "Optional extension description text"),
     Column("path", TEXT, "Path to extension XAR bundle"),
+    Column("extension_type", TEXT, "Extension Type: WebOrAppExtension or LegacyExtension"),	
     ForeignKey(column="uid", table="users")
 ])
 attributes(user_data=True)


### PR DESCRIPTION
This relates to #6498  and Fleet's #[6950](https://github.com/fleetdm/fleet/issues/6950)

Fixes: #6498