### PR TITLE
ci: Fix DistributedTests.test_run_queries_with_denylisted_query test

### DIFF
--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -281,7 +281,7 @@ TEST_F(DistributedTests, test_run_queries_with_denylisted_query) {
 {
   "queries": {
     "q1": "SELECT * FROM osquery_info;",
-    "q2": "SELECT * FROM osquery_info WHERE version > '5.3.0';"
+    "q2": "SELECT * FROM osquery_info WHERE CAST(split(version, '.', 0) as integer) >= 5"
   }
 }
 )json";


### PR DESCRIPTION
The constraint was compared in lexicographic order, so `5.10.0` is less than `5.3.0`.
The version doesn't have any specific meaning, so just check the first number.