### PR TITLE
Adding Hidden LaunchAgent/Daemon Discovery

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -444,8 +444,25 @@ inline Status listInAbsoluteDirectory(const fs::path& path,
 Status listFilesInDirectory(const fs::path& path,
                             std::vector<std::string>& results,
                             bool recursive) {
-  return listInAbsoluteDirectory(
-      (path / ((recursive) ? "**" : "*")), results, GLOB_FILES);
+  if (path.empty() || !pathExists(path)) {
+    return Status(1, "Target directory is invalid");
+  }
+
+  if (recursive) {
+    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+      if (fs::is_regular_file(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  } else {
+    for (const auto& entry : fs::directory_iterator(path)) {
+      if (fs::is_regular_file(entry)) {
+        results.push_back(entry.path().string());
+      }
+    }
+  }
+
+  return Status::success();
 }
 
 Status listDirectoriesInDirectory(const fs::path& path,


### PR DESCRIPTION
Please see the [original PR](https://github.com/osquery/osquery/pull/7704) for historical comments. Opening a clean PR to move away from some chaotic branch conflicts.

# Hidden LaunchAgent/Daemon Discovery

## Background

As per this issue -> https://github.com/osquery/osquery/issues/7703 <- this PR introduces the capability for osquery to identify LaunchAgents/Daemons that are defined in hidden `.plist` files.

The TL;DR from the issue linked above is -> 

Malware commonly persists on macOS devices using LaunchAgents/Daemons. It [has been observed](https://www.welivesecurity.com/2022/07/19/i-see-what-you-did-there-look-cloudmensis-macos-spyware/) that certain malware samples have been utilising hidden `plist` files i.e. `/Library/LaunchDaemons/.com.apple.WindowServer.plist`. This PR aims to cover off this blind spot within the current launchd table.

## Changes
 One file has been altered within this PR:
 * `osquery/filesystem/filesystem.cpp` - adding a consistent approach to discovering files and directories. This allows us to identify hidden files; which in this case enables us to identify hidden launch items.
 
 ## Impact

This PR prevents malicious LaunchAgents/Daemons from evading detection by using a hidden plist files. As shown in the screenshot below, we can now identify these hidden plists:
<br>
![image](https://user-images.githubusercontent.com/27683329/181013155-e2c3d3b4-561d-4ff9-9f5c-d8f156d4e57b.png)
 
 ## Updates

Since the opening of the original PR, [@marcosd4h](https://github.com/marcosd4h) made some great changes to directory listing (👏) - which I was able to replicate for file discovery to allow us to identify hidden files. Specifically in this case to target macOS launch items.

cc. @Smjert, @directionless from the previous PR.