### PR TITLE
Fix openssl build arch for Windows ARM64

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -137,9 +137,15 @@ function(opensslMain)
     set(CMAKE_PREFIX_PATH "C:\\Strawberry\\perl\\bin")
     find_package(Perl REQUIRED)
 
+    if("${TARGET_PROCESSOR}" STREQUAL "aarch64")
+      set(OPENSSL_ARCH VC-WIN64-ARM)
+    else()
+      set(OPENSSL_ARCH VC-WIN64A)
+    endif()
+
     set(configure_command
       "${CMAKE_COMMAND}" -E env
-      "${PERL_EXECUTABLE}" Configure VC-WIN64A
+      "${PERL_EXECUTABLE}" Configure ${OPENSSL_ARCH}
       ${common_options}
     )
 


### PR DESCRIPTION
The build we do now still creates an ARM64 static library (otherwise the build would've broken), but how openssl was configured was wrong.
I could at least see a difference in the RC4_INT definition, which shouldn't affect correctness, just performance, but I haven't deeply checked what other issues were present with the incorrect configuration.