### PR TITLE
unicode: Improve Windows unicode conversion functions

### DIFF
--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -292,7 +292,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
   // of the string content. Also it is guaranteed that the buffer is
   // null-terminated. See
   // https://en.cppreference.com/w/cpp/string/basic_string/data
-  auto argv = argv_stream.str();
+  auto argv_str = argv_stream.str();
 
   // In POSIX, this environment variable is set to the child's process ID. But
   // that is not easily accomplishable on Windows and provides no value since
@@ -305,11 +305,11 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
 
   // We are autoloading a Python extension, so pass off to our helper
   if (ext_path.extension().wstring() == L".ext") {
-    return launchTestPythonScript(wstringToString(argv));
+    return launchTestPythonScript(wstringToString(argv_str));
   } else {
     auto status =
         ::CreateProcess(nullptr,
-                        argv.data(),
+                        argv_str.data(),
                         nullptr,
                         nullptr,
                         TRUE,

--- a/osquery/system/usersgroups/windows/users_service.cpp
+++ b/osquery/system/usersgroups/windows/users_service.cpp
@@ -105,20 +105,18 @@ std::optional<std::vector<std::string>> getRoamingProfileSids() {
     return {};
   }
 
-  std::wstring key_name;
-  key_name.resize(max_key_length);
+  WCHAR key_name[max_key_length]{};
 
   std::vector<std::string> subkeys_names;
 
   // Process registry subkeys
   for (DWORD i = 0; i < subkeys_count; i++) {
-    ret_code =
-        RegEnumKeyW(registry_handle.get(), i, key_name.data(), max_key_length);
+    ret_code = RegEnumKeyW(registry_handle.get(), i, key_name, max_key_length);
     if (ret_code != ERROR_SUCCESS) {
       return std::nullopt;
     }
 
-    subkeys_names.emplace_back(wstringToString(key_name));
+    subkeys_names.emplace_back(wstringToString(key_name, max_key_length));
   }
 
   return subkeys_names;
@@ -312,7 +310,8 @@ void UsersService::processRoamingProfiles(
       LocalFree(sid);
 
       if (ret != FALSE) {
-        new_user.username = wstringToString(account_name);
+        new_user.username =
+            wstringToString(account_name, ARRAYSIZE(account_name));
         /* NOTE: This still keeps the old behavior where if getting the gid
         from the first local group or the primary group id fails,
         then we use the uid of the user. */

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -22,10 +22,10 @@
 #include <iomanip>
 // clang-format on
 
+#include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
-#include <osquery/core/tables.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
 
@@ -342,7 +342,7 @@ Status getCertificateInformation(SignatureInformation& signature_info,
       return false;
     }
 
-    value = wstringToString(buffer);
+    value = wstringToString(buffer.data(), buffer.size());
     return true;
   };
 
@@ -536,5 +536,5 @@ QueryData genAuthenticode(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -18,10 +18,10 @@
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
 
-#include <osquery/utils/conversions/tryto.h>
 #include "osquery/core/windows/wmi.h"
 #include "osquery/filesystem/fileops.h"
 #include "osquery/tables/system/windows/registry.h"
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -28,8 +28,8 @@
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
 
-#include <osquery/utils/conversions/tryto.h>
 #include <osquery/tables/system/intel_me.hpp>
+#include <osquery/utils/conversions/tryto.h>
 
 // The AMT documentation can be found at the following address:
 // https://software.intel.com/sites/manageability/AMT_Implementation_and_Reference_Guide/default.htm
@@ -333,14 +333,17 @@ osquery::Status getDeviceInterfacePath(
         std::to_string(err));
   }
 
-  std::wstring path;
-  path.assign(device_details->DevicePath, buffer.size() - sizeof(DWORD));
+  const auto device_path_size =
+      wcsnlen(device_details->DevicePath,
+              (buffer.size() - sizeof(DWORD)) / sizeof(WCHAR));
 
-  if (std::wcslen(path.c_str()) == 0U) {
+  if (device_path_size == 0U) {
     return osquery::Status::failure(
         "Invalid path returned for the given device interface; the string is "
         "empty");
   }
+
+  std::wstring path(device_details->DevicePath, device_path_size);
 
   dev_interface_path = wstringToString(path);
   return osquery::Status::success();

--- a/osquery/tables/system/windows/kernel_info.cpp
+++ b/osquery/tables/system/windows/kernel_info.cpp
@@ -39,7 +39,7 @@ void GetSystemDriveGUID(Row& r) {
   auto sysRoot = getSystemRoot().root_name().wstring() + L"\\";
   if (GetVolumeNameForVolumeMountPoint(
           sysRoot.c_str(), static_cast<LPWSTR>(buf), 50)) {
-    r["device"] = SQL_TEXT(wstringToString(buf));
+    r["device"] = SQL_TEXT(wstringToString(buf, ARRAYSIZE(buf)));
   }
 }
 

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -77,7 +77,8 @@ QueryData genLoggedInUsers(QueryContext& context) {
     }
 
     const auto wtsSession = reinterpret_cast<WTSINFOW*>(sessionInfo);
-    r["user"] = SQL_TEXT(wstringToString(wtsSession->UserName));
+    r["user"] = SQL_TEXT(
+        wstringToString(wtsSession->UserName, ARRAYSIZE(wtsSession->UserName)));
     r["type"] = SQL_TEXT(kSessionStates.at(pSessionInfo[i].State));
     r["tty"] = pSessionInfo[i].pSessionName == nullptr
                    ? ""

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -139,7 +139,7 @@ std::string pSidToStrUserName(PSID psid) {
     VLOG(1) << "LookupAccountSid Error " << GetLastError();
     return "";
   } else {
-    return wstringToString(uname.data());
+    return wstringToString(uname.data(), uname.size());
   }
 }
 

--- a/osquery/tables/system/windows/pipes.cpp
+++ b/osquery/tables/system/windows/pipes.cpp
@@ -33,10 +33,12 @@ QueryData genPipes(QueryContext& context) {
   do {
     Row r;
 
-    r["name"] = wstringToString(findFileData.cFileName);
+    std::wstring filename = findFileData.cFileName;
+
+    r["name"] = wstringToString(filename);
 
     unsigned long pid = 0;
-    auto pipePath = L"\\\\.\\pipe\\" + std::wstring(findFileData.cFileName);
+    auto pipePath = L"\\\\.\\pipe\\" + filename;
     auto pipeHandle =
         CreateFileW(pipePath.c_str(),
                     GENERIC_READ,
@@ -82,5 +84,5 @@ QueryData genPipes(QueryContext& context) {
   FindClose(findHandle);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -240,7 +240,7 @@ Status genMemoryMap(unsigned long pid, QueryData& results) {
           BIGINT(reinterpret_cast<unsigned long long>(mInfo.AllocationBase));
       r["device"] = "-1";
       r["inode"] = INTEGER(-1);
-      r["path"] = wstringToString(me.szExePath);
+      r["path"] = wstringToString(me.szExePath, ARRAYSIZE(me.szExePath));
       r["pseudo"] = INTEGER(-1);
       results.push_back(r);
     }
@@ -333,7 +333,7 @@ Status getProcessCommandLineLegacy(HANDLE proc,
     return Status::failure("Failed to read command line for " +
                            std::to_string(pid));
   }
-  out = wstringToString(command_line.data());
+  out = wstringToString(command_line.data(), command_line.size());
   return Status::success();
 }
 
@@ -390,7 +390,7 @@ Status getProcessCurrentDirectory(HANDLE proc,
     return Status::failure("Failed to read current working directory for " +
                            std::to_string(pid));
   }
-  out = wstringToString(current_directory.data());
+  out = wstringToString(current_directory.data(), current_directory.size());
   return Status::success();
 }
 
@@ -409,7 +409,7 @@ void getProcessPathInfo(HANDLE& proc,
     VLOG(1) << "Failed to lookup path information for process " << pid
             << " with " << GetLastError();
   } else {
-    r["path"] = SQL_TEXT(wstringToString(path.data()));
+    r["path"] = SQL_TEXT(wstringToString(path.data(), path.size()));
   }
 
   {
@@ -586,7 +586,8 @@ TableRows genProcesses(QueryContext& context) {
     auto r = make_table_row();
     r["pid"] = BIGINT(pid);
     r["parent"] = BIGINT(proc.th32ParentProcessID);
-    r["name"] = SQL_TEXT(wstringToString(proc.szExeFile));
+    r["name"] =
+        SQL_TEXT(wstringToString(proc.szExeFile, ARRAYSIZE(proc.szExeFile)));
     r["threads"] = INTEGER(proc.cntThreads);
 
     // Set default values for columns, in the event opening the process fails

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -182,7 +182,7 @@ QueryData genMemoryDevices(QueryContext& context) {
     wmiResults[i].GetLong("DataWidth", dataWidth);
     r["data_width"] = INTEGER(dataWidth);
     std::wstring capacityWStr;
-    wmiResults[i].GetString(stringToWstring("Capacity"), capacityWStr);
+    wmiResults[i].GetString(L"Capacity", capacityWStr);
     r["size"] = INTEGER(getMemorySize(capacityWStr));
     wmiResults[i].GetString("DeviceLocator", r["device_locator"]);
     wmiResults[i].GetString("BankLabel", r["bank_locator"]);

--- a/osquery/tables/system/windows/windows_crashes.cpp
+++ b/osquery/tables/system/windows/windows_crashes.cpp
@@ -447,8 +447,8 @@ Status logPEBInfo(IDebugClient5* client,
   }
   wchar_t curDir[MAX_PATH + 1] = {0};
   data->ReadUnicodeStringVirtualWide(
-      curDirBufferAddr, sizeof(curDir), curDir, MAX_PATH + 1, nullptr);
-  r["current_directory"] = wstringToString(curDir);
+      curDirBufferAddr, sizeof(curDir), curDir, ARRAYSIZE(curDir), nullptr);
+  r["current_directory"] = wstringToString(curDir, ARRAYSIZE(curDir));
 
   // Get CommandLine offset in ProcessParameters
   unsigned long cmdLineOffset = 0;
@@ -464,13 +464,11 @@ Status logPEBInfo(IDebugClient5* client,
                                 &cmdLineBufferAddr) != S_OK) {
     return Status(1);
   }
-  wchar_t cmdLine[UNICODE_STRING_MAX_BYTES] = {0};
-  data->ReadUnicodeStringVirtualWide(cmdLineBufferAddr,
-                                     sizeof(cmdLine),
-                                     cmdLine,
-                                     UNICODE_STRING_MAX_BYTES,
-                                     nullptr);
-  r["command_line"] = wstringToString(cmdLine);
+
+  wchar_t cmdLine[UNICODE_STRING_MAX_CHARS] = {0};
+  data->ReadUnicodeStringVirtualWide(
+      cmdLineBufferAddr, sizeof(cmdLine), cmdLine, ARRAYSIZE(cmdLine), nullptr);
+  r["command_line"] = wstringToString(cmdLine, ARRAYSIZE(cmdLine));
 
   // Get Environment offset in ProcessParameters
   unsigned long envOffset = 0;
@@ -489,13 +487,13 @@ Status logPEBInfo(IDebugClient5* client,
   // Loop through environment variables and log those of interest
   // The environment variables are stored in the following format:
   // Var1=Value1\0Var2=Value2\0Var3=Value3\0 ... VarN=ValueN\0\0
-  wchar_t env[UNICODE_STRING_MAX_BYTES] = {0};
+  wchar_t env[UNICODE_STRING_MAX_CHARS] = {0};
   unsigned long bytesRead = 0;
   auto ret = data->ReadUnicodeStringVirtualWide(
-      envBufferAddr, sizeof(env), env, UNICODE_STRING_MAX_BYTES, &bytesRead);
+      envBufferAddr, sizeof(env), env, ARRAYSIZE(env), &bytesRead);
   while (ret == S_OK) {
     envBufferAddr += bytesRead;
-    auto envVar = wstringToString(env);
+    auto envVar = wstringToString(env, ARRAYSIZE(env));
     auto pos = envVar.find('=');
     auto varName = envVar.substr(0, pos);
     auto varValue = envVar.substr(pos + 1, envVar.length());
@@ -507,7 +505,7 @@ Status logPEBInfo(IDebugClient5* client,
     }
 
     ret = data->ReadUnicodeStringVirtualWide(
-        envBufferAddr, sizeof(env), env, UNICODE_STRING_MAX_BYTES, &bytesRead);
+        envBufferAddr, sizeof(env), env, ARRAYSIZE(env), &bytesRead);
   }
 
   return Status::success();
@@ -654,5 +652,5 @@ QueryData genCrashLogs(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -45,7 +45,9 @@ QueryData genTime(QueryContext& context) {
         TIME_ZONE_ID_INVALID) {
       LOG(ERROR) << "Failed to acquire the time";
     } else {
-      local_timezone = wstringToString(time_zone_information.StandardName);
+      local_timezone =
+          wstringToString(time_zone_information.StandardName,
+                          ARRAYSIZE(time_zone_information.StandardName));
     }
 
 #else
@@ -64,7 +66,6 @@ QueryData genTime(QueryContext& context) {
 
   char timezone[5] = {0};
   strftime(timezone, sizeof(timezone), "%Z", &now);
-
 
   char iso_8601[21] = {0};
   strftime(iso_8601, sizeof(iso_8601), "%FT%TZ", &gmt);

--- a/osquery/utils/conversions/windows/strings.h
+++ b/osquery/utils/conversions/windows/strings.h
@@ -18,24 +18,42 @@ namespace osquery {
 
 /**
  * @brief Windows helper function for converting narrow strings to wide
- *
+ * The string must be null-terminated, otherwise it will overflow.
+ * @returns A wide string, constructed from a narrow string
+ */
+std::wstring stringToWstring(const char* src);
+
+/**
+ * @brief Windows helper function for converting narrow strings to wide
+ * The input string is assumed to only contain characters that need to be
+ * converted, no null terminator is necessary. Embedded nulls will be kept.
  * @returns A wide string, constructed from a narrow string
  */
 std::wstring stringToWstring(const std::string& src);
 
 /**
  * @brief Windows helper function for converting wide strings to narrow
- *
+ * The input string is assumed to only contain characters that need to be
+ * converted, no null terminator is necessary. Embedded nulls will be kept.
  * @returns A narrow string, constructed from a wide string
  */
 std::string wstringToString(const std::wstring& src);
 
 /**
  * @brief Windows helper function for converting wide C-strings to narrow
- *
+ * The string must be null-terminated, otherwise it will overflow.
  * @returns A narrow string, constructed from a wide C-string
  */
 std::string wstringToString(const wchar_t* src);
+
+/**
+ * @brief Windows helper function for converting wide C-strings and a maximum
+ * size to narrow. max_chars represents the maximum amount of characters that
+ * will be scanned to find a null-terminator. The null terminator does not need
+ * to exist; when it's not found, the size for the string will be max_chars.
+ * @returns A narrow string, constructed from a wide C-string and a size
+ */
+std::string wstringToString(const wchar_t* src, std::size_t max_chars);
 
 /**
  * @brief Windows helper function to convert a CIM Datetime to Unix timestamp

--- a/osquery/utils/pidfile/pidfile_windows.cpp
+++ b/osquery/utils/pidfile/pidfile_windows.cpp
@@ -49,8 +49,10 @@ std::string getCurrentPID() noexcept {
 
 Expected<Pidfile::FileHandle, Pidfile::Error> Pidfile::createFile(
     const std::string& path) noexcept {
+  auto path_wstr = stringToWstring(path);
+
   auto file_handle =
-      CreateFileW(stringToWstring(path).c_str(),
+      CreateFileW(path_wstr.c_str(),
                   GENERIC_READ,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr,
@@ -60,7 +62,7 @@ Expected<Pidfile::FileHandle, Pidfile::Error> Pidfile::createFile(
 
   if (file_handle == INVALID_HANDLE_VALUE) {
     file_handle =
-        CreateFileW(stringToWstring(path).c_str(),
+        CreateFileW(path_wstr.c_str(),
                     GENERIC_READ,
                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                     nullptr,

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -55,7 +55,7 @@ boost::optional<std::string> getEnvVar(const std::string& name) {
     return boost::none;
   }
 
-  // It is always possible that between the first GetEnvironmentVariableA call
+  // It is always possible that between the first GetEnvironmentVariableW call
   // and this one, a change was made to our target environment variable that
   // altered the size. Currently, we ignore this scenario and fail if the
   // returned size is greater than what we expect.
@@ -72,12 +72,11 @@ boost::optional<std::string> getEnvVar(const std::string& name) {
     return boost::none;
   }
 
-  return wstringToString(buf.data());
+  return wstringToString(buf.data(), buf.size());
 }
 
 boost::optional<std::string> expandEnvString(const std::string& input) {
-  std::vector<WCHAR> buf;
-  buf.assign(kInitialBufferSize, L'\0');
+  std::vector<WCHAR> buf(kInitialBufferSize);
 
   if (input.size() > kEnvironmentExpansionMax) {
     VLOG(1) << "Not expanding environment string larger than "

--- a/osquery/utils/system/windows/system.cpp
+++ b/osquery/utils/system/windows/system.cpp
@@ -19,7 +19,7 @@ std::string getHostname() {
   if (0 == GetComputerNameW(nullptr, &size)) {
     std::vector<WCHAR> computer_name(size, 0);
     GetComputerNameW(computer_name.data(), &size);
-    return wstringToString(computer_name.data());
+    return wstringToString(computer_name.data(), computer_name.size());
   }
 
   return {};
@@ -30,7 +30,7 @@ std::string getFqdn() {
   if (0 == GetComputerNameExW(ComputerNameDnsFullyQualified, nullptr, &size)) {
     std::vector<WCHAR> fqdn(size, 0);
     GetComputerNameExW(ComputerNameDnsFullyQualified, fqdn.data(), &size);
-    return wstringToString(fqdn.data());
+    return wstringToString(fqdn.data(), fqdn.size());
   }
 
   return {};

--- a/osquery/utils/system/windows/users_groups_helpers.cpp
+++ b/osquery/utils/system/windows/users_groups_helpers.cpp
@@ -324,11 +324,8 @@ std::string getUserHomeDir(const std::string& sid) {
   }
 
   DWORD value_type;
-  DWORD value_data_length;
-  std::wstring value_data;
-  value_data.resize(max_value_data_length);
-
-  value_data_length = max_value_data_length;
+  DWORD value_data_length = max_value_data_length;
+  std::wstring value_data(max_value_data_length / sizeof(WCHAR), L'\0');
 
   ret = RegQueryValueExW(registry_handle.get(),
                          kProfileValueName.c_str(),
@@ -349,6 +346,8 @@ std::string getUserHomeDir(const std::string& sid) {
             << wstringToString(profile_key_path) << " is not a string";
     return {};
   }
+
+  value_data.resize(value_data_length / sizeof(WCHAR));
 
   return wstringToString(value_data);
 }


### PR DESCRIPTION
- Add a wstringToString overload that takes a wchar_t pointer and the maximum amount of characters to scan for a null terminator in the provided pointer/buffer, to prevent overflowing.

- Add a to_bytes overload, similar to the new wstringToString overload which permits to avoid to construct a std::wstring from a wchar_t pointer, therefore reducing overhead caused by allocations and copies, just to be able to do the conversion to a UTF8 std::string. A difference from the wstringToString overload is that the size is actually the expected size of the input string, not the max size of the buffer.

- Changed the to_bytes and from_bytes conversions functions to always call the respective Windows API conversion functions with the precise size of the input string, to avoid the need to scan for the null terminator. When std::wstring and std::string are passed to wstringToString and stringToWstring, they are expected to be already of the correct size, so to terminate exactly just before the null terminator. For the other overloads, wstringToString and stringToWstring will scan the provided buffers for a null terminator.

- Reduced overallocation to prepare the biggest needed output due to conversions between UTF8 -> UTF16 and UTF16 -> UTF8. The overallocation was considering sizes given to std::string and std::wstring to be always a factor of bytes, but that's not the case because the size of the strings is in characters.

- Added checks to ensure that the strings are not going outside of the size limits imposed by the conversion and the Windows APIs.

- User code changed to reflect the previous implementation changes, specifically to call the overload that provides the bounded scan where possible. Done some improvements around how many times conversions were done.

- Added some additional tests for the unicode conversion functions to test special cases.


## Additional notes:

For the UTF8 -> UTF16 and UTF16 -> UTF8 conversions and size of the output string in respect to the input one,
the original sizes are incorrect because I think it was assuming that the sizes were all in bytes.

First we have to remember that in the UTF8 -> UTF16 conversion, the `MultiByteToWideChar` conversion function wants the input to be in bytes and in the output in UTF16 chars.
Now in this conversion the worst case/the maximum factor if we consider bytes is 2, because going from 1 byte/character ASCII in UTF8 to UTF16 requires 1 UTF16 character, which is 2 bytes.
But since the output size is counted in UTF16 characters, the conversion factor is actually 1. In all other cases going from UTF8 -> UTF16 reduces the size in bytes or remains the same.
For instance the range U+0800 to U+0FFF requires 3 bytes, but in UTF16 it requires 1 character, so 2 bytes.

Conversely from UTF16 -> UTF16 the worst cases are to be considered when the count of characters has to be multiplied by some number higher than 1, to match the size in UTF8. This is 3, because as we've previously seen, 1 UTF16 character may have to be translated to 3 bytes.
Although 3 bytes is not the biggest UTF8 code point, but 4, these are surrogate pairs which are represented with 4 bytes in both UTF8 and UTF16, or 2 characters in UTF16. This means that going from 2 UTF16 character representing the surrogate pair to the 4 UTF8 bytes the factor is 2.
