### PR TITLE
macos: `es_process_file_events` -- add support for open events, and for only triggering on `file_paths`

### DIFF
--- a/osquery/events/darwin/endpointsecurity.h
+++ b/osquery/events/darwin/endpointsecurity.h
@@ -181,6 +181,8 @@ class EndpointSecurityFileEventPublisher
   bool es_file_client_success_{false};
   std::vector<std::string> muted_path_literals_;
   std::vector<std::string> muted_path_prefixes_;
+  std::vector<std::string> file_paths_;
+  std::vector<std::string> exclude_paths_;
   // clang-format off
   std::vector<std::string> default_muted_path_literals_ = {
       "/System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/Resources/WindowServer",
@@ -195,7 +197,7 @@ class EndpointSecurityFileEventPublisher
       "/usr/libexec/amfid",
       "/usr/libexec/watchdogd",
   };
-  // clang-format on 
+  // clang-format on
 };
 
 class ESProcessEventSubscriber

--- a/osquery/events/darwin/endpointsecurity_fim.cpp
+++ b/osquery/events/darwin/endpointsecurity_fim.cpp
@@ -123,7 +123,7 @@ void EndpointSecurityFileEventPublisher::configure() {
         VLOG(1) << "Unable to mute default path: " << p;
       }
     }
-    
+
     if (__builtin_available(macos 13.0, *)) {
       auto parser = Config::getParser("file_paths");
       if (parser != nullptr) {

--- a/osquery/events/darwin/endpointsecurity_fim.cpp
+++ b/osquery/events/darwin/endpointsecurity_fim.cpp
@@ -137,9 +137,11 @@ void EndpointSecurityFileEventPublisher::configure() {
             for (const auto& cat : doc["exclude_paths"].GetObject()) {
               if (cat.value.IsArray()) {
                 for (const auto& ex_path : cat.value.GetArray()) {
-                  std::string pattern = ex_path.GetString();
-                  if (!pattern.empty()) {
-                    resolveFilePattern(pattern, exclude_paths_);
+                  if (ex_path.IsString()) {
+                    std::string pattern = ex_path.GetString();
+                    if (!pattern.empty()) {
+                      resolveFilePattern(pattern, exclude_paths_);
+                    }
                   }
                 }
               }

--- a/osquery/events/darwin/es_utils.cpp
+++ b/osquery/events/darwin/es_utils.cpp
@@ -35,7 +35,14 @@ FLAG(string,
 FLAG(string,
      es_fim_mute_path_prefix,
      "",
-     "Comma delimited list of path prefxes to be muted for FIM");
+     "Comma delimited list of path prefixes to be muted for FIM");
+
+// document performance issues
+FLAG(bool,
+     es_fim_enable_open_events,
+     false,
+     "Enable open events");
+
 
 std::string getEsNewClientErrorMessage(const es_new_client_result_t r) {
   switch (r) {

--- a/osquery/events/darwin/es_utils.cpp
+++ b/osquery/events/darwin/es_utils.cpp
@@ -38,11 +38,7 @@ FLAG(string,
      "Comma delimited list of path prefixes to be muted for FIM");
 
 // document performance issues
-FLAG(bool,
-     es_fim_enable_open_events,
-     false,
-     "Enable open events");
-
+FLAG(bool, es_fim_enable_open_events, false, "Enable open events");
 
 std::string getEsNewClientErrorMessage(const es_new_client_result_t r) {
   switch (r) {

--- a/osquery/tables/events/darwin/es_process_file_events.cpp
+++ b/osquery/tables/events/darwin/es_process_file_events.cpp
@@ -12,6 +12,7 @@
 #include <os/availability.h>
 
 #include <osquery/core/flags.h>
+#include <osquery/events/darwin/es_utils.h>
 #include <osquery/events/darwin/endpointsecurity.h>
 #include <osquery/events/events.h>
 #include <osquery/registry/registry_factory.h>
@@ -22,6 +23,8 @@ REGISTER(ESProcessFileEventSubscriber,
          "event_subscriber",
          "es_process_file_events");
 
+DECLARE_bool(es_fim_enable_open_events);
+
 Status ESProcessFileEventSubscriber::init() {
   if (__builtin_available(macos 10.15, *)) {
     auto sc = createSubscriptionContext();
@@ -30,6 +33,10 @@ Status ESProcessFileEventSubscriber::init() {
     sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_RENAME);
     sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_WRITE);
     sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_TRUNCATE);
+
+    if (FLAGS_es_fim_enable_open_events) {
+      sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_OPEN);
+    }
 
     subscribe(&ESProcessFileEventSubscriber::Callback, sc);
 

--- a/osquery/tables/events/darwin/es_process_file_events.cpp
+++ b/osquery/tables/events/darwin/es_process_file_events.cpp
@@ -35,7 +35,12 @@ Status ESProcessFileEventSubscriber::init() {
     sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_TRUNCATE);
 
     if (FLAGS_es_fim_enable_open_events) {
-      sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_OPEN);
+      // we only want open events on macOS 13 and above
+      if (__builtin_available(macos 13.0, *)) {
+        sc->es_file_event_subscriptions_.push_back(ES_EVENT_TYPE_NOTIFY_OPEN);
+      } else {
+        VLOG(1) << "open events are only enabled for macOS 13 and above";
+      }
     }
 
     subscribe(&ESProcessFileEventSubscriber::Callback, sc);

--- a/osquery/tables/events/darwin/es_process_file_events.cpp
+++ b/osquery/tables/events/darwin/es_process_file_events.cpp
@@ -12,8 +12,8 @@
 #include <os/availability.h>
 
 #include <osquery/core/flags.h>
-#include <osquery/events/darwin/es_utils.h>
 #include <osquery/events/darwin/endpointsecurity.h>
+#include <osquery/events/darwin/es_utils.h>
 #include <osquery/events/events.h>
 #include <osquery/registry/registry_factory.h>
 


### PR DESCRIPTION
Tested on: 
* macOS 11 (Big Sur)
* macOS 12 (Monterey)
* macOS 13 (Ventura)

Test `osquery.conf`:

```json
{
  "options": {
    "disable_events": "false",
    "verbose": "true",
    "disable_events": "false",
    "ephemeral": "true",
    "disable_endpointsecurity": "false",
    "disable_endpointsecurity_fim": "false",
    "es_fim_enable_open_events": "true"
  },
  "schedule": {
    "es_file_events": {
      "query": "SELECT * FROM es_process_file_events;",
      "interval": 20
    }
  },
  "file_paths": {
    "monitor": [
      "/Users/*/.aws/*",
      "/Users/*/.ssh/*",
      "/Users/*/.config/gcloud/*",
      "/Library/Keychains/*.keychain"
    ]
  },
  "exclude_paths": {
    "monitor": [
      "/Users/*/.ssh/id_ed25519.pub"
    ]
  }
}
```