### PR TITLE
Update linux `disk_encryption` to recursively query parent crypt status

### DIFF
--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -109,7 +109,7 @@ void genFDEStatusForBlockDevice(const bool& runSelectAll,
     // If there is no parent, we are likely at the root of the block device.
     // Since no good crypt status has been found, we set the empty status and
     // exit. All children of this block device will inherit this status.
-    if (!parent_name.empty()) {
+    if (parent_name.empty()) {
       r["encryption_status"] = kEncryptionStatusNotEncrypted;
       r["encrypted"] = "0";
       r["type"] = "";
@@ -201,8 +201,8 @@ QueryData genFDEStatus(QueryContext& context) {
     // Copy encrypted rows back to results. Omit rows that aren't in the query
     // context.
     if (runSelectAll ||
-        std::count(
-            queried_devices.begin(), queried_devices.end(), pair.first)) {
+        std::find(queried_devices.begin(), queried_devices.end(), pair.first) !=
+            queried_devices.end()) {
       results.push_back(encrypted_rows[pair.first]);
     }
   }

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -29,15 +29,37 @@ const std::string kEncryptionStatusNotEncrypted = "not encrypted";
 
 namespace osquery {
 namespace tables {
+// Calls to block_devices is done here to allow genFDEStatusForBlockDevice
+// to query parent block devices for crypt status after initial queries.
+void queryBlockDevice(const bool& runSelectAll,
+                      const std::string& device,
+                      std::map<std::string, Row>& block_devices) {
+  // There's protection around calls, but this ensures no duplicates.
+  if ((runSelectAll && block_devices.size() > 0) ||
+      (!runSelectAll && block_devices.count(device) > 0)) {
+    return;
+  }
 
-void genFDEStatusForBlockDevice(const std::string& name,
-                                const std::string& uuid,
-                                const std::string& parent_name,
-                                std::map<std::string, Row>& encrypted_rows,
-                                QueryData& results) {
+  auto data = runSelectAll
+                  ? SQL::selectAllFrom("block_devices")
+                  : SQL::selectAllFrom("block_devices", "name", EQUALS, device);
+  for (const auto& row : data) {
+    if (row.count("name") > 0) {
+      block_devices[row.at("name")] = row;
+    }
+  }
+}
+
+void genFDEStatusForBlockDevice(const bool& runSelectAll,
+                                const Row& block_device,
+                                std::map<std::string, Row>& block_devices,
+                                std::map<std::string, Row>& encrypted_rows) {
+  const auto name = block_device.at("name");
+  const auto parent_name =
+      (block_device.count("parent") > 0 ? block_device.at("parent") : "");
   Row r;
   r["name"] = name;
-  r["uuid"] = uuid;
+  r["uuid"] = (block_device.count("uuid") > 0) ? block_device.at("uuid") : "";
 
   struct crypt_device* cd = nullptr;
   auto ci = crypt_status(cd, name.c_str());
@@ -47,6 +69,7 @@ void genFDEStatusForBlockDevice(const std::string& name,
   case CRYPT_BUSY: {
     r["encrypted"] = "1";
     r["encryption_status"] = kEncryptionStatusEncrypted;
+    r["type"] = "";
 
     auto crypt_init = crypt_init_by_name_and_header(&cd, name.c_str(), nullptr);
     if (crypt_init < 0) {
@@ -79,31 +102,42 @@ void genFDEStatusForBlockDevice(const std::string& name,
     }
 
     r["type"] = osquery::join(items, "-");
-    encrypted_rows[name] = r;
     break;
   }
-
-    // If there's no good crypt status, check to see if we've already
-    // defined the parent_name. If so, inherit data from there. This
-    // works because the `SQL::selectAllFrom("block_devices")` is
-    // ordered enough. If that order proves inadequate, we may need
-    // to explicitly sort it.
+  // If there's no good crypt status, use the parent device's crypt status.
   default:
-    if (encrypted_rows.count(parent_name)) {
+    // Step through each parent once until we either reach
+    // the root device, or a device with valid encryption.
+    if (!parent_name.empty()) {
+      if (!encrypted_rows.count(parent_name)) {
+        if (!block_devices.count(parent_name)) {
+          queryBlockDevice(runSelectAll, parent_name, block_devices);
+        }
+
+        genFDEStatusForBlockDevice(runSelectAll,
+                                   block_devices[parent_name],
+                                   block_devices,
+                                   encrypted_rows);
+      }
+
+      // The recursive calls return back, and each child
+      // device takes the encryption values of their parent.
       auto parent_row = encrypted_rows[parent_name];
-      r["encryption_status"] = kEncryptionStatusEncrypted;
-      r["encrypted"] = "1";
+      r["encryption_status"] = parent_row["encryption_status"];
+      r["encrypted"] = parent_row["encrypted"];
       r["type"] = parent_row["type"];
     } else {
       r["encryption_status"] = kEncryptionStatusNotEncrypted;
       r["encrypted"] = "0";
+      r["type"] = "";
     }
   }
+
+  encrypted_rows[name] = r;
 
   if (cd != nullptr) {
     crypt_free(cd);
   }
-  results.push_back(r);
 }
 
 QueryData genFDEStatus(QueryContext& context) {
@@ -114,34 +148,40 @@ QueryData genFDEStatus(QueryContext& context) {
     return results;
   }
 
-  std::map<std::string, Row> encrypted_rows;
-
   bool runSelectAll(true);
-  QueryData block_devices;
+  std::vector<std::string> queried_devices;
+  std::map<std::string, Row> block_devices;
+  std::map<std::string, Row> encrypted_rows;
 
   if (auto constraint_it = context.constraints.find("name");
       constraint_it != context.constraints.end()) {
     const auto& constraints = constraint_it->second;
-    for (const auto& name : constraints.getAll(EQUALS)) {
+    for (const auto& device : constraints.getAll(EQUALS)) {
       runSelectAll = false;
 
-      auto data = SQL::selectAllFrom("block_devices", "name", EQUALS, name);
-      for (const auto& row : data) {
-        block_devices.push_back(row);
+      if (!block_devices.count(device)) {
+        queryBlockDevice(runSelectAll, device, block_devices);
+        queried_devices.push_back(device);
       }
     }
   }
 
   if (runSelectAll) {
-    block_devices = SQL::selectAllFrom("block_devices");
+    queryBlockDevice(runSelectAll, "", block_devices);
   }
 
-  for (const auto& row : block_devices) {
-    const auto name = (row.count("name") > 0) ? row.at("name") : "";
-    const auto uuid = (row.count("uuid") > 0) ? row.at("uuid") : "";
-    const auto parent_name = (row.count("parent") > 0 ? row.at("parent") : "");
-    genFDEStatusForBlockDevice(
-        name, uuid, parent_name, encrypted_rows, results);
+  // Generate and add an encryption row result for each queried block device.
+  for (const auto& pair : block_devices) {
+    if (!encrypted_rows.count(pair.first)) {
+      genFDEStatusForBlockDevice(
+          runSelectAll, pair.second, block_devices, encrypted_rows);
+    }
+
+    if (queried_devices.empty() ||
+        std::count(
+            queried_devices.begin(), queried_devices.end(), pair.first)) {
+      results.push_back(encrypted_rows[pair.first]);
+    }
   }
 
   return results;

--- a/specs/posix/disk_encryption.table
+++ b/specs/posix/disk_encryption.table
@@ -1,7 +1,7 @@
 table_name("disk_encryption")
 description("Disk encryption status and information.")
 schema([
-    Column("name", TEXT, "Disk name", index=True),
+    Column("name", TEXT, "Disk name", additional=True),
     Column("uuid", TEXT, "Disk Universally Unique Identifier"),
     Column("encrypted", INTEGER, "1 If encrypted: true (disk is encrypted), else 0"),
     Column("type", TEXT, "Description of cipher type and mode if available"),

--- a/specs/posix/disk_encryption.table
+++ b/specs/posix/disk_encryption.table
@@ -1,7 +1,7 @@
 table_name("disk_encryption")
 description("Disk encryption status and information.")
 schema([
-    Column("name", TEXT, "Disk name", additional=True),
+    Column("name", TEXT, "Disk name"),
     Column("uuid", TEXT, "Disk Universally Unique Identifier"),
     Column("encrypted", INTEGER, "1 If encrypted: true (disk is encrypted), else 0"),
     Column("type", TEXT, "Description of cipher type and mode if available"),


### PR DESCRIPTION
This change will rely on #8037

Functionally this should minimize getting encryption status from parent devices, but without the constraint being added in block_devices this will not perform well.

Below is the process of acquiring crypt status and overall what is different. 

1. Query block devices all or by name constraint
2. Generate encryption row for each queried block device
   - If current block device has encryption
     - Set the encryption row with those values
   - If current block device does not have valid encryption
     - If we have a parent block device defined
       - If we need to create the parent's encryption status
         - If we need to query the parent block device
           - Query the parent block device
         - Generate parent encryption status
       - If we have already generated an encryption status for the parent
         - Use already generated parent device's encryption status
     - If we do not have a parent i.e is a root device
       - Set unencrypted status for this device
3. Add encryption row results to output if that device was a part of the initial query

This avoids sorting parents altogether, which I figured made sense here.