### PR TITLE
docs: add very basic file carving documentation

### DIFF
--- a/docs/wiki/deployment/file-carving.md
+++ b/docs/wiki/deployment/file-carving.md
@@ -1,0 +1,28 @@
+# File Carving with osquery
+
+Osquery has the capability to pull files from endpoints that it is monitoring with file carving.
+
+Simply query the `carves` table with your desired filepath and `carve=1`, which tells osquery that you want to start this carve.
+
+```sql
+SELECT * FROM carves WHERE path LIKE '/tmp/files/%%' AND carve=1;
+```
+
+The carving will happen once the scheduler dispatches the request. You can check on the `status` of a carve to see if it's completed yet. The status will be one of [STARTING, PENDING, SUCCESS, or FAILED](https://www.osquery.io/schema/current/#carves).
+
+## How to enable file carving
+
+File carving is disabled by default. In order to enable it, you must pass the flag `--disable_carver=false`.
+
+Additionally you may want to configure the following flags for your backend.
+```
+--carver_compression=true
+--carver_block_size=300000
+--carver_start_endpoint=/start_uploads
+--carver_continue_endpoint=/upload_blocks
+--carver_disable_function=false
+```
+Excerpted from [this blog post](https://www.metalliccode.com/carving):
+
+- `carver_compression` turns on Zstd compression for the files being returned
+- `carver_disable_function` allows for using carve as a function

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Syslog Consumption: deployment/syslog.md
   - Debugging: deployment/debugging.md
   - Dependency Security: deployment/dependency-security.md
+  - File Carving: deployment/file-carving.md
 - Development:
   - Building osquery: development/building.md
   - Creating New Tables: development/creating-tables.md


### PR DESCRIPTION
Adds a new wiki page with minimum information about osquery's file carving tool.

Addresses the empty void of file carving documentation i.e. #7677 but not even close to enough detail to satisfy #3797.