### PR TITLE
cve: Fix the expat product name in the libraries manifest

### DIFF
--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -105,7 +105,7 @@
     "commit": "31db0a7acdaede9cd6a0311ff5e48ac64cd130cb"
   },
   "expat": {
-    "product": "expat",
+    "product": "libexpat",
     "vendor": "libexpat_project",
     "version": "2.4.7",
     "commit": "27d5b8ba1771f916d9cfea2aac6bdac72071dc66",


### PR DESCRIPTION
The correct name is `libexpat`, not `expat`.
This was preventing the CI workflow to pick up CVEs.