### PR TITLE
Do not pass wstring::c_str() to wstringToString function

### DIFF
--- a/osquery/events/windows/ntfs_event_publisher.cpp
+++ b/osquery/events/windows/ntfs_event_publisher.cpp
@@ -239,7 +239,7 @@ Status NTFSEventPublisher::getPathFromReferenceNumber(
       description = L"Unknown error";
     }
 
-    message << wstringToString(description.c_str());
+    message << wstringToString(description);
     return Status::failure(message.str());
   }
 
@@ -273,7 +273,7 @@ Status NTFSEventPublisher::getPathFromReferenceNumber(
       description = L"Unknown error";
     }
 
-    message << wstringToString(description.c_str());
+    message << wstringToString(description);
     return Status::failure(message.str());
   }
 
@@ -377,7 +377,7 @@ Status NTFSEventPublisher::getVolumeData(VolumeData& volume,
       description = L"Unknown error";
     }
 
-    message << wstringToString(description.c_str());
+    message << wstringToString(description);
     return Status::failure(message.str());
   }
 
@@ -407,7 +407,7 @@ Status NTFSEventPublisher::getVolumeData(VolumeData& volume,
       description = L"Unknown error";
     }
 
-    message << wstringToString(description.c_str());
+    message << wstringToString(description);
     return Status::failure(message.str());
   }
 

--- a/osquery/events/windows/usn_journal_reader.cpp
+++ b/osquery/events/windows/usn_journal_reader.cpp
@@ -278,7 +278,7 @@ Status USNJournalReader::initialize() {
     if (!getWindowsErrorDescription(description, error_code)) {
       description = L"Unknown error";
     }
-    error_message << wstringToString(description.c_str());
+    error_message << wstringToString(description);
 
     return Status::failure(error_message.str());
   }
@@ -331,7 +331,7 @@ Status USNJournalReader::acquireRecords() {
     if (!getWindowsErrorDescription(description, ::GetLastError())) {
       description = L"Unknown error";
     }
-    error_message << wstringToString(description.c_str());
+    error_message << wstringToString(description);
 
     return Status::failure(error_message.str());
   }
@@ -803,7 +803,7 @@ bool GetEventString(std::string& buffer, const USN_RECORD* record) {
   }
 
   std::wstring wide_chars_file_name(filename, (name_length / sizeof(wchar_t)));
-  buffer = wstringToString(wide_chars_file_name.c_str());
+  buffer = wstringToString(wide_chars_file_name);
 
   return true;
 }

--- a/osquery/events/windows/windowseventlogparser.cpp
+++ b/osquery/events/windows/windowseventlogparser.cpp
@@ -78,7 +78,7 @@ Status parseWindowsEventLogXML(pt::ptree& event_object,
   event_object = {};
 
   try {
-    auto converted_xml_event = wstringToString(xml_event.c_str());
+    auto converted_xml_event = wstringToString(xml_event);
     std::stringstream stream(std::move(converted_xml_event));
 
     pt::ptree output;

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -342,7 +342,7 @@ Status getCertificateInformation(SignatureInformation& signature_info,
       return false;
     }
 
-    value = wstringToString(buffer.c_str());
+    value = wstringToString(buffer);
     return true;
   };
 

--- a/osquery/tables/system/windows/objects.cpp
+++ b/osquery/tables/system/windows/objects.cpp
@@ -207,8 +207,8 @@ QueryData genBaseNamedObjects(QueryContext& context) {
     for (auto& object : objects) {
       Row r;
       r["session_id"] = INTEGER(tryTo<int>(session.first).takeOr(0));
-      r["object_name"] = wstringToString(object.first.c_str());
-      r["object_type"] = wstringToString(object.second.c_str());
+      r["object_name"] = wstringToString(object.first);
+      r["object_type"] = wstringToString(object.second);
 
       results.push_back(r);
     }

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -91,7 +91,8 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
     ret = pRegisteredTask->get_Name(&taskName);
     std::wstring wTaskName(taskName, SysStringLen(taskName));
     ::SysFreeString(taskName);
-    r["name"] = ret == S_OK ? SQL_TEXT(wstringToString(wTaskName.c_str())) : "";
+    r["name"] =
+        ret == S_OK ? SQL_TEXT(wstringToString(wTaskName)) : std::string();
 
     VARIANT_BOOL enabled = false;
     pRegisteredTask->get_Enabled(&enabled);
@@ -106,7 +107,7 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
     BSTR taskPath;
     ret = pRegisteredTask->get_Path(&taskPath);
     std::wstring wTaskPath(taskPath, SysStringLen(taskPath));
-    r["path"] = ret == S_OK ? wstringToString(wTaskPath.c_str()) : "";
+    r["path"] = ret == S_OK ? wstringToString(wTaskPath) : std::string();
     ::SysFreeString(taskPath);
 
     VARIANT_BOOL hidden = false;
@@ -185,7 +186,7 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
       execAction->Release();
 
       auto full = wTaskExecRoot + L" " + wTaskExecPath + L" " + wTaskExecArgs;
-      actions.push_back(wstringToString(full.c_str()));
+      actions.push_back(wstringToString(full));
     }
     if (tActionCollection != nullptr) {
       tActionCollection->Release();

--- a/osquery/tables/system/windows/windows_security_products.cpp
+++ b/osquery/tables/system/windows/windows_security_products.cpp
@@ -226,10 +226,9 @@ QueryData gen_wsp(QueryContext& context) {
     Row r;
     r["type"] = tryTakeCopy(kSecurityProviders, product.provider)
                     .takeOr(std::string("Unknown"));
-    r["name"] = wstringToString(product.product_name.c_str());
-    r["state_timestamp"] =
-        wstringToString(product.product_state_timestamp.c_str());
-    r["remediation_path"] = wstringToString(product.remediation_path.c_str());
+    r["name"] = wstringToString(product.product_name);
+    r["state_timestamp"] = wstringToString(product.product_state_timestamp);
+    r["remediation_path"] = wstringToString(product.remediation_path);
     r["state"] = tryTakeCopy(kSecurityProviderStates, product.product_state)
                      .takeOr(std::string("Unknown"));
     r["signatures_up_to_date"] =


### PR DESCRIPTION
It looks that the `wstringToString()` function can be called with few types of arguments:
- with constructed `std::wstring` object
- with some `WCHAR buf[N]` buffer that can be casted to `const wchar_t *` and this is OK
- with `std::wstring("").c_str()` pointer and this is the case I am trying to address with this PR

I think that there is no sense to pass a `c_str()` from a `std::wstring` object to `wstringToString` because it will copy the whole string one more time via `std::wstring(const wchat_t*)` constructor in the end. Also `c_str()` will always return a zero terminated string and never a `nullptr` pointer value.