### PR TITLE
logger: Add new `string_batch` request type to compliment existing `string` type

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -47,6 +47,7 @@ function(externalsExamples)
     "config_plugin"
     "read_only_table"
     "writable_table"
+    "string_batch"
   )
 
   foreach(example_name ${example_name_list})

--- a/external/examples/string_batch/CMakeLists.txt
+++ b/external/examples/string_batch/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+project("string_batch_extension")
+
+addOsqueryExtension(
+  "${PROJECT_NAME}"
+  main.cpp
+)

--- a/external/examples/string_batch/main.cpp
+++ b/external/examples/string_batch/main.cpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/core/system.h>
+#include <osquery/sdk/sdk.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+using namespace osquery;
+
+namespace {
+
+class StringBatch final {
+  rapidjson::Document doc;
+
+  void initialize() {
+    doc = {};
+    doc.SetArray();
+  }
+
+ public:
+  StringBatch() {
+    initialize();
+  }
+
+  void append(const std::string& str) {
+    rapidjson::Value value;
+    value.SetString(str.c_str(), str.size(), doc.GetAllocator());
+
+    doc.PushBack(value, doc.GetAllocator());
+  }
+
+  std::string take() {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    doc.Accept(writer);
+
+    auto batch = buffer.GetString();
+    initialize();
+
+    return batch;
+  }
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  osquery::Initializer runner(argc, argv, ToolType::EXTENSION);
+
+  auto status = startExtension("string_batch_example", "0.0.1");
+  if (!status.ok()) {
+    LOG(ERROR) << status.getMessage();
+    runner.requestShutdown(status.getCode());
+  }
+
+  StringBatch string_batch;
+  int entry_number{};
+
+  for (int i{0}; i < 10; ++i) {
+    for (int k{0}; k < 10; ++k) {
+      string_batch.append("This is item #" + std::to_string(entry_number));
+      ++entry_number;
+    }
+
+    std::cout << "Sending batch #" << i << "\n";
+
+    auto status = Registry::call(
+        "logger", "filesystem", {{"string_batch", string_batch.take()}});
+
+    if (!status.ok()) {
+      std::cerr << "Failed to execute the logger::string_batch request\n";
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+  }
+
+  runner.waitForShutdown();
+  return runner.shutdown(0);
+}

--- a/osquery/core/plugins/logger.cpp
+++ b/osquery/core/plugins/logger.cpp
@@ -48,6 +48,8 @@ Status LoggerPlugin::call(const PluginRequest& request,
   std::vector<StatusLogLine> intermediate_logs;
   if (request.count("string") > 0) {
     return this->logString(request.at("string"));
+  } else if (request.count("string_batch") > 0) {
+    return this->logStringBatch(request.at("string_batch"));
   } else if (request.count("snapshot") > 0) {
     return this->logSnapshot(request.at("snapshot"));
   } else if (request.count("init") > 0) {


### PR DESCRIPTION
This PR adds support for a batched version of the `string` logger plugin request