### PR TITLE
Allow querying of kernel and filesystem drivers

### DIFF
--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -46,9 +46,9 @@ const std::string kSvcStatus[] = {"UNKNOWN",
                                   "PAUSED"};
 
 /* Possible values defined here (dwServiceType): 
-* https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
-* https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
-*/
+ * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
+ * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
+ */
 const std::map<int, std::string> kServiceType = {
     {0x00000001, "KERNEL_DRIVER"},
     {0x00000002, "FILE_SYSTEM_DRIVER"},
@@ -60,7 +60,7 @@ const std::map<int, std::string> kServiceType = {
     {0x000000e0, "USER_SHARE_PROCESS(Instance)"},
     {0x00000100, "INTERACTIVE_PROCESS"},
     {0x00000110, "OWN_PROCESS(Interactive)"},
-    {0x00000120, "SHARE_PROCESS(Interactive)"} };
+    {0x00000120, "SHARE_PROCESS(Interactive)"}};
 
 static inline Status getService(const SC_HANDLE& scmHandle,
                                 const ENUM_SERVICE_STATUS_PROCESS& svc,

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -45,9 +45,10 @@ const std::string kSvcStatus[] = {"UNKNOWN",
                                   "PAUSE_PENDING",
                                   "PAUSED"};
 
-// Possible values defined here (dwServiceType): 
-//  https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
-//  https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
+/* Possible values defined here (dwServiceType): 
+* https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
+* https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
+*/
 const std::map<int, std::string> kServiceType = {
     {0x00000001, "KERNEL_DRIVER"},
     {0x00000002, "FILE_SYSTEM_DRIVER"},
@@ -57,9 +58,9 @@ const std::map<int, std::string> kServiceType = {
     {0x00000060, "USER_SHARE_PROCESS"},
     {0x000000d0, "USER_OWN_PROCESS(Instance)"},
     {0x000000e0, "USER_SHARE_PROCESS(Instance)"},
-    {0x00000100, "INTERACTIVE_PROCESS"}, // according to msdn (see above link), this value alone shouldn't be possible
+    {0x00000100, "INTERACTIVE_PROCESS"},
     {0x00000110, "OWN_PROCESS(Interactive)"},
-    {0x00000120, "SHARE_PROCESS(Interactive)"}};
+    {0x00000120, "SHARE_PROCESS(Interactive)"} };
 
 static inline Status getService(const SC_HANDLE& scmHandle,
                                 const ENUM_SERVICE_STATUS_PROCESS& svc,

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -45,10 +45,19 @@ const std::string kSvcStatus[] = {"UNKNOWN",
                                   "PAUSE_PENDING",
                                   "PAUSED"};
 
+// Possible values defined here (dwServiceType): 
+//  https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
+//  https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
 const std::map<int, std::string> kServiceType = {
+    {0x00000001, "KERNEL_DRIVER"},
+    {0x00000002, "FILE_SYSTEM_DRIVER"},
     {0x00000010, "OWN_PROCESS"},
     {0x00000020, "SHARE_PROCESS"},
-    {0x00000100, "INTERACTIVE_PROCESS"},
+    {0x00000050, "USER_OWN_PROCESS"},
+    {0x00000060, "USER_SHARE_PROCESS"},
+    {0x000000d0, "USER_OWN_PROCESS(Instance)"},
+    {0x000000e0, "USER_SHARE_PROCESS(Instance)"},
+    {0x00000100, "INTERACTIVE_PROCESS"}, // according to msdn (see above link), this value alone shouldn't be possible
     {0x00000110, "OWN_PROCESS(Interactive)"},
     {0x00000120, "SHARE_PROCESS(Interactive)"}};
 
@@ -162,7 +171,7 @@ static inline Status getServices(QueryData& results) {
   DWORD serviceCount;
   (void)EnumServicesStatusEx(scmHandle.get(),
                              SC_ENUM_PROCESS_INFO,
-                             SERVICE_WIN32,
+                             (SERVICE_WIN32 | SERVICE_DRIVER),
                              SERVICE_STATE_ALL,
                              nullptr,
                              0,
@@ -183,7 +192,7 @@ static inline Status getServices(QueryData& results) {
 
   auto ret = EnumServicesStatusEx(scmHandle.get(),
                                   SC_ENUM_PROCESS_INFO,
-                                  SERVICE_WIN32,
+                                  (SERVICE_WIN32 | SERVICE_DRIVER),
                                   SERVICE_STATE_ALL,
                                   (LPBYTE)lpSvcBuf.get(),
                                   bytesNeeded,

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -45,7 +45,7 @@ const std::string kSvcStatus[] = {"UNKNOWN",
                                   "PAUSE_PENDING",
                                   "PAUSED"};
 
-/* Possible values defined here (dwServiceType): 
+/* Possible values defined here (dwServiceType):
  * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
  * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
  */


### PR DESCRIPTION
Fixes #6852

Windows "Services" can be created as drivers too. 
Currently osquery has no way to query info about File System Drivers or Kernel Drivers that are registered as "Services".
As the "drivers" table, rightly only includes Device Drivers. 

Local testing done:
```
C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT * FROM services WHERE name LIKE 'wof';"
+------+--------------------+-------------------------------------------+---------+-----+------------+-----------------+-------------------+------+-------------+-------------+--------------+
| name | service_type       | display_name                              | status  | pid | start_type | win32_exit_code | service_exit_code | path | module_path | description | user_account |
+------+--------------------+-------------------------------------------+---------+-----+------------+-----------------+-------------------+------+-------------+-------------+--------------+
| Wof  | FILE_SYSTEM_DRIVER | Windows Overlay File System Filter Driver | RUNNING | 0   | BOOT_START | 0               | 0                 |      |             |             |              |
+------+--------------------+-------------------------------------------+---------+-----+------------+-----------------+-------------------+------+-------------+-------------+--------------+

C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT * FROM services WHERE name LIKE 'ws2ifsl';"
+---------+---------------+-----------------------------------------------------------------+---------+-----+--------------+-----------------+-------------------+------------------------------------------+-------------+--------------------+--------------+
| name    | service_type  | display_name                                                    | status  | pid | start_type   | win32_exit_code | service_exit_code | path                                     | module_path | description        | user_account |
+---------+---------------+-----------------------------------------------------------------+---------+-----+--------------+-----------------+-------------------+------------------------------------------+-------------+--------------------+--------------+
| ws2ifsl | KERNEL_DRIVER | Windows Socket 2.0 Non-IFS Service Provider Support Environment | RUNNING | 0   | SYSTEM_START | 0               | 0                 | \SystemRoot\system32\drivers\ws2ifsl.sys |             | Winsock IFS Driver |              |
+---------+---------------+-----------------------------------------------------------------+---------+-----+--------------+-----------------+-------------------+------------------------------------------+-------------+--------------------+--------------+

C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT count(*) FROM services;"
+----------+
| count(*) |
+----------+
| 619      |
+----------+

C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT count(*) FROM services WHERE service_type LIKE '%PROCESS%';"
+----------+
| count(*) |
+----------+
| 252      |
+----------+

C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT count(*) FROM services WHERE service_type LIKE '%DRIVER%';"
+----------+
| count(*) |
+----------+
| 367      |
+----------+

C:\Source\osquery\build\osquery\RelWithDebInfo>osqueryi.exe "SELECT count(*) FROM services WHERE service_type LIKE 'unknown';"
+----------+
| count(*) |
+----------+
| 0        |
+----------+
```

- [?] Ensure your PR contains tests for the changes you're submitting.
    - all tests for the services table seem disabled.  https://github.com/osquery/osquery/blob/master/tests/integration/tables/services.cpp


