### PR TITLE
aws: Add an option to enforce FIPS endpoints

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -645,3 +645,9 @@ Base seconds to wait between attempts at requesting an IMDSv2 token. Scales quad
 `--aws_disable_imdsv1_fallback=false`
 
 Whether to disable support for IMDSv1 and fail if an IMDSv2 token could not be retrieved
+
+`--aws_enforce_fips`
+
+Enforces that only FIPS endpoints can be used for the logger plugins (Kinesis, Firehose), the STS authentication and the EC2 tables.  
+Using a non compliant region for the logger plugins will cause osquery to fail to start; for other non compliant cases the specific service will fail to work.  
+In all non compliant cases, an error or warning message will be printed. In verbose mode an additional message will show if a certain service has FIPS enforced.

--- a/osquery/tables/cloud/aws/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/aws/ec2_instance_tags.cpp
@@ -43,7 +43,7 @@ QueryData genEc2InstanceTags(QueryContext& context) {
   std::shared_ptr<ec2::EC2Client> client;
   Status s = makeAWSClient<ec2::EC2Client>(client, region, false);
   if (!s.ok()) {
-    VLOG(1) << "Failed to create EC2 client: " << s.what();
+    LOG(WARNING) << "Failed to create EC2 client: " << s.what();
     return results;
   }
 

--- a/osquery/utils/aws/CMakeLists.txt
+++ b/osquery/utils/aws/CMakeLists.txt
@@ -26,6 +26,9 @@ function(generateOsqueryUtilsAws)
     osquery_utils_json
     osquery_utils_status
     thirdparty_aws-cpp-sdk-sts
+    thirdparty_aws-cpp-sdk-ec2
+    thirdparty_aws-cpp-sdk-kinesis
+    thirdparty_aws-cpp-sdk-firehose
   )
 
   set(public_header_files

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -139,6 +139,8 @@ static const std::set<std::string> kAwsRegions = {
     "us-east-2",      "us-gov-east-1", "us-gov-west-1",  "us-west-1",
     "us-west-2"};
 
+/// Map of AWS region names that support FIPS,
+/// taken from https://aws.amazon.com/compliance/fips/
 static const std::set<std::string> kAwsFipsRegions = {"us-east-1",
                                                       "us-east-2",
                                                       "us-gov-east-1",
@@ -707,7 +709,7 @@ void setAWSProxy(Aws::Client::ClientConfiguration& config) {
 void enableFIPSInClientConfig(const std::string& service,
                               Aws::Client::ClientConfiguration& config) {
   // Gov FIPS endpoints for Kinesis, EC2, STS are used as-is, do nothing
-  if (config.region.rfind("us-gov") == 0 &&
+  if (config.region.rfind("us-gov", 0) == 0 &&
       (service == "kinesis" || service == "ec2" || service == "sts")) {
     return;
   }


### PR DESCRIPTION
Add the "aws_enforce_fips" to force that all current services using AWS (Kinesis, Firehose, EC2, STS),
must use FIPS endpoints, or fail to.