### PR TITLE
cve: Update libmagic to 5.45

### DIFF
--- a/libraries/cmake/source/libmagic/CMakeLists.txt
+++ b/libraries/cmake/source/libmagic/CMakeLists.txt
@@ -18,6 +18,7 @@ function(libmagicMain)
     "${library_root}/src/compress.c"
     "${library_root}/src/is_csv.c"
     "${library_root}/src/is_json.c"
+    "${library_root}/src/is_simh.c"
     "${library_root}/src/is_tar.c"
     "${library_root}/src/readelf.c"
     "${library_root}/src/print.c"

--- a/libraries/cmake/source/libmagic/README.md
+++ b/libraries/cmake/source/libmagic/README.md
@@ -18,7 +18,7 @@ Note: If building for macOS ARM, substitute the target with `-target arm64-apple
 ```bash
 export CC=clang
 export OSQUERY_LZMA_HEADER="/Users/<user>/osquery/src/libraries/cmake/source/lzma/src/src/liblzma/api"
-export CFLAGS="-isysroot /Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -I${OSQUERY_LZMA_HEADER} -target x86_64-apple-macos10.14"
+export CFLAGS="-isysroot /Applications/Xcode_14.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -I${OSQUERY_LZMA_HEADER} -target x86_64-apple-macos10.15"
 ```
 
 Configure and build the project:

--- a/libraries/cmake/source/libmagic/config/linux/aarch64/config.h
+++ b/libraries/cmake/source/libmagic/config/linux/aarch64/config.h
@@ -439,7 +439,7 @@
 #endif
 
 /* Enable xzlib compression support */
-/* #undef XZLIBSUPPORT */
+#define XZLIBSUPPORT 1
 
 /* Enable zlib compression support */
 #define ZLIBSUPPORT 1

--- a/libraries/cmake/source/libmagic/config/linux/aarch64/config.h
+++ b/libraries/cmake/source/libmagic/config/linux/aarch64/config.h
@@ -19,6 +19,9 @@
 /* Define to 1 if you have the `asprintf' function. */
 #define HAVE_ASPRINTF 1
 
+/* Define to 1 if you have the <byteswap.h> header file. */
+#define HAVE_BYTESWAP_H 1
+
 /* Define to 1 if you have the <bzlib.h> header file. */
 /* #undef HAVE_BZLIB_H */
 
@@ -87,8 +90,11 @@
 /* Define to 1 if you have the `gnurx' library (-lgnurx). */
 /* #undef HAVE_LIBGNURX */
 
+/* Define to 1 if you have the `lz' library (-llz). */
+/* #undef HAVE_LIBLZ */
+
 /* Define to 1 if you have the `lzma' library (-llzma). */
-#define HAVE_LIBLZMA 1
+/* #undef HAVE_LIBLZMA */
 
 /* Define to 1 if you have the `seccomp' library (-lseccomp). */
 /* #undef HAVE_LIBSECCOMP */
@@ -96,11 +102,17 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
 
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+/* #undef HAVE_LIBZSTD */
+
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
 
+/* Define to 1 if you have the <lzlib.h> header file. */
+/* #undef HAVE_LZLIB_H */
+
 /* Define to 1 if you have the <lzma.h> header file. */
-#define HAVE_LZMA_H 1
+/* #undef HAVE_LZMA_H */
 
 /* Define to 1 if mbrtowc and mbstate_t are properly declared. */
 #define HAVE_MBRTOWC 1
@@ -111,8 +123,8 @@
 /* Define to 1 if you have the `memmem' function. */
 #define HAVE_MEMMEM 1
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
 
 /* Define to 1 if you have the `mkostemp' function. */
 #define HAVE_MKOSTEMP 1
@@ -129,14 +141,23 @@
 /* Define to 1 if you have the `pipe2' function. */
 #define HAVE_PIPE2 1
 
+/* Define to 1 if you have the `posix_spawnp' function. */
+#define HAVE_POSIX_SPAWNP 1
+
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1
 
 /* Have sig_t type */
 #define HAVE_SIG_T 1
 
+/* Define to 1 if you have the <spawn.h> header file. */
+#define HAVE_SPAWN_H 1
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -173,6 +194,12 @@
 
 /* Define to 1 if `tm_zone' is a member of `struct tm'. */
 #define HAVE_STRUCT_TM_TM_ZONE 1
