### PR TITLE
Use JSON member iterator instead of rescanning

### DIFF
--- a/osquery/events/darwin/endpointsecurity_fim.cpp
+++ b/osquery/events/darwin/endpointsecurity_fim.cpp
@@ -133,8 +133,8 @@ void EndpointSecurityFileEventPublisher::configure() {
         const auto& doc = parser->getData().doc();
         auto it = doc.FindMember("exclude_paths");
         if (it != doc.MemberEnd()) {
-          if (doc["exclude_paths"].IsObject()) {
-            for (const auto& cat : doc["exclude_paths"].GetObject()) {
+          if (it->value.IsObject()) {
+            for (const auto& cat : it->value.GetObject()) {
               if (cat.value.IsArray()) {
                 for (const auto& ex_path : cat.value.GetArray()) {
                   if (ex_path.IsString()) {


### PR DESCRIPTION
A minor improvement I missed in the review, to avoid repetition and rescanning the JSON member we've already found.
