### PR TITLE
cleanup: Substitute the TEXT macro with SQL_TEXT in table code

### DIFF
--- a/osquery/core/tables.h
+++ b/osquery/core/tables.h
@@ -95,11 +95,9 @@ inline std::string __sqliteField(const std::string& source) noexcept {
 }
 
 #ifdef WIN32
-// TEXT is also defined in windows.h, we should not re-define it
 #define SQL_TEXT(x) __sqliteField(x)
 #else
 #define SQL_TEXT(x) __sqliteField(x)
-#define TEXT(x) __sqliteField(x)
 #endif
 
 /// See the affinity type documentation for TEXT.
@@ -589,7 +587,7 @@ struct QueryContext {
                                   const std::string& colName,
                                   const Type& value) const {
     if (isColumnUsed(colName)) {
-      r[colName] = TEXT(value);
+      r[colName] = SQL_TEXT(value);
     }
   }
 

--- a/osquery/tables/events/linux/bpf_process_events.cpp
+++ b/osquery/tables/events/linux/bpf_process_events.cpp
@@ -47,18 +47,18 @@ bool BPFProcessEventSubscriber::generateRow(
     return false;
   }
 
-  row["ntime"] = TEXT(event.bpf_header.timestamp);
+  row["ntime"] = SQL_TEXT(event.bpf_header.timestamp);
   row["tid"] = INTEGER(event.bpf_header.thread_id);
   row["pid"] = INTEGER(event.bpf_header.process_id);
   row["uid"] = INTEGER(event.bpf_header.user_id);
   row["gid"] = INTEGER(event.bpf_header.group_id);
   row["cid"] = INTEGER(event.bpf_header.cgroup_id);
-  row["exit_code"] = TEXT(std::to_string(event.bpf_header.exit_code));
+  row["exit_code"] = SQL_TEXT(std::to_string(event.bpf_header.exit_code));
   row["probe_error"] = INTEGER(event.bpf_header.probe_error);
-  row["syscall"] = TEXT("exec");
+  row["syscall"] = SQL_TEXT("exec");
   row["parent"] = INTEGER(event.parent_process_id);
