### PR TITLE
ci: Remove flakyness when removing unused packages on Linux

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -255,9 +255,12 @@ jobs:
 
     steps:
     - name: Make space uninstalling packages
+      shell: bash
       run: |
-        nsenter -t 1 -m -u -n -i apt purge clang-* llvm-* php* mono-* mongodb-* libmono-* temurin-* dotnet-* \
-        google-chrome-stable microsoft-edge-stable google-cloud-sdk firefox hhvm snapd
+        run_on_host="nsenter -t 1 -m -u -n -i"
+        packages_to_remove=$($run_on_host dpkg-query -f '${Package}\n' -W | grep "^clang-.*\|^llvm-.*\|^php.*\|^mono-.*\|^mongodb-.*\
+        \|^libmono-.*\|^temurin-.*\|^dotnet-.*\|^google-chrome-stable\|^microsoft-edge-stable\|^google-cloud-sdk\|^firefox\|^hhvm\|^snapd")
+        $run_on_host apt purge $packages_to_remove
 
     - name: Clone the osquery repository
       uses: actions/checkout@v1


### PR DESCRIPTION
Sometimes apt decides to fail the removal of the packages if one of them is missing.
Lets get a list of only the packages that are installed, and match on those, so that we only delete what we know it's present.

For instance here: https://github.com/osquery/osquery/actions/runs/6308677593/job/17127241840