### PR TITLE
Add `--enable_watchdog_logging` flag and improve error messages

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -127,6 +127,11 @@ Note that on Windows this doesn't have any effect currently, since the watchdog 
 
 By default the watchdog monitors extensions for improper shutdown, but NOT for performance and utilization issues. Enable this flag if you would like extensions to use the same CPU and memory limits as the osquery worker. This means that your extensions or third-party extensions may be asked to stop and restart during execution.
 
+`--enable_watchdog_debug=false`
+
+If set to true, every 3 seconds the watchdog will log the measured CPU utilization and memory footprint of all the monitored processes.
+(To generate the logs this flag requires `--verbose` to be set.)
+
 `--table_delay=0`
 
 Add a millisecond delay between multiple table calls (when a table is used in a JOIN). A `200` millisecond delay will trade about 20% additional time for a reduced 5% CPU utilization.

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -100,9 +100,21 @@ If this value is >0 then the watchdog level (`--watchdog_level`) for maximum mem
 
 `--watchdog_utilization_limit=0`
 
-If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 10% of a thread for more than `--watchdog_latency_limit` seconds of wall time. The length of sustained utilization is configurable with `--watchdog_latency_limit`.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 10% of CPU for more than `--watchdog_latency_limit` seconds of wall time. The length of sustained utilization is configurable with `--watchdog_latency_limit`.
 
-This value is a maximum number of CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default is 90, meaning less 90 seconds of cpu time per 3 seconds of wall time is allowed.
+This value sets a maximum number of allowed CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default value is is `10`, meaning 10% of CPU utilization allowed.
+
+The CPU utilization limit is calculated the following way:
+```text
+cpu_limit_ms = number_of_real_cores * check_interval_ms * (watchdog_utilization_limit / 100.0)
+```
+Where:
+- `number_of_real_cores` is the number of physical (not virtual) cores.
+- `check_interval_ms` is 3 seconds. It is how often the watchdog checks worker and extension processes for CPU utilization.
+
+Example: On a 2020 MacBook with Quad-Core Intel Core i7, `number_of_real_cores` is 4 (virtual cores are 8), thus by default the CPU utilization limit is `1200ms` meaning that every three seconds the processes are expected to use less than `1200ms` of CPU time (10% of all the CPU time `4 * 3000ms`).
+
+> NOTE: On the example above you can see that, on systems with virtual cores, osquery is actually setting the limit to half of the configured utilization (`1200ms` is actually 5% of the full `8 * 3000ms` CPU time).
 
 `--watchdog_latency_limit=0`
 
@@ -113,6 +125,8 @@ utilization limit for longer than the defaults.
 
 This value is a duration in seconds that the watchdog allows osquery to spend
 at maximum sustained CPU utilization.
+
+The default value is 12 seconds.
 
 `--watchdog_delay=60`
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -90,15 +90,13 @@ The level limits are as follows:
 Memory: default 200M, restrictive 100M
 CPU: default 10% (for 12 seconds), restrictive 5% (for 6 seconds)
 
-The normal level allows for 10 restarts if the limits are violated. The restrictive allows for only 4, then the service will be disabled. For both there is a linear backoff of 5 seconds, doubling each retry.
-
 It is better to set the level to disabled (`-1`) rather than disabling the watchdog outright, as the worker/watcher concept is used for extensions auto-loading too.
 
 The watchdog "profiles" can be overridden for Memory and CPU Utilization.
 
 `--watchdog_memory_limit=0`
 
-If this value is >0 then the watchdog level (`--watchdog_level`) for maximum memory is overridden. Use this if you would like to allow the `osqueryd` process to allocate more than 200M, but somewhere less than 1G. This memory limit is expressed as a value representing MB.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum memory is overridden. Use this if you would like to allow the `osqueryd` process to allocate more than 200M, but somewhere less than 10G. This memory limit is expressed as a value representing MB.
 
 `--watchdog_utilization_limit=0`
 
@@ -131,7 +129,7 @@ By default the watchdog monitors extensions for improper shutdown, but NOT for p
 
 `--table_delay=0`
 
