### PR TITLE
Simplify hashMultiFromFile function

### DIFF
--- a/osquery/hashing/hashing.h
+++ b/osquery/hashing/hashing.h
@@ -79,6 +79,16 @@ class Hash : private boost::noncopyable {
   explicit Hash(HashType algorithm, HashEncodingType encoding);
 
   /**
+   * @brief Hash move constructor
+   *
+   * Initialize the Hash class from an existing object and take ownership of the
+   * context.
+   *
+   * @param other Source objest to move the state from.
+   */
+  Hash(Hash&& other);
+
+  /**
    * @brief Hash destructor
    */
   ~Hash();
@@ -107,14 +117,14 @@ class Hash : private boost::noncopyable {
    *
    * The osquery::Hash class should only ever be instantiated with a HashType
    */
-  Hash(){};
+  Hash() = delete;
 
  private:
   /// The hashing algorithm which is used to compute the hash
-  HashType algorithm_;
+  const HashType algorithm_;
 
   /// The encoding type used to encode the digest.
-  HashEncodingType encoding_;
+  const HashEncodingType encoding_;
 
   /// The buffer used to maintain the context and state of the hashing
   /// operations

--- a/osquery/hashing/tests/hashing.cpp
+++ b/osquery/hashing/tests/hashing.cpp
@@ -56,6 +56,7 @@ TEST_F(HashingFilesystemTests, test_multi_hashing_file) {
   const auto mask = HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256;
   const auto hashes = hashMultiFromFile(mask, file_path.string());
 
+  EXPECT_EQ(hashes.mask, mask);
   EXPECT_EQ(hashes.md5, kHelloMD5Digest);
   EXPECT_EQ(hashes.sha1, kHelloSHA1Digest);
   EXPECT_EQ(hashes.sha256, kHelloSHA256Digest);


### PR DESCRIPTION
Main intent of this PR is to simplify `hashMultiFromFile` a little bit:
- Remove `shared_ptr` completely, because there are no clients that can share the pointer, all usage is localised in `hashMultiFromFile` function.
- Remove map (or even unordered_map), just because we don't need to address map elements by keys.
- Add few `std::move` calls to help the compiler better understand what is going on.

To achieve that I have to add new move-ctor for the Hash class. Hope that this is not forbidden.
In other way, this behaviour can be done with `std::unique_ptr<Hash>`.

PTAL.