### PR TITLE
Improve extended_attributes implementation for Linux and macOS

### DIFF
--- a/osquery/filesystem/posix/xattrs.cpp
+++ b/osquery/filesystem/posix/xattrs.cpp
@@ -7,61 +7,121 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <osquery/filesystem/fileops.h>
 #include <osquery/filesystem/posix/xattrs.h>
 #include <osquery/logger/logger.h>
+#include <osquery/utils/scope_guard.h>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/xattr.h>
 
 namespace osquery {
 #if defined(__APPLE__)
-#define listxattr(path, buffer, buffer_size)                                   \
-  ::listxattr(path, buffer, buffer_size, 0)
+#define flistxattr(fd, buffer, buffer_size)                                    \
+  ::flistxattr(fd, buffer, buffer_size, 0)
 
-#define getxattr(path, attr_name, buffer, buffer_size)                         \
-  ::getxattr(path, attr_name, buffer, buffer_size, 0, 0)
+#define fgetxattr(fd, attr_name, buffer, buffer_size)                          \
+  ::fgetxattr(fd, attr_name, buffer, buffer_size, 0, 0)
 #endif
 
-Status getExtendedAttributeNameList(std::vector<std::string>& name_list,
-                                    const std::string& path) {
-  name_list = {};
+std::string xAttrFileErrorToString(XAttrFileError error,
+                                   const std::string& path) {
+  std::string error_message;
+  switch (error) {
+  case XAttrFileError::List: {
+    error_message +=
+        "Failed to list the extended attributes for the following path: ";
+    error_message += path;
+    break;
+  }
+  case XAttrFileError::NoLength: {
+    error_message +=
+        "Failed to determine the length the extended attribute "
+        "list for the following path: ";
+    error_message += path;
+    break;
+  }
+  case XAttrFileError::SizeChanged: {
+    error_message +=
+        "Failed to list the extended attributes for the following path: ";
+    error_message += path;
+    error_message +=
+        ". The list of extended attributes has changed while it was being "
+        "acquired.";
+    break;
+  }
+  }
+  return error_message;
+}
 
-  auto buffer_size = listxattr(path.c_str(), nullptr, 0);
+std::string xAttrValueErrorToString(XAttrValueError error,
+                                    const std::string& path,
+                                    const std::string& name) {
+  std::string error_message;
+  switch (error) {
+  case XAttrValueError::NoLength: {
+    error_message +=
+        "Failed to determine the length of the extended attribute named '";
+    error_message += name;
+    error_message += "' from the following path: ";
+    error_message += path;
+    break;
+  }
+  case XAttrValueError::Get: {
+    error_message += "Failed to acquire the extended attribute named '";
+    error_message += name;
+    error_message += "' from the following path: ";
+    error_message += path;
+    break;
+  }
+  case XAttrValueError::SizeChanged: {
+    error_message += "Failed to acquire the extended attribute named '";
+    error_message += name;
+    error_message += "' from the following path: ";
+    error_message += path;
+    error_message +=
+        ". The extended attribute value has been changed while it was being "
+        "acquired.";
+    break;
+  }
+  }
+
+  return error_message;
+}
+
+XAttrNameListResult getExtendedAttributesNames(int fd) {
+  std::vector<std::string> name_list;
+
+  auto buffer_size = flistxattr(fd, nullptr, 0);
   if (buffer_size == 0) {
-    return Status::success();
+    return name_list;
 
   } else if (buffer_size < 0) {
-    return Status::failure(
-        "Failed to determine the length the extended attribute list for the "
-        "following path: " +
-        path);
+    return createError(XAttrFileError::NoLength);
   }
 
   std::vector<char> buffer(static_cast<std::size_t>(buffer_size), 0);
 
-  auto err = listxattr(path.c_str(), buffer.data(), buffer.size());
+  auto err = flistxattr(fd, buffer.data(), buffer.size());
   if (err == 0) {
-    return Status::success();
+    return name_list;
 
   } else if (err < 0) {
-    return Status::failure(
-        "Failed to list the extended attributes for the following path: " +
-        path);
+    return createError(XAttrFileError::List);
   }
 
   if (err < buffer_size) {
     buffer.resize(static_cast<std::size_t>(err));
 
   } else if (err > buffer_size) {
-    return Status::failure(
-        "Failed to list the extended attributes for the following path: " +
-        path +
-        ". The list of extended attributes has changed while it was being "
-        "acquired.");
+    return createError(XAttrFileError::SizeChanged);
   }
 
   std::size_t start_index{0U};
   for (std::size_t i{0U}; i < buffer.size(); ++i) {
-    if (buffer.at(i) != 0) {
+    if (buffer[i] != 0) {
       continue;
     }
 
@@ -70,73 +130,92 @@ Status getExtendedAttributeNameList(std::vector<std::string>& name_list,
     start_index = i + 1U;
 
     auto name = std::string(name_ptr, name_length);
-    name_list.push_back(std::move(name));
+    name_list.emplace_back(std::move(name));
   }
 
-  return Status::success();
+  return name_list;
 }
 
-Status getExtendedAttributeValue(ExtendedAttributeValue& value,
-                                 const std::string& path,
-                                 const std::string& name) {
-  value = {};
-
-  auto buffer_size = getxattr(path.c_str(), name.c_str(), nullptr, 0);
+XAttrValueResult getExtendedAttributeValue(int fd, const std::string& name) {
+  auto buffer_size = fgetxattr(fd, name.c_str(), nullptr, 0);
   if (buffer_size == 0) {
-    return Status::success();
-
+    return XAttrValueResult::success({});
   } else if (buffer_size < 0) {
-    return Status::failure(
-        "Failed to determine the length of the extended attribute named '" +
-        name + "' from the following path: " + path);
+    return createError(XAttrValueError::NoLength);
   }
 
-  ExtendedAttributeValue buffer(static_cast<std::size_t>(buffer_size), 0U);
+  ExtendedAttributeValue value(static_cast<std::size_t>(buffer_size), 0U);
 
-  auto err = getxattr(path.c_str(), name.c_str(), buffer.data(), buffer.size());
+  auto err = fgetxattr(fd, name.c_str(), value.data(), value.size());
   if (err == 0) {
-    return Status::success();
+    return value;
 
   } else if (err < 0) {
-    return Status::failure("Failed to acquire the extended attribute named '" +
-                           name + "' from the following path: " + path);
+    return createError(XAttrValueError::Get);
   }
 
   if (err < buffer_size) {
-    buffer.resize(static_cast<std::size_t>(err));
+    value.resize(static_cast<std::size_t>(err));
 
   } else if (err > buffer_size) {
-    return Status::failure("Failed to acquire the extended attribute named '" +
-                           name + "' from the following path: " + path +
-                           ". The extended attribute value has been changed "
-                           "while it was being acquired.");
+    return createError(XAttrValueError::SizeChanged);
   }
 
-  value = std::move(buffer);
-  return Status::success();
+  return value;
 }
 
-Status getExtendedAttributes(ExtendedAttributeMap& xattr_map,
-                             const std::string& path) {
-  xattr_map = {};
+XAttrGetResult getExtendedAttributes(const std::string& path) {
+  int fd = open(path.c_str(), O_RDONLY);
 
-  std::vector<std::string> name_list;
-  auto status = getExtendedAttributeNameList(name_list, path);
-  if (!status.ok()) {
-    return status;
-  }
-
-  for (const auto& name : name_list) {
-    ExtendedAttributeValue value;
-    status = getExtendedAttributeValue(value, path, name);
-    if (!status.ok()) {
-      LOG(ERROR) << status.getMessage();
-      continue;
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      return createError(XAttrGetError::NoFile);
     }
 
-    xattr_map.insert({name, std::move(value)});
+    std::string error_message =
+        "Failed to open file to read extended attributes at the "
+        "following path: ";
+    error_message += path;
+
+    return XAttrGetResult::failure(XAttrGetError::GenericError,
+                                   std::move(error_message));
   }
 
-  return Status::success();
+  auto fd_guard = scope_guard::create([&] { close(fd); });
+
+  auto list_result = getExtendedAttributesNames(fd);
+  if (list_result.isError()) {
+    std::string error_message =
+        xAttrFileErrorToString(list_result.getErrorCode(), path);
+
+    return XAttrGetResult::failure(std::move(error_message));
+  }
+
+  ExtendedAttributeMap xattr_map;
+  auto name_list = list_result.take();
+
+  bool had_value_error = false;
+  for (const auto& name : name_list) {
+    auto value_result = getExtendedAttributeValue(fd, name);
+    if (value_result.isError()) {
+      /* NOTE: here we don't return an error to the caller, because we
+         potentially would need to collect a lot of error messages.
+         We could coalesce the errors in a single generic one only,
+         without printing anything here, but then we would lose
+         on important information about what exactly has gone wrong. */
+      had_value_error = true;
+      VLOG(1) << xAttrValueErrorToString(
+          value_result.getErrorCode(), path, name);
+
+      continue;
+    }
+    xattr_map.emplace(name, value_result.take());
+  }
+
+  if (had_value_error) {
+    LOG(ERROR) << "Failed to read some extended attributes from " << path;
+  }
+
+  return xattr_map;
 }
 } // namespace osquery

--- a/osquery/filesystem/posix/xattrs.h
+++ b/osquery/filesystem/posix/xattrs.h
@@ -14,14 +14,32 @@
 #include <unordered_map>
 #include <vector>
 
-#include <osquery/utils/status/status.h>
+#include <boost/optional/optional.hpp>
+#include <osquery/utils/expected/expected.h>
 
 namespace osquery {
+
+enum class XAttrFileError { NoLength, List, SizeChanged };
+enum class XAttrValueError { NoLength, Get, SizeChanged };
+enum class XAttrGetError { GenericError, NoFile };
+
 using ExtendedAttributeValue = std::vector<std::uint8_t>;
 
 using ExtendedAttributeMap =
     std::unordered_map<std::string, ExtendedAttributeValue>;
 
-Status getExtendedAttributes(ExtendedAttributeMap& xattr_map,
-                             const std::string& path);
+using XAttrGetResult = Expected<ExtendedAttributeMap, XAttrGetError>;
+using XAttrNameListResult = Expected<std::vector<std::string>, XAttrFileError>;
+using XAttrValueResult = Expected<ExtendedAttributeValue, XAttrValueError>;
+
+std::string xAttrFileErrorToString(XAttrFileError error,
+                                   const std::string& path);
+std::string xAttrValueErrorToString(XAttrValueError error,
+                                    const std::string& path,
+                                    const std::string& name);
+
+XAttrNameListResult getExtendedAttributesNames(int fd);
+XAttrValueResult getExtendedAttributeValue(int fd, const std::string& name);
+XAttrGetResult getExtendedAttributes(const std::string& path);
+
 } // namespace osquery

--- a/osquery/tables/system/linux/extended_attributes.cpp
+++ b/osquery/tables/system/linux/extended_attributes.cpp
@@ -75,10 +75,14 @@ Status getCapabilities(std::string& capabilities, const std::string& path) {
 } // namespace
 
 Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
-  ExtendedAttributeMap xattr_map;
-  auto status = getExtendedAttributes(xattr_map, path);
-  if (!status.ok()) {
-    return status;
+  XAttrGetResult xattr_result = getExtendedAttributes(path);
+  if (xattr_result.isError()) {
+    if (xattr_result.getErrorCode() == XAttrGetError::NoFile) {
+      // Just ignore non-existing files
+      return Status::success();
+    }
+
+    return Status::failure(xattr_result.getError().getMessage());
   }
 
   Row row = {};
@@ -87,10 +91,10 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
   auto path_obj = boost::filesystem::path(path);
   row["directory"] = TEXT(path_obj.parent_path().string());
 
-  std::string capabilities = {};
+  std::string capabilities;
   bool capabilities_found{false};
 
-  status = getCapabilities(capabilities, path);
+  auto status = getCapabilities(capabilities, path);
   if (status.ok()) {
     if (!capabilities.empty()) {
       row["key"] = TEXT(kSecurityCapabilityXattrName);
@@ -103,7 +107,7 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
     capabilities_found = true;
   }
 
-  for (const auto& p : xattr_map) {
+  for (const auto& p : xattr_result.get()) {
     const auto& key_name = p.first;
     const auto& key_value = p.second;
 
@@ -127,34 +131,23 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
     // 1. A null terminator must be present
     // 2. All characters up to the null terminator must be printable
     // 3. The null terminator must be located at the end of the value buffer
-    auto char_it = std::find_if(key_value.begin(),
-                                key_value.end(),
+    auto value = std::string_view(
+        reinterpret_cast<const char*>(key_value.data()), key_value.size());
 
-                                [](std::uint8_t byte) -> bool {
-                                  auto as_integer = static_cast<int>(byte);
-                                  return !std::isprint(as_integer);
-                                });
+    bool printable = true;
+    if (value[key_value.size() - 1] != '\0') {
+      printable = false;
+    } else {
+      // Drop the null-terminator
+      value.remove_suffix(1);
 
-    bool printable = false;
-    if (char_it != key_value.end() &&
-        std::next(char_it, 1) == key_value.end() && *char_it == 0) {
-      printable = true;
-    }
-
-    auto value_size = key_value.size();
-    if (printable) {
-      --value_size;
-    }
-
-    auto value = std::string(value_size, 0);
-    std::memcpy(&value[0], key_value.data(), value_size);
-
-    if (!printable) {
-      value = base64::encode(value);
+      printable = std::all_of(value.begin(), value.end(), [](char c) -> bool {
+        return std::isprint(c);
+      });
     }
 
     row["key"] = TEXT(key_name);
-    row["value"] = TEXT(value);
+    row["value"] = printable ? TEXT(std::string(value)) : base64::encode(value);
     row["base64"] = printable ? INTEGER(0) : INTEGER(1);
 
     output.push_back(row);

--- a/osquery/utils/base64.cpp
+++ b/osquery/utils/base64.cpp
@@ -26,7 +26,7 @@ namespace {
 
 typedef bai::binary_from_base64<const char*> base64_str;
 typedef bai::transform_width<base64_str, 8, 6> base64_dec;
-typedef bai::transform_width<std::string::const_iterator, 6, 8> base64_enc;
+typedef bai::transform_width<std::string_view::iterator, 6, 8> base64_enc;
 typedef bai::base64_from_binary<base64_enc> it_base64;
 
 } // namespace
@@ -49,20 +49,20 @@ std::string decode(std::string encoded) {
   }
 }
 
-std::string encode(const std::string& unencoded) {
+std::string encode(const std::string_view unencoded) {
   if (unencoded.empty()) {
-    return unencoded;
+    return {};
   }
 
   size_t writePaddChars = (3U - unencoded.length() % 3U) % 3U;
   try {
     auto encoded =
         std::string(it_base64(unencoded.begin()), it_base64(unencoded.end()));
-    encoded.append(std::string(writePaddChars, '='));
+    encoded.append(writePaddChars, '=');
     return encoded;
   } catch (const boost::archive::iterators::dataflow_exception& e) {
     LOG(INFO) << "Could not base64 encode string: " << e.what();
-    return "";
+    return {};
   }
 }
 

--- a/osquery/utils/base64.h
+++ b/osquery/utils/base64.h
@@ -29,7 +29,7 @@ std::string decode(std::string encoded);
  * @param A string to encode.
  * @return Encoded string.
  */
-std::string encode(const std::string& unencoded);
+std::string encode(const std::string_view unencoded);
 
 } // namespace base64
 

--- a/osquery/utils/chars.cpp
+++ b/osquery/utils/chars.cpp
@@ -7,17 +7,16 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <string>
+#include "chars.h"
+
 #include <cstddef>
 
 #include <osquery/logger/logger.h>
-
-#include <osquery/utils/chars.h>
 #include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 
-bool isPrintable(const std::string& check) {
+bool isPrintable(const std::string_view check) {
   for (const unsigned char ch : check) {
     if (ch >= 0x7F || ch <= 0x1F) {
       return false;

--- a/osquery/utils/chars.h
+++ b/osquery/utils/chars.h
@@ -10,16 +10,17 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace osquery {
 
 /**
  * @brief Check if a string is ASCII printable
  *
- * @param A string to check.
+ * @param check string to check.
  * @return If the string is printable.
  */
-bool isPrintable(const std::string& check);
+bool isPrintable(const std::string_view check);
 
 /**
  * @brief In-line helper function for use with utf8StringSize


### PR DESCRIPTION
- Fix a bug in the macOS implementation where a race condition could cause a read out of bound when the read file is deleted. Use the xattr variant of APIs which uses a fd, so that the file remains valid even if deleted, and also check error codes.

- Improve error reporting for the extended_attributes implementation on Linux and macOS

- Minor improvements to prevent unnecessary string copies by using string_view
