### PR TITLE
Add basic implementation for ComPtr<> scoped class and simple tests

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -145,6 +145,7 @@ function(generateOsqueryCore)
 
   if(DEFINED PLATFORM_WINDOWS)
     list(APPEND public_header_files
+      windows/comptr.h
       windows/handle.h
       windows/ntapi.h
       windows/wmi.h

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -99,7 +99,7 @@ endfunction()
 function(generateOsqueryCoreTestsComptrtestsTest)
    add_osquery_executable(osquery_core_tests_comptrtests-test windows/comptr_tests.cpp)
 
-   target_link_libraries(osquery_core_tests_bstrtests-test PRIVATE
+   target_link_libraries(osquery_core_tests_comptrtests-test PRIVATE
      osquery_cxx_settings
      osquery_core
      osquery_extensions

--- a/osquery/core/tests/CMakeLists.txt
+++ b/osquery/core/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ function(osqueryCoreTestsMain)
 
   if(DEFINED PLATFORM_WINDOWS)
     generateOsqueryCoreTestsWmitestsTest()
+    generateOsqueryCoreTestsComptrtestsTest()
   endif()
 endfunction()
 
@@ -94,5 +95,19 @@ function(generateOsqueryCoreTestsWmitestsTest)
     thirdparty_googletest
   )
 endfunction()
+
+function(generateOsqueryCoreTestsComptrtestsTest)
+   add_osquery_executable(osquery_core_tests_comptrtests-test windows/comptr_tests.cpp)
+
+   target_link_libraries(osquery_core_tests_bstrtests-test PRIVATE
+     osquery_cxx_settings
+     osquery_core
+     osquery_extensions
+     osquery_extensions_implthrift
+     osquery_utils_info
+     tests_helper
+     thirdparty_googletest
+   )
+ endfunction()
 
 osqueryCoreTestsMain()

--- a/osquery/core/tests/windows/comptr_tests.cpp
+++ b/osquery/core/tests/windows/comptr_tests.cpp
@@ -42,12 +42,19 @@ TEST_F(ComPtrTests, test_basic_comptr) {
   EXPECT_TRUE(qi_test.get() != nullptr);
   qi_test.release();
 
-  // test ComPtr& constructor
+  // Test ComPtr& constructor.
   ComPtr<IMalloc> copy1(mem_alloc);
   IMalloc* naked_copy = copy1.detach();
-  naked_copy->Release();
 
+  // Test the =(T*) operator.
+  copy1 = naked_copy;
+  naked_copy->Release();
   copy1.release();
+
+  // Test =(ComPtr&) operator.
+  copy1 = mem_alloc;
+  // Compare pointer but not the reference counter.
+  EXPECT_EQ(copy1, mem_alloc);
 }
 
 } // namespace osquery

--- a/osquery/core/tests/windows/comptr_tests.cpp
+++ b/osquery/core/tests/windows/comptr_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <gtest/gtest.h>
 
-#include <osquery/config/tests/test_utils.h>
 #include <osquery/core/core.h>
 #include <osquery/core/system.h>
 
@@ -28,14 +27,14 @@ class ComPtrTests : public testing::Test {
 
 TEST_F(ComPtrTests, test_basic_comptr) {
   ComPtr<IUnknown> unk;
-  EXPECT_TRUE(SUCCEEDED(unk.createInstance(CLSID_ShellLink)));
+  EXPECT_HRESULT_SUCCEEDED(unk.createInstance(CLSID_ShellLink));
   ComPtr<IUnknown> unk2;
   unk2.attach(unk.detach());
   EXPECT_TRUE(unk == nullptr);
   EXPECT_TRUE(unk2 != nullptr);
 
   ComPtr<IMalloc> mem_alloc;
-  EXPECT_TRUE(SUCCEEDED(CoGetMalloc(1, mem_alloc.receive())));
+  EXPECT_HRESULT_SUCCEEDED(CoGetMalloc(1, mem_alloc.receive()));
 
   ComPtr<IUnknown> qi_test;
   EXPECT_HRESULT_SUCCEEDED(

--- a/osquery/core/tests/windows/comptr_tests.cpp
+++ b/osquery/core/tests/windows/comptr_tests.cpp
@@ -45,7 +45,6 @@ TEST_F(ComPtrTests, test_basic_comptr) {
   // test ComPtr& constructor
   ComPtr<IMalloc> copy1(mem_alloc);
   IMalloc* naked_copy = copy1.detach();
-  copy1 = naked_copy; // Test the =(T*) operator.
   naked_copy->Release();
 
   copy1.release();

--- a/osquery/core/tests/windows/comptr_tests.cpp
+++ b/osquery/core/tests/windows/comptr_tests.cpp
@@ -30,8 +30,8 @@ TEST_F(ComPtrTests, test_basic_comptr) {
   EXPECT_HRESULT_SUCCEEDED(unk.createInstance(CLSID_ShellLink));
   ComPtr<IUnknown> unk2;
   unk2.attach(unk.detach());
-  EXPECT_TRUE(unk == nullptr);
-  EXPECT_TRUE(unk2 != nullptr);
+  EXPECT_TRUE(!unk);
+  EXPECT_TRUE(unk2);
 
   ComPtr<IMalloc> mem_alloc;
   EXPECT_HRESULT_SUCCEEDED(CoGetMalloc(1, mem_alloc.receive()));

--- a/osquery/core/tests/windows/comptr_tests.cpp
+++ b/osquery/core/tests/windows/comptr_tests.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/config/tests/test_utils.h>
+#include <osquery/core/core.h>
+#include <osquery/core/system.h>
+
+#include <shlobj.h>
+
+#include "osquery/core/windows/comptr.h"
+
+namespace osquery {
+
+class ComPtrTests : public testing::Test {
+ protected:
+  void SetUp() override {
+    platformSetup();
+  }
+};
+
+TEST_F(ComPtrTests, test_basic_comptr) {
+  ComPtr<IUnknown> unk;
+  EXPECT_TRUE(SUCCEEDED(unk.createInstance(CLSID_ShellLink)));
+  ComPtr<IUnknown> unk2;
+  unk2.attach(unk.detach());
+  EXPECT_TRUE(unk == nullptr);
+  EXPECT_TRUE(unk2 != nullptr);
+
+  ComPtr<IMalloc> mem_alloc;
+  EXPECT_TRUE(SUCCEEDED(CoGetMalloc(1, mem_alloc.receive())));
+
+  ComPtr<IUnknown> qi_test;
+  EXPECT_HRESULT_SUCCEEDED(
+      mem_alloc.queryInterface(IID_IUnknown, qi_test.receiveVoid()));
+  EXPECT_TRUE(qi_test.get() != nullptr);
+  qi_test.release();
+
+  // test ComPtr& constructor
+  ComPtr<IMalloc> copy1(mem_alloc);
+  IMalloc* naked_copy = copy1.detach();
+  copy1 = naked_copy; // Test the =(T*) operator.
+  naked_copy->Release();
+
+  copy1.release();
+}
+
+} // namespace osquery

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/utils/system/system.h>
+
+#include <cassert>
+
+namespace osquery {
+
+template <class Interface, const IID* interface_id = &__uuidof(Interface)>
+class ComPtr {
+  Interface* ptr_{nullptr};
+
+ public:
+  class BlockIUnknownMethods : public Interface {
+   private:
+    using Interface::AddRef;
+    using Interface::QueryInterface;
+    using Interface::Release;
+  };
+
+  ComPtr() = default;
+
+  explicit ComPtr(Interface* p) : ptr_(p) {
+    if (ptr_)
+      ptr_->AddRef();
+  }
+
+  ComPtr(const ComPtr<Interface, interface_id>& p) : ComPtr(p.get()) {}
+
+  ~ComPtr() {
+    static_assert(sizeof(ComPtr<Interface, interface_id>) == sizeof(Interface*),
+                  ComPtrSize);
+  }
+
+  explicit operator bool() const {
+    return ptr_ != nullptr;
+  }
+
+  void release() {
+    Interface* const temp = ptr_;
+    if (temp) {
+      ptr_ = nullptr;
+      temp->Release();
+    }
+  }
+
+  Interface* detach() {
+    Interface* const p = ptr_;
+    ptr_ = nullptr;
+    return p;
+  }
+
+  void attach(Interface* p) {
+    assert(!ptr_);
+    ptr_ = p;
+  }
+
+  Interface** receive() {
+    assert(!ptr_ && "pointer must be null");
+    return &ptr_;
+  }
+
+  void** receiveVoid() {
+    return reinterpret_cast<void**>(receive());
+  }
+
+  template <class Query>
+  HRESULT queryInterface(Query** p) {
+    assert(p);
+    assert(ptr_);
+    return ptr_->QueryInterface(p);
+  }
+
+  HRESULT createInstance(const CLSID& clsid,
+                         IUnknown* outer = nullptr,
+                         DWORD context = CLSCTX_ALL) {
+    HRESULT hr =
+        ::CoCreateInstance(clsid, outer, context, *interface_id, receiveVoid());
+    return hr;
+  }
+
+  BlockIUnknownMethods* operator->() const {
+    assert(ptr_);
+    return reinterpret_cast<BlockIUnknownMethods*>(ptr_);
+  }
+
+  ComPtr<Interface, interface_id>& operator=(
+      const ComPtr<Interface, interface_id>& rhs) {
+    return *this = rhs.ptr_;
+  }
+
+  Interface& operator*() const {
+    assert(ptr_);
+    return *ptr_;
+  }
+
+  bool operator==(const ComPtr<Interface, interface_id>& rhs) const {
+    return ptr_ == rhs.get();
+  }
+
+  void swap(ComPtr<Interface, interface_id>& r) {
+    Interface* tmp = ptr_;
+    ptr_ = r.ptr_;
+    r.ptr_ = tmp;
+  }
+};
+} // namespace osquery

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -11,6 +11,8 @@
 
 #include <cassert>
 
+#include <unknwn.h>
+
 namespace osquery {
 
 template <class Interface, const IID* interface_id = &__uuidof(Interface)>

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -42,6 +42,10 @@ class ComPtr {
     release();
   }
 
+  Interface* get() const {
+    return ptr_;
+  }
+
   explicit operator bool() const {
     return !!ptr_;
   }
@@ -79,6 +83,12 @@ class ComPtr {
     assert(p);
     assert(ptr_);
     return ptr_->QueryInterface(p);
+  }
+
+  HRESULT queryInterface(const IID& iid, void** obj) {
+    assert(p);
+    assert(ptr_);
+    return ptr_->QueryInterface(iid, obj);
   }
 
   HRESULT createInstance(const CLSID& clsid,

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -28,8 +28,9 @@ class ComPtr {
   ComPtr() = default;
 
   explicit ComPtr(Interface* p) : ptr_(p) {
-    if (ptr_)
+    if (ptr_) {
       ptr_->AddRef();
+    }
   }
 
   ComPtr(const ComPtr<Interface, interface_id>& p) : ComPtr(p.get()) {}
@@ -42,7 +43,7 @@ class ComPtr {
   }
 
   explicit operator bool() const {
-    return ptr_ != nullptr;
+    return !!ptr_;
   }
 
   void release() {

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -37,7 +37,7 @@ class ComPtr {
 
   ~ComPtr() {
     static_assert(sizeof(ComPtr<Interface, interface_id>) == sizeof(Interface*),
-                  ComPtrSize);
+                  "ComPtr size bigger than raw pointer");
 
     release();
   }

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -37,6 +37,8 @@ class ComPtr {
   ~ComPtr() {
     static_assert(sizeof(ComPtr<Interface, interface_id>) == sizeof(Interface*),
                   ComPtrSize);
+
+    release();
   }
 
   explicit operator bool() const {

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -15,7 +15,7 @@
 
 namespace osquery {
 
-template <class Interface, const IID* interface_id = &__uuidof(Interface)>
+template <class Interface, const IID* InterfaceId = &__uuidof(Interface)>
 class ComPtr {
   Interface* ptr_{nullptr};
 
@@ -35,10 +35,10 @@ class ComPtr {
     }
   }
 
-  ComPtr(const ComPtr<Interface, interface_id>& p) : ComPtr(p.get()) {}
+  ComPtr(const ComPtr<Interface, InterfaceId>& p) : ComPtr(p.get()) {}
 
   ~ComPtr() {
-    static_assert(sizeof(ComPtr<Interface, interface_id>) == sizeof(Interface*),
+    static_assert(sizeof(ComPtr<Interface, InterfaceId>) == sizeof(Interface*),
                   "ComPtr size bigger than raw pointer");
 
     release();
@@ -97,7 +97,7 @@ class ComPtr {
                          IUnknown* outer = nullptr,
                          DWORD context = CLSCTX_ALL) {
     HRESULT hr =
-        ::CoCreateInstance(clsid, outer, context, *interface_id, receiveVoid());
+        ::CoCreateInstance(clsid, outer, context, *InterfaceId, receiveVoid());
     return hr;
   }
 
@@ -106,19 +106,19 @@ class ComPtr {
     return reinterpret_cast<BlockIUnknownMethods*>(ptr_);
   }
 
-  ScopedComPtr<Interface, interface_id>& operator=(Interface* rhs) {
+  ComPtr<Interface, InterfaceId>& operator=(Interface* rhs) {
     // AddRef first so that self assignment should work.
     if (rhs)
       rhs->AddRef();
-    Interface* old_ptr = ptr_;
+    Interface* oldPtr = ptr_;
     ptr_ = rhs;
-    if (old_ptr)
-      old_ptr->Release();
+    if (oldPtr)
+      oldPtr->Release();
     return *this;
   }
 
-  ComPtr<Interface, interface_id>& operator=(
-      const ComPtr<Interface, interface_id>& rhs) {
+  ComPtr<Interface, InterfaceId>& operator=(
+      const ComPtr<Interface, InterfaceId>& rhs) {
     return *this = rhs.ptr_;
   }
 
@@ -127,11 +127,11 @@ class ComPtr {
     return *ptr_;
   }
 
-  bool operator==(const ComPtr<Interface, interface_id>& rhs) const {
+  bool operator==(const ComPtr<Interface, InterfaceId>& rhs) const {
     return ptr_ == rhs.get();
   }
 
-  void swap(ComPtr<Interface, interface_id>& r) {
+  void swap(ComPtr<Interface, InterfaceId>& r) {
     Interface* tmp = ptr_;
     ptr_ = r.ptr_;
     r.ptr_ = tmp;

--- a/osquery/core/windows/comptr.h
+++ b/osquery/core/windows/comptr.h
@@ -104,6 +104,17 @@ class ComPtr {
     return reinterpret_cast<BlockIUnknownMethods*>(ptr_);
   }
 
+  ScopedComPtr<Interface, interface_id>& operator=(Interface* rhs) {
+    // AddRef first so that self assignment should work.
+    if (rhs)
+      rhs->AddRef();
+    Interface* old_ptr = ptr_;
+    ptr_ = rhs;
+    if (old_ptr)
+      old_ptr->Release();
+    return *this;
+  }
+
   ComPtr<Interface, interface_id>& operator=(
       const ComPtr<Interface, interface_id>& rhs) {
     return *this = rhs.ptr_;


### PR DESCRIPTION
Here I'm trying to add new scoped class to manage COM objects in a `refptr<>` manner.
Related to #8003 

I've changed few places in the codebase to demonstrate how it could be changed in a new fashion.
PTAL.