### PR TITLE
Do not copy string content if possible while base64 encoding/decoding

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -347,7 +347,8 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
     params.add("block_id", i);
     params.add("session_id", session_id);
     params.add("request_id", requestId_);
-    params.add("data", base64::encode(std::string(block.begin(), block.end())));
+    params.add("data",
+               base64::encode(std::string_view(block.data(), block.size())));
 
     // TODO: Error sending files.
     status = contRequest.call(params);

--- a/osquery/sql/sqlite_encoding.cpp
+++ b/osquery/sql/sqlite_encoding.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <string>
+#include <string_view>
 
 #include <sqlite3.h>
 
@@ -38,7 +39,7 @@ static void b64SqliteValue(sqlite3_context* ctx,
   const auto* value = sqlite3_value_text(argv[0]);
   auto size = static_cast<size_t>(sqlite3_value_bytes(argv[0]));
 
-  std::string input(reinterpret_cast<const char*>(value), size);
+  const std::string_view input(reinterpret_cast<const char*>(value), size);
   std::string result;
   switch (encode) {
   case B64Type::B64_ENCODE_CONDITIONAL:

--- a/osquery/tables/system/linux/extended_attributes.cpp
+++ b/osquery/tables/system/linux/extended_attributes.cpp
@@ -146,9 +146,7 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
       --value_size;
     }
 
-    auto value = std::string(value_size, 0);
-    std::memcpy(&value[0], key_value.data(), value_size);
-
+    const std::string_view value(key_value.data(), value_size);
     if (!printable) {
       value = base64::encode(value);
     }

--- a/osquery/utils/base64.cpp
+++ b/osquery/utils/base64.cpp
@@ -29,6 +29,7 @@ typedef bai::transform_width<base64_str, 8, 6> base64_dec;
 typedef bai::transform_width<std::string_view::const_iterator, 6, 8> base64_enc;
 typedef bai::base64_from_binary<base64_enc> it_base64;
 
+// Helper function to do all work for decoding a string.
 std::string decode_impl(std::string_view encoded) {
   if (encoded.empty()) {
     return std::string();
@@ -45,6 +46,10 @@ std::string decode_impl(std::string_view encoded) {
 
 } // namespace
 
+// This overload of the `decode` function expects the input
+// as a mutable string to erase few symbols from it.
+// Can be called in forms of:
+// `decode(someStringResultFunc())` or `decode(std::move(stringVar))`
 std::string decode(std::string&& encoded) {
   boost::erase_all(encoded, "\r\n");
   boost::erase_all(encoded, "\n");
@@ -53,11 +58,17 @@ std::string decode(std::string&& encoded) {
   return decode_impl(encoded);
 }
 
+// Main entry point to decode a string as a read-only buffer.
+// Will copy the input string and clear few special symbols only if needed.
 std::string decode(std::string_view encoded) {
+  // Do a linear lookup to decide whether we can avoid copying the input string.
+  // See the `decode(std::string&&)` function overload above for a list of
+  // symbols we are looking.
   if (encoded.find_first_of("\r\n=") == std::string_view::npos) {
     return decode_impl(encoded);
   }
 
+  // If we have to clear the string, then build a copy of it explicitly.
   return decode(std::string(encoded));
 }
 

--- a/osquery/utils/base64.cpp
+++ b/osquery/utils/base64.cpp
@@ -26,18 +26,12 @@ namespace {
 
 typedef bai::binary_from_base64<const char*> base64_str;
 typedef bai::transform_width<base64_str, 8, 6> base64_dec;
-typedef bai::transform_width<std::string::const_iterator, 6, 8> base64_enc;
+typedef bai::transform_width<std::string_view::const_iterator, 6, 8> base64_enc;
 typedef bai::base64_from_binary<base64_enc> it_base64;
 
-} // namespace
-
-std::string decode(std::string encoded) {
-  boost::erase_all(encoded, "\r\n");
-  boost::erase_all(encoded, "\n");
-  boost::trim_right_if(encoded, boost::is_any_of("="));
-
+std::string decode_impl(std::string_view encoded) {
   if (encoded.empty()) {
-    return encoded;
+    return std::string();
   }
 
   try {
@@ -45,24 +39,42 @@ std::string decode(std::string encoded) {
                        base64_dec(encoded.data() + encoded.size()));
   } catch (const boost::archive::iterators::dataflow_exception& e) {
     LOG(INFO) << "Could not base64 decode string: " << e.what();
-    return "";
+    return std::string();
   }
 }
 
-std::string encode(const std::string& unencoded) {
+} // namespace
+
+std::string decode(std::string&& encoded) {
+  boost::erase_all(encoded, "\r\n");
+  boost::erase_all(encoded, "\n");
+  boost::trim_right_if(encoded, boost::is_any_of("="));
+
+  return decode_impl(encoded);
+}
+
+std::string decode(std::string_view encoded) {
+  if (encoded.find_first_of("\r\n=") == std::string_view::npos) {
+    return decode_impl(encoded);
+  }
+
+  return decode(std::string(encoded));
+}
+
+std::string encode(std::string_view unencoded) {
   if (unencoded.empty()) {
-    return unencoded;
+    return std::string();
   }
 
   size_t writePaddChars = (3U - unencoded.length() % 3U) % 3U;
   try {
     auto encoded =
         std::string(it_base64(unencoded.begin()), it_base64(unencoded.end()));
-    encoded.append(std::string(writePaddChars, '='));
+    encoded.append(writePaddChars, '=');
     return encoded;
   } catch (const boost::archive::iterators::dataflow_exception& e) {
     LOG(INFO) << "Could not base64 encode string: " << e.what();
-    return "";
+    return std::string();
   }
 }
 

--- a/osquery/utils/base64.h
+++ b/osquery/utils/base64.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace osquery {
 
@@ -21,7 +22,17 @@ namespace base64 {
  * @param encoded The encode base64 string.
  * @return Decoded string.
  */
-std::string decode(std::string encoded);
+std::string decode(std::string_view encoded);
+
+/**
+ * @brief Decode a base64 encoded string in the form of rvalue reference.
+ *
+ * This function can change the encoded string content.
+ *
+ * @param encoded The encode base64 string.
+ * @return Decoded string.
+ */
+std::string decode(std::string&& encoded);
 
 /**
  * @brief Encode a  string.
@@ -29,7 +40,7 @@ std::string decode(std::string encoded);
  * @param A string to encode.
  * @return Encoded string.
  */
-std::string encode(const std::string& unencoded);
+std::string encode(std::string_view unencoded);
 
 } // namespace base64
 

--- a/osquery/utils/chars.cpp
+++ b/osquery/utils/chars.cpp
@@ -17,7 +17,7 @@
 
 namespace osquery {
 
-bool isPrintable(const std::string& check) {
+bool isPrintable(std::string_view check) {
   for (const unsigned char ch : check) {
     if (ch >= 0x7F || ch <= 0x1F) {
       return false;

--- a/osquery/utils/chars.h
+++ b/osquery/utils/chars.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace osquery {
 
@@ -19,7 +20,7 @@ namespace osquery {
  * @param A string to check.
  * @return If the string is printable.
  */
-bool isPrintable(const std::string& check);
+bool isPrintable(std::string_view check);
 
 /**
  * @brief In-line helper function for use with utf8StringSize

--- a/osquery/utils/tests/base64.cpp
+++ b/osquery/utils/tests/base64.cpp
@@ -16,12 +16,26 @@ namespace osquery {
 class Base64Tests : public testing::Test {};
 
 TEST_F(Base64Tests, test_base64) {
-  std::string unencoded = "HELLO";
+  std::string_view unencoded("HELLO");
   auto encoded = base64::encode(unencoded);
   EXPECT_NE(encoded.size(), 0U);
 
-  auto unencoded2 = base64::decode(encoded);
+  // Decode input as a string_view.
+  auto unencoded2 = base64::decode(std::string_view(encoded));
   EXPECT_EQ(unencoded, unencoded2);
+
+  // Skip line breaks while decoding.
+  std::string encoded_with_line_breaks = "\n" + encoded + "\r\n==";
+  auto unencoded3 = base64::decode(encoded_with_line_breaks);
+  EXPECT_EQ(unencoded3, unencoded2);
+
+  // Check that the string_view input with line breaks still can be decoded.
+  auto unencoded4 = base64::decode(std::string_view(encoded_with_line_breaks));
+  EXPECT_EQ(unencoded4, unencoded2);
+
+  // Decode rvalue reference from the encoded string.
+  auto unencoded5 = base64::decode(std::move(encoded_with_line_breaks));
+  EXPECT_EQ(unencoded5, unencoded2);
 }
 
 } // namespace osquery


### PR DESCRIPTION
Main intent of this PR is to avoid string copying while encoding/decoding.
The `encode` change is quite trivial since it didn't copy the input.
But the `decode` case is opposite: it needs to remove few symbols from the input string.

So I decided to split code of `decode` function into 2 overloads: first that takes a `string_view` and a special function that takes a rvalue reference and can change the string content.

I believe that the added linear lookup with `find_first_of("\r\n=")` will not make things worse in comparison with previous code but now the encoded string is not copied every time.

PTAL