### PR TITLE
Fix waiting for mutiple extensions to be loaded not correctly waiting for timeout

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -652,19 +652,22 @@ bool Initializer::isWatcher() {
 
 void Initializer::initActivePlugin(const std::string& type,
                                    const std::string& name) const {
-  auto status = applyExtensionDelay(([type, name](bool& stop) {
-    auto rs = RegistryFactory::get().setActive(type, name);
-    if (rs.ok()) {
-      // The plugin was found, and is now active.
-      return rs;
-    }
+  size_t delay = 0;
+  auto status = applyExtensionDelay(
+      ([type, name](bool& stop) {
+        auto rs = RegistryFactory::get().setActive(type, name);
+        if (rs.ok()) {
+          // The plugin was found, and is now active.
+          return rs;
+        }
 
-    if (!Watcher::hasManagedExtensions()) {
-      // The plugin must be local, and is not active, problem.
-      stop = true;
-    }
-    return rs;
-  }));
+        if (!Watcher::hasManagedExtensions()) {
+          // The plugin must be local, and is not active, problem.
+          stop = true;
+        }
+        return rs;
+      }),
+      delay);
 
   if (!status.ok()) {
     std::string message = "Cannot activate " + name + " " + type +

--- a/osquery/extensions/extensions.h
+++ b/osquery/extensions/extensions.h
@@ -76,9 +76,11 @@ Status pingExtension(const std::string& path);
  * loaded or broadcasted a registry.
  *
  * @param predicate return true or set stop to end the timeout loop.
+ * @param delay the value to check the timeout against.
  * @return the last status from the predicate.
  */
-Status applyExtensionDelay(std::function<Status(bool& stop)> predicate);
+Status applyExtensionDelay(std::function<Status(bool& stop)> predicate,
+                           size_t& delay);
 
 /**
  * @brief Read the autoload flags and return a set of autoload paths.


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/7256
- Use a common delay when waiting for extensions.
- Only set waited to finish waiting for extensions early on failure (timeout)