### PR TITLE
improvement: Avoid unnecessary string conversions

### DIFF
--- a/osquery/events/windows/ntfs_event_publisher.cpp
+++ b/osquery/events/windows/ntfs_event_publisher.cpp
@@ -346,7 +346,7 @@ Status NTFSEventPublisher::getVolumeData(VolumeData& volume,
       description = L"Unknown error";
     }
 
-    message << wstringToString(description.c_str());
+    message << wstringToString(description);
     return Status::failure(message.str());
   }
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1333,7 +1333,7 @@ bool platformSetSafeDbPerms(const std::string& path) {
     return false;
   }
 
-  std::wstring wide_path = stringToWstring(path.c_str());
+  std::wstring wide_path = stringToWstring(path);
   // Apply 'safe' DACL and avoid returning to attempt applying the DACL
   ret = SetNamedSecurityInfoW(
       const_cast<PWSTR>(wide_path.c_str()),

--- a/osquery/utils/conversions/windows/tests/strings.cpp
+++ b/osquery/utils/conversions/windows/tests/strings.cpp
@@ -33,7 +33,7 @@ class ConversionsTests : public testing::Test {
 
 TEST_F(ConversionsTests, test_string_to_wstring) {
   std::string narrowString{"The quick brown fox jumps over the lazy dog"};
-  auto wideString = stringToWstring(narrowString.c_str());
+  auto wideString = stringToWstring(narrowString);
   std::wstring expected{L"The quick brown fox jumps over the lazy dog"};
   EXPECT_EQ(wideString, expected);
 }
@@ -46,21 +46,21 @@ TEST_F(ConversionsTests, test_cim_datetime_to_unixtime) {
 
 TEST_F(ConversionsTests, test_wstring_to_string) {
   std::wstring wideString{L"The quick brown fox jumps over the lazy dog"};
-  auto narrowString = wstringToString(wideString.c_str());
+  auto narrowString = wstringToString(wideString);
   std::string expected{"The quick brown fox jumps over the lazy dog"};
   EXPECT_EQ(narrowString, expected);
 }
 
 TEST_F(ConversionsTests, test_string_to_wstring_extended) {
   std::string narrowString{"fr\xc3\xb8tz-jorn"};
-  auto wideString = stringToWstring(narrowString.c_str());
+  auto wideString = stringToWstring(narrowString);
   std::wstring expected{L"fr\x00f8tz-jorn"};
   EXPECT_EQ(wideString, expected);
 }
 
 TEST_F(ConversionsTests, test_wstring_to_string_extended) {
   std::wstring wideString{L"fr\x00f8tz-jorn"};
-  auto narrowString = wstringToString(wideString.c_str());
+  auto narrowString = wstringToString(wideString);
   std::string expected{"fr\xc3\xb8tz-jorn"};
   EXPECT_EQ(narrowString, expected);
 }


### PR DESCRIPTION
The UTF16 and UTF8 conversion APIs already accept `std::string` and `std::wstring` correctly, without the need to convert them to a wchar_t or char pointer, which is then converted back to the original type, but with potentially allocating other memory.
