### PR TITLE
test: Fix leaks in inotify and rocksdb tests

### DIFF
--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -550,5 +550,7 @@ TEST_F(INotifyTests, test_inotify_embedded_wildcards) {
   // Assume there is one watched path: real_test_dir.
   ASSERT_EQ(event_pub_->numDescriptors(), 1U);
   EXPECT_EQ(event_pub_->path_descriptors_.count(real_test_dir + "/2/1/"), 1U);
+
+  EventFactory::deregisterEventPublisher("inotify");
 }
-}
+} // namespace osquery

--- a/plugins/database/tests/rocksdb.cpp
+++ b/plugins/database/tests/rocksdb.cpp
@@ -85,6 +85,7 @@ TEST_F(RocksDBDatabasePluginTests, test_column_families_rollback) {
   rocksdb::ColumnFamilyHandle* cf = nullptr;
   auto rs = db.db_->CreateColumnFamily(db.options_, "foo", &cf);
   ASSERT_TRUE(rs.ok()) << rs.ToString();
+  db.db_->DestroyColumnFamilyHandle(cf);
   db.tearDown();
 
   // Open the existing database that has unknown column family "foo".


### PR DESCRIPTION
inotify:
```
62: =================================================================
62: ==440195==ERROR: LeakSanitizer: detected memory leaks
62: 
62: Direct leak of 139264 byte(s) in 1 object(s) allocated from:
62:     #0 0x55efb459af1d in malloc /opt/osquery-toolchain/llvm/compiler-rt/lib/asan/asan_malloc_linux.cc:145:3
62:     #1 0x55efb46bfccd in osquery::INotifyEventPublisher::setUp() /home/smjert/Development/osquery/src/osquery/events/linux/inotify.cpp:70:21
62:     #2 0x55efb4758727 in osquery::EventFactory::registerEventPublisher(std::__1::shared_ptr<osquery::Plugin> const&) /home/smjert/Development/osquery/src/osquery/events/eventfactory.cpp:152:29
62:     #3 0x55efb497bb0d in osquery::INotifyTests_test_inotify_embedded_wildcards_Test::TestBody() /home/smjert/Development/osquery/src/osquery/events/tests/linux/inotify_tests.cpp:531:3
62:     #4 0x55efb776a55c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58a755c)
62:     #5 0x55efb776a385 in testing::Test::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58a7385)
62:     #6 0x55efb776be6f in testing::TestInfo::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58a8e6f)
62:     #7 0x55efb776da6a in testing::TestSuite::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58aaa6a)
62:     #8 0x55efb7785c23 in testing::internal::UnitTestImpl::RunAllTests() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58c2c23)
62:     #9 0x55efb7785318 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58c2318)
62:     #10 0x55efb778501f in testing::UnitTest::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x58c201f)
62:     #11 0x55efb775115b in RUN_ALL_TESTS() (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x588e15b)
62:     #12 0x55efb77510cd in main (/home/smjert/Development/osquery/build/relwithdebinfo/osquery/events/tests/osquery_events_tests_linuxtests-test+0x588e0cd)
62:     #13 0x7f4d34d7f082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
62: 
62: SUMMARY: AddressSanitizer: 139264 byte(s) leaked in 1 allocation(s).
```

RocksDB:
```
74: =================================================================
74: ==445095==ERROR: LeakSanitizer: detected memory leaks
74: 
74: Direct leak of 32 byte(s) in 1 object(s) allocated from:
74:     #0 0x55b45390867d in operator new(unsigned long) /opt/osquery-toolchain/llvm/compiler-rt/lib/asan/asan_new_delete.cc:99:3
74:     #1 0x55b453d85c4e in rocksdb::DBImpl::CreateColumnFamilyImpl(rocksdb::ColumnFamilyOptions const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, rocksdb::ColumnFamilyHandle**) (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x2df8c4e)
74:     #2 0x55b453d84a5b in rocksdb::DBImpl::CreateColumnFamily(rocksdb::ColumnFamilyOptions const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, rocksdb::ColumnFamilyHandle**) (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x2df7a5b)
74:     #3 0x55b453c885a5 in osquery::RocksDBDatabasePluginTests_test_column_families_rollback_Test::TestBody() /home/smjert/Development/osquery/src/plugins/database/tests/rocksdb.cpp:86:21
74:     #4 0x55b45719ba8e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x620ea8e)
74:     #5 0x55b45719b8b7 in testing::Test::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x620e8b7)
74:     #6 0x55b45719d3a1 in testing::TestInfo::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x62103a1)
74:     #7 0x55b45719ef9c in testing::TestSuite::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x6211f9c)
74:     #8 0x55b4571b7155 in testing::internal::UnitTestImpl::RunAllTests() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x622a155)
74:     #9 0x55b4571b684a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x622984a)
74:     #10 0x55b4571b6551 in testing::UnitTest::Run() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x6229551)
74:     #11 0x55b45718299b in RUN_ALL_TESTS() (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x61f599b)
74:     #12 0x55b45718290d in main (/home/smjert/Development/osquery/build/relwithdebinfo/plugins/database/tests/plugins_database_tests_rocksdbtests-test+0x61f590d)
74:     #13 0x7f8e7cf1d082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
74: 
74: SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
```