### PR TITLE
Update expired Slack invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -17,7 +17,7 @@ We only use issues to track bugs, feature requests or blueprints. For everything
 
 Slack : https://osquery.slack.com
 
-Slack newcomers, first use this invite link: https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw 
+Slack newcomers, first use this invite link: https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ
 
 Reddit : https://www.reddit.com/r/osquery/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ page](https://github.com/orgs/osquery/teams) on the osquery GitHub
 organization.
 
 If you need help, both the core team and community members are on the osquery [Slack](https://osquery.slack.com).
-Feel free to register using the following [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+Feel free to register using the following [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ).
 The `#code-review` Slack channel has been set up to handle urgent review needs as well as questions about your PR.
 Note: prefer to keep discussion about code changes in the GitHub pull request thread.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available for Linux, macOS, and Windows.
 - Stack Overflow: [Stack Overflow questions](https://stackoverflow.com/questions/tagged/osquery)
 - Table Schema: [osquery.io/schema](https://osquery.io/schema)
 - Query Packs: [osquery.io/packs](https://github.com/osquery/osquery/tree/master/packs)
-- Slack: [Browse the archives](https://chat.osquery.io/c/general) or [Join the conversation](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw)
+- Slack: [Browse the archives](https://chat.osquery.io/c/general) or [Join the conversation](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ)
 - Build Status: [![GitHub Actions Build x86 Status](https://github.com/osquery/osquery/actions/workflows/hosted_runners.yml/badge.svg?branch=master)](https://github.com/osquery/osquery/actions/workflows/hosted_runners.yml) [![GitHub Actions Build AArch64 Status](https://github.com/osquery/osquery/actions/workflows/self_hosted_runners.yml/badge.svg?branch=master)](https://github.com/osquery/osquery/actions/workflows/self_hosted_runners.yml) [![Documentation Status](https://readthedocs.org/projects/osquery/badge/?version=latest)](https://osquery.readthedocs.io/en/latest/?badge=latest)
 - CII Best Practices: [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3125/badge)](https://bestpractices.coreinfrastructure.org/projects/3125)
 
@@ -109,7 +109,7 @@ We will mark the release as 'stable' on GitHub when enough testing has occurred,
 Building osquery from source is encouraged! Check out our [build
 guide](https://osquery.readthedocs.io/en/latest/development/building/). Also
 check out our [contributing guide](CONTRIBUTING.md) and join the
-community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+community on [Slack](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ).
 
 ## License
 
@@ -136,4 +136,4 @@ for background on the project, visit the [users
 guide](https://osquery.readthedocs.org/).
 
 Development and usage discussion is happening in the osquery Slack, grab an invite
-[here](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw)!
+[here](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ)!

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ free to reach out on osquery Slack.
 
 ## Slack
 
-You can register on our Slack using our [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+You can register on our Slack using our [shared invite](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ).
 Before posting to the `general` channel take a look at other available channels where your question might be a better fit.
 If you have a question about a vendor solution post **only** on the vendor specific channel.
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -33,7 +33,7 @@ Additionally, osquery's codebase is made up of high-performance, modular compone
 
 ## Getting Help
 
-If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/osquery/osquery/issues). Keep in touch with osquery developers and users in our Slack: [Join osquery](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw).
+If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/osquery/osquery/issues). Keep in touch with osquery developers and users in our Slack: [Join osquery](https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ).
 
 ## Documentation
 

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -430,7 +430,7 @@ function New-ChocolateyPackage() {
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/osquery/osquery</projectSourceUrl>
     <docsUrl>https://osquery.readthedocs.io/en/stable</docsUrl>
-    <mailingListUrl>https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw</mailingListUrl>
+    <mailingListUrl>https://join.slack.com/t/osquery/shared_invite/zt-1wi6cdgf7-zR2wt7FZ0ClHj6tEym6KFQ</mailingListUrl>
     <bugTrackerUrl>https://github.com/osquery/osquery/issues</bugTrackerUrl>
     <tags>InfoSec Tools</tags>
     <summary>


### PR DESCRIPTION
The website was updated, we miss links here in the osquery repo.

Fixes #8047 