### PR TITLE
Add additional chrome extensions paths

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -52,6 +52,9 @@ using ChromePathSuffixMap =
 // clang-format off
 const ChromePathSuffixMap kWindowsPathList = {
     {ChromeBrowserType::GoogleChrome, "AppData\\Local\\Google\\Chrome\\User Data"},
+    {ChromeBrowserType::GoogleChromeBeta, "AppData\\Local\\Google\\Chrome Beta\\User Data"},
+    {ChromeBrowserType::GoogleChromeDev, "AppData\\Local\\Google\\Chrome Dev\\User Data"},
+    {ChromeBrowserType::GoogleChromeCanary, "AppData\\Local\\Google\\Chrome SxS\\User Data"},
     {ChromeBrowserType::Brave, "AppData\\Roaming\\brave"},
     {ChromeBrowserType::Chromium, "AppData\\Local\\Chromium"},
     {ChromeBrowserType::Yandex, "AppData\\Local\\Yandex\\YandexBrowser\\User Data"},
@@ -63,6 +66,9 @@ const ChromePathSuffixMap kWindowsPathList = {
 // clang-format off
 const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::GoogleChrome, "Library/Application Support/Google/Chrome"},
+    {ChromeBrowserType::GoogleChromeBeta, "Library/Application Support/Google/Chrome Beta"},
+    {ChromeBrowserType::GoogleChromeDev, "Library/Application Support/Google/Chrome Dev"},
+    {ChromeBrowserType::GoogleChromeCanary, "Library/Application Support/Google/Chrome Canary"},
     {ChromeBrowserType::Brave, "Library/Application Support/BraveSoftware/Brave-Browser"},
     {ChromeBrowserType::Chromium, "Library/Application Support/Chromium"},
     {ChromeBrowserType::Yandex, "Library/Application Support/Yandex/YandexBrowser"},
@@ -73,6 +79,8 @@ const ChromePathSuffixMap kMacOsPathList = {
 
 const ChromePathSuffixMap kLinuxPathList = {
     {ChromeBrowserType::GoogleChrome, ".config/google-chrome"},
+    {ChromeBrowserType::GoogleChromeBeta, ".config/google-chrome-beta"},
+    {ChromeBrowserType::GoogleChromeDev, ".config/google-chrome-unstable"},
     {ChromeBrowserType::Brave, ".config/BraveSoftware/Brave-Browser"},
     {ChromeBrowserType::Chromium, ".config/chromium"},
     {ChromeBrowserType::Chromium, "snap/chromium/common/chromium"},
@@ -84,6 +92,9 @@ const ChromePathSuffixMap kLinuxPathList = {
 const std::unordered_map<ChromeBrowserType, std::string>
     kChromeBrowserTypeToString = {
         {ChromeBrowserType::GoogleChrome, "chrome"},
+        {ChromeBrowserType::GoogleChromeBeta, "chrome_beta"},
+        {ChromeBrowserType::GoogleChromeDev, "chrome_dev"},
+        {ChromeBrowserType::GoogleChromeCanary, "chrome_canary"},
         {ChromeBrowserType::Brave, "brave"},
         {ChromeBrowserType::Chromium, "chromium"},
         {ChromeBrowserType::Yandex, "yandex"},

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -60,7 +60,8 @@ const ChromePathSuffixMap kWindowsPathList = {
     {ChromeBrowserType::Yandex, "AppData\\Local\\Yandex\\YandexBrowser\\User Data"},
     {ChromeBrowserType::Edge, "AppData\\Local\\Microsoft\\Edge\\User Data"},
     {ChromeBrowserType::EdgeBeta, "AppData\\Local\\Microsoft\\Edge Beta\\User Data"},
-    {ChromeBrowserType::Opera, "AppData\\Roaming\\Opera Software\\Opera Stable"}};
+    {ChromeBrowserType::Opera, "AppData\\Roaming\\Opera Software\\Opera Stable"},
+    {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"}};
 // clang-format on
 
 // clang-format off
@@ -74,7 +75,8 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::Yandex, "Library/Application Support/Yandex/YandexBrowser"},
     {ChromeBrowserType::Edge, "Library/Application Support/Microsoft Edge"},
     {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
-    {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"}};
+    {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"},
+    {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"}};
 // clang-format on
 
 const ChromePathSuffixMap kLinuxPathList = {
@@ -86,6 +88,7 @@ const ChromePathSuffixMap kLinuxPathList = {
     {ChromeBrowserType::Chromium, "snap/chromium/common/chromium"},
     {ChromeBrowserType::Yandex, ".config/yandex-browser-beta"},
     {ChromeBrowserType::Opera, ".config/opera"},
+    {ChromeBrowserType::Vivaldi, ".config/vivaldi"},
 };
 
 /// Maps ChromeBrowserType values to readable strings
@@ -101,6 +104,7 @@ const std::unordered_map<ChromeBrowserType, std::string>
         {ChromeBrowserType::Opera, "opera"},
         {ChromeBrowserType::Edge, "edge"},
         {ChromeBrowserType::Edge, "edge_beta"},
+        {ChromeBrowserType::Vivaldi, "vivaldi"},
 };
 
 /// Base paths for built-in extensions; used to silence warnings for

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -37,7 +37,8 @@ enum class ChromeBrowserType {
   Yandex,
   Opera,
   Edge,
-  EdgeBeta
+  EdgeBeta,
+  Vivaldi
 };
 
 /// Converts the browser type to a printable string

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -29,6 +29,9 @@ namespace tables {
 /// One of the possible Chrome-based browser names
 enum class ChromeBrowserType {
   GoogleChrome,
+  GoogleChromeBeta,
+  GoogleChromeDev,
+  GoogleChromeCanary,
   Brave,
   Chromium,
   Yandex,


### PR DESCRIPTION
Adds additional Chrome paths, for Google Chrome Beta and Dev, as well as Vivaldi, which are currently not picked up by the chrome extensions table.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