-Add a microsecond delay between multiple table calls (when a table is used in a JOIN). A `200` microsecond delay will trade about 20% additional time for a reduced 5% CPU utilization.
+Add a millisecond delay between multiple table calls (when a table is used in a JOIN). A `200` millisecond delay will trade about 20% additional time for a reduced 5% CPU utilization.
 
 `--hash_cache_max=500`
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -100,9 +100,9 @@ If this value is >0 then the watchdog level (`--watchdog_level`) for maximum mem
 
 `--watchdog_utilization_limit=0`
 
-If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 10% of CPU for more than `--watchdog_latency_limit` seconds of wall time. The length of sustained utilization is configurable with `--watchdog_latency_limit`.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 10% of CPU for `--watchdog_latency_limit` seconds of wall time.
 
-This value sets a maximum number of allowed CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default value is is `10`, meaning 10% of CPU utilization allowed.
+This value sets a maximum number of allowed CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default value is `10`, meaning 10% of CPU utilization allowed.
 
 The CPU utilization limit is calculated the following way:
 ```text

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <gmock/gmock.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <osquery/config/config.h>
@@ -326,7 +327,7 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
 
   auto status = runner.isWatcherHealthy(*test_process, state);
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.getMessage(), "Memory limits exceeded");
+  EXPECT_THAT(status.getMessage(), ::testing::HasSubstr("Memory limits exceeded"));
 
   // Now emulate a rapid increase in CPU requirements.
   r["user_time"] = INTEGER(1024 * 1024 * 1024);

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <gmock/gmock.h>
 #include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <osquery/config/config.h>
@@ -327,7 +327,8 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
 
   auto status = runner.isWatcherHealthy(*test_process, state);
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.getMessage(), ::testing::HasSubstr("Memory limits exceeded"));
+  EXPECT_THAT(status.getMessage(),
+              ::testing::HasSubstr("Memory limits exceeded"));
 
   // Now emulate a rapid increase in CPU requirements.
   r["user_time"] = INTEGER(1024 * 1024 * 1024);

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -48,10 +48,20 @@ struct LimitDefinition {
 };
 
 struct PerformanceChange {
+  /// Number of consecutive times the CPU limit was exceeded.
   size_t sustained_latency{0};
+  /// Memory footprint.
   uint64_t footprint{0};
-  uint64_t iv{0};
+  /// Watcher check interval in seconds.
+  uint64_t check_interval{0};
+  /// Process ID of the parent process.
   pid_t parent{0};
+
+  /**
+   * @brief Returns the configured CPU utilization time limit accounting
+   * for the check interval time window.
+   */
+  UNSIGNED_BIGINT_LITERAL cpuUtilizationTimeLimit();
 };
 
 using WatchdogLimitMap = std::map<WatchdogLimitType, LimitDefinition>;
@@ -64,7 +74,7 @@ const WatchdogLimitMap kWatchdogLimits = {
     // Maximum MB worker can privately allocate.
     {WatchdogLimitType::MEMORY_LIMIT, {200, 100, 10000}},
 
-    // % of (User + System + Idle) CPU time worker can utilize
+    // % of (User + System) CPU time worker can utilize
     // for LATENCY_LIMIT seconds.
     {WatchdogLimitType::UTILIZATION_LIMIT, {10, 5, 100}},
 
@@ -128,7 +138,24 @@ CLI_FLAG(uint64,
 
 CLI_FLAG(bool, disable_watchdog, false, "Disable userland watchdog process");
 
+HIDDEN_FLAG(bool,
+            enable_watchdog_logging,
+            false,
+            "Enable logging of CPU and memory footprint of watched processes");
+
 DECLARE_uint64(alarm_timeout);
+
+UNSIGNED_BIGINT_LITERAL PerformanceChange::cpuUtilizationTimeLimit() {
+  auto percent_ul = getWorkerLimit(WatchdogLimitType::UTILIZATION_LIMIT);
+  percent_ul = (percent_ul > 100) ? 100 : percent_ul;
+
+  const UNSIGNED_BIGINT_LITERAL check_interval_milliseconds =
+      check_interval * 1000;
+  const UNSIGNED_BIGINT_LITERAL cpu_ul =
+      (percent_ul * check_interval_milliseconds * kNumOfCPUs) / 100;
+
+  return cpu_ul;
+}
 
 void Watcher::resetWorkerCounters(uint64_t respawn_time) {
   // Reset the monitoring counters for the watcher.
@@ -451,11 +478,13 @@ void WatcherRunner::warnWorkerResourceLimitHit(
   child.warnResourceLimitHit();
 }
 
-PerformanceChange getChange(const Row& r, PerformanceState& state) {
+PerformanceChange getChange(const int pid,
+                            const Row& r,
+                            PerformanceState& state) {
   PerformanceChange change;
 
-  // IV is the check interval in seconds, and utilization is set per-second.
-  change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
+  change.check_interval =
+      std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   long long user_time = 0, system_time = 0;
   try {
     change.parent =
@@ -472,13 +501,8 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   }
 
   // Check the difference of CPU time used since last check.
-  auto percent_ul = getWorkerLimit(WatchdogLimitType::UTILIZATION_LIMIT);
-  percent_ul = (percent_ul > 100) ? 100 : percent_ul;
 
-  UNSIGNED_BIGINT_LITERAL iv_milliseconds = change.iv * 1000;
-  UNSIGNED_BIGINT_LITERAL cpu_ul =
-      (percent_ul * iv_milliseconds * kNumOfCPUs) / 100;
-
+  const UNSIGNED_BIGINT_LITERAL cpu_ul = change.cpuUtilizationTimeLimit();
   auto user_time_diff = user_time - state.user_time;
   auto sys_time_diff = system_time - state.system_time;
   UNSIGNED_BIGINT_LITERAL cpu_utilization_time = user_time_diff + sys_time_diff;
@@ -509,6 +533,14 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
     change.footprint = change.footprint - state.initial_footprint;
   }
 
+  if (FLAGS_enable_watchdog_logging) {
+    VLOG(1) << "pid: " << pid << ", cpu: " << cpu_utilization_time << "ms/"
+            << cpu_ul << "ms"
+            << ", memory: " << std::fixed << std::setprecision(2)
+            << double(change.footprint) / (1024 * 1024) << "MB/"
+            << getWorkerLimit(WatchdogLimitType::MEMORY_LIMIT) << "MB";
+  }
+
   return change;
 }
 
@@ -526,21 +558,27 @@ static bool exceededCyclesLimit(const PerformanceChange& change) {
     return false;
   }
 
-  auto latency = change.sustained_latency * change.iv;
+  auto latency = change.sustained_latency * change.check_interval;
   return (latency >= getWorkerLimit(WatchdogLimitType::LATENCY_LIMIT));
 }
 
 Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
                                        PerformanceState& watcher_state) const {
-  auto rows = getProcessRow(watcher.pid());
+  const auto watcher_pid = watcher.pid();
+  auto rows = getProcessRow(watcher_pid);
   if (rows.size() == 0) {
     // Could not find worker process?
     return Status(1, "Cannot find watcher process");
   }
 
-  auto change = getChange(rows[0], watcher_state);
+  auto change = getChange(watcher_pid, rows[0], watcher_state);
   if (exceededMemoryLimit(change)) {
-    return Status(1, "Memory limits exceeded");
+    return Status(
+        1,
+        "Memory limits exceeded: " + std::to_string(change.footprint) +
+            " bytes (limit is " +
+            std::to_string(getWorkerLimit(WatchdogLimitType::MEMORY_LIMIT)) +
+            "MB)");
   }
 
   return Status(0);
@@ -574,7 +612,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
   PerformanceChange change;
   {
     auto& state = watcher_->getState(child);
-    change = getChange(rows[0], state);
+    change = getChange(child.pid(), rows[0], state);
   }
 
   // Only make a decision about the child sanity if it is still the watcher's
@@ -587,15 +625,23 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
   }
 
   if (exceededCyclesLimit(change)) {
-    return Status(1,
-                  "Maximum sustainable CPU utilization limit exceeded: " +
-                      std::to_string(change.sustained_latency * change.iv));
+    return Status(
+        1,
+        "Maximum sustainable CPU utilization limit " +
+            std::to_string(change.cpuUtilizationTimeLimit()) +
+            "ms exceeded for " +
+            std::to_string(change.sustained_latency * change.check_interval) +
+            " seconds");
   }
 
   // Check if the private memory exceeds a memory limit.
   if (exceededMemoryLimit(change)) {
     return Status(
-        1, "Memory limits exceeded: " + std::to_string(change.footprint));
+        1,
+        "Memory limits exceeded: " + std::to_string(change.footprint) +
+            " bytes (limit is " +
+            std::to_string(getWorkerLimit(WatchdogLimitType::MEMORY_LIMIT)) +
+            "MB)");
   }
 
   return Status(0);

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -138,10 +138,10 @@ CLI_FLAG(uint64,
 
 CLI_FLAG(bool, disable_watchdog, false, "Disable userland watchdog process");
 
-HIDDEN_FLAG(bool,
-            enable_watchdog_logging,
-            false,
-            "Enable logging of CPU and memory footprint of watched processes");
+CLI_FLAG(bool,
+         enable_watchdog_debug,
+         false,
+         "Enable logging of CPU and memory footprint of watched processes");
 
 DECLARE_uint64(alarm_timeout);
 
@@ -533,7 +533,7 @@ PerformanceChange getChange(const int pid,
     change.footprint = change.footprint - state.initial_footprint;
   }
 
-  if (FLAGS_enable_watchdog_logging) {
+  if (FLAGS_enable_watchdog_debug) {
     VLOG(1) << "pid: " << pid << ", cpu: " << cpu_utilization_time << "ms/"
             << cpu_ul << "ms"
             << ", memory: " << std::fixed << std::setprecision(2)

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -28,7 +28,7 @@ FLAG(bool, enable_foreign, false, "Enable no-op foreign virtual tables");
 FLAG(uint64,
      table_delay,
      0,
-     "Add an optional microsecond delay between table scans");
+     "Add an optional millisecond delay between table scans");
 
 FLAG(bool,
      extensions_default_index,


### PR DESCRIPTION
See #8069.

With the changes in this PR, the following is logged every check interval (3s) for every process being watched:
```
[...]
I0623 17:54:02.500684 81305600 watcher.cpp:537] pid: 93084, cpu: 97ms/1200ms, memory: 0.00MB/200MB
I0623 17:54:02.500970 81305600 watcher.cpp:537] pid: 93083, cpu: 0ms/1200ms, memory: 0.03MB/200MB
I0623 17:54:05.503715 81305600 watcher.cpp:537] pid: 93084, cpu: 1ms/1200ms, memory: 0.02MB/200MB
I0623 17:54:05.504016 81305600 watcher.cpp:537] pid: 93083, cpu: 2ms/1200ms, memory: 0.04MB/200MB
[...]
```

---

The following is a log from `master` when the CPU limit is exceeded:
```
2668:W0623 15:27:06.032490 221732864 watcher.cpp:415] osqueryd worker (72457) stopping:
Maximum sustainable CPU utilization limit: 12
```
The following is a log with this PR when the CPU limit is exceeded:
```
2668:W0623 15:27:06.032490 221732864 watcher.cpp:415] osqueryd worker (72457) stopping:
Maximum sustainable CPU utilization limit 1200ms exceeded for 12 seconds
```

The following is a log from `master` when the memory footprint limit is exceeded:
```
18277:W0623 16:21:05.841567 221732864 watcher.cpp:415] osqueryd worker (73620) stopping:
Memory limits exceeded: 212180992
```
The following is a log with this PR when the memory footprint limit is exceeded:
```
18277:W0623 16:21:05.841567 221732864 watcher.cpp:415] osqueryd worker (73620) stopping:
Memory limits exceeded: 212180992 bytes (limit is 200MB)
```