### PR TITLE
cve: Update openssl to 3.1.3

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "3.1.2")
-set(OPENSSL_ARCHIVE_SHA256 "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539")
+set(OPENSSL_VERSION "3.1.3")
+set(OPENSSL_ARCHIVE_SHA256 "f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "ignored-cves": [
       "CVE-2019-0190"
     ]


### PR DESCRIPTION
Resolves CVE-2023-4807.

Fixes #8140 