### PR TITLE
es_process_events: quote spaces in command line and environment variables

### DIFF
--- a/osquery/events/darwin/endpointsecurity.cpp
+++ b/osquery/events/darwin/endpointsecurity.cpp
@@ -116,7 +116,11 @@ void EndpointSecurityPublisher::handleMessage(const es_message_t* message) {
       for (auto i = 0; i < ec->argc; i++) {
         auto arg = es_exec_arg(&message->event.exec, i);
         auto s = getStringFromToken(&arg);
-        args << s << ' ';
+        if (s.find(" ") != std::string::npos) {
+          args << std::quoted(s) << ' ';
+        } else {
+          args << s << ' ';
+        }
       }
       ec->args = args.str();
     }
@@ -127,7 +131,11 @@ void EndpointSecurityPublisher::handleMessage(const es_message_t* message) {
       for (auto i = 0; i < ec->envc; i++) {
         auto env = es_exec_env(&message->event.exec, i);
         auto s = getStringFromToken(&env);
-        envs << s << ' ';
+        if (s.find(" ") != std::string::npos) {
+          envs << std::quoted(s) << ' ';
+        } else {
+          envs << s << ' ';
+        }
       }
       ec->envs = envs.str();
     }


### PR DESCRIPTION
This quotes values in the `cmdline` and `env` columns in `es_process_events` that have spaces, so that the space delimited concatenation that creates the column is unambiguous.

This only quotes values that actually have spaces for cleanliness and to minimize backward compatibility issues (values without spaces are rendered the same as before). Checking for spaces requires iterating over the string an extra time, but that should not be too much additional overhead compared to the overall cost of processing the event.

We could try to add this change to the other process related tables, but this pr doesn't for simplicity. Having a slight difference in behavior like this doesn't seem too bad given there are already variations in how the tables work.

### Testing ###
To test `cmdline`, these commands can be run:
```
$ cp arg arg testdir
$ cp "arg arg" testdir
```
Current behavior is to output them the same:
```
> select cmdline from es_process_events where cmdline like 'cp%'
+---------------------+
| cmdline             |
+---------------------+
| cp arg arg testdir  |
| cp arg arg testdir  |
+---------------------+
```

After this change, it shows the difference:
```
> select cmdline from es_process_events where cmdline like 'cp%'
+-----------------------+
| cmdline               |
+-----------------------+
| cp arg arg testdir    |
| cp "arg arg" testdir  |
+-----------------------+
```

A similar test can be done with an environment variable containing a space, where `... TESTVAR=test spaces in var ...` is instead outputted as `... "TESTVAR=test spaces in var" ...`.
