### PR TITLE
Add some indexing to `block_devices`

### DIFF
--- a/osquery/tables/system/linux/block_devices.cpp
+++ b/osquery/tables/system/linux/block_devices.cpp
@@ -150,23 +150,46 @@ QueryData genBlockDevs(QueryContext &context) {
     return {};
   }
 
-  struct udev_enumerate *enumerate = udev_enumerate_new(udev);
-  udev_enumerate_add_match_subsystem(enumerate, "block");
-  udev_enumerate_scan_devices(enumerate);
+  bool runSelectAll(true);
 
-  std::map<std::string, std::string> lvm_lv2pv;
-  struct udev_list_entry *devices, *dev_list_entry;
-  devices = udev_enumerate_get_list_entry(enumerate);
-  udev_list_entry_foreach(dev_list_entry, devices) {
-    const char *path = udev_list_entry_get_name(dev_list_entry);
-    struct udev_device *dev = udev_device_new_from_syspath(udev, path);
-    if (path != nullptr && dev != nullptr) {
-      getBlockDevice(dev, results, lvm_lv2pv);
+  auto constraint_it = context.constraints.find("name");
+  if (constraint_it != context.constraints.end()) {
+    std::map<std::string, std::string> lvm_lv2pv;
+    const auto& constraints = constraint_it->second;
+    for (const auto& name : constraints.getAll(EQUALS)) {
+      runSelectAll = false;
+
+      struct stat sb;
+      if (stat(name.c_str(), &sb) == 0 && (sb.st_mode & S_IFMT) == S_IFBLK) {
+        if (struct udev_device* dev =
+                udev_device_new_from_devnum(udev, 'b', sb.st_rdev)) {
+          getBlockDevice(dev, results, lvm_lv2pv);
+          udev_device_unref(dev);
+        }
+      }
     }
-    udev_device_unref(dev);
   }
 
-  udev_enumerate_unref(enumerate);
+  if (runSelectAll) {
+    struct udev_enumerate *enumerate = udev_enumerate_new(udev);
+    udev_enumerate_add_match_subsystem(enumerate, "block");
+    udev_enumerate_scan_devices(enumerate);
+
+    std::map<std::string, std::string> lvm_lv2pv;
+    struct udev_list_entry *devices, *dev_list_entry;
+    devices = udev_enumerate_get_list_entry(enumerate);
+    udev_list_entry_foreach(dev_list_entry, devices) {
+      const char *path = udev_list_entry_get_name(dev_list_entry);
+      struct udev_device *dev = udev_device_new_from_syspath(udev, path);
+      if (path != nullptr && dev != nullptr) {
+        getBlockDevice(dev, results, lvm_lv2pv);
+      }
+      udev_device_unref(dev);
+    }
+
+    udev_enumerate_unref(enumerate);
+  }
+
   udev_unref(udev);
 
   return results;

--- a/osquery/tables/system/linux/block_devices.cpp
+++ b/osquery/tables/system/linux/block_devices.cpp
@@ -171,7 +171,7 @@ QueryData genBlockDevs(QueryContext &context) {
   }
 
   if (runSelectAll) {
-    struct udev_enumerate *enumerate = udev_enumerate_new(udev);
+    struct udev_enumerate* enumerate = udev_enumerate_new(udev);
     udev_enumerate_add_match_subsystem(enumerate, "block");
     udev_enumerate_scan_devices(enumerate);
 
@@ -179,8 +179,8 @@ QueryData genBlockDevs(QueryContext &context) {
     struct udev_list_entry *devices, *dev_list_entry;
     devices = udev_enumerate_get_list_entry(enumerate);
     udev_list_entry_foreach(dev_list_entry, devices) {
-      const char *path = udev_list_entry_get_name(dev_list_entry);
-      struct udev_device *dev = udev_device_new_from_syspath(udev, path);
+      const char* path = udev_list_entry_get_name(dev_list_entry);
+      struct udev_device* dev = udev_device_new_from_syspath(udev, path);
       if (path != nullptr && dev != nullptr) {
         getBlockDevice(dev, results, lvm_lv2pv);
       }

--- a/specs/posix/block_devices.table
+++ b/specs/posix/block_devices.table
@@ -1,7 +1,7 @@
 table_name("block_devices")
 description("Block (buffered access) device file nodes: disks, ramdisks, and DMG containers.")
 schema([
-    Column("name", TEXT, "Block device name"),
+    Column("name", TEXT, "Block device name", additional=True),
     Column("parent", TEXT, "Block device parent name"),
     Column("vendor", TEXT, "Block device vendor string"),
     Column("model", TEXT, "Block device model string identifier"),


### PR DESCRIPTION
This extends the work originally done in #7209 to the `block_devices` table. And relates to #8033

With it, I hope to fix an o(n^2) bug.

As the underlying code doesn't support this on darwin, I opted to flag the spec as `additional=True` and not `index=True`

(Thanks @uptycs-rmack for talking through this with me)