### PR TITLE
Mark time column as "additional" for event tables

### DIFF
--- a/specs/darwin/disk_events.table
+++ b/specs/darwin/disk_events.table
@@ -16,7 +16,7 @@ schema([
     Column("vendor", TEXT, "Disk event vendor string"),
     Column("filesystem", TEXT, "Filesystem if available"),
     Column("checksum", TEXT, "UDIF Master checksum if available (CRC32)"),
-    Column("time", BIGINT, "Time of appearance/disappearance in UNIX time"),
+    Column("time", BIGINT, "Time of appearance/disappearance in UNIX time", additional=True),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/darwin/es_process_events.table
+++ b/specs/darwin/es_process_events.table
@@ -24,7 +24,7 @@ schema([
     Column("platform_binary", INTEGER, "Indicates if the binary is Apple signed binary (1) or not (0)"),
     Column("exit_code", INTEGER, "Exit code of a process in case of an exit event"),
     Column("child_pid", BIGINT, "Process ID of a child process in case of a fork event"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("event_type", TEXT, "Type of EndpointSecurity event"),
     Column("eid", TEXT, "Event ID", hidden=True),
     Column("codesigning_flags", TEXT, "Codesigning flags matching one of these options, in a comma separated list: NOT_VALID, ADHOC, NOT_RUNTIME, INSTALLER. See kern/cs_blobs.h in XNU for descriptions."),

--- a/specs/darwin/es_process_file_events.table
+++ b/specs/darwin/es_process_file_events.table
@@ -10,7 +10,7 @@ schema([
     Column("filename", TEXT, "The source or target filename for the event"),
     Column("dest_filename", TEXT, "Destination filename for the event"),
     Column("event_type", TEXT, "Type of EndpointSecurity event"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/darwin/user_interaction_events.table
+++ b/specs/darwin/user_interaction_events.table
@@ -1,7 +1,7 @@
 table_name("user_interaction_events")
 description("Track user interaction events from macOS' event tapping framework.")
 schema([
-    Column("time", BIGINT, "Time")
+    Column("time", BIGINT, "Time", additional=True)
 ])
 attributes(event_subscriber=True)
 implementation("events/darwin/user_interaction_events@user_interaction_events::genTable")

--- a/specs/linux/apparmor_events.table
+++ b/specs/linux/apparmor_events.table
@@ -3,7 +3,7 @@ description("Track AppArmor events.")
 schema([
     Column("type", TEXT, "Event type"),
     Column("message", TEXT, "Raw audit message"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
     Column("apparmor", TEXT, "Apparmor Status like ALLOWED, DENIED etc."),

--- a/specs/linux/bpf_process_events.table
+++ b/specs/linux/bpf_process_events.table
@@ -16,7 +16,7 @@ schema([
     Column("duration", INTEGER, "How much time was spent inside the syscall (nsecs)"),
     Column("json_cmdline", TEXT, "Command line arguments, in JSON format", hidden=True),
     Column("ntime", TEXT, "The nsecs uptime timestamp as obtained from BPF"),
-    Column("time", BIGINT, "Time of execution in UNIX time", hidden=True),
+    Column("time", BIGINT, "Time of execution in UNIX time", hidden=True, additional=True),
     Column("eid", INTEGER, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/linux/bpf_socket_events.table
+++ b/specs/linux/bpf_socket_events.table
@@ -21,7 +21,7 @@ schema([
     Column("remote_port", INTEGER, "Remote network protocol port number"),
     Column("duration", INTEGER, "How much time was spent inside the syscall (nsecs)"),
     Column("ntime", TEXT, "The nsecs uptime timestamp as obtained from BPF"),
-    Column("time", BIGINT, "Time of execution in UNIX time", hidden=True),
+    Column("time", BIGINT, "Time of execution in UNIX time", hidden=True, additional=True),
     Column("eid", INTEGER, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/linux/process_file_events.table
+++ b/specs/linux/process_file_events.table
@@ -5,7 +5,7 @@ schema([
     Column("operation", TEXT, "Operation type"),
     Column("pid", BIGINT, "Process ID"),
     Column("ppid", BIGINT, "Parent process ID"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("executable", TEXT, "The executable path"),
     Column("partial", TEXT, "True if this is a partial event (i.e.: this process existed before we started osquery)"),
     Column("cwd", TEXT, "The current working directory of the process"),

--- a/specs/linux/seccomp_events.table
+++ b/specs/linux/seccomp_events.table
@@ -3,7 +3,7 @@ table_name("seccomp_events")
 description("A virtual table that tracks seccomp events.")
 
 schema([
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("auid", UNSIGNED_BIGINT, "Audit user ID (loginuid) of the user who started the analyzed process"),
     Column("uid", UNSIGNED_BIGINT, "User ID of the user who started the analyzed process"),

--- a/specs/linux/selinux_events.table
+++ b/specs/linux/selinux_events.table
@@ -3,7 +3,7 @@ description("Track SELinux events.")
 schema([
     Column("type", TEXT, "Event type"),
     Column("message", TEXT, "Message"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])

--- a/specs/linux/syslog_events.table
+++ b/specs/linux/syslog_events.table
@@ -1,6 +1,6 @@
 table_name("syslog_events", aliases=["syslog"])
 schema([
-    Column("time", BIGINT, "Current unix epoch time"),
+    Column("time", BIGINT, "Current unix epoch time", additional=True),
     Column("datetime", TEXT, "Time known to syslog"),
     Column("host", TEXT, "Hostname configured for syslog"),
     Column("severity", INTEGER, "Syslog severity"),

--- a/specs/posix/file_events.table
+++ b/specs/posix/file_events.table
@@ -18,7 +18,7 @@ schema([
     Column("sha256", TEXT, "The SHA256 of the file after change"),
     Column("hashed", INTEGER,
       "1 if the file was hashed, 0 if not, -1 if hashing failed"),
-    Column("time", BIGINT, "Time of file event"),
+    Column("time", BIGINT, "Time of file event", additional=True),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/posix/hardware_events.table
+++ b/specs/posix/hardware_events.table
@@ -11,7 +11,7 @@ schema([
     Column("model_id", TEXT, "Hex encoded Hardware model identifier"),
     Column("serial", TEXT, "Device serial (optional)"),
     Column("revision", TEXT, "Device revision (optional)"),
-    Column("time", BIGINT, "Time of hardware event"),
+    Column("time", BIGINT, "Time of hardware event", additional=True),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -31,7 +31,7 @@ schema([
         aliases=["create_time"]),
     Column("overflows", TEXT, "List of structures that overflowed", hidden=True),
     Column("parent", BIGINT, "Process parent's PID, or -1 if cannot be determined."),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])

--- a/specs/posix/socket_events.table
+++ b/specs/posix/socket_events.table
@@ -16,7 +16,7 @@ schema([
     Column("remote_port", INTEGER, "Remote network protocol port number"),
     Column("socket", TEXT, "The local path (UNIX domain socket only)",
         hidden=True),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
     Column("success", INTEGER, "Deprecated. Use the 'status' column instead", hidden=True),

--- a/specs/posix/user_events.table
+++ b/specs/posix/user_events.table
@@ -9,7 +9,7 @@ schema([
     Column("path", TEXT, "Supplied path from event"),
     Column("address", TEXT, "The Internet protocol address or family ID"),
     Column("terminal", TEXT, "The network protocol ID"),
-    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("time", BIGINT, "Time of execution in UNIX time", additional=True),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])

--- a/specs/windows/ntfs_journal_events.table
+++ b/specs/windows/ntfs_journal_events.table
@@ -12,7 +12,7 @@ schema ([
     Column("drive_letter", TEXT, "The drive letter identifying the source journal"),
     Column("file_attributes", TEXT, "File attributes"),
     Column("partial", BIGINT, "Set to 1 if either path or old_path only contains the file or folder name"),
-    Column("time", BIGINT, "Time of file event"),
+    Column("time", BIGINT, "Time of file event", additional=True),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])
 

--- a/specs/windows/powershell_events.table
+++ b/specs/windows/powershell_events.table
@@ -1,7 +1,7 @@
 table_name("powershell_events")
 description("Powershell script blocks reconstructed to their full script content, this table requires script block logging to be enabled.")
 schema([
-    Column("time", BIGINT, "Timestamp the event was received by the osquery event publisher"),
+    Column("time", BIGINT, "Timestamp the event was received by the osquery event publisher", additional=True),
     Column("datetime", TEXT, "System time at which the Powershell script event occurred"),
     Column("script_block_id", TEXT, "The unique GUID of the powershell script to which this block belongs"),
     Column("script_block_count", INTEGER, "The total number of script blocks for this script"),

--- a/specs/windows/process_etw_events.table
+++ b/specs/windows/process_etw_events.table
@@ -15,7 +15,7 @@ schema([
     Column("mandatory_label", TEXT, "Primary token mandatory label sid - Present only on ProcessStart events"),
     Column("datetime", DATETIME, "Event timestamp in DATETIME format"),
     Column("time_windows", BIGINT, "Event timestamp in Windows format", hidden=True),
-    Column("time", BIGINT, "Event timestamp in Unix format", hidden=True),
+    Column("time", BIGINT, "Event timestamp in Unix format", hidden=True, additional=True),
     Column("eid", INTEGER, "Event ID", hidden=True),
     Column("header_pid", BIGINT, "Process ID of the process reporting the event", hidden=True),
     Column("process_sequence_number", BIGINT, "Process Sequence Number - Present only on ProcessStart events", hidden=True),

--- a/specs/windows/windows_events.table
+++ b/specs/windows/windows_events.table
@@ -1,7 +1,7 @@
 table_name("windows_events")
 description("Windows Event logs.")
 schema([
-    Column("time", BIGINT, "Timestamp the event was received"),
+    Column("time", BIGINT, "Timestamp the event was received", additional=True),
     Column("datetime", TEXT, "System time at which the event occurred"),
     Column("source", TEXT, "Source or channel of the event"),
     Column("provider_name", TEXT, "Provider name of the event"),


### PR DESCRIPTION
## Background
Osquery optimizes event tables in scheduled queries to only return data since the last time the scheduled query was run (unless `--events_optimize=false` is set). Sometimes this behavior is not desirable if the query is for a specifically set time range, so there is [code](https://github.com/osquery/osquery/blob/90648c36aa74e18be02dc4ad5ffb8ea7598c013c/osquery/events/eventsubscriberplugin.cpp#L297) to turn off the optimization if a constraint on the `time` column is present. However this does not work today because the constraint is not available to the table implementation unless it is marked "additional" in the schema.

## Change
This change adds `additional=True` to `time` columns in event tables, disabling event optimization when a time constraint is present in a scheduled query.

If the old behavior is desired (having the time constraint filtered by SQL while optimization is applied), this is still possible by using the `+` operator to disable indexing in a query like `+time > 0`.

In theory this change has been the expected behavior, but it's possible others are relying on the old behavior. This should help fix https://github.com/osquery/osquery/issues/7352 (at least partially)


## Test Plan
I did a couple basic tests with the query planner and disk events tables to make sure the time constraint was passed to xFilter when expected. It would be helpful if anyone else has more time or ideas on how to best test this.

```
{
  "schedule": {
      "optimized_query": {
          "query": "select time, action, name from disk_events order by time asc limit 5",
          "interval": 30
      },
      "unoptimized_query": {
          "query": "select time, action, name from disk_events where time > 0 order by time asc limit 5",
          "interval": 30
      },
      "force_optimized_query": {
          "query": "select time, action, name from disk_events where +time > 0 order by time asc limit 5",
          "interval": 30
      }
  }
}
```