### PR TITLE
firefox_addons: Use rapidjson to parse and don't block on read

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -621,25 +621,4 @@ std::string lsperms(int mode) {
   bits += rwx[(mode >> 0) & 7];
   return bits;
 }
-
-Status parseJSON(const fs::path& path, pt::ptree& tree) {
-  try {
-    pt::read_json(path.string(), tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    return Status(1, "Could not parse JSON from file");
-  }
-  return Status::success();
-}
-
-Status parseJSONContent(const std::string& content, pt::ptree& tree) {
-  // Read the extensions data into a JSON blob, then property tree.
-  try {
-    std::stringstream json_stream;
-    json_stream << content;
-    pt::read_json(json_stream, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    return Status(1, "Could not parse JSON from file");
-  }
-  return Status::success();
-}
 } // namespace osquery

--- a/osquery/filesystem/filesystem.h
+++ b/osquery/filesystem/filesystem.h
@@ -299,17 +299,6 @@ std::string lsperms(int mode);
 Status parseJSON(const boost::filesystem::path& path,
                  boost::property_tree::ptree& tree);
 
-/**
- * @brief Parse JSON content into a property tree.
- *
- * @param content JSON string data.
- * @param tree output property tree.
- *
- * @return an instance of Status, indicating success or failure if malformed.
- */
-Status parseJSONContent(const std::string& content,
-                        boost::property_tree::ptree& tree);
-
 #ifdef __linux__
 /**
  * @brief Iterate over `/proc` process, returns a list of pids.
@@ -376,7 +365,8 @@ Status readRawMem(size_t base, size_t length, void** buffer);
  * Given a set of paths we bundle these into a tar archive.
  */
 Status archive(const std::set<boost::filesystem::path>& path,
-               const boost::filesystem::path& out, std::size_t block_size = 8192);
+               const boost::filesystem::path& out,
+               std::size_t block_size = 8192);
 
 /*
  * @brief Given a path, compress it with zstd and save to out.

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -141,7 +141,7 @@ void genFirefoxAddonsFromExtensions(const std::string& uid,
         continue;
       }
 
-      r[it.second] = TEXT(*value);
+      r[it.second] = SQL_TEXT(*value);
     }
 
     // There are several ways to disabled the addon, check each.

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -13,6 +13,7 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
 
 namespace fs = boost::filesystem;
@@ -23,16 +24,6 @@ namespace osquery {
 namespace tables {
 
 namespace {
-
-/// A helper check to rename bool-type values as 1 or 0.
-inline void jsonBoolAsInt(std::string& s) {
-  auto expected = tryTo<bool>(s);
-  if (expected.isValue()) {
-    s = expected.get() ? "1" : "0";
-  }
-}
-
-} // namespace
 
 /// Each home directory will include custom extensions.
 #if defined(__APPLE__)
@@ -64,30 +55,99 @@ const std::map<std::string, std::string> kFirefoxAddonKeys = {
     {"path", "path"},
 };
 
+bool isMemberTrue(const char* member_name, const rapidjson::Value& from) {
+  auto member = from.FindMember(member_name);
+
+  return member != from.MemberEnd() ? JSON::valueToBool(member->value) : false;
+}
+
+rapidjson::Value::ConstMemberIterator findNestedMember(
+    const std::string& member_name, const rapidjson::Value& value) {
+  auto child_members = osquery::split(member_name, ".");
+
+  rapidjson::Value::ConstMemberIterator member_it;
+  const rapidjson::Value* current_value = &value;
+  for (const auto& child_member : child_members) {
+    member_it = current_value->FindMember(child_member);
+
+    if (member_it == current_value->MemberEnd()) {
+      return member_it;
+    }
+
+    current_value = &member_it->value;
+  }
+
+  return member_it;
+}
+} // namespace
+
 void genFirefoxAddonsFromExtensions(const std::string& uid,
                                     const std::string& path,
                                     QueryData& results) {
-  pt::ptree tree;
-  if (!osquery::parseJSON(path + kFirefoxExtensionsFile, tree).ok()) {
-    TLOG << "Could not parse JSON from: " << path + kFirefoxExtensionsFile;
+  JSON extensions;
+  Status status;
+  std::string extensions_path = path + kFirefoxExtensionsFile;
+  {
+    std::string content;
+
+    status = readFile(extensions_path, content);
+    if (!status.ok()) {
+      TLOG << "Failed to read the extensions file at: " << extensions_path
+           << ", error: " << status.getMessage();
+      return;
+    }
+
+    status = extensions.fromString(content);
+
+    if (!status.ok()) {
+      TLOG << "Failed to parse to JSON the extensions file at: "
+           << extensions_path << ", error: " << status.getMessage();
+      return;
+    }
+  }
+
+  const auto addons_it = extensions.doc().FindMember("addons");
+
+  if (addons_it == extensions.doc().MemberEnd()) {
+    TLOG << "Failed to parse the JSON extensions file at: " << extensions_path
+         << ", could not find the 'addons' JSON member";
     return;
   }
 
-  for (const auto& addon : tree.get_child("addons")) {
+  const auto& addons = addons_it->value;
+
+  if (!addons.IsArray()) {
+    TLOG << "Unrecognized format for the 'addons' member in the extensions "
+            "file at: "
+         << extensions_path << ", it's not an array";
+  }
+
+  for (const auto& addon : addons.GetArray()) {
     Row r;
     r["uid"] = uid;
     // Most of the keys are in the top-level JSON dictionary.
     for (const auto& it : kFirefoxAddonKeys) {
-      r[it.second] = addon.second.get(it.first, "");
+      const auto member_it = findNestedMember(it.first, addon);
 
-      // Convert bool-types to an integer.
-      jsonBoolAsInt(r[it.second]);
+      if (member_it == addon.MemberEnd()) {
+        continue;
+      }
+
+      const auto value = JSON::valueToString(member_it->value);
+      if (!value.has_value()) {
+        TLOG << "Failed to convert member '" << member_it->name.GetString()
+             << "' to a string, in JSON extensions file at: "
+             << extensions_path;
+        continue;
+      }
+
+      r[it.second] = TEXT(*value);
     }
 
     // There are several ways to disabled the addon, check each.
-    if (addon.second.get("softDisable", "false") == "true" ||
-        addon.second.get("appDisabled", "false") == "true" ||
-        addon.second.get("userDisabled", "false") == "true") {
+    if (isMemberTrue("softDisable", addon) ||
+        isMemberTrue("appDisabled", addon) ||
+        isMemberTrue("userDisabled", addon)) {
       r["disabled"] = INTEGER(1);
     } else {
       r["disabled"] = INTEGER(0);

--- a/osquery/utils/json/json.cpp
+++ b/osquery/utils/json/json.cpp
@@ -391,4 +391,42 @@ bool JSON::valueToBool(const rj::Value& value) {
   return false;
 }
 
+boost::optional<std::string> JSON::valueToString(const rj::Value& value) {
+  switch (value.GetType()) {
+  case rapidjson::Type::kFalseType: {
+    return std::string{"0"};
+  }
+  case rapidjson::Type::kTrueType: {
+    return std::string{"1"};
+  }
+  case rapidjson::Type::kNumberType: {
+    if (value.IsInt()) {
+      return std::to_string(value.GetInt());
+    } else if (value.IsInt64()) {
+      return std::to_string(value.GetInt64());
+    } else if (value.IsUint()) {
+      return std::to_string(value.GetUint());
+    } else if (value.IsUint64()) {
+      return std::to_string(value.GetUint64());
+    } else if (value.IsDouble()) {
+      return std::to_string(value.GetDouble());
+    }
+    break;
+  }
+  case rapidjson::Type::kStringType: {
+    return std::string{value.GetString()};
+  }
+  case rapidjson::Type::kNullType: {
+    return std::string{"null"};
+  }
+  case rapidjson::Type::kObjectType:
+  case rapidjson::Type::kArrayType: {
+    // These are not supported, use a Writer instead.
+    break;
+  }
+  }
+
+  return boost::none;
+}
+
 } // namespace osquery

--- a/osquery/utils/json/json.h
+++ b/osquery/utils/json/json.h
@@ -11,6 +11,8 @@
 
 #include <cstddef>
 
+#include <boost/optional.hpp>
+
 #include <osquery/utils/only_movable.h>
 #include <osquery/utils/status/status.h>
 #include <osquery/utils/system/system.h>
@@ -373,6 +375,15 @@ class JSON : private only_movable {
 
   /// Get the value as a 'bool' or false.
   static bool valueToBool(const rapidjson::Value& value);
+
+  /// @brief Convert a single, non-object, non-array value to a string
+  /// Booleans are converted to "0" or "1",
+  /// null values are converted to the "null" string
+  /// @param value The value to convert
+  /// @return The value in string form or boost::none
+  /// if it's an unsupported value type
+  static boost::optional<std::string> valueToString(
+      const rapidjson::Value& value);
 
  private:
   rapidjson::Document doc_;


### PR DESCRIPTION
- Remove usages of boost::ptree to parse JSON, use rapidjson instead
- Don't block when attempting to read a file
