### PR TITLE
Release objects and free memory obtained from COM

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -431,6 +431,9 @@ Expected<WmiRequest, WmiError> WmiRequest::CreateWmiRequest(
                                &authInfo,
                                &ifCapabilites);
   if (FAILED(hr)) {
+    CoTaskMemFree(serverPrincName);
+    pSecurity->Release();
+
     return createError(WmiError::ConstructionError)
            << "WmiRequest creation failed in QueryBlanket call";
   }
@@ -444,13 +447,13 @@ Expected<WmiRequest, WmiError> WmiRequest::CreateWmiRequest(
                              RPC_C_IMP_LEVEL_IMPERSONATE,
                              authInfo,
                              EOAC_NONE);
+  CoTaskMemFree(serverPrincName);
+  pSecurity->Release();
 
   if (FAILED(hr)) {
     return createError(WmiError::ConstructionError)
            << "WmiRequest creation failed in SetBlanket call";
   }
-
-  pSecurity->Release();
 
   wmi_request.services_.reset(services);
 


### PR DESCRIPTION
It seems to me that the COM objects and strings from PR #7963 should be released.

@marcosd4h PTAL