+
+/* Define to 1 if you have the <sys/bswap.h> header file. */
+/* #undef HAVE_SYS_BSWAP_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -234,6 +261,10 @@
 /* Define to 1 if you have the <vfork.h> header file. */
 /* #undef HAVE_VFORK_H */
 
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
@@ -255,8 +286,17 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #define HAVE_ZLIB_H 1
 
+/* Define to 1 if you have the <zstd_errors.h> header file. */
+/* #undef HAVE_ZSTD_ERRORS_H */
+
+/* Define to 1 if you have the <zstd.h> header file. */
+/* #undef HAVE_ZSTD_H */
+
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
+
+/* Enable lzlib compression support */
+/* #undef LZLIBSUPPORT */
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */
@@ -264,7 +304,7 @@
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in
    <sysmacros.h>. */
-/* #undef MAJOR_IN_SYSMACROS */
+#define MAJOR_IN_SYSMACROS 1
 
 /* Name of package */
 #define PACKAGE "file"
@@ -276,7 +316,7 @@
 #define PACKAGE_NAME "file"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "file 5.40"
+#define PACKAGE_STRING "file 5.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "file"
@@ -285,9 +325,11 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "5.40"
+#define PACKAGE_VERSION "5.45"
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
 /* Define to 1 if your <sys/time.h> declares `struct tm'. */
@@ -297,26 +339,92 @@
 #ifndef _ALL_SOURCE
 # define _ALL_SOURCE 1
 #endif
-/* Enable GNU extensions on systems that have them.  */
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE 1
-#endif
-/* Enable threading extensions on Solaris.  */
-#ifndef _POSIX_PTHREAD_SEMANTICS
-# define _POSIX_PTHREAD_SEMANTICS 1
-#endif
-/* Enable extensions on HP NonStop.  */
-#ifndef _TANDEM_SOURCE
-# define _TANDEM_SOURCE 1
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
 #endif
 /* Enable general extensions on Solaris.  */
 #ifndef __EXTENSIONS__
 # define __EXTENSIONS__ 1
 #endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
 
 
 /* Version number of package */
-#define VERSION "5.40"
+#define VERSION "5.45"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -331,15 +439,13 @@
 #endif
 
 /* Enable xzlib compression support */
-#define XZLIBSUPPORT 1
+/* #undef XZLIBSUPPORT */
 
 /* Enable zlib compression support */
 #define ZLIBSUPPORT 1
 
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
-#endif
+/* Enable zstdlib compression support */
+/* #undef ZSTDLIBSUPPORT */
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */
@@ -349,16 +455,6 @@
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
-
-/* Define to 1 if on MINIX. */
-/* #undef _MINIX */
-
-/* Define to 2 if the system does not provide POSIX.1 features except with
-   this defined. */
-/* #undef _POSIX_1_SOURCE */
-
-/* Define to 1 if you need to in order for `stat' and other things to work. */
-/* #undef _POSIX_SOURCE */
 
 /* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
    <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
@@ -393,7 +489,7 @@
 /* Define to `long int' if <sys/types.h> does not define. */
 /* #undef off_t */
 
-/* Define to `int' if <sys/types.h> does not define. */
+/* Define as a signed integer type capable of holding a process identifier. */
 /* #undef pid_t */
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */

--- a/libraries/cmake/source/libmagic/config/linux/x86_64/config.h
+++ b/libraries/cmake/source/libmagic/config/linux/x86_64/config.h
@@ -19,6 +19,9 @@
 /* Define to 1 if you have the `asprintf' function. */
 #define HAVE_ASPRINTF 1
 
+/* Define to 1 if you have the <byteswap.h> header file. */
+#define HAVE_BYTESWAP_H 1
+
 /* Define to 1 if you have the <bzlib.h> header file. */
 /* #undef HAVE_BZLIB_H */
 
@@ -87,6 +90,9 @@
 /* Define to 1 if you have the `gnurx' library (-lgnurx). */
 /* #undef HAVE_LIBGNURX */
 
+/* Define to 1 if you have the `lz' library (-llz). */
+/* #undef HAVE_LIBLZ */
+
 /* Define to 1 if you have the `lzma' library (-llzma). */
 /* #undef HAVE_LIBLZMA */
 
@@ -96,8 +102,14 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
 
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+/* #undef HAVE_LIBZSTD */
+
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <lzlib.h> header file. */
+/* #undef HAVE_LZLIB_H */
 
 /* Define to 1 if you have the <lzma.h> header file. */
 #define HAVE_LZMA_H 1
