### PR TITLE
Add number of sockets to `system_info`

### DIFF
--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -83,6 +83,15 @@ QueryData genSystemInfo(QueryContext& context) {
         if (details.size() == 2) {
           r["cpu_microcode"] = details[1];
         }
+      } else if (line.find("siblings") == 0) {
+        auto details = osquery::split(line, ":");
+        if (details.size() == 2) {
+          unsigned int logical_cores_per_socket = std::stoi(details[1]);
+          r["cpu_sockets"] =
+              (logical_cores > 0)
+                  ? INTEGER(logical_cores / logical_cores_per_socket)
+                  : "-1";
+        }
       }
 
       // Minor optimization to not parse every line.

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -88,7 +88,7 @@ QueryData genSystemInfo(QueryContext& context) {
         if (details.size() == 2) {
           unsigned int logical_cores_per_socket = std::stoi(details[1]);
           r["cpu_sockets"] =
-              (logical_cores > 0)
+              (logical_cores > 0 && logical_cores_per_socket > 0)
                   ? INTEGER(logical_cores / logical_cores_per_socket)
                   : "-1";
         }

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -50,12 +50,15 @@ QueryData genSystemInfo(QueryContext& context) {
     long numProcs = 0;
     wmiResults[0].GetLong("NumberOfLogicalProcessors", numProcs);
     r["cpu_logical_cores"] = INTEGER(numProcs);
+    wmiResults[0].GetLong("NumberOfProcessors", numProcs);
+    r["cpu_sockets"] = INTEGER(numProcs);
     wmiResultsProc[0].GetLong("NumberOfCores", numProcs);
     r["cpu_physical_cores"] = INTEGER(numProcs);
     wmiResults[0].GetString("Manufacturer", r["hardware_vendor"]);
     wmiResults[0].GetString("Model", r["hardware_model"]);
   } else {
     r["cpu_logical_cores"] = "-1";
+    r["cpu_sockets"] = "-1";
     r["cpu_physical_cores"] = "-1";
     r["hardware_vendor"] = "-1";
     r["hardware_model"] = "-1";

--- a/specs/system_info.table
+++ b/specs/system_info.table
@@ -8,6 +8,7 @@ schema([
     Column("cpu_brand", TEXT, "CPU brand string, contains vendor and model"),
     Column("cpu_physical_cores", INTEGER, "Number of physical CPU cores in to the system"),
     Column("cpu_logical_cores", INTEGER, "Number of logical CPU cores available to the system"),
+    Column("cpu_sockets", INTEGER, "Number of processor sockets in the system"),
     Column("cpu_microcode", TEXT, "Microcode version"),
     Column("physical_memory", BIGINT, "Total physical memory in bytes"),
     Column("hardware_vendor", TEXT, "Hardware vendor"),

--- a/tests/integration/tables/system_info.cpp
+++ b/tests/integration/tables/system_info.cpp
@@ -32,6 +32,7 @@ TEST_F(SystemInfo, test_sanity) {
                            {"cpu_brand", NormalType},
                            {"cpu_physical_cores", NonNegativeInt},
                            {"cpu_logical_cores", NonNegativeInt},
+                           {"cpu_sockets", NonNegativeInt},
                            {"cpu_microcode", NormalType},
                            {"physical_memory", NonNegativeInt},
                            {"hardware_vendor", NormalType},


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

Resolves #7931.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
