### PR TITLE
Ignore CVE-2023-30571

### DIFF
--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -132,7 +132,9 @@
     "vendor": "libarchive",
     "version": "3.6.2",
     "commit": "ba80276ccc3c941c4918ec6e2460059f0c525c43",
-    "ignored-cves": []
+    "ignored-cves": [
+      "CVE-2023-30571"
+    ]
   },
   "libaudit": {
     "product": "audit-userspace",


### PR DESCRIPTION
Fixes: #8049

As discussed in offices today (2023-06-20) we do not think osquery is vulnerable to this. From the description:
> Libarchive through 3.6.2 can cause directories to have world-writable permissions. The umask() call inside archive_write_disk_posix.c changes the umask of the whole process for a very short period of time; a race condition with another thread can lead to a permanent umask 0 setting. Such a race condition could lead to implicit directory creation with permissions 0777 (without the sticky bit), which means that any low-privileged local user can delete and rename files inside those directories.

Osquery does not unpack files, so we do not believe this effects us.

Furthermore, there is not yet an upstream fix, and this appears limited to multithreaded environments.

See Also:
- https://github.com/libarchive/libarchive/issues/1876
- https://github.com/libarchive/libarchive/pull/1875