@@ -129,11 +141,17 @@
 /* Define to 1 if you have the `pipe2' function. */
 #define HAVE_PIPE2 1
 
+/* Define to 1 if you have the `posix_spawnp' function. */
+#define HAVE_POSIX_SPAWNP 1
+
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1
 
 /* Have sig_t type */
 #define HAVE_SIG_T 1
+
+/* Define to 1 if you have the <spawn.h> header file. */
+#define HAVE_SPAWN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -173,6 +191,12 @@
 
 /* Define to 1 if `tm_zone' is a member of `struct tm'. */
 #define HAVE_STRUCT_TM_TM_ZONE 1
+
+/* Define to 1 if you have the <sys/bswap.h> header file. */
+/* #undef HAVE_SYS_BSWAP_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -234,6 +258,10 @@
 /* Define to 1 if you have the <vfork.h> header file. */
 /* #undef HAVE_VFORK_H */
 
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
@@ -255,9 +283,18 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #define HAVE_ZLIB_H 1
 
+/* Define to 1 if you have the <zstd_errors.h> header file. */
+/* #undef HAVE_ZSTD_ERRORS_H */
+
+/* Define to 1 if you have the <zstd.h> header file. */
+/* #undef HAVE_ZSTD_H */
+
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #define LT_OBJDIR ".libs/"
+
+/* Enable lzlib compression support */
+/* #undef LZLIBSUPPORT */
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */
@@ -266,6 +303,9 @@
 /* Define to 1 if `major', `minor', and `makedev' are declared in
    <sysmacros.h>. */
 /* #undef MAJOR_IN_SYSMACROS */
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+/* #undef NO_MINUS_C_MINUS_O */
 
 /* Name of package */
 #define PACKAGE "file"
@@ -277,7 +317,7 @@
 #define PACKAGE_NAME "file"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "file 5.40"
+#define PACKAGE_STRING "file 5.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "file"
@@ -286,7 +326,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "5.40"
+#define PACKAGE_VERSION "5.45"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -317,7 +357,7 @@
 
 
 /* Version number of package */
-#define VERSION "5.40"
+#define VERSION "5.45"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -336,6 +376,9 @@
 
 /* Enable zlib compression support */
 #define ZLIBSUPPORT 1
+
+/* Enable zstdlib compression support */
+/* #undef ZSTDLIBSUPPORT */
 
 /* Enable large inode numbers on Mac OS X 10.5.  */
 #ifndef _DARWIN_USE_64_BIT_INODE

--- a/libraries/cmake/source/libmagic/config/macos/aarch64/config.h
+++ b/libraries/cmake/source/libmagic/config/macos/aarch64/config.h
@@ -19,6 +19,9 @@
 /* Define to 1 if you have the `asprintf' function. */
 #define HAVE_ASPRINTF 1
 
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
 /* Define to 1 if you have the <bzlib.h> header file. */
 /* #undef HAVE_BZLIB_H */
 
@@ -26,7 +29,7 @@
 #define HAVE_CTIME_R 1
 
 /* HAVE_DAYLIGHT */
-/* #undef HAVE_DAYLIGHT */
+#define HAVE_DAYLIGHT 1
 
 /* Define to 1 if you have the declaration of `daylight', and to 0 if you
    don't. */
@@ -87,6 +90,9 @@
 /* Define to 1 if you have the `gnurx' library (-lgnurx). */
 /* #undef HAVE_LIBGNURX */
 
+/* Define to 1 if you have the `lz' library (-llz). */
+/* #undef HAVE_LIBLZ */
+
 /* Define to 1 if you have the `lzma' library (-llzma). */
 #define HAVE_LIBLZMA 1
 
@@ -96,8 +102,14 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
 
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+/* #undef HAVE_LIBZSTD */
+
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <lzlib.h> header file. */
+/* #undef HAVE_LZLIB_H */
 
 /* Define to 1 if you have the <lzma.h> header file. */
 #define HAVE_LZMA_H 1
@@ -121,7 +133,7 @@
 #define HAVE_MKSTEMP 1
 
 /* Define to 1 if you have a working `mmap' system call. */
-/* #undef HAVE_MMAP */
+#define HAVE_MMAP 1
 
 /* Define to 1 if you have the `newlocale' function. */
 #define HAVE_NEWLOCALE 1
@@ -129,11 +141,17 @@
 /* Define to 1 if you have the `pipe2' function. */
 /* #undef HAVE_PIPE2 */
 
