### PR TITLE
Include missing data about key types in keychain_items

### DIFF
--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -8,6 +8,7 @@ schema([
     Column("created", TEXT, "Date item was created"),
     Column("modified", TEXT, "Date of last modification"),
     Column("type", TEXT, "Keychain item type (class)"),
+    Column("pk_hash", TEXT, "Hash of associated public key (SHA1 of DER PKCS#1)"),
     Column("path", TEXT, "Path to keychain containing item", additional=True),
 ])
 implementation("keychain_items@genKeychainItems")

--- a/tests/integration/tables/keychain_items.cpp
+++ b/tests/integration/tables/keychain_items.cpp
@@ -30,6 +30,7 @@ TEST_F(KeychainItemsTest, test_sanity) {
       {"account", NormalType},
       {"created", NormalType},
       {"modified", NormalType},
+      {"pk_hash", NormalType},
       {"type",
        SpecificValuesCheck{"password",
                            "internet password",


### PR DESCRIPTION
Includes the label and associated public key hash for keys in the `keychain_items` table.

Before this change, the label column was blank for "public key", "symmetric key", and "private key" item types because these can use a different attribute for their label (`kSecKeyPrintName`).

The new column "pk_hash" is useful to identify which public key and private keys are linked to which certificates, described in the docs for [kSecKeyLabel](https://developer.apple.com/documentation/security/kSecKeyLabel).

While the new attributes are marked deprecated, there does not seem to be a non-deprecated replacement.

Tested this change on macOS Ventura 13.3 (many entries removed to just show 1 example of each case):
```
select label, type, pk_hash from keychain_items;
| Developer ID Certification Authority                                   | certificate       | 5717EDA2CFDC7C98A110E0FCBE872D2CF2E31754 |
| Developer ID Certification Authority                                   | certificate       | F83A0C691176E0EDACD1EBA659FA37D5C455B01E |
| Developer ID Installer: Bradley Girareau (VRCY35483Y)                  | certificate       | C4ABFB1F1F5316E9914B24E0390364D570E85BA6 |
| Mac Developer ID Installer: Bradley Girareau                           | private key       | C4ABFB1F1F5316E9914B24E0390364D570E85BA6 |
| Spotlight Metadata Privacy (9547B18D-F428-3365-8D69-9EA526ED5F06)      | symmetric key     |                                          |
| com.apple.systemdefault                                                | public key        | DE2232008405EE16C541DEEC59C89EAD9DC56D17 |
| Spotlight Metadata Privacy                                             | password          |                                          |
| Docker Credentials                                                     | internet password |                                          |
```

Before this PR the same items look like:
```
select label, type from keychain_items;
| Developer ID Certification Authority                                    | certificate       |
| Developer ID Certification Authority                                    | certificate       |
| Developer ID Installer: Bradley Girareau (VRCY35483Y)                   | certificate       |
|                                                                         | private key       |
|                                                                         | symmetric key     |
|                                                                         | public key        |
| Spotlight Metadata Privacy                                              | password          |
| Docker Credentials                                                      | internet password |
```