### PR TITLE
Fix version column in homebrew_packages

### DIFF
--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -49,7 +49,7 @@ std::vector<std::string> getHomebrewVersionsFromInfoPlistPath(
   auto status = osquery::listDirectoriesInDirectory(path, app_versions);
   if (status.ok()) {
     for (const auto& version : app_versions) {
-      results.push_back(fs::path(version).parent_path().filename().string());
+      results.push_back(fs::path(version).filename().string());
     }
   } else {
     TLOG << "Error listing " << path << ": " << status.toString();


### PR DESCRIPTION
Fixes a bug introduced in osquery 5.9.0 where the version column in `homebrew_packages` was the name of the package instead of its version. 

Tested manually:
```
osquery> select * from homebrew_packages order by name;
+--------------------------+-----------------------------------------------+----------------+
| name                     | path                                          | version        |
+--------------------------+-----------------------------------------------+----------------+
| aom                      | /opt/homebrew/Cellar/aom                      | 3.6.0          |
| aribb24                  | /opt/homebrew/Cellar/aribb24                  | 1.0.4          |
| autoconf                 | /opt/homebrew/Cellar/autoconf                 | 2.71           |
| awscli                   | /opt/homebrew/Cellar/awscli                   | 2.11.13        |
| bazelisk                 | /opt/homebrew/Cellar/bazelisk                 | 1.14.0         |
```