### PR TITLE
cve: Update expat to version 2.5.0

### DIFF
--- a/libraries/cmake/source/expat/CMakeLists.txt
+++ b/libraries/cmake/source/expat/CMakeLists.txt
@@ -17,7 +17,7 @@ function(expatMain)
   )
 
   target_include_directories(thirdparty_expat PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/config/linux"
+    "${CMAKE_CURRENT_SOURCE_DIR}/config/${TARGET_PROCESSOR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/expat/lib"
   )
 
@@ -27,10 +27,6 @@ function(expatMain)
 
   target_include_directories(thirdparty_expat SYSTEM INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/src/expat/lib"
-  )
-
-  target_compile_definitions(thirdparty_expat PRIVATE
-    HAVE_EXPAT_CONFIG_H
   )
 endfunction()
 

--- a/libraries/cmake/source/expat/README.md
+++ b/libraries/cmake/source/expat/README.md
@@ -1,16 +1,20 @@
 # Linux
 
+Integrate the cmake/toolchain.cmake file in the project top level CMakeLists.txt, before the `project()` directive
+
 Create a build folder inside the root of the cloned project and move inside it.
 
 Generated with the following commands:
 
 ```sh
 cmake ../expat -DCMAKE_BUILD_TYPE=Release \
+-DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain \
 -DEXPAT_BUILD_TOOLS=OFF \
 -DEXPAT_BUILD_TESTS=OFF \
 -DEXPAT_SHARED_LIBS=OFF \
 -DEXPAT_BUILD_PKGCONFIG=OFF \
 -DEXPAT_BUILD_EXAMPLES=OFF \
+-DEXPAT_BUILD_DOCS=OFF \
 -DEXPAT_DTD=OFF \
 -DEXPAT_NS=OFF \
 -DEXPAT_DEV_URANDOM=OFF
@@ -18,4 +22,4 @@ cmake ../expat -DCMAKE_BUILD_TYPE=Release \
 
 Copy the following files:
 
-build/expat_config.h -> \<osquery libexpat folder\>/config/
+`build/expat_config.h` -> `<osquery libexpat folder>/config/<arch>`

--- a/libraries/cmake/source/expat/config/aarch64/expat_config.h
+++ b/libraries/cmake/source/expat/config/aarch64/expat_config.h
@@ -1,5 +1,8 @@
 /* expat_config.h.cmake.  Based upon generated expat_config.h.in.  */
 
+#ifndef EXPAT_CONFIG_H
+#define EXPAT_CONFIG_H 1
+
 /* 1234 = LIL_ENDIAN, 4321 = BIGENDIAN */
 #define BYTEORDER 1234
 
@@ -67,7 +70,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.4.7"
+#define PACKAGE_STRING "expat 2.5.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -76,10 +79,12 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.4.7"
+#define PACKAGE_VERSION "2.5.0"
 
 /* Define to 1 if you have the ANSI C header files. */
+#ifndef STDC_HEADERS
 #define STDC_HEADERS
+#endif
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */
@@ -89,7 +94,7 @@
 /* #undef XML_ATTR_INFO */
 
 /* Define to specify how much context to retain around the current parse
-   point. */
+   point, 0 to disable. */
 #define XML_CONTEXT_BYTES 1024
 
 #if ! defined(_WIN32)
@@ -113,3 +118,5 @@
 
 /* Define to `unsigned' if <sys/types.h> does not define. */
 /* #undef size_t */
+
+#endif // ndef EXPAT_CONFIG_H

--- a/libraries/cmake/source/expat/config/x86_64/expat_config.h
+++ b/libraries/cmake/source/expat/config/x86_64/expat_config.h
@@ -1,0 +1,120 @@
+/* expat_config.h.cmake.  Based upon generated expat_config.h.in.  */
+
+#ifndef EXPAT_CONFIG_H
+#define EXPAT_CONFIG_H 1
+
+/* 1234 = LIL_ENDIAN, 4321 = BIGENDIAN */
+#define BYTEORDER 1234
+
+/* Define to 1 if you have the `arc4random' function. */
+/* #undef HAVE_ARC4RANDOM */
+
+/* Define to 1 if you have the `arc4random_buf' function. */
+/* #undef HAVE_ARC4RANDOM_BUF */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE
+
+/* Define to 1 if you have the `getrandom' function. */
+/* #undef HAVE_GETRANDOM */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `bsd' library (-lbsd). */
+/* #undef HAVE_LIBBSD */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H
+
+/* Define to 1 if you have a working `mmap' system call. */
+#define HAVE_MMAP
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H
+
+/* Define to 1 if you have `syscall' and `SYS_getrandom'. */
+#define HAVE_SYSCALL_GETRANDOM
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H
+
+/* Name of package */
+#define PACKAGE "expat"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "expat"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "expat 2.5.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "expat"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.5.0"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS
+
+/* whether byteorder is bigendian */
+/* #undef WORDS_BIGENDIAN */
+
+/* Define to allow retrieving the byte offsets for attribute names and values.
+ */
+/* #undef XML_ATTR_INFO */
+
+/* Define to specify how much context to retain around the current parse
+   point. */
+#define XML_CONTEXT_BYTES 1024
+
+#if ! defined(_WIN32)
+/* Define to include code reading entropy from `/dev/urandom'. */
+/* #undef XML_DEV_URANDOM */
+#endif
+
+/* Define to make parameter entity parsing functionality available. */
+/* #undef XML_DTD */
+
+/* Define to make XML Namespaces functionality available. */
+/* #undef XML_NS */
+
+/* Define to __FUNCTION__ or "" if `__func__' does not conform to ANSI C. */
+#ifdef _MSC_VER
+#  define __func__ __FUNCTION__
+#endif
+
+/* Define to `long' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to `unsigned' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+#endif // ndef EXPAT_CONFIG_H

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -107,8 +107,8 @@
   "expat": {
     "product": "libexpat",
     "vendor": "libexpat_project",
-    "version": "2.4.7",
-    "commit": "27d5b8ba1771f916d9cfea2aac6bdac72071dc66",
+    "version": "2.5.0",
+    "commit": "654d2de0da85662fcc7644a7acd7c2dd2cfb21f0",
     "ignored-cves": []
   },
   "gflags": {


### PR DESCRIPTION
This also resolves CVE-2022-40674 and
CVE-2022-43680.

Depends on #8158

Fixes #8160 
Fixes #8161 