### PR TITLE
Fix named virtual table create statement

### DIFF
--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -80,8 +80,7 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "benchmark", dbc, false);
+  attachTableInternal("benchmark", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -101,8 +100,7 @@ static void SQL_virtual_table_internal_yield(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "benchmark_yield", dbc, false);
+  attachTableInternal("benchmark_yield", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -123,8 +121,7 @@ static void SQL_virtual_table_internal_global(benchmark::State& state) {
   while (state.KeepRunning()) {
     // Get a connection to the persistent database.
     auto dbc = SQLiteDBManager::get();
-    attachTableInternal(
-        "benchmark", dbc, false);
+    attachTableInternal("benchmark", dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -144,8 +141,7 @@ static void SQL_virtual_table_internal_unique(benchmark::State& state) {
   while (state.KeepRunning()) {
     // Get a new database connection (to a unique database).
     auto dbc = SQLiteDBManager::getUnique();
-    attachTableInternal(
-        "benchmark", dbc, false);
+    attachTableInternal("benchmark", dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -183,8 +179,7 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "long_benchmark", dbc, false);
+  attachTableInternal("long_benchmark", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -247,8 +242,7 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "wide_benchmark", dbc, false);
+  attachTableInternal("wide_benchmark", dbc, false);
 
   kWideCount = state.range(1);
   while (state.KeepRunning()) {
@@ -274,8 +268,7 @@ static void SQL_virtual_table_internal_wide_yield(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "wide_benchmark_yield", dbc, false);
+  attachTableInternal("wide_benchmark_yield", dbc, false);
 
   kWideCount = state.range(1);
   while (state.KeepRunning()) {

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -81,7 +81,7 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "benchmark", columnDefinition(res, false, false), dbc, false);
+      "benchmark", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -102,7 +102,7 @@ static void SQL_virtual_table_internal_yield(benchmark::State& state) {
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "benchmark_yield", columnDefinition(res, false, false), dbc, false);
+      "benchmark_yield", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -124,7 +124,7 @@ static void SQL_virtual_table_internal_global(benchmark::State& state) {
     // Get a connection to the persistent database.
     auto dbc = SQLiteDBManager::get();
     attachTableInternal(
-        "benchmark", columnDefinition(res, false, false), dbc, false);
+        "benchmark", dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -145,7 +145,7 @@ static void SQL_virtual_table_internal_unique(benchmark::State& state) {
     // Get a new database connection (to a unique database).
     auto dbc = SQLiteDBManager::getUnique();
     attachTableInternal(
-        "benchmark", columnDefinition(res, false, false), dbc, false);
+        "benchmark", dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -184,7 +184,7 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "long_benchmark", columnDefinition(res, false, false), dbc, false);
+      "long_benchmark", dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -248,7 +248,7 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "wide_benchmark", columnDefinition(res, false, false), dbc, false);
+      "wide_benchmark", dbc, false);
 
   kWideCount = state.range(1);
   while (state.KeepRunning()) {
@@ -275,7 +275,7 @@ static void SQL_virtual_table_internal_wide_yield(benchmark::State& state) {
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "wide_benchmark_yield", columnDefinition(res, false, false), dbc, false);
+      "wide_benchmark_yield", dbc, false);
 
   kWideCount = state.range(1);
   while (state.KeepRunning()) {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -276,7 +276,6 @@ Status SQLiteSQLPlugin::attach(const std::string& name) {
   }
 
   bool is_extension = true;
-  auto statement = columnDefinition(response, false, is_extension);
 
   // Attach requests occurring via the plugin/registry APIs must act on the
   // primary database. To allow this, getConnection can explicitly request the
@@ -284,7 +283,7 @@ Status SQLiteSQLPlugin::attach(const std::string& name) {
   auto dbc = SQLiteDBManager::getConnection(true);
 
   // Attach as an extension, allowing read/write tables
-  return attachTableInternal(name, statement, dbc, is_extension);
+  return attachTableInternal(name, dbc, is_extension);
 }
 
 Status SQLiteSQLPlugin::detach(const std::string& name) {

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -215,7 +215,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
 
   // Virtual tables require the registry/plugin API to query tables.
   auto status =
-      attachTableInternal("failed_sample", "(foo INTEGER)", dbc, false);
+      attachTableInternal("failed_sample", dbc, false);
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -228,7 +228,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
 
   // Use the table name, plugin-generated schema to attach.
   status = attachTableInternal(
-      "sample", columnDefinition(response, false, false), dbc, false);
+      "sample", dbc, false);
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string const q =
@@ -318,9 +318,9 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   {
     // To simplify the attach, just access the column definition directly.
     auto p = std::make_shared<pTablePlugin>();
-    attachTableInternal("p", p->columnDefinition(false), dbc, false);
+    attachTableInternal("p", dbc, false);
     auto k = std::make_shared<kTablePlugin>();
-    attachTableInternal("k", k->columnDefinition(false), dbc, false);
+    attachTableInternal("k", dbc, false);
   }
 
   std::vector<std::pair<std::string, QueryData>> constraint_tests = {
@@ -403,7 +403,7 @@ TEST_F(VirtualTableTests, test_json_extract) {
   tables->add("json", json);
 
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("json", json->columnDefinition(false), dbc, false);
+  attachTableInternal("json", dbc, false);
 
   QueryData results;
   // Run a query with a join within.
@@ -483,7 +483,7 @@ TEST_F(VirtualTableTests, test_table_cache) {
   auto cache = std::make_shared<cacheTablePlugin>();
   tables->add("cache", cache);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("cache", cache->columnDefinition(false), dbc, false);
+  attachTableInternal("cache", dbc, false);
 
   QueryData results;
   // Run a query with a join within.
@@ -539,7 +539,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   tables->add("table_cache", cache);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "table_cache", cache->columnDefinition(false), dbc, false);
+      "table_cache", dbc, false);
 
   QueryData results;
   std::string statement = "SELECT * from table_cache;";
@@ -606,7 +606,7 @@ TEST_F(VirtualTableTests, test_table_results_cache_colcheck) {
   tables->add("table_cache_cols", cache);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "table_cache_cols", cache->columnDefinition(false), dbc, false);
+      "table_cache_cols", dbc, false);
 
   // Request that caching be used.
   dbc->useCache(true);
@@ -667,7 +667,7 @@ TEST_F(VirtualTableTests, test_yield_generator) {
   table_registry->add("yield", table);
 
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("yield", table->columnDefinition(false), dbc, false);
+  attachTableInternal("yield", dbc, false);
 
   QueryData results;
   queryInternal("SELECT * from yield", results, dbc);
@@ -725,7 +725,7 @@ TEST_F(VirtualTableTests, test_like_constraints) {
   table_registry->add("like_table", table);
 
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("like_table", table->columnDefinition(false), dbc, false);
+  attachTableInternal("like_table", dbc, false);
 
   // Base case, without constrains this table has no results.
   QueryData results;
@@ -883,16 +883,16 @@ TEST_F(VirtualTableTests, test_indexing_costs) {
 
   auto i = std::make_shared<indexIOptimizedTablePlugin>();
   table_registry->add("index_i", i);
-  attachTableInternal("index_i", i->columnDefinition(false), dbc, false);
+  attachTableInternal("index_i", dbc, false);
 
   auto j = std::make_shared<indexJOptimizedTablePlugin>();
   table_registry->add("index_j", j);
-  attachTableInternal("index_j", j->columnDefinition(false), dbc, false);
+  attachTableInternal("index_j", dbc, false);
 
   auto default_scan = std::make_shared<defaultScanTablePlugin>();
   table_registry->add("default_scan", default_scan);
   attachTableInternal(
-      "default_scan", default_scan->columnDefinition(false), dbc, false);
+      "default_scan", dbc, false);
 
   QueryData results;
   queryInternal(
@@ -975,7 +975,7 @@ TEST_F(VirtualTableTests, test_used_columns) {
   tables->add("colsUsed1", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "colsUsed1", colsUsed->columnDefinition(false), dbc, false);
+      "colsUsed1", dbc, false);
 
   QueryData results;
   auto status = queryInternal("SELECT col1, col3 FROM colsUsed1", results, dbc);
@@ -994,7 +994,7 @@ TEST_F(VirtualTableTests, test_used_columns_with_alias) {
   tables->add("colsUsed2", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "colsUsed2", colsUsed->columnDefinition(false), dbc, false);
+      "colsUsed2", dbc, false);
 
   QueryData results;
   auto status =
@@ -1052,7 +1052,7 @@ TEST_F(VirtualTableTests, test_used_columns_bitset) {
   tables->add("colsUsedBitset1", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "colsUsedBitset1", colsUsed->columnDefinition(false), dbc, false);
+      "colsUsedBitset1", dbc, false);
 
   QueryData results;
   auto status =
@@ -1072,7 +1072,7 @@ TEST_F(VirtualTableTests, test_used_columns_bitset_with_alias) {
   tables->add("colsUsedBitset2", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "colsUsedBitset2", colsUsed->columnDefinition(false), dbc, false);
+      "colsUsedBitset2", dbc, false);
 
   QueryData results;
   auto status =
@@ -1118,7 +1118,7 @@ TEST_F(VirtualTableTests, test_used_columns_default) {
   tables->add("colsUsedDefault", colsUsedDefault);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "colsUsedDefault", colsUsedDefault->columnDefinition(false), dbc, false);
+      "colsUsedDefault", dbc, false);
 
   {
     QueryData results;
@@ -1178,7 +1178,7 @@ TEST_F(VirtualTableTests, test_noindex_constraints) {
 
   auto tablePlugin = std::make_shared<NoConstraintTestTablePlugin>();
   table_registry->add("noco", tablePlugin);
-  attachTableInternal("noco", tablePlugin->columnDefinition(false), dbc, false);
+  attachTableInternal("noco", dbc, false);
 
   QueryData results;
   queryInternal(
@@ -1217,7 +1217,7 @@ TEST_F(VirtualTableTests, test_table_exceptions) {
   tables->add("exceptional", exceptional);
   auto dbc = SQLiteDBManager::getUnique();
   attachTableInternal(
-      "exceptional", exceptional->columnDefinition(false), dbc, false);
+      "exceptional", dbc, false);
 
   auto backup_flag = FLAGS_ignore_table_exceptions;
   FLAGS_ignore_table_exceptions = true;

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -234,7 +234,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   QueryData results;
   status = queryInternal(q, results, dbc);
   EXPECT_EQ(
-      "CREATE VIRTUAL TABLE sample USING sample(`foo` INTEGER, `bar` TEXT)",
+      "CREATE VIRTUAL TABLE sample USING sample",
       results[0]["sql"]);
 }
 

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -233,9 +233,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
       "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
   QueryData results;
   status = queryInternal(q, results, dbc);
-  EXPECT_EQ(
-      "CREATE VIRTUAL TABLE sample USING sample",
-      results[0]["sql"]);
+  EXPECT_EQ("CREATE VIRTUAL TABLE sample USING sample", results[0]["sql"]);
 }
 
 TEST_F(VirtualTableTests, test_sqlite3_table_joins) {

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -214,8 +214,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto dbc = SQLiteDBManager::get();
 
   // Virtual tables require the registry/plugin API to query tables.
-  auto status =
-      attachTableInternal("failed_sample", dbc, false);
+  auto status = attachTableInternal("failed_sample", dbc, false);
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -227,8 +226,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   ASSERT_TRUE(status.ok());
 
   // Use the table name, plugin-generated schema to attach.
-  status = attachTableInternal(
-      "sample", dbc, false);
+  status = attachTableInternal("sample", dbc, false);
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string const q =
@@ -538,8 +536,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   auto cache = std::make_shared<tableCacheTablePlugin>();
   tables->add("table_cache", cache);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "table_cache", dbc, false);
+  attachTableInternal("table_cache", dbc, false);
 
   QueryData results;
   std::string statement = "SELECT * from table_cache;";
@@ -605,8 +602,7 @@ TEST_F(VirtualTableTests, test_table_results_cache_colcheck) {
   auto cache = std::make_shared<tableCacheTablePlugin>();
   tables->add("table_cache_cols", cache);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "table_cache_cols", dbc, false);
+  attachTableInternal("table_cache_cols", dbc, false);
 
   // Request that caching be used.
   dbc->useCache(true);
@@ -891,8 +887,7 @@ TEST_F(VirtualTableTests, test_indexing_costs) {
 
   auto default_scan = std::make_shared<defaultScanTablePlugin>();
   table_registry->add("default_scan", default_scan);
-  attachTableInternal(
-      "default_scan", dbc, false);
+  attachTableInternal("default_scan", dbc, false);
 
   QueryData results;
   queryInternal(
@@ -974,8 +969,7 @@ TEST_F(VirtualTableTests, test_used_columns) {
   auto colsUsed = std::make_shared<colsUsedTablePlugin>();
   tables->add("colsUsed1", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "colsUsed1", dbc, false);
+  attachTableInternal("colsUsed1", dbc, false);
 
   QueryData results;
   auto status = queryInternal("SELECT col1, col3 FROM colsUsed1", results, dbc);
@@ -993,8 +987,7 @@ TEST_F(VirtualTableTests, test_used_columns_with_alias) {
   auto colsUsed = std::make_shared<colsUsedTablePlugin>();
   tables->add("colsUsed2", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "colsUsed2", dbc, false);
+  attachTableInternal("colsUsed2", dbc, false);
 
   QueryData results;
   auto status =
@@ -1051,8 +1044,7 @@ TEST_F(VirtualTableTests, test_used_columns_bitset) {
   auto colsUsed = std::make_shared<colsUsedBitsetTablePlugin>();
   tables->add("colsUsedBitset1", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "colsUsedBitset1", dbc, false);
+  attachTableInternal("colsUsedBitset1", dbc, false);
 
   QueryData results;
   auto status =
@@ -1071,8 +1063,7 @@ TEST_F(VirtualTableTests, test_used_columns_bitset_with_alias) {
   auto colsUsed = std::make_shared<colsUsedBitsetTablePlugin>();
   tables->add("colsUsedBitset2", colsUsed);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "colsUsedBitset2", dbc, false);
+  attachTableInternal("colsUsedBitset2", dbc, false);
 
   QueryData results;
   auto status =
@@ -1117,8 +1108,7 @@ TEST_F(VirtualTableTests, test_used_columns_default) {
   auto colsUsedDefault = std::make_shared<colsUsedDefaultTablePlugin>();
   tables->add("colsUsedDefault", colsUsedDefault);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "colsUsedDefault", dbc, false);
+  attachTableInternal("colsUsedDefault", dbc, false);
 
   {
     QueryData results;
@@ -1216,8 +1206,7 @@ TEST_F(VirtualTableTests, test_table_exceptions) {
   auto exceptional = std::make_shared<exceptionalTablePlugin>();
   tables->add("exceptional", exceptional);
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal(
-      "exceptional", dbc, false);
+  attachTableInternal("exceptional", dbc, false);
 
   auto backup_flag = FLAGS_ignore_table_exceptions;
   FLAGS_ignore_table_exceptions = true;

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -1084,7 +1084,6 @@ struct sqlite3_module* getVirtualTableModule(const std::string& table_name,
 } // namespace tables
 
 Status attachTableInternal(const std::string& name,
-                           const std::string& statement,
                            const SQLiteDBInstanceRef& instance,
                            bool is_extension) {
   if (SQLiteDBManager::isDisabled(name)) {
@@ -1109,7 +1108,7 @@ Status attachTableInternal(const std::string& name,
 
   if (rc == SQLITE_OK || rc == SQLITE_MISUSE) {
     auto format =
-        "CREATE VIRTUAL TABLE temp." + name + " USING " + name + statement;
+        "CREATE VIRTUAL TABLE temp." + name + " USING " + name;
 
     rc =
         sqlite3_exec(instance->db(), format.c_str(), nullptr, nullptr, nullptr);
@@ -1165,12 +1164,10 @@ void attachVirtualTables(const SQLiteDBInstanceRef& instance) {
   bool is_extension = false;
 
   for (const auto& name : RegistryFactory::get().names("table")) {
-    // Column information is nice for virtual table create call.
     auto status =
         Registry::call("table", name, {{"action", "columns"}}, response);
     if (status.ok()) {
-      auto statement = columnDefinition(response, true, is_extension);
-      attachTableInternal(name, statement, instance, is_extension);
+      attachTableInternal(name, instance, is_extension);
     }
   }
 }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -1107,13 +1107,13 @@ Status attachTableInternal(const std::string& name,
       instance->db(), name.c_str(), module, (void*)&(*instance));
 
   if (rc == SQLITE_OK || rc == SQLITE_MISUSE) {
-    auto format =
-        "CREATE VIRTUAL TABLE temp." + name + " USING " + name;
+    auto format = "CREATE VIRTUAL TABLE temp." + name + " USING " + name;
 
     rc =
         sqlite3_exec(instance->db(), format.c_str(), nullptr, nullptr, nullptr);
     if (rc != SQLITE_OK) {
-      LOG(ERROR) << "Error creating named virtual table: " << name << " (" << rc << ")";
+      LOG(ERROR) << "Error creating named virtual table: " << name << " (" << rc
+                 << ")";
     }
   } else {
     LOG(ERROR) << "Error attaching table: " << name << " (" << rc << ")";

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -1112,7 +1112,9 @@ Status attachTableInternal(const std::string& name,
 
     rc =
         sqlite3_exec(instance->db(), format.c_str(), nullptr, nullptr, nullptr);
-
+    if (rc != SQLITE_OK) {
+      LOG(ERROR) << "Error creating named virtual table: " << name << " (" << rc << ")";
+    }
   } else {
     LOG(ERROR) << "Error attaching table: " << name << " (" << rc << ")";
   }

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -79,7 +79,6 @@ struct VirtualTable : private boost::noncopyable {
 
 /// Attach a table plugin name to an in-memory SQLite database.
 Status attachTableInternal(const std::string& name,
-                           const std::string& statement,
                            const SQLiteDBInstanceRef& instance,
                            bool is_extension);
 


### PR DESCRIPTION
Fixes: #7000 
Fixes: #5714

I noticed some of the named virtual tables don’t appear in the osquery instance. This can be seen by querying `sqlite_temp_master`.

Digging a lot, this is because we add `WITHOUT ROWID` to the column definitions when a table contains a column with either an index or additional flag set. This breaks parsing on the named virtual table create statements.

```
osquery> CREATE VIRTUAL TABLE test USING users() WITHOUT ROWID;
Error: near "WITHOUT": syntax error

osquery> CREATE VIRTUAL TABLE test USING users();

osquery> SELECT uid FROM test LIMIT 1;
+-----+
| uid |
+-----+
| 278 |
+-----+
```

This has been true since we added support for [sqlite 3.14.0](https://github.com/osquery/osquery/commit/763f4e94372c768e3c8f9f235ac5ce7370d2a2c6#diff-496b07a6ace3d0702ddd348f9b0b4fc3f13bcf22c159e2601b23668937d254c0). It wasn’t caught because we ignore the return code. This [Commit](https://github.com/osquery/osquery/commit/0cc9bbbaf7b2687032ee7829f424c19b650986ab) adds some error handling and we can see this. It might make sense to panic, or exit on error here.
```
E0914 10:17:00.132483 -167157632 virtual_table.cpp:1116] Error creating named virtual table: users (1)
E0914 10:17:00.132673 -167157632 virtual_table.cpp:1116] Error creating named virtual table: yara (1)
E0914 10:17:00.132719 -167157632 virtual_table.cpp:1116] Error creating named virtual table: ycloud_instance_metadata (1)
```

This PR additionally removes the column definitions from the `CREATE VIRTUAL TABLE` statement. As these additional arguments are not needed, and don’t appear to be adding much.

```
CREATE VIRTUAL TABLE tablename USING modulename(arg1, arg2, ...);

Each module-argument is passed as written (as text) into the constructor method (xCreate) of the virtual table implementation when the virtual table is created and that constructor is responsible for parsing and interpreting the arguments.

xCreate: If present, the fourth and subsequent strings in the argv[] array report the arguments to the module name in the CREATE VIRTUAL TABLE statement.
```

xCreate could access the column definitions that are in `argv[]`, but instead there’s a second call to `columnDefinition` for `sqlite3_declare_vtab()`.

The only side effect I’ve noticed so far with these changes, is that the schema is not in the `sqlite_temp_master`. But it still appears in `.schema`.

```
osquery> SELECT * FROM sqlite_temp_master WHERE name = 'users';
    type = table
    name = users
    tbl_name = users
    rootpage = 0
    sql = CREATE VIRTUAL TABLE users USING users

osquery> .schema users
CREATE TABLE users(`uid` BIGINT, `gid` BIGINT, `uid_signed` BIGINT, `gid_signed` BIGINT, `username` TEXT, `description` TEXT, `directory` TEXT, `shell` TEXT, `uuid` TEXT, `type` TEXT HIDDEN, `is_hidden` INTEGER, `pid_with_namespace` INTEGER HIDDEN, PRIMARY KEY (`uid`, `username`, `uuid`, `pid_with_namespace`)) WITHOUT ROWID;
```