### PR TITLE
GitHub Action to cleanup at stale ec2 runners

### DIFF
--- a/.github/workflows/cleanup_ec2_runners.yml
+++ b/.github/workflows/cleanup_ec2_runners.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: Find Instances
               run: |
-                cutoff=$(gdate -u --date="-2 hours" "+%Y-%m-%dT%H:%M")
+                cutoff=$(date -u --date="-2 hours" "+%Y-%m-%dT%H:%M")
 
                 aws ec2 describe-instances \
                     --filters Name=instance-state-name,Values=running Name=instance.group-id,Values=sg-0757a3162c999331b \

--- a/.github/workflows/cleanup_ec2_runners.yml
+++ b/.github/workflows/cleanup_ec2_runners.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+
+# Cleanup any lingering ec2 runners
+name: cleanup_ec2_runners
+
+on:
+    schedule:
+     - cron: "0 */1 * * *"
+    workflow_dispatch:
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v3
+              with:
+                aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.EC2_GITHUB_RUNNER_AWS_REGION }}
+
+            - name: Find Instances
+              run: |
+                cutoff=$(gdate -u --date="-2 hours" "+%Y-%m-%dT%H:%M")
+
+                aws ec2 describe-instances \
+                    --filters Name=instance-state-name,Values=running Name=instance.group-id,Values=sg-0757a3162c999331b \
+                    --query "Reservations[].Instances[?LaunchTime<=\`$cutoff\`][].{id: InstanceId, type: InstanceType, launched: LaunchTime}" \
+                    | tee instances.json
+
+            - name: Terminate Instances
+              run: |
+                # This is a for loop, so that any failures don't stop all the instances from terminating
+                for i in $(jq -r '.[].id' instances.json); do
+                    aws ec2 terminate-instances --instance-ids "$i"
+                done


### PR DESCRIPTION
Every now and again, I've caught an ec2 CI node hanging out. To prevent that, this is an attempt at a cleanup script.

It might be interesting to build this into [`osquery/ec2-github-runner`](https://github.com/osquery/ec2-github-runner), but this was easy.