### PR TITLE
libs: Update openssl to 3.1.2

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "3.1.1")
-set(OPENSSL_ARCHIVE_SHA256 "b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674")
+set(OPENSSL_VERSION "3.1.2")
+set(OPENSSL_ARCHIVE_SHA256 "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "ignored-cves": [
       "CVE-2019-0190"
     ]


### PR DESCRIPTION
Resolves CVE-2023-3817, CVE-2023-3446
and CVE-2023-2975

Fixes #8095 
Fixes #8097 
Fixes #8111