### PR TITLE
Added cloud_id to ycloud_instance_metadata - the vm metadata table for Yandex Cloud

### DIFF
--- a/osquery/tables/cloud/ycloud/ycloud_instance_metadata.cpp
+++ b/osquery/tables/cloud/ycloud/ycloud_instance_metadata.cpp
@@ -50,11 +50,10 @@ QueryData genYCloudMetadata(QueryContext& context) {
       continue;
     }
 
-    auto [folderId, zone] =
-        getFolderIdAndZoneFromZoneField(getYCloudKey(doc, "zone"));
     r["instance_id"] = getYCloudKey(doc, "id");
-    r["folder_id"] = folderId;
-    r["zone"] = zone;
+    r["folder_id"] = getVendorKey(doc, "folderId");
+    r["cloud_id"] = getVendorKey(doc, "cloudId");
+    r["zone"] = getZoneId(getYCloudKey(doc, "zone"));
     r["name"] = getYCloudKey(doc, "name");
     r["description"] = getYCloudKey(doc, "description");
     r["hostname"] = getYCloudKey(doc, "hostname");

--- a/osquery/utils/ycloud/tests/ycloud.cpp
+++ b/osquery/utils/ycloud/tests/ycloud.cpp
@@ -17,15 +17,13 @@ class YCloudUtilsTests : public testing::Test {};
 
 TEST_F(YCloudUtilsTests, pass) {
   const std::string zone = "projects/b1g1slgali4fssudpn26/zones/ru-central1-a";
-  auto [folder_id, zone_id] = getFolderIdAndZoneFromZoneField(zone);
-  EXPECT_EQ(folder_id, "b1g1slgali4fssudpn26");
+  std::string zone_id = getZoneId(zone);
   EXPECT_EQ(zone_id, "ru-central1-a");
 }
 
 TEST_F(YCloudUtilsTests, fail) {
   const std::string zone = "projects/b1g1slgali4fssudpn26/zones-ru-central1-a";
-  auto [folder_id, zone_id] = getFolderIdAndZoneFromZoneField(zone);
-  EXPECT_EQ(folder_id, "");
+  std::string zone_id = getZoneId(zone);
   EXPECT_EQ(zone_id, "");
 }
 

--- a/osquery/utils/ycloud/ycloud_util.cpp
+++ b/osquery/utils/ycloud/ycloud_util.cpp
@@ -24,18 +24,18 @@ namespace osquery {
 const std::string kYCloudMetadataPathAndQuery =
     "/computeMetadata/v1/instance/?alt=json&recursive=true";
 const std::string kAttributes = "attributes";
+const std::string kVendor = "vendor";
 const int kYCloudMetadataTimeout = 3;
 
-std::tuple<std::string, std::string> getFolderIdAndZoneFromZoneField(
-    const std::string& zone) {
+std::string getZoneId(const std::string& zone) {
   if (boost::algorithm::starts_with(zone, "projects/")) {
     auto s = osquery::split(zone, "/");
     if (s.size() >= 4) {
-      return {s[1], s[3]};
+      return s[3];
     }
   }
 
-  return {"", ""};
+  return "";
 }
 
 std::string getSerialPortEnabled(JSON& doc) {
@@ -58,6 +58,26 @@ std::string getSerialPortEnabled(JSON& doc) {
   }
 
   return doc.doc()[kAttributes][kSerialPortFlag].GetString();
+}
+
+std::string getVendorKey(JSON& doc, const std::string& key) {
+  if (!doc.doc().HasMember(kVendor)) {
+    return "";
+  }
+
+  if (!doc.doc()[kVendor].IsObject()) {
+    return "";
+  }
+
+  if (!doc.doc()[kVendor].HasMember(key)) {
+    return "";
+  }
+
+  if (!doc.doc()[kVendor][key].IsString()) {
+    return "";
+  }
+
+  return doc.doc()[kVendor][key].GetString();
 }
 
 std::string getYCloudSshKey(JSON& doc) {

--- a/osquery/utils/ycloud/ycloud_util.h
+++ b/osquery/utils/ycloud/ycloud_util.h
@@ -14,9 +14,9 @@
 
 namespace osquery {
 std::string getYCloudKey(JSON& doc, const std::string& key);
+std::string getVendorKey(JSON& doc, const std::string& key);
 std::string getYCloudSshKey(JSON& doc);
 std::string getSerialPortEnabled(JSON& doc);
-std::tuple<std::string, std::string> getFolderIdAndZoneFromZoneField(
-    const std::string& zone);
+std::string getZoneId(const std::string& zone);
 Status fetchYCloudMetadata(JSON& doc, const std::string& endpoint);
 } // namespace osquery

--- a/specs/ycloud_instance_metadata.table
+++ b/specs/ycloud_instance_metadata.table
@@ -3,6 +3,7 @@ description("Yandex.Cloud instance metadata.")
 schema([
     Column("instance_id", TEXT, "Unique identifier for the VM", index=True),
     Column("folder_id", TEXT, "Folder identifier for the VM"),
+    Column("cloud_id", TEXT, "Cloud identifier for the VM"),
     Column("name", TEXT, "Name of the VM"),
     Column("description", TEXT, "Description of the VM"),
     Column("hostname", TEXT, "Hostname of the VM"),


### PR DESCRIPTION
Added `cloud_id` column for `ycloud_instance_metadata` table. 

`cloud_id` is a container for resources in Yandex Cloud which is similar to a "project" in Google Cloud Platform. This change will allow people that use osquery in Yandex Cloud to get more information about the resource path of their virtual machines. 