+/* Define to 1 if you have the `posix_spawnp' function. */
+#define HAVE_POSIX_SPAWNP 1
+
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1
 
 /* Have sig_t type */
 #define HAVE_SIG_T 1
+
+/* Define to 1 if you have the <spawn.h> header file. */
+#define HAVE_SPAWN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -176,6 +194,12 @@
 
 /* Define to 1 if `tm_zone' is a member of `struct tm'. */
 #define HAVE_STRUCT_TM_TM_ZONE 1
+
+/* Define to 1 if you have the <sys/bswap.h> header file. */
+/* #undef HAVE_SYS_BSWAP_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -237,6 +261,10 @@
 /* Define to 1 if you have the <vfork.h> header file. */
 /* #undef HAVE_VFORK_H */
 
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
@@ -258,8 +286,17 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #define HAVE_ZLIB_H 1
 
+/* Define to 1 if you have the <zstd_errors.h> header file. */
+/* #undef HAVE_ZSTD_ERRORS_H */
+
+/* Define to 1 if you have the <zstd.h> header file. */
+/* #undef HAVE_ZSTD_H */
+
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
+
+/* Enable lzlib compression support */
+/* #undef LZLIBSUPPORT */
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */
@@ -279,7 +316,7 @@
 #define PACKAGE_NAME "file"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "file 5.40"
+#define PACKAGE_STRING "file 5.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "file"
@@ -288,7 +325,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "5.40"
+#define PACKAGE_VERSION "5.45"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -387,7 +424,7 @@
 
 
 /* Version number of package */
-#define VERSION "5.40"
+#define VERSION "5.45"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -406,6 +443,9 @@
 
 /* Enable zlib compression support */
 #define ZLIBSUPPORT 1
+
+/* Enable zstdlib compression support */
+/* #undef ZSTDLIBSUPPORT */
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libmagic/config/macos/x86_64/config.h
+++ b/libraries/cmake/source/libmagic/config/macos/x86_64/config.h
@@ -19,6 +19,9 @@
 /* Define to 1 if you have the `asprintf' function. */
 #define HAVE_ASPRINTF 1
 
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
 /* Define to 1 if you have the <bzlib.h> header file. */
 /* #undef HAVE_BZLIB_H */
 
@@ -26,7 +29,7 @@
 #define HAVE_CTIME_R 1
 
 /* HAVE_DAYLIGHT */
-/* #undef HAVE_DAYLIGHT */
+#define HAVE_DAYLIGHT 1
 
 /* Define to 1 if you have the declaration of `daylight', and to 0 if you
    don't. */
@@ -87,6 +90,9 @@
 /* Define to 1 if you have the `gnurx' library (-lgnurx). */
 /* #undef HAVE_LIBGNURX */
 
+/* Define to 1 if you have the `lz' library (-llz). */
+/* #undef HAVE_LIBLZ */
+
 /* Define to 1 if you have the `lzma' library (-llzma). */
 #define HAVE_LIBLZMA 1
 
@@ -96,8 +102,14 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
 
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+/* #undef HAVE_LIBZSTD */
+
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <lzlib.h> header file. */
+/* #undef HAVE_LZLIB_H */
 
 /* Define to 1 if you have the <lzma.h> header file. */
 #define HAVE_LZMA_H 1
@@ -129,11 +141,17 @@
 /* Define to 1 if you have the `pipe2' function. */
 /* #undef HAVE_PIPE2 */
 
+/* Define to 1 if you have the `posix_spawnp' function. */
+#define HAVE_POSIX_SPAWNP 1
+
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1
 
 /* Have sig_t type */
 #define HAVE_SIG_T 1
+
+/* Define to 1 if you have the <spawn.h> header file. */
+#define HAVE_SPAWN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -176,6 +194,12 @@
 
 /* Define to 1 if `tm_zone' is a member of `struct tm'. */
 #define HAVE_STRUCT_TM_TM_ZONE 1
+
+/* Define to 1 if you have the <sys/bswap.h> header file. */
+/* #undef HAVE_SYS_BSWAP_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -237,6 +261,10 @@
 /* Define to 1 if you have the <vfork.h> header file. */
 /* #undef HAVE_VFORK_H */
 
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
@@ -258,8 +286,17 @@
 /* Define to 1 if you have the <zlib.h> header file. */
 #define HAVE_ZLIB_H 1
 
