### PR TITLE
docs: Call out in the CHANGELOG the format changes of the status logs decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This release has several updates and bugfixes. Several improvements to various t
 One potential breaking change, is in how [the watchdog calculates CPU utilization](https://github.com/osquery/osquery/pull/8104).
 Previously, this calculation was based on physical CPUs, now it is based on virtual cores. We believe this makes more sense with modern CPUs.
 
+A second potential breaking change, is in PR [#8102](https://github.com/osquery/osquery/pull/8102), which beyond adding support to top level decorations for status logs when using the `--decorations_top_level` flag, also uniforms the status log decorations format to the results log.
+This in practice means that the `unixTime`, `severity` and `line` JSON fields are now numbers instead of strings.
+
 Representing commits from 18 contributors! Thank you all.
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ This release has several updates and bugfixes. Several improvements to various t
 One potential breaking change, is in how [the watchdog calculates CPU utilization](https://github.com/osquery/osquery/pull/8104).
 Previously, this calculation was based on physical CPUs, now it is based on virtual cores. We believe this makes more sense with modern CPUs.
 
-A second potential breaking change, is in PR [#8102](https://github.com/osquery/osquery/pull/8102), which beyond adding support to top level decorations for status logs when using the `--decorations_top_level` flag, also uniforms the status log decorations format to the results log.
-This in practice means that the `unixTime`, `severity` and `line` JSON fields are now numbers instead of strings.
+A second potential breaking change, is in PR [#8102](https://github.com/osquery/osquery/pull/8102). In addition to allowing decorations to the top level of the status logs, this PR normalizes the decorations format to the results log. In practice, this means that the `unixTime`, `severity` and `line` JSON fields are now numbers instead of strings.
 
 Representing commits from 18 contributors! Thank you all.
 


### PR DESCRIPTION
Fixes #8173