### PR TITLE
Add few unit tests for the hashing component

### DIFF
--- a/osquery/hashing/CMakeLists.txt
+++ b/osquery/hashing/CMakeLists.txt
@@ -27,6 +27,30 @@ function(generateOsqueryHashing)
   )
 
   generateIncludeNamespace(osquery_hashing "osquery/hashing" "FILE_ONLY" ${public_header_files})
+
+  if(OSQUERY_BUILD_TESTS)
+    generateOsqueryHashingTestsTest()
+  endif()
+
+  add_test(NAME osquery_hashing_tests-test COMMAND osquery_hashing_tests-test)
+endfunction()
+
+function(generateOsqueryHashingTestsTest)
+  set(source_files
+    tests/hashing.cpp
+  )
+
+  add_osquery_executable(osquery_hashing_tests-test ${source_files})
+
+  target_link_libraries(osquery_hashing_tests-test PRIVATE
+    osquery_cxx_settings
+    osquery_hashing
+    osquery_filesystem
+    osquery_extensions
+    osquery_extensions_implthrift
+    tests_helper
+    thirdparty_googletest
+  )
 endfunction()
 
 osqueryHashingMain()

--- a/osquery/hashing/tests/hashing.cpp
+++ b/osquery/hashing/tests/hashing.cpp
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/hashing/hashing.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+namespace {
+const std::string kHelloString("HELLO");
+const std::string kHelloMD5Digest("eb61eead90e3b899c6bcbe27ac581660");
+const std::string kHelloSHA1Digest("c65f99f8c5376adadddc46d5cbcf5762f9e55eb7");
+const std::string kHelloSHA256Digest(
+    "3733cd977ff8eb18b987357e22ced99f46097f31ecb239e878ae63760e83e4d5");
+} // namespace
+
+class HashingFilesystemTests : public testing::Test {
+ protected:
+  fs::path test_working_dir_;
+
+  void SetUp() override {
+    initializeFilesystemAPILocale();
+
+    test_working_dir_ = fs::temp_directory_path() /
+                        fs::unique_path("osquery.test_working_dir.%%%%.%%%%");
+    fs::create_directories(test_working_dir_);
+  }
+
+  void TearDown() override {
+    fs::remove_all(test_working_dir_);
+  }
+};
+
+TEST_F(HashingFilesystemTests, test_multi_hashing_file) {
+  auto file_path = test_working_dir_ / "hashing_file.txt";
+
+  std::ofstream test_file(file_path.string());
+
+  test_file.write(kHelloString.c_str(), kHelloString.length());
+  test_file.close();
+
+  const auto mask = HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256;
+  const auto hashes = hashMultiFromFile(mask, file_path.string());
+
+  EXPECT_EQ(hashes.md5, kHelloMD5Digest);
+  EXPECT_EQ(hashes.sha1, kHelloSHA1Digest);
+  EXPECT_EQ(hashes.sha256, kHelloSHA256Digest);
+
+  EXPECT_EQ(hashFromFile(HASH_TYPE_MD5, file_path.string()), kHelloMD5Digest);
+  EXPECT_EQ(hashFromFile(HASH_TYPE_SHA1, file_path.string()), kHelloSHA1Digest);
+  EXPECT_EQ(hashFromFile(HASH_TYPE_SHA256, file_path.string()),
+            kHelloSHA256Digest);
+}
+
+TEST(HashingTests, test_hashing_md5) {
+  Hash hash(HASH_TYPE_MD5);
+  hash.update(kHelloString.c_str(), kHelloString.length());
+
+  auto digest = hash.digest();
+  EXPECT_EQ(digest, kHelloMD5Digest);
+
+  digest = hashFromBuffer(
+      HASH_TYPE_MD5, kHelloString.c_str(), kHelloString.length());
+  EXPECT_EQ(digest, kHelloMD5Digest);
+}
+
+TEST(HashingTests, test_hashing_sha1) {
+  Hash hash(HASH_TYPE_SHA1);
+  hash.update(kHelloString.c_str(), kHelloString.length());
+
+  auto digest = hash.digest();
+  EXPECT_EQ(digest, kHelloSHA1Digest);
+
+  digest = hashFromBuffer(
+      HASH_TYPE_SHA1, kHelloString.c_str(), kHelloString.length());
+  EXPECT_EQ(digest, kHelloSHA1Digest);
+}
+
+TEST(HashingTests, test_hashing_sha256) {
+  Hash hash(HASH_TYPE_SHA256);
+  hash.update(kHelloString.c_str(), kHelloString.length());
+
+  auto digest = hash.digest();
+  EXPECT_EQ(digest, kHelloSHA256Digest);
+
+  digest = hashFromBuffer(
+      HASH_TYPE_SHA256, kHelloString.c_str(), kHelloString.length());
+  EXPECT_EQ(digest, kHelloSHA256Digest);
+}
+
+} // namespace osquery


### PR DESCRIPTION
Hi!

While walking across the osquery project I tried to change some code in the hashing component.
But I believe that it would be better to land some tests first to be sure that I don't broke anything later.
So this PR contains only a few basic tests for hashing classes and functions.

PTAL.