+/* Define to 1 if you have the <zstd_errors.h> header file. */
+/* #undef HAVE_ZSTD_ERRORS_H */
+
+/* Define to 1 if you have the <zstd.h> header file. */
+/* #undef HAVE_ZSTD_H */
+
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
+
+/* Enable lzlib compression support */
+/* #undef LZLIBSUPPORT */
 
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */
@@ -279,7 +316,7 @@
 #define PACKAGE_NAME "file"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "file 5.40"
+#define PACKAGE_STRING "file 5.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "file"
@@ -288,7 +325,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "5.40"
+#define PACKAGE_VERSION "5.45"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -387,7 +424,7 @@
 
 
 /* Version number of package */
-#define VERSION "5.40"
+#define VERSION "5.45"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -406,6 +443,9 @@
 
 /* Enable zlib compression support */
 #define ZLIBSUPPORT 1
+
+/* Enable zstdlib compression support */
+/* #undef ZSTDLIBSUPPORT */
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libmagic/include/magic.h
+++ b/libraries/cmake/source/libmagic/include/magic.h
@@ -47,6 +47,8 @@
 					   * extensions */
 #define MAGIC_COMPRESS_TRANSP	0x2000000 /* Check inside compressed files
 					   * but not report compression */
+#define MAGIC_NO_COMPRESS_FORK	0x4000000 /* Don't allow decompression that
+					   * needs to fork */
 #define MAGIC_NODESC		(MAGIC_EXTENSION|MAGIC_MIME|MAGIC_APPLE)
 
 #define	MAGIC_NO_CHECK_COMPRESS	0x0001000 /* Don't check for compressed files */
@@ -60,6 +62,7 @@
 #define	MAGIC_NO_CHECK_TOKENS	0x0100000 /* Don't check tokens */
 #define MAGIC_NO_CHECK_ENCODING 0x0200000 /* Don't check text encodings */
 #define MAGIC_NO_CHECK_JSON	0x0400000 /* Don't check for JSON files */
+#define MAGIC_NO_CHECK_SIMH	0x0800000 /* Don't check for SIMH tape files */
 
 /* No built-in tests; only consult the magic file */
 #define MAGIC_NO_CHECK_BUILTIN	( \
@@ -74,6 +77,7 @@
 	MAGIC_NO_CHECK_TOKENS	| \
 	MAGIC_NO_CHECK_ENCODING	| \
 	MAGIC_NO_CHECK_JSON	| \
+	MAGIC_NO_CHECK_SIMH	| \
 	0			  \
 )
 
@@ -97,11 +101,11 @@ b\17no_check_sapptype\0\
 b\20no_check_elf\0\
 b\21no_check_text\0\
 b\22no_check_cdf\0\
-b\23no_check_reserved0\0\
+b\23no_check_csv\0\
 b\24no_check_tokens\0\
 b\25no_check_encoding\0\
 b\26no_check_json\0\
-b\27no_check_reserved2\0\
+b\27no_check_simh\0\
 b\30extension\0\
 b\31transp_compression\0\
 "
@@ -113,7 +117,7 @@ b\31transp_compression\0\
 #define	MAGIC_NO_CHECK_FORTRAN	0x000000 /* Don't check ascii/fortran */
 #define	MAGIC_NO_CHECK_TROFF	0x000000 /* Don't check ascii/troff */
 
-#define MAGIC_VERSION		540	/* This implementation */
+#define MAGIC_VERSION		545	/* This implementation */
 
 
 #ifdef __cplusplus
@@ -150,6 +154,7 @@ int magic_errno(magic_t);
 #define MAGIC_PARAM_REGEX_MAX		5
 #define	MAGIC_PARAM_BYTES_MAX		6
 #define	MAGIC_PARAM_ENCODING_MAX	7
+#define	MAGIC_PARAM_ELF_SHSIZE_MAX		8
 
 int magic_setparam(magic_t, int, const void *);
 int magic_getparam(magic_t, int, void *);

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -208,8 +208,8 @@
   "libmagic": {
     "product": "file",
     "vendor": "file_project",
-    "version": "5.40",
-    "commit": "f49fda6f52a9477d817dbd9c06afab02daf025f8",
+    "version": "5.45",
+    "commit": "4cbd5c8f0851201d203755b76cb66ba991ffd8be",
     "ignored-cves": []
   },
   "librdkafka": {


### PR DESCRIPTION
Resolves CVE-2022-48554.

Fixes #8121 