-  row["path"] = TEXT(event.binary_path);
-  row["cwd"] = TEXT(event.cwd);
+  row["path"] = SQL_TEXT(event.binary_path);
+  row["cwd"] = SQL_TEXT(event.cwd);
   row["duration"] = INTEGER(event.bpf_header.duration);
 
   if (!std::holds_alternative<ISystemStateTracker::Event::ExecData>(

--- a/osquery/tables/events/linux/bpf_socket_events.cpp
+++ b/osquery/tables/events/linux/bpf_socket_events.cpp
@@ -37,45 +37,45 @@ bool BPFSocketEventSubscriber::generateRow(
 
   switch (event.type) {
   case ISystemStateTracker::Event::Type::Connect:
-    row["syscall"] = TEXT("connect");
+    row["syscall"] = SQL_TEXT("connect");
     break;
 
   case ISystemStateTracker::Event::Type::Bind:
-    row["syscall"] = TEXT("bind");
+    row["syscall"] = SQL_TEXT("bind");
     break;
 
   case ISystemStateTracker::Event::Type::Listen:
-    row["syscall"] = TEXT("listen");
+    row["syscall"] = SQL_TEXT("listen");
     break;
 
   case ISystemStateTracker::Event::Type::Accept:
-    row["syscall"] = TEXT("accept");
+    row["syscall"] = SQL_TEXT("accept");
     break;
 
   default:
     return false;
   }
 
-  row["ntime"] = TEXT(event.bpf_header.timestamp);
+  row["ntime"] = SQL_TEXT(event.bpf_header.timestamp);
   row["tid"] = INTEGER(event.bpf_header.thread_id);
   row["pid"] = INTEGER(event.bpf_header.process_id);
   row["uid"] = INTEGER(event.bpf_header.user_id);
   row["gid"] = INTEGER(event.bpf_header.group_id);
   row["cid"] = INTEGER(event.bpf_header.cgroup_id);
-  row["exit_code"] = TEXT(std::to_string(event.bpf_header.exit_code));
+  row["exit_code"] = SQL_TEXT(std::to_string(event.bpf_header.exit_code));
   row["probe_error"] = INTEGER(event.bpf_header.probe_error);
   row["parent"] = INTEGER(event.parent_process_id);
-  row["path"] = TEXT(event.binary_path);
+  row["path"] = SQL_TEXT(event.binary_path);
   row["duration"] = INTEGER(event.bpf_header.duration);
 
   if (!std::holds_alternative<ISystemStateTracker::Event::SocketData>(
           event.data)) {
-    row["fd"] = TEXT("");
+    row["fd"] = SQL_TEXT("");
     row["family"] = INTEGER(-1);
     row["type"] = INTEGER(-1);
     row["protocol"] = INTEGER(-1);
-    row["local_address"] = TEXT("");
-    row["remote_address"] = TEXT("");
+    row["local_address"] = SQL_TEXT("");
+    row["remote_address"] = SQL_TEXT("");
     row["local_port"] = INTEGER(0);
     row["remote_port"] = INTEGER(0);
 
@@ -87,8 +87,8 @@ bool BPFSocketEventSubscriber::generateRow(
     row["family"] = INTEGER(socket_data.domain);
     row["type"] = INTEGER(socket_data.type);
     row["protocol"] = INTEGER(socket_data.protocol);
-    row["local_address"] = TEXT(socket_data.local_address);
-    row["remote_address"] = TEXT(socket_data.remote_address);
+    row["local_address"] = SQL_TEXT(socket_data.local_address);
+    row["remote_address"] = SQL_TEXT(socket_data.remote_address);
     row["local_port"] = INTEGER(socket_data.local_port);
     row["remote_port"] = INTEGER(socket_data.remote_port);
   }

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -43,7 +43,7 @@ std::string formatInvFlag(const iptcproxy_rule& rule, int flag) {
 
 void parseIptcpRule(const iptcproxy_rule& rule, Row& r) {
   if (rule.target != nullptr) {
-    r["target"] = TEXT(rule.target);
+    r["target"] = SQL_TEXT(rule.target);
   } else {
     r["target"] = "";
   }
@@ -68,14 +68,14 @@ void parseIptcpRule(const iptcproxy_rule& rule, Row& r) {
       formatInvFlag(rule, IPTC_INV_PROTO) + INTEGER(rule.ip_data.proto);
   if (strlen(rule.ip_data.iniface)) {
     r["iniface"] =
-        formatInvFlag(rule, IPTC_INV_VIA_IN) + TEXT(rule.ip_data.iniface);
+        formatInvFlag(rule, IPTC_INV_VIA_IN) + SQL_TEXT(rule.ip_data.iniface);
   } else {
     r["iniface"] = "all";
   }
 
   if (strlen(rule.ip_data.outiface)) {
     r["outiface"] =
-        formatInvFlag(rule, IPTC_INV_VIA_OUT) + TEXT(rule.ip_data.outiface);
+        formatInvFlag(rule, IPTC_INV_VIA_OUT) + SQL_TEXT(rule.ip_data.outiface);
   } else {
     r["outiface"] = "all";
   }
@@ -96,7 +96,7 @@ void parseIptcpRule(const iptcproxy_rule& rule, Row& r) {
     iniface_mask += aux_char[1];
   }
 
-  r["iniface_mask"] = TEXT(iniface_mask);
+  r["iniface_mask"] = SQL_TEXT(iniface_mask);
   std::string outiface_mask = "";
   for (int i = 0; i < IFNAMSIZ && rule.ip_data.outiface_mask[i] != 0x00; i++) {
     aux_char[0] = kHexMap[(int)rule.ip_data.outiface_mask[i] >> kMaskHighBits];
@@ -104,10 +104,10 @@ void parseIptcpRule(const iptcproxy_rule& rule, Row& r) {
     outiface_mask += aux_char[0];
     outiface_mask += aux_char[1];
   }
-  r["outiface_mask"] = TEXT(outiface_mask);
+  r["outiface_mask"] = SQL_TEXT(outiface_mask);
 }
 
-void genIPTablesRules(const std::string &filter, QueryData &results) {
+void genIPTablesRules(const std::string& filter, QueryData& results) {
   Row r;
   r["filter_name"] = filter;
 
@@ -118,13 +118,12 @@ void genIPTablesRules(const std::string &filter, QueryData &results) {
   }
 
   // Iterate through chains
-  for (auto chain = iptcproxy_first_chain(handle);
-      chain != nullptr;
-      chain = iptcproxy_next_chain(handle)) {
-    r["chain"] = TEXT(chain->chain);
+  for (auto chain = iptcproxy_first_chain(handle); chain != nullptr;
+       chain = iptcproxy_next_chain(handle)) {
+    r["chain"] = SQL_TEXT(chain->chain);
 
     if (chain->policy != nullptr) {
-      r["policy"] = TEXT(chain->policy);
+      r["policy"] = SQL_TEXT(chain->policy);
       r["packets"] = INTEGER(chain->policy_data.pcnt);
       r["bytes"] = INTEGER(chain->policy_data.bcnt);
     } else {
@@ -147,14 +146,14 @@ void genIPTablesRules(const std::string &filter, QueryData &results) {
   iptcproxy_free(handle);
 }
 
-QueryData genIptables(QueryContext &context) {
+QueryData genIptables(QueryContext& context) {
   QueryData results;
 
   // Read in table names
   std::string content;
   auto s = osquery::readFile(kLinuxIpTablesNames, content);
   if (s.ok()) {
-    for (auto &line : split(content, "\n")) {
+    for (auto& line : split(content, "\n")) {
       boost::trim(line);
       if (line.size() > 0) {
         genIPTablesRules(line, results);
@@ -167,5 +166,5 @@ QueryData genIptables(QueryContext &context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/authorizations.mm
+++ b/osquery/tables/system/darwin/authorizations.mm
@@ -72,18 +72,19 @@ QueryData genAuthorizationMechanisms(QueryContext& context) {
         }
 
         for (NSString* mech in mechs) {
-          r["label"] = TEXT([label UTF8String]);
+          r["label"] = SQL_TEXT([label UTF8String]);
           r["privileged"] =
               ([mech rangeOfString:@"privileged"].location != NSNotFound)
                   ? "true"
                   : "false";
-          r["entry"] = TEXT([mech UTF8String]);
+          r["entry"] = SQL_TEXT([mech UTF8String]);
           NSRange colon_loc = [mech rangeOfString:@":"];
           NSRange plugin_loc = NSMakeRange(0, colon_loc.location);
           NSRange mech_loc = NSMakeRange(
               colon_loc.location + 1, [mech length] - (colon_loc.location + 1));
-          r["plugin"] = TEXT([[mech substringWithRange:plugin_loc] UTF8String]);
-          r["mechanism"] = TEXT([[[mech substringWithRange:mech_loc]
+          r["plugin"] =
+              SQL_TEXT([[mech substringWithRange:plugin_loc] UTF8String]);
+          r["mechanism"] = SQL_TEXT([[[mech substringWithRange:mech_loc]
               stringByReplacingOccurrencesOfString:@",privileged"
                                         withString:@""] UTF8String]);
           results.push_back(r);
@@ -114,18 +115,18 @@ QueryData genAuthorizations(QueryContext& context) {
 
           Row r;
           for (CFIndex i = 0; i < count; i++) {
-            r["label"] = TEXT([label UTF8String]);
+            r["label"] = SQL_TEXT([label UTF8String]);
             id value = (__bridge id)values[i];
             auto key = [[(__bridge NSString*)keys[i]
                 stringByReplacingOccurrencesOfString:@"-"
                                           withString:@"_"] UTF8String];
 
             if (CFGetTypeID(values[i]) == CFNumberGetTypeID()) {
-              r[key] = TEXT([value intValue]);
+              r[key] = SQL_TEXT([value intValue]);
             } else if (CFGetTypeID(values[i]) == CFStringGetTypeID()) {
-              r[key] = TEXT([value UTF8String]);
+              r[key] = SQL_TEXT([value UTF8String]);
             } else if (CFGetTypeID(values[i]) == CFBooleanGetTypeID()) {
-              r[key] = TEXT(([value boolValue]) ? "true" : "false");
+              r[key] = SQL_TEXT(([value boolValue]) ? "true" : "false");
             }
           }
 
@@ -135,5 +136,5 @@ QueryData genAuthorizations(QueryContext& context) {
   }
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -84,21 +84,21 @@ BOOL genIopmBatteryInfo(Row& r) {
     return NO;
   }
   if ([batteryInfo objectForKey:@kIOPSHardwareSerialNumberKey]) {
-    r["serial_number"] = TEXT([
-        [batteryInfo objectForKey:@kIOPSHardwareSerialNumberKey] UTF8String]);
+    r["serial_number"] = SQL_TEXT(
+        [[batteryInfo objectForKey:@kIOPSHardwareSerialNumberKey] UTF8String]);
   }
   if ([batteryInfo objectForKey:@kIOPSBatteryHealthKey]) {
-    r["health"] =
-        TEXT([[batteryInfo objectForKey:@kIOPSBatteryHealthKey] UTF8String]);
+    r["health"] = SQL_TEXT(
+        [[batteryInfo objectForKey:@kIOPSBatteryHealthKey] UTF8String]);
   }
   if ([batteryInfo objectForKey:@kIOPSBatteryHealthConditionKey]) {
-    r["condition"] = TEXT([[batteryInfo
+    r["condition"] = SQL_TEXT([[batteryInfo
         objectForKey:@kIOPSBatteryHealthConditionKey] UTF8String]);
   } else {
-    r["condition"] = TEXT("Normal");
+    r["condition"] = SQL_TEXT("Normal");
   }
   if ([batteryInfo objectForKey:@kIOPSPowerSourceStateKey]) {
-    r["state"] = TEXT(
+    r["state"] = SQL_TEXT(
         [[batteryInfo objectForKey:@kIOPSPowerSourceStateKey] UTF8String]);
   }
   if ([batteryInfo objectForKey:@kIOPSIsChargingKey]) {
@@ -111,8 +111,8 @@ BOOL genIopmBatteryInfo(Row& r) {
     r["charged"] = INTEGER(0);
   }
   if ([batteryInfo objectForKey:@kIOPSCurrentCapacityKey]) {
-    r["percent_remaining"] = INTEGER(
-        [[batteryInfo objectForKey:@kIOPSCurrentCapacityKey] intValue]);
+    r["percent_remaining"] =
+        INTEGER([[batteryInfo objectForKey:@kIOPSCurrentCapacityKey] intValue]);
   }
   if ([batteryInfo objectForKey:@kIOPSTimeToEmptyKey]) {
     r["minutes_until_empty"] =
@@ -131,7 +131,7 @@ BOOL genAdvancedBatteryInfo(Row& r) {
     return NO;
   }
   if ([advancedBatteryInfo objectForKey:@kIOPMPSManufacturerKey]) {
-    r["manufacturer"] = TEXT([[advancedBatteryInfo
+    r["manufacturer"] = SQL_TEXT([[advancedBatteryInfo
         objectForKey:@kIOPMPSManufacturerKey] UTF8String]);
   }
 
@@ -158,7 +158,7 @@ BOOL genAdvancedBatteryInfo(Row& r) {
     r["manufacture_date"] = INTEGER([date timeIntervalSince1970]);
   }
   if ([advancedBatteryInfo objectForKey:@kIOPMDeviceNameKey]) {
-    r["model"] = TEXT(
+    r["model"] = SQL_TEXT(
         [[advancedBatteryInfo objectForKey:@kIOPMDeviceNameKey] UTF8String]);
   }
   if ([advancedBatteryInfo objectForKey:@kIOPMPSCycleCountKey]) {
@@ -182,8 +182,8 @@ BOOL genAdvancedBatteryInfo(Row& r) {
         [[advancedBatteryInfo objectForKey:@kIOPMPSAmperageKey] intValue]);
   }
   if ([advancedBatteryInfo objectForKey:@kIOPSVoltageKey]) {
-    r["voltage"] = INTEGER(
-        [[advancedBatteryInfo objectForKey:@kIOPSVoltageKey] intValue]);
+    r["voltage"] =
+        INTEGER([[advancedBatteryInfo objectForKey:@kIOPSVoltageKey] intValue]);
   }
   return YES;
 }
@@ -192,7 +192,7 @@ QueryData genBatteryInfo(QueryContext& context) {
   QueryData results;
   Row row;
   @autoreleasepool {
-    if (genIopmBatteryInfo(row)){
+    if (genIopmBatteryInfo(row)) {
       genAdvancedBatteryInfo(row);
       results.push_back(row);
     }

--- a/osquery/tables/system/darwin/connected_displays.mm
+++ b/osquery/tables/system/darwin/connected_displays.mm
@@ -102,21 +102,21 @@ QueryData genConnectedDisplays(QueryContext& context) {
       }
 
       if ([obj valueForKey:@"_name"]) {
-        r["name"] = TEXT([[obj valueForKey:@"_name"] UTF8String]);
+        r["name"] = SQL_TEXT([[obj valueForKey:@"_name"] UTF8String]);
       }
 
       if ([obj valueForKey:@"_spdisplays_display-product-id"]) {
-        r["product_id"] = TEXT(
+        r["product_id"] = SQL_TEXT(
             [[obj valueForKey:@"_spdisplays_display-product-id"] UTF8String]);
       }
 
       if ([obj valueForKey:@"_spdisplays_display-serial-number"]) {
-        r["serial_number"] = TEXT([[obj
+        r["serial_number"] = SQL_TEXT([[obj
             valueForKey:@"_spdisplays_display-serial-number"] UTF8String]);
       }
 
       if ([obj valueForKey:@"_spdisplays_display-vendor-id"]) {
-        r["vendor_id"] = TEXT(
+        r["vendor_id"] = SQL_TEXT(
             [[obj valueForKey:@"_spdisplays_display-vendor-id"] UTF8String]);
       }
 
@@ -129,24 +129,24 @@ QueryData genConnectedDisplays(QueryContext& context) {
 
       if ([obj valueForKey:@"_spdisplays_display-year"]) {
         r["manufactured_year"] =
-            TEXT([[obj valueForKey:@"_spdisplays_display-year"] intValue]);
+            SQL_TEXT([[obj valueForKey:@"_spdisplays_display-year"] intValue]);
       } else {
         r["manufactured_year"] = INTEGER(-1);
       }
 
       if ([obj valueForKey:@"_spdisplays_displayID"]) {
         r["display_id"] =
-            TEXT([[obj valueForKey:@"_spdisplays_displayID"] UTF8String]);
+            SQL_TEXT([[obj valueForKey:@"_spdisplays_displayID"] UTF8String]);
       }
 
       if ([obj valueForKey:@"_spdisplays_pixels"]) {
         r["pixels"] =
-            TEXT([[obj valueForKey:@"_spdisplays_pixels"] UTF8String]);
+            SQL_TEXT([[obj valueForKey:@"_spdisplays_pixels"] UTF8String]);
       }
 
       if ([obj valueForKey:@"_spdisplays_resolution"]) {
         r["resolution"] =
-            TEXT([[obj valueForKey:@"_spdisplays_resolution"] UTF8String]);
+            SQL_TEXT([[obj valueForKey:@"_spdisplays_resolution"] UTF8String]);
       }
 
       if (NSString* ambient_brightness_enabled =
@@ -162,13 +162,13 @@ QueryData genConnectedDisplays(QueryContext& context) {
       }
 
       if ([obj valueForKey:@"spdisplays_connection_type"]) {
-        r["connection_type"] =
-            TEXT([[obj valueForKey:@"spdisplays_connection_type"] UTF8String]);
+        r["connection_type"] = SQL_TEXT(
+            [[obj valueForKey:@"spdisplays_connection_type"] UTF8String]);
       }
 
       if ([obj valueForKey:@"spdisplays_display_type"]) {
         r["display_type"] =
-            TEXT([[obj valueForKey:@"spdisplays_display_type"] UTF8String]);
+            SQL_TEXT([[obj valueForKey:@"spdisplays_display_type"] UTF8String]);
       }
 
       if (NSString* main = [obj valueForKey:@"spdisplays_main"]) {

--- a/osquery/tables/system/darwin/cpu_info.cpp
+++ b/osquery/tables/system/darwin/cpu_info.cpp
@@ -267,7 +267,7 @@ QueryData genAarch64CpuInfo(QueryContext& context) {
       sysctlbyname("machdep.cpu.brand_string", &brand_string, &len, nullptr, 0);
 
   if (res == 0) {
-    r["model"] = TEXT(brand_string.data());
+    r["model"] = SQL_TEXT(brand_string.data());
   }
   r["manufacturer"] = "Apple";
   r["processor_type"] = INTEGER(3); // 3 = Central Processor

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -418,7 +418,7 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
       uuid_string_t uuid_string = {0};
       if (genUid(uid, uuid_string).ok()) {
         r["uid"] = BIGINT(uid);
-        r["user_uuid"] = TEXT(uuid_string);
+        r["user_uuid"] = SQL_TEXT(uuid_string);
       }
     }
     r["type"] = (r.at("encrypted") == "1") ? kEncryptionType : std::string();

--- a/osquery/tables/system/darwin/kernel_extensions.cpp
+++ b/osquery/tables/system/darwin/kernel_extensions.cpp
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <IOKit/kext/KextManager.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/kext/KextManager.h>
 
 #include <boost/algorithm/string/trim.hpp>
 
@@ -21,19 +21,19 @@
 namespace osquery {
 namespace tables {
 
-inline std::string getKextInt(const CFDictionaryRef &value,
+inline std::string getKextInt(const CFDictionaryRef& value,
                               const CFStringRef key) {
   auto num = (CFDataRef)CFDictionaryGetValue(value, key);
   return stringFromCFNumber(num, kCFNumberSInt32Type);
 }
 
-inline std::string getKextBigInt(const CFDictionaryRef &value,
+inline std::string getKextBigInt(const CFDictionaryRef& value,
                                  const CFStringRef key) {
   auto num = (CFDataRef)CFDictionaryGetValue(value, key);
   return stringFromCFNumber(num, kCFNumberSInt64Type);
 }
 
-inline std::string getKextString(const CFDictionaryRef &value,
+inline std::string getKextString(const CFDictionaryRef& value,
                                  const CFStringRef key) {
   // Some values are optional, meaning the key is empty or does not exist.
   if (!CFDictionaryContainsKey(value, key)) {
@@ -47,7 +47,7 @@ inline std::string getKextString(const CFDictionaryRef &value,
   return stringFromCFString(string);
 }
 
-inline std::string getKextLinked(const CFDictionaryRef &value,
+inline std::string getKextLinked(const CFDictionaryRef& value,
                                  const CFStringRef key) {
   std::string result;
   auto links = (CFArrayRef)CFDictionaryGetValue(value, key);
@@ -72,11 +72,11 @@ inline std::string getKextLinked(const CFDictionaryRef &value,
     int link;
     CFNumberGetValue((CFNumberRef)CFArrayGetValueAtIndex(link_indexes, i),
                      kCFNumberSInt32Type,
-                     (void *)&link);
+                     (void*)&link);
     if (i > 0) {
       result += " ";
     }
-    result += TEXT(link);
+    result += std::to_string(link);
   }
 
   CFRelease(link_indexes);
@@ -84,7 +84,7 @@ inline std::string getKextLinked(const CFDictionaryRef &value,
   return "<" + result + ">";
 }
 
-void genExtension(const void *key, const void *value, void *results) {
+void genExtension(const void* key, const void* value, void* results) {
   if (key == nullptr || value == nullptr || results == nullptr) {
     return;
   }
@@ -107,10 +107,10 @@ void genExtension(const void *key, const void *value, void *results) {
   r["version"] = getKextString(extension, CFSTR("CFBundleVersion"));
   r["linked_against"] = getKextLinked(extension, CFSTR("OSBundleDependencies"));
   r["path"] = getKextString(extension, CFSTR("OSBundlePath"));
-  ((QueryData *)results)->push_back(r);
+  ((QueryData*)results)->push_back(r);
 }
 
-QueryData genKernelExtensions(QueryContext &context) {
+QueryData genKernelExtensions(QueryContext& context) {
   QueryData results;
 
   // Populate dict of kernel extensions.
@@ -123,5 +123,5 @@ QueryData genKernelExtensions(QueryContext &context) {
   CFRelease(dict);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/mounts.cpp
+++ b/osquery/tables/system/darwin/mounts.cpp
@@ -31,10 +31,10 @@ QueryData genMounts(QueryContext& context) {
 
   for (i = 0; i < mnts; i++) {
     Row r;
-    r["path"] = TEXT(mnt[i].f_mntonname);
-    r["device"] = TEXT(mnt[i].f_mntfromname);
+    r["path"] = SQL_TEXT(mnt[i].f_mntonname);
+    r["device"] = SQL_TEXT(mnt[i].f_mntfromname);
     r["device_alias"] = canonicalize_file_name(mnt[i].f_mntfromname);
-    r["type"] = TEXT(mnt[i].f_fstypename);
+    r["type"] = SQL_TEXT(mnt[i].f_fstypename);
     r["flags"] = INTEGER(mnt[i].f_flags);
     r["blocks"] = BIGINT(mnt[i].f_blocks);
     r["blocks_free"] = BIGINT(mnt[i].f_bfree);

--- a/osquery/tables/system/darwin/os_version.mm
+++ b/osquery/tables/system/darwin/os_version.mm
@@ -111,7 +111,7 @@ QueryData genOSVersion(QueryContext& context) {
   struct utsname uname_buf {};
 
   if (uname(&uname_buf) == 0) {
-    r["arch"] = TEXT(uname_buf.machine);
+    r["arch"] = SQL_TEXT(uname_buf.machine);
   } else {
     LOG(INFO) << "Failed to determine the OS architecture, error " << errno;
   }

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -121,7 +121,7 @@ QueryData genGroups(QueryContext& context) {
         if (grp != nullptr) {
           genGroupRow(r, grp);
         } else {
-          r["groupname"] = TEXT(groupname.first);
+          r["groupname"] = SQL_TEXT(groupname.first);
         }
 
         results.push_back(r);
@@ -132,14 +132,14 @@ QueryData genGroups(QueryContext& context) {
 }
 
 void genUserRow(Row& r, const passwd* pwd) {
-  r["username"] = TEXT(pwd->pw_name);
+  r["username"] = SQL_TEXT(pwd->pw_name);
   r["uid"] = BIGINT(pwd->pw_uid);
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
   r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
-  r["description"] = TEXT(pwd->pw_gecos);
-  r["directory"] = TEXT(pwd->pw_dir);
-  r["shell"] = TEXT(pwd->pw_shell);
+  r["description"] = SQL_TEXT(pwd->pw_gecos);
+  r["directory"] = SQL_TEXT(pwd->pw_dir);
+  r["shell"] = SQL_TEXT(pwd->pw_shell);
 
   uuid_t uuid = {0};
   uuid_string_t uuid_string = {0};
@@ -150,7 +150,7 @@ void genUserRow(Row& r, const passwd* pwd) {
   mbr_uid_to_uuid(pwd->pw_uid, uuid);
 
   uuid_unparse(uuid, uuid_string);
-  r["uuid"] = TEXT(uuid_string);
+  r["uuid"] = SQL_TEXT(uuid_string);
 }
 
 QueryData genUsers(QueryContext& context) {
@@ -189,7 +189,7 @@ QueryData genUsers(QueryContext& context) {
         if (pwd != nullptr) {
           genUserRow(r, pwd);
         } else {
-          r["username"] = TEXT(username.first.c_str());
+          r["username"] = SQL_TEXT(username.first.c_str());
         }
 
         results.push_back(r);

--- a/osquery/tables/system/linux/extended_attributes.cpp
+++ b/osquery/tables/system/linux/extended_attributes.cpp
@@ -86,10 +86,10 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
   }
 
   Row row = {};
-  row["path"] = TEXT(path);
+  row["path"] = SQL_TEXT(path);
 
   auto path_obj = boost::filesystem::path(path);
-  row["directory"] = TEXT(path_obj.parent_path().string());
+  row["directory"] = SQL_TEXT(path_obj.parent_path().string());
 
   std::string capabilities;
   bool capabilities_found{false};
@@ -97,8 +97,8 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
   auto status = getCapabilities(capabilities, path);
   if (status.ok()) {
     if (!capabilities.empty()) {
-      row["key"] = TEXT(kSecurityCapabilityXattrName);
-      row["value"] = TEXT(capabilities);
+      row["key"] = SQL_TEXT(kSecurityCapabilityXattrName);
+      row["value"] = SQL_TEXT(capabilities);
       row["base64"] = INTEGER(0);
 
       output.push_back(row);
@@ -119,8 +119,8 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
 
     // Add empty values as base64
     if (key_value.empty()) {
-      row["key"] = TEXT(key_name);
-      row["value"] = TEXT("");
+      row["key"] = SQL_TEXT(key_name);
+      row["value"] = SQL_TEXT("");
       row["base64"] = INTEGER("1");
 
       output.push_back(row);
@@ -146,8 +146,9 @@ Status generateXattrRowsForPath(QueryData& output, const std::string& path) {
       });
     }
 
-    row["key"] = TEXT(key_name);
-    row["value"] = printable ? TEXT(std::string(value)) : base64::encode(value);
+    row["key"] = SQL_TEXT(key_name);
+    row["value"] =
+        printable ? SQL_TEXT(std::string(value)) : base64::encode(value);
     row["base64"] = printable ? INTEGER(0) : INTEGER(1);
 
     output.push_back(row);

--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -20,7 +20,7 @@ namespace osquery {
 namespace tables {
 
 void setGroupRow(Row& r, const group* grp) {
-  r["groupname"] = TEXT(grp->gr_name);
+  r["groupname"] = SQL_TEXT(grp->gr_name);
   r["gid"] = INTEGER(grp->gr_gid);
   r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
   r["pid_with_namespace"] = "0";

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -110,7 +110,7 @@ QueryData genOSVersionImpl(QueryContext& context, Logger& logger) {
   struct utsname uname_buf {};
 
   if (uname(&uname_buf) == 0) {
-    r["arch"] = TEXT(uname_buf.machine);
+    r["arch"] = SQL_TEXT(uname_buf.machine);
   } else {
     LOG(INFO) << "Failed to determine the OS architecture, error " << errno;
   }

--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -70,7 +70,7 @@ static std::string getRpmAttribute(const Header& header,
   } else if (rpmTagGetClass(tag) == RPM_STRING_CLASS) {
     const char* attr = rpmtdGetString(td);
     if (attr != nullptr) {
-      result = TEXT(attr);
+      result = SQL_TEXT(attr);
     }
   }
 

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -31,7 +31,7 @@ void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
   r["expire"] = BIGINT(spwd->sp_expire);
   r["flag"] = BIGINT(spwd->sp_flag);
 
-  r["username"] = spwd->sp_namp != nullptr ? TEXT(spwd->sp_namp) : "";
+  r["username"] = spwd->sp_namp != nullptr ? SQL_TEXT(spwd->sp_namp) : "";
 
   if (spwd->sp_pwdp != nullptr) {
     std::string password = std::string(spwd->sp_pwdp);
@@ -80,5 +80,5 @@ QueryData genShadow(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/systemd_units.cpp
+++ b/osquery/tables/system/linux/systemd_units.cpp
@@ -56,16 +56,16 @@ TableRows genSystemdUnits(QueryContext& context) {
   for (const auto& unit : unit_list) {
     auto row = make_table_row();
 
-    row["id"] = TEXT(unit.id);
-    row["description"] = TEXT(unit.description);
-    row["load_state"] = TEXT(unit.load_state);
-    row["active_state"] = TEXT(unit.active_state);
-    row["sub_state"] = TEXT(unit.sub_state);
-    row["following"] = TEXT(unit.following);
-    row["object_path"] = TEXT(unit.path);
+    row["id"] = SQL_TEXT(unit.id);
+    row["description"] = SQL_TEXT(unit.description);
+    row["load_state"] = SQL_TEXT(unit.load_state);
+    row["active_state"] = SQL_TEXT(unit.active_state);
+    row["sub_state"] = SQL_TEXT(unit.sub_state);
+    row["following"] = SQL_TEXT(unit.following);
+    row["object_path"] = SQL_TEXT(unit.path);
     row["job_id"] = BIGINT(unit.job_id);
-    row["job_type"] = TEXT(unit.job_type);
-    row["job_path"] = TEXT(unit.job_path);
+    row["job_type"] = SQL_TEXT(unit.job_type);
+    row["job_path"] = SQL_TEXT(unit.job_path);
 
     for (const auto& query : kStringPropertyQueryList) {
       std::string property_value;
@@ -81,7 +81,7 @@ TableRows genSystemdUnits(QueryContext& context) {
                    << " on the following systemd unit: " << unit.path;
       }
 
-      row[query.column_name] = TEXT(property_value);
+      row[query.column_name] = SQL_TEXT(property_value);
     }
 
     results.push_back(std::move(row));

--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -26,19 +26,19 @@ void genUser(const struct passwd* pwd, QueryData& results) {
   r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
 
   if (pwd->pw_name != nullptr) {
-    r["username"] = TEXT(pwd->pw_name);
+    r["username"] = SQL_TEXT(pwd->pw_name);
   }
 
   if (pwd->pw_gecos != nullptr) {
-    r["description"] = TEXT(pwd->pw_gecos);
+    r["description"] = SQL_TEXT(pwd->pw_gecos);
   }
 
   if (pwd->pw_dir != nullptr) {
-    r["directory"] = TEXT(pwd->pw_dir);
+    r["directory"] = SQL_TEXT(pwd->pw_dir);
   }
 
   if (pwd->pw_shell != nullptr) {
-    r["shell"] = TEXT(pwd->pw_shell);
+    r["shell"] = SQL_TEXT(pwd->pw_shell);
   }
   r["pid_with_namespace"] = "0";
   results.push_back(r);
@@ -97,5 +97,5 @@ QueryData genUsers(QueryContext& context) {
     return genUsersImpl(context, logger);
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -46,13 +46,13 @@ std::string typeNameForType(const utmpx& ut) {
 void genLastAccessForRow(const utmpx& ut, QueryData& results) {
   if (ut.ut_type == USER_PROCESS || ut.ut_type == DEAD_PROCESS) {
     Row r;
-    r["username"] = TEXT(ut.ut_user);
-    r["tty"] = TEXT(ut.ut_line);
+    r["username"] = SQL_TEXT(ut.ut_user);
+    r["tty"] = SQL_TEXT(ut.ut_line);
     r["pid"] = INTEGER(ut.ut_pid);
     r["type"] = INTEGER(ut.ut_type);
-    r["type_name"] = TEXT(typeNameForType(ut));
+    r["type_name"] = SQL_TEXT(typeNameForType(ut));
     r["time"] = INTEGER(ut.ut_tv.tv_sec);
-    r["host"] = TEXT(ut.ut_host);
+    r["host"] = SQL_TEXT(ut.ut_host);
     results.push_back(r);
   }
 }
@@ -88,5 +88,5 @@ QueryData genLastAccess(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/logged_in_users.cpp
+++ b/osquery/tables/system/posix/logged_in_users.cpp
@@ -52,9 +52,9 @@ QueryData genLoggedInUsers(QueryContext& context) {
     } else {
       r["type"] = kLoginTypes.at(entry->ut_type);
     }
-    r["user"] = TEXT(entry->ut_user);
-    r["tty"] = TEXT(entry->ut_line);
-    r["host"] = TEXT(entry->ut_host);
+    r["user"] = SQL_TEXT(entry->ut_user);
+    r["tty"] = SQL_TEXT(entry->ut_line);
+    r["host"] = SQL_TEXT(entry->ut_host);
     r["time"] = INTEGER(entry->ut_tv.tv_sec);
     r["pid"] = INTEGER(entry->ut_pid);
     results.push_back(r);
@@ -63,5 +63,5 @@ QueryData genLoggedInUsers(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
Don't keep a macro which on Windows cannot be used due to collisions.
Use only one version for clarity.
