### PR TITLE
Always lock event_index_mutex when accessing event_index map

### DIFF
--- a/osquery/events/eventsubscriberplugin.h
+++ b/osquery/events/eventsubscriberplugin.h
@@ -224,6 +224,12 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
                                  std::size_t events_expiry,
                                  std::size_t current_time);
 
+  struct GenerateRowsResult {
+    bool isEnd;
+    EventTime last_time;
+    EventID last_id;
+  };
+
   /**
    * @brief Return all events added by this EventSubscriber within start, stop.
    *
@@ -237,12 +243,12 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * @param last_eid (optional) The last visited event id.
    * @return The upper bound time or 0 if there were no events in the range.
    */
-  static EventIndex::iterator generateRows(Context& context,
-                                           IDatabaseInterface& db_interface,
-                                           std::function<void(Row)> callback,
-                                           EventTime start_time,
-                                           EventTime end_time,
-                                           EventID last_eid = 0);
+  static GenerateRowsResult generateRows(Context& context,
+                                         IDatabaseInterface& db_interface,
+                                         std::function<void(Row)> callback,
+                                         EventTime start_time,
+                                         EventTime end_time,
+                                         EventID last_eid = 0);
 
   explicit EventSubscriberPlugin(EventSubscriberPlugin const&) = delete;
   EventSubscriberPlugin& operator=(EventSubscriberPlugin const&) = delete;

--- a/osquery/events/tests/eventsubscriberplugin.cpp
+++ b/osquery/events/tests/eventsubscriberplugin.cpp
@@ -210,31 +210,33 @@ TEST_F(EventSubscriberPluginTests, generateRows) {
   std::size_t callback_count{0U};
   auto callback = [&callback_count](Row) { ++callback_count; };
 
-  EventIndex::iterator last;
-  last = EventSubscriberPlugin::generateRows(
+  auto result = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 2, 1);
   EXPECT_EQ(callback_count, 0U);
-  EXPECT_EQ(last, context.event_index.end());
+  EXPECT_EQ(result.isEnd, true);
 
-  last = EventSubscriberPlugin::generateRows(
+  result = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 0, 0);
   EXPECT_EQ(callback_count, 10U);
-  EXPECT_EQ(last->first, 9U);
+  EXPECT_EQ(result.isEnd, false);
+  EXPECT_EQ(result.last_time, 9U);
 
-  last = EventSubscriberPlugin::generateRows(
+  result = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 0, 4);
   EXPECT_EQ(callback_count, 15U);
-  EXPECT_EQ(last->first, 4U);
+  EXPECT_EQ(result.isEnd, false);
+  EXPECT_EQ(result.last_time, 4U);
 
-  last = EventSubscriberPlugin::generateRows(
+  result = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 5, 9);
   EXPECT_EQ(callback_count, 20U);
-  EXPECT_EQ(last->first, 9U);
+  EXPECT_EQ(result.isEnd, false);
+  EXPECT_EQ(result.last_time, 9U);
 
-  last = EventSubscriberPlugin::generateRows(
+  result = EventSubscriberPlugin::generateRows(
       context, mocked_database, callback, 10, 15);
   EXPECT_EQ(callback_count, 20U);
-  EXPECT_EQ(last, context.event_index.end());
+  EXPECT_EQ(result.isEnd, true);
 }
 
 class FakeEventSubscriberPlugin : public EventSubscriberPlugin {


### PR DESCRIPTION
Concurrent iteration and modification can cause crashes so ensure proper locking for all operations with event_index. 
#8076 

To reduce scope of locking EventSubscriberPlugin::generateRows() was slightly refactored to separate index operations from DB access.