### PR TITLE
cleanup: Remove forensicReadFile

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -269,9 +269,6 @@ class PlatformFile : private boost::noncopyable {
   /// Return the modified, created, birth, updated, etc times.
   bool getFileTimes(PlatformTime& times);
 
-  /// Change the file times.
-  bool setFileTimes(const PlatformTime& times);
-
   /// Read a number of bytes into a buffer.
   ssize_t read(void* buf, size_t nbyte);
 

--- a/osquery/filesystem/filesystem.h
+++ b/osquery/filesystem/filesystem.h
@@ -63,15 +63,8 @@ Status readFile(const boost::filesystem::path& path,
                 std::string& content,
                 size_t size = 0,
                 bool dry_run = false,
-                bool preserve_time = false,
                 bool blocking = false,
                 bool log = true);
-
-/// Read a file and preserve the atime and mtime.
-Status forensicReadFile(const boost::filesystem::path& path,
-                        std::string& content,
-                        bool blocking = false,
-                        bool log = true);
 
 /**
  * @brief Return the status of an attempted file read.
@@ -89,7 +82,6 @@ Status readFile(const boost::filesystem::path& path,
                 size_t size,
                 size_t block_size,
                 bool dry_run,
-                bool preserve_time,
                 std::function<void(std::string& buffer, size_t size)> predicate,
                 bool blocking = false,
                 bool log = true);
@@ -376,7 +368,8 @@ Status readRawMem(size_t base, size_t length, void** buffer);
  * Given a set of paths we bundle these into a tar archive.
  */
 Status archive(const std::set<boost::filesystem::path>& path,
-               const boost::filesystem::path& out, std::size_t block_size = 8192);
+               const boost::filesystem::path& out,
+               std::size_t block_size = 8192);
 
 /*
  * @brief Given a path, compress it with zstd and save to out.

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -191,14 +191,6 @@ bool PlatformFile::getFileTimes(PlatformTime& times) {
   return true;
 }
 
-bool PlatformFile::setFileTimes(const PlatformTime& times) {
-  if (!isValid()) {
-    return false;
-  }
-
-  return (::futimes(handle_, times.times) == 0);
-}
-
 ssize_t PlatformFile::read(void* buf, size_t nbyte) {
   if (!isValid()) {
     return -1;

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1076,15 +1076,6 @@ bool PlatformFile::getFileTimes(PlatformTime& times) {
           FALSE);
 }
 
-bool PlatformFile::setFileTimes(const PlatformTime& times) {
-  if (!isValid()) {
-    return false;
-  }
-
-  return (::SetFileTime(handle_, nullptr, &times.times[0], &times.times[1]) !=
-          FALSE);
-}
-
 ssize_t PlatformFile::getOverlappedResultForRead(void* buf,
                                                  size_t requested_size) {
   ssize_t nret = 0;

--- a/osquery/hashing/hashing.cpp
+++ b/osquery/hashing/hashing.cpp
@@ -114,7 +114,6 @@ MultiHashes hashMultiFromFile(int mask, const std::string& path) {
                     0,
                     kHashChunkSize,
                     false,
-                    true,
                     ([&hashes, &mask](std::string& buffer, size_t size) {
                       for (auto& hash : hashes) {
                         if (mask & hash.first) {

--- a/osquery/tables/applications/posix/carbon_black.cpp
+++ b/osquery/tables/applications/posix/carbon_black.cpp
@@ -33,7 +33,7 @@ namespace tables {
 // Get the Carbon Black sensor ID
 void getSensorId(Row& r) {
   std::string file_contents;
-  if (!forensicReadFile(kCbSensorIdFile, file_contents).ok()) {
+  if (!readFile(kCbSensorIdFile, file_contents).ok()) {
     return;
   }
   // check to make sure we have sane data
@@ -133,5 +133,5 @@ QueryData genCarbonBlackInfo(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -66,7 +66,7 @@ QueryData genEtcHostsImpl(QueryContext& context, Logger& logger) {
   std::string content;
   QueryData qres = {};
 
-  auto s = readFile(kEtcHosts, content, 0, false, false, false, false);
+  auto s = readFile(kEtcHosts, content, 0, false, false, false);
   if (s.ok()) {
     qres = parseEtcHostsContent(content);
   } else {
@@ -93,5 +93,5 @@ QueryData genEtcHosts(QueryContext& context) {
     return genEtcHostsImpl(context, logger);
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -232,7 +232,7 @@ void genBOMPaths(const std::string& path,
 void genPackageBOM(const std::string& path, QueryData& results) {
   std::string content;
   // Read entire BOM file.
-  if (!forensicReadFile(path, content).ok()) {
+  if (!readFile(path, content).ok()) {
     return;
   }
 

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -143,7 +143,7 @@ void genAptUrl(const std::string& source,
   }
 
   std::string content;
-  auto s = readFile(cache_files[0], content, 0, false, false, false, false);
+  auto s = readFile(cache_files[0], content, 0, false, false, false);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return;
@@ -183,7 +183,7 @@ static void genAptSource(const std::string& source,
                          Logger& logger) {
   std::string content;
 
-  auto s = readFile(source, content, 0, false, false, false, false);
+  auto s = readFile(source, content, 0, false, false, false);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return;

--- a/osquery/tables/system/linux/memory_info.cpp
+++ b/osquery/tables/system/linux/memory_info.cpp
@@ -40,7 +40,7 @@ QueryData getMemoryInfo(QueryContext& context) {
   Row r;
 
   std::string meminfo_content;
-  if (forensicReadFile(kMemInfoPath, meminfo_content).ok()) {
+  if (readFile(kMemInfoPath, meminfo_content).ok()) {
     // Able to read meminfo file, now grab info we want
     for (const auto& line : split(meminfo_content, "\n")) {
       std::vector<std::string> tokens;
@@ -61,5 +61,5 @@ QueryData getMemoryInfo(QueryContext& context) {
   results.push_back(r);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -101,7 +101,7 @@ void genSSHkeysForUser(const std::string& uid,
       continue;
     }
 
-    auto s = forensicReadFile(keys_file, keys_content, false, false);
+    auto s = readFile(keys_file, keys_content, false, false, false);
     if (!s.ok()) {
       // Cannot read a specific keys file.
       logger.log(google::GLOG_ERROR, s.getMessage());
@@ -180,5 +180,5 @@ QueryData getAuthorizedKeys(QueryContext& context) {
     return getAuthorizedKeysImpl(context, logger);
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/crontab.cpp
+++ b/osquery/tables/system/posix/crontab.cpp
@@ -38,7 +38,7 @@ std::vector<std::string> cronFromFile(const std::string& path, Logger& logger) {
     return cron_lines;
   }
 
-  auto s = forensicReadFile(path, content, false, false);
+  auto s = readFile(path, content, false, false, false);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return cron_lines;
@@ -131,5 +131,5 @@ QueryData genCronTab(QueryContext& context) {
     return genCronTabImpl(context, logger);
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/known_hosts.cpp
+++ b/osquery/tables/system/posix/known_hosts.cpp
@@ -35,7 +35,7 @@ void genSSHkeysForHosts(const std::string& uid,
     keys_file /= kfile;
 
     std::string keys_content;
-    if (!forensicReadFile(keys_file, keys_content).ok()) {
+    if (!readFile(keys_file, keys_content).ok()) {
       // Cannot read a specific keys file.
       continue;
     }
@@ -68,5 +68,5 @@ QueryData getKnownHostsKeys(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/shell_history.cpp
+++ b/osquery/tables/system/posix/shell_history.cpp
@@ -100,7 +100,7 @@ void genShellHistoryFromFile(
     }
   };
 
-  if (!readFile(history_file, 0, 4096, false, false, parseChunk, false)) {
+  if (!readFile(history_file, 0, 4096, false, parseChunk, false)) {
     return;
   }
 

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -45,7 +45,7 @@ void genSudoersFile(const std::string& filename,
 
   bool is_long_line = false;
   std::string contents;
-  if (!forensicReadFile(filename, contents).ok()) {
+  if (!readFile(filename, contents).ok()) {
     TLOG << "couldn't read sudoers file: " << filename;
     return;
   }

--- a/osquery/tables/system/ssh_configs.cpp
+++ b/osquery/tables/system/ssh_configs.cpp
@@ -37,7 +37,7 @@ void genSshConfig(const std::string& uid,
                   const fs::path& filepath,
                   QueryData& results) {
   std::string ssh_config_content;
-  if (!forensicReadFile(filepath, ssh_config_content).ok()) {
+  if (!readFile(filepath, ssh_config_content).ok()) {
     VLOG(1) << "Cannot read ssh_config file " << filepath;
     return;
   }

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -146,7 +146,7 @@ void genSSHkeyForHosts(const std::string& uid,
   // Go through each file
   for (const auto& kfile : files_list) {
     std::string keys_content;
-    auto s = forensicReadFile(kfile, keys_content, false, false);
+    auto s = readFile(kfile, keys_content, false, false, false);
     if (!s.ok()) {
       // Cannot read a specific keys file.
       logger.log(google::GLOG_WARNING, s.getMessage());


### PR DESCRIPTION
The function doesn't do much especially due to relatime or noatime on Linux.
Furthermore even if it did something, it tampers with times and does not prevent an application to read the updated atime.
