### PR TITLE
fix: Correct the aws_sts_region behavior

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -27,7 +27,7 @@ Some configuration is shared between the two plugins:
 
 When working with AWS, osquery will look for credentials and region configuration in the following order:
 
-1. Configuration flags
+1. Configuration flags; for the region, the service specific flags first (sts, kinesis, firehose) and then `aws_region` as a fallback
 2. Profile from the [AWS config files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (only if `--aws_profile_name` is specified)
 3. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
 4. `default` profile in the AWS config files
@@ -43,11 +43,15 @@ Setting `aws_kinesis_random_partition_key` to `true` will use random partition k
 
 Custom endpoint for non-AWS Kinesis implementations can be specified with `aws_kinesis_endpoint`.
 
+If the region to be used is different from the default one present in `aws_region`, or the one in the profile file, then `aws_kinesis_region` can be used.
+
 ### Kinesis Firehose
 
 Similarly for Kinesis Firehose delivery streams, the stream name must be specified with `aws_firehose_stream`, and the period can be configured with `aws_firehose_period`.
 
 Custom endpoint for non-AWS Firehose implementations can be specified with `aws_firehose_endpoint`.
+
+If the region to be used is different from the default one present in `aws_region`, or the one in the profile file, then `aws_firehose_region` can be used.
 
 ### Sample Config File
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -669,3 +669,24 @@ Whether to disable support for IMDSv1 and fail if an IMDSv2 token could not be r
 Enforces that only FIPS endpoints can be used for the logger plugins (Kinesis, Firehose), the STS authentication and the EC2 tables.  
 Using a non compliant region for the logger plugins will cause osquery to fail to start; for other non compliant cases the specific service will fail to work.  
 In all non compliant cases, an error or warning message will be printed. In verbose mode an additional message will show if a certain service has FIPS enforced.
+
+`--aws_region`
+
+Configure the default region to use for the AWS services and tables. If not specified and a more specific region flag is not provided,
+a fallback mechanism will be used, which will try to read the local profile configuration and take the region from there.  
+If that fails too, the default region of `us-east-1` will be chosen.
+
+`--aws_sts_region`
+
+Configure the region to use when acquiring STS credentials. If not specified, the `--aws_region` flag value will be used if set,
+otherwise its fallback mechanism will be used.
+
+`--aws_firehose_region`
+
+Configure the region to use for the AWS Firehose logger plugin. If not specified, the `--aws_region` flag value will be used if set,
+otherwise its fallback mechanism will be used.
+
+`--aws_kinesis_region`
+
+Configure the region to use for the AWS Kinesis logger plugin. If not specified, the `--aws_region` flag value will be used if set,
+otherwise its fallback mechanism will be used.

--- a/osquery/tables/cloud/aws/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/aws/ec2_instance_tags.cpp
@@ -40,8 +40,16 @@ QueryData genEc2InstanceTags(QueryContext& context) {
     return results;
   }
 
+  auto aws_region_res = AWSRegion::make(region, false);
+
+  if (aws_region_res.isError()) {
+    LOG(WARNING) << "Invalid region used to get EC2 instance tag: "
+                 << aws_region_res.getError();
+    return results;
+  }
+
   std::shared_ptr<ec2::EC2Client> client;
-  Status s = makeAWSClient<ec2::EC2Client>(client, region, false);
+  Status s = makeAWSClient<ec2::EC2Client>(client, aws_region_res.get(), false);
   if (!s.ok()) {
     LOG(WARNING) << "Failed to create EC2 client: " << s.what();
     return results;

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -40,6 +40,7 @@
 #include <osquery/utils/aws/aws_util.h>
 #include <osquery/utils/json/json.h>
 #include <osquery/utils/system/time.h>
+#include <osquery/utils/expected/expected.h>
 
 namespace pt = boost::property_tree;
 
@@ -54,7 +55,7 @@ FLAG(string,
      aws_profile_name,
      "",
      "AWS profile for authentication and region configuration");
-FLAG(string, aws_region, "", "AWS region");
+FLAG(string, aws_region, "", "Default AWS region for all services");
 FLAG(string, aws_sts_arn_role, "", "AWS STS ARN role");
 FLAG(string, aws_sts_region, "", "AWS STS region");
 FLAG(string, aws_sts_session_name, "default", "AWS STS session name");
@@ -155,6 +156,9 @@ static RegionName kDefaultAWSRegion = Aws::Region::US_EAST_1;
 // To protect the access to the AWS instance id and region that are being cached
 static std::mutex cached_values_mutex;
 
+DECLARE_string(aws_firehose_region);
+DECLARE_string(aws_kinesis_region);
+
 namespace {
 bool validateIMDSV2RequestAttempts(const char* flagname, std::uint32_t value) {
   if (value == 0) {
@@ -168,9 +172,132 @@ bool validateIMDSV2RequestAttempts(const char* flagname, std::uint32_t value) {
 
   return true;
 }
+
+std::string awsServiceTypeToString(const AWSServiceType service_type) {
+  switch (service_type) {
+  case AWSServiceType::Kinesis: {
+    return "kinesis";
+  }
+  case AWSServiceType::Firehose: {
+    return "firehose";
+  }
+  case AWSServiceType::STS: {
+    return "sts";
+  }
+  case AWSServiceType::EC2: {
+    return "ec2";
+  }
+  }
+
+  return "unsupported";
+}
+
+Status validateRegion(const std::string& region) {
+  if (!region.empty()) {
+    auto index = kAwsRegions.find(region);
+    if (index != kAwsRegions.end()) {
+      return Status::success();
+    } else {
+      return Status::failure("Invalid region " + region);
+    }
+  }
+
+  return Status::success();
+}
+
+Status getAWSRegionFromProfile(std::string& region) {
+  pt::ptree tree;
+  try {
+    auto profile_dir = Aws::Auth::ProfileConfigFileAWSCredentialsProvider::
+        GetProfileDirectory();
+    pt::ini_parser::read_ini(profile_dir + "/config", tree);
+  } catch (const pt::ini_parser::ini_parser_error& e) {
+    return Status(1, std::string("Error reading profile file: ") + e.what());
+  }
+
+  // Profile names are prefixed with "profile ", except for "default".
+  std::string profile_key = FLAGS_aws_profile_name;
+  if (!profile_key.empty() && profile_key != "default") {
+    profile_key = "profile " + profile_key;
+  } else {
+    profile_key = "default";
+  }
+
+  auto section_it = tree.find(profile_key);
+  if (section_it == tree.not_found()) {
+    return Status(1, "AWS profile not found: " + FLAGS_aws_profile_name);
+  }
+
+  auto key_it = section_it->second.find("region");
+  if (key_it == section_it->second.not_found()) {
+    return Status(
+        1, "AWS region not found for profile: " + FLAGS_aws_profile_name);
+  }
+
+  std::string region_string = key_it->second.data();
+  auto index = kAwsRegions.find(region_string);
+  if (index != kAwsRegions.end()) {
+    region = region_string;
+  } else {
+    return Status(1, "Invalid aws_region in profile: " + region_string);
+  }
+
+  return Status(0);
+}
+
+Status getAWSRegion(std::string& region, bool validate_region) {
+  if (region.empty()) {
+    region = FLAGS_aws_region;
+  }
+
+  if (!region.empty()) {
+    if (validate_region) {
+      auto status = validateRegion(region);
+      if (!status.ok()) {
+        return status;
+      }
+    }
+
+    return Status::success();
+  }
+
+  // Try finding in profile.
+  auto s = getAWSRegionFromProfile(region);
+  if (s.ok() || !FLAGS_aws_profile_name.empty()) {
+    VLOG(1) << "Using AWS region from profile: " << region;
+    return s;
+  }
+
+  // Use the default region.
+  region = kDefaultAWSRegion;
+  VLOG(1) << "Using default AWS region: " << region;
+  return Status(0);
+}
 }; // namespace
 
 DEFINE_validator(aws_imdsv2_request_attempts, validateIMDSV2RequestAttempts);
+
+AWSRegion::AWSRegion(const std::string& region) : region_(region) {}
+
+Expected<AWSRegion, AWSRegionError> AWSRegion::make(
+    const std::string& suggested_region, bool validate_region) {
+  AWSRegion aws_region{suggested_region};
+
+  auto status = getAWSRegion(aws_region.region_, validate_region);
+  if (!status.ok()) {
+    return Expected<AWSRegion, AWSRegionError>::failure(status.getMessage());
+  }
+
+  if (FLAGS_aws_enforce_fips) {
+    if (kAwsFipsRegions.find(aws_region.region_) == kAwsFipsRegions.end()) {
+      return Expected<AWSRegion, AWSRegionError>::failure(
+          AWSRegionError::NotFIPSCompliant,
+          "Region " + aws_region.region_ + " is not FIPS compliant");
+    }
+  }
+
+  return aws_region;
+}
 
 std::shared_ptr<Aws::Http::HttpClient>
 OsqueryHttpClientFactory::CreateHttpClient(
@@ -352,7 +479,16 @@ OsquerySTSAWSCredentialsProvider::GetAWSCredentials() {
       initAwsSdk();
     }
 
-    Status s = makeAWSClient<Aws::STS::STSClient>(client_, "", false);
+    auto aws_region_res = AWSRegion::make(FLAGS_aws_sts_region);
+
+    if (aws_region_res.isError()) {
+      LOG(WARNING) << "Failed to generate STS Credentials: "
+                   << aws_region_res.getError();
+      return Aws::Auth::AWSCredentials("", "");
+    }
+
+    Status s = makeAWSClient<Aws::STS::STSClient>(
+        client_, aws_region_res.get(), false);
     if (!s.ok()) {
       LOG(WARNING) << "Error creating AWS client: " << s.what();
       return Aws::Auth::AWSCredentials("", "");
@@ -420,46 +556,6 @@ OsqueryAWSCredentialsProviderChain::OsqueryAWSCredentialsProviderChain(bool sts)
       std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());
   AddProvider(
       std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
-}
-
-Status getAWSRegionFromProfile(std::string& region) {
-  pt::ptree tree;
-  try {
-    auto profile_dir = Aws::Auth::ProfileConfigFileAWSCredentialsProvider::
-        GetProfileDirectory();
-    pt::ini_parser::read_ini(profile_dir + "/config", tree);
-  } catch (const pt::ini_parser::ini_parser_error& e) {
-    return Status(1, std::string("Error reading profile file: ") + e.what());
-  }
-
-  // Profile names are prefixed with "profile ", except for "default".
-  std::string profile_key = FLAGS_aws_profile_name;
-  if (!profile_key.empty() && profile_key != "default") {
-    profile_key = "profile " + profile_key;
-  } else {
-    profile_key = "default";
-  }
-
-  auto section_it = tree.find(profile_key);
-  if (section_it == tree.not_found()) {
-    return Status(1, "AWS profile not found: " + FLAGS_aws_profile_name);
-  }
-
-  auto key_it = section_it->second.find("region");
-  if (key_it == section_it->second.not_found()) {
-    return Status(
-        1, "AWS region not found for profile: " + FLAGS_aws_profile_name);
-  }
-
-  std::string region_string = key_it->second.data();
-  auto index = kAwsRegions.find(region_string);
-  if (index != kAwsRegions.end()) {
-    region = region_string;
-  } else {
-    return Status(1, "Invalid aws_region in profile: " + region_string);
-  }
-
-  return Status(0);
 }
 
 void initAwsSdk() {
@@ -577,79 +673,25 @@ boost::optional<std::string> getIMDSToken() {
   return token;
 }
 
-Status getAWSRegion(std::string& region, bool sts, bool validate_region) {
-  // First try using the explicit region flags (STS or otherwise).
-  if (sts && !FLAGS_aws_sts_region.empty()) {
-    auto index = kAwsRegions.find(FLAGS_aws_sts_region);
-    if (index != kAwsRegions.end() || !validate_region) {
-      VLOG(1) << "Using AWS STS region from flag: " << FLAGS_aws_sts_region;
-      region = FLAGS_aws_sts_region;
-      return Status(0);
-    } else {
-      return Status(1, "Invalid aws_region specified: " + FLAGS_aws_sts_region);
-    }
-  }
-
-  if (!FLAGS_aws_region.empty()) {
-    auto index = kAwsRegions.find(FLAGS_aws_region);
-    if (index != kAwsRegions.end() || !validate_region) {
-      VLOG(1) << "Using AWS region from flag: " << FLAGS_aws_region;
-      region = FLAGS_aws_region;
-      return Status(0);
-    } else {
-      return Status(1, "Invalid aws_region specified: " + FLAGS_aws_region);
-    }
-  }
-
-  // Try finding in profile.
-  auto s = getAWSRegionFromProfile(region);
-  if (s.ok() || !FLAGS_aws_profile_name.empty()) {
-    VLOG(1) << "Using AWS region from profile: " << region;
-    return s;
-  }
-
-  // Use the default region.
-  region = kDefaultAWSRegion;
-  VLOG(1) << "Using default AWS region: " << region;
-  return Status(0);
-}
-
-Status setAwsClientConfig(const std::string& region,
-                          const std::string& service_type,
+Status setAwsClientConfig(const AWSRegion& region,
+                          const AWSServiceType service_type,
                           const std::string& endpoint_override,
-                          bool sts,
                           Aws::Client::ClientConfiguration& client_config) {
-  // Set up client
-  if (region.empty()) {
-    // If the endpoint_override is set, we are most likely running in non-AWS
-    // environment, skip region validation.
-    bool validate_region = endpoint_override.empty();
-    Status s = getAWSRegion(client_config.region, sts, validate_region);
-    if (!s.ok()) {
-      return s;
-    }
-  } else {
-    client_config.region = region;
-  }
+  client_config.region = region.getRegion();
 
   if (FLAGS_aws_enforce_fips) {
-    if (service_type.empty()) {
+    if (!endpoint_override.empty()) {
       return Status::failure(
-          "Attempted FIPS communication towards an unsupported service");
+          "Cannot override the endpoint when FIPS is enforced");
     }
 
-    if (kAwsFipsRegions.find(client_config.region) == kAwsFipsRegions.end()) {
-      return Status::failure(service_type +
-                             " client cannot communicate with region " +
-                             client_config.region + " when FIPS is enforced");
-    }
     enableFIPSInClientConfig(service_type, client_config);
 
-    VLOG(1) << "Enforcing FIPS for " << service_type << " client in region "
-            << client_config.region;
+    VLOG(1) << "Enforcing FIPS for " << awsServiceTypeToString(service_type)
+            << " client in region " << client_config.region;
   } else {
-    VLOG(1) << "Configuring " << service_type << " client in region "
-            << client_config.region;
+    VLOG(1) << "Configuring " << awsServiceTypeToString(service_type)
+            << " client in region " << client_config.region;
     client_config.endpointOverride = endpoint_override;
 
     // Setup any proxy options on the config if desired
@@ -707,15 +749,17 @@ void setAWSProxy(Aws::Client::ClientConfiguration& config) {
   }
 }
 
-void enableFIPSInClientConfig(const std::string& service,
+void enableFIPSInClientConfig(const AWSServiceType service_type,
                               Aws::Client::ClientConfiguration& config) {
   // Gov FIPS endpoints for Kinesis, EC2, STS are used as-is, do nothing
   if (config.region.rfind("us-gov", 0) == 0 &&
-      (service == "kinesis" || service == "ec2" || service == "sts")) {
+      (service_type == AWSServiceType::Kinesis ||
+       service_type == AWSServiceType::EC2 ||
+       service_type == AWSServiceType::STS)) {
     return;
   }
 
-  config.endpointOverride =
-      service + "-fips." + config.region + ".amazonaws.com";
+  config.endpointOverride = awsServiceTypeToString(service_type) + "-fips." +
+                            config.region + ".amazonaws.com";
 }
 } // namespace osquery

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -38,9 +38,9 @@
 #include <osquery/logger/data_logger.h>
 #include <osquery/logger/logger.h>
 #include <osquery/utils/aws/aws_util.h>
+#include <osquery/utils/expected/expected.h>
 #include <osquery/utils/json/json.h>
 #include <osquery/utils/system/time.h>
-#include <osquery/utils/expected/expected.h>
 
 namespace pt = boost::property_tree;
 

--- a/plugins/logger/aws_firehose.cpp
+++ b/plugins/logger/aws_firehose.cpp
@@ -43,7 +43,8 @@ FLAG(string,
 Status FirehoseLoggerPlugin::setUp() {
   initAwsSdk();
 
-  auto aws_region_res = AWSRegion::make(FLAGS_aws_firehose_region);
+  auto aws_region_res = AWSRegion::make(FLAGS_aws_firehose_region,
+                                        FLAGS_aws_firehose_endpoint.empty());
 
   if (aws_region_res.isError()) {
     return Status::failure(aws_region_res.getError().getMessage());

--- a/plugins/logger/aws_firehose.cpp
+++ b/plugins/logger/aws_firehose.cpp
@@ -34,14 +34,27 @@ FLAG(string, aws_firehose_stream, "", "Name of Firehose stream for logging")
 
 FLAG(string, aws_firehose_endpoint, "", "Custom Firehose endpoint");
 
+FLAG(string,
+     aws_firehose_region,
+     "",
+     "Region to use for Firehose instead of the default. This takes precedence "
+     "over the aws_region flag")
+
 Status FirehoseLoggerPlugin::setUp() {
   initAwsSdk();
+
+  auto aws_region_res = AWSRegion::make(FLAGS_aws_firehose_region);
+
+  if (aws_region_res.isError()) {
+    return Status::failure(aws_region_res.getError().getMessage());
+  }
 
   forwarder_ =
       std::make_shared<FirehoseLogForwarder>("aws_firehose",
                                              FLAGS_aws_firehose_period,
                                              500,
-                                             FLAGS_aws_firehose_endpoint);
+                                             FLAGS_aws_firehose_endpoint,
+                                             aws_region_res.get());
   Status s = forwarder_->setUp();
   if (!s.ok()) {
     LOG(ERROR) << "Error initializing Firehose logger: " << s.getMessage();
@@ -122,4 +135,4 @@ FirehoseLogForwarder::Result FirehoseLogForwarder::getResult(
     Outcome& outcome) const {
   return outcome.GetResult().GetRequestResponses();
 }
-}
+} // namespace osquery

--- a/plugins/logger/aws_firehose.h
+++ b/plugins/logger/aws_firehose.h
@@ -39,8 +39,10 @@ class FirehoseLogForwarder final : public IFirehoseLogForwarder {
   FirehoseLogForwarder(const std::string& name,
                        uint64_t log_period,
                        uint64_t max_lines,
-                       const std::string& endpoint_override)
-      : IFirehoseLogForwarder(name, log_period, max_lines, endpoint_override) {}
+                       const std::string& endpoint_override,
+                       const AWSRegion& region)
+      : IFirehoseLogForwarder(
+            name, log_period, max_lines, endpoint_override, region) {}
 
  protected:
   Status internalSetup() override;

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -60,7 +60,8 @@ FLAG(string,
 Status KinesisLoggerPlugin::setUp() {
   initAwsSdk();
 
-  auto aws_region_res = AWSRegion::make(FLAGS_aws_kinesis_region);
+  auto aws_region_res = AWSRegion::make(FLAGS_aws_kinesis_region,
+                                        FLAGS_aws_kinesis_endpoint.empty());
 
   if (aws_region_res.isError()) {
     return Status::failure(aws_region_res.getError().getMessage());

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -51,10 +51,26 @@ FLAG(bool,
 
 FLAG(string, aws_kinesis_endpoint, "", "Custom Kinesis endpoint");
 
+FLAG(string,
+     aws_kinesis_region,
+     "",
+     "Region to use for Kinesis instead of the default. This takes precedence "
+     "over the aws_region flag")
+
 Status KinesisLoggerPlugin::setUp() {
   initAwsSdk();
-  forwarder_ = std::make_shared<KinesisLogForwarder>(
-      "aws_kinesis", FLAGS_aws_kinesis_period, 500, FLAGS_aws_kinesis_endpoint);
+
+  auto aws_region_res = AWSRegion::make(FLAGS_aws_kinesis_region);
+
+  if (aws_region_res.isError()) {
+    return Status::failure(aws_region_res.getError().getMessage());
+  }
+
+  forwarder_ = std::make_shared<KinesisLogForwarder>("aws_kinesis",
+                                                     FLAGS_aws_kinesis_period,
+                                                     500,
+                                                     FLAGS_aws_kinesis_endpoint,
+                                                     aws_region_res.get());
   Status s = forwarder_->setUp();
   if (!s.ok()) {
     LOG(ERROR) << "Error initializing Kinesis logger: " << s.getMessage();
@@ -149,4 +165,4 @@ KinesisLogForwarder::Result KinesisLogForwarder::getResult(
     Outcome& outcome) const {
   return outcome.GetResult().GetRecords();
 }
-}
+} // namespace osquery

--- a/plugins/logger/aws_kinesis.h
+++ b/plugins/logger/aws_kinesis.h
@@ -12,9 +12,9 @@
 #include "aws_log_forwarder.h"
 
 #include <chrono>
+#include <gflags/gflags.h>
 #include <memory>
 #include <vector>
-#include <gflags/gflags.h>
 
 #include <aws/kinesis/KinesisClient.h>
 #include <aws/kinesis/model/PutRecordsRequestEntry.h>
@@ -37,8 +37,10 @@ class KinesisLogForwarder final : public IKinesisLogForwarder {
   KinesisLogForwarder(const std::string& name,
                       uint64_t log_period,
                       uint64_t max_lines,
-                      const std::string& endpoint_override)
-      : IKinesisLogForwarder(name, log_period, max_lines, endpoint_override) {}
+                      const std::string& endpoint_override,
+                      const AWSRegion& region)
+      : IKinesisLogForwarder(
+            name, log_period, max_lines, endpoint_override, region) {}
 
  protected:
   Status internalSetup() override;
@@ -83,4 +85,4 @@ class KinesisLoggerPlugin : public LoggerPlugin {
  private:
   std::shared_ptr<KinesisLogForwarder> forwarder_{nullptr};
 };
-}
+} // namespace osquery

--- a/plugins/logger/aws_log_forwarder.h
+++ b/plugins/logger/aws_log_forwarder.h
@@ -40,13 +40,15 @@ class AwsLogForwarder : public BufferedLogForwarder {
   AwsLogForwarder(const std::string& name,
                   size_t log_period,
                   size_t max_lines,
-                  const std::string& endpoint_override)
+                  const std::string& endpoint_override,
+                  const AWSRegion& region)
       : BufferedLogForwarder(std::string("AwsLogForwarder:") + name,
                              name,
                              std::chrono::seconds(log_period),
                              max_lines),
         name_(name),
-        endpoint_override_(endpoint_override) {}
+        endpoint_override_(endpoint_override),
+        region_(region) {}
 
   /// Common plugin initialization
   Status setUp() override {
@@ -55,7 +57,7 @@ class AwsLogForwarder : public BufferedLogForwarder {
       return s;
     }
 
-    s = makeAWSClient<Client>(client_, "", true, endpoint_override_);
+    s = makeAWSClient<Client>(client_, region_, true, endpoint_override_);
     if (!s.ok()) {
       return s;
     }
@@ -355,5 +357,8 @@ class AwsLogForwarder : public BufferedLogForwarder {
 
   /// Service endpoint override
   std::string endpoint_override_;
+
+  /// Service selected region
+  AWSRegion region_;
 };
 } // namespace osquery

--- a/plugins/logger/tests/aws_kinesis_logger_tests.cpp
+++ b/plugins/logger/tests/aws_kinesis_logger_tests.cpp
@@ -58,7 +58,8 @@ using IDummyLogForwarder =
 class DummyLogForwarder final : public IDummyLogForwarder {
  public:
   DummyLogForwarder()
-      : IDummyLogForwarder("dummy", 10, 50, "http://example.com") {}
+      : IDummyLogForwarder(
+            "dummy", 10, 50, "http://example.com", AWSRegion{""}) {}
 
  protected:
   Status internalSetup() override {
@@ -186,4 +187,4 @@ TEST_F(AwsLoggerTests, test_send) {
             "test\":\"2\",\"log_type\":\"result\"}\n");
   EXPECT_EQ(third_batch[1], "{\"batch3\":\"3\",\"log_type\":\"result\"}\n");
 }
-}
+} // namespace osquery


### PR DESCRIPTION
The `aws_sts_region` flag was controlling the region used by services using STS, like Kinesis and Firehose,
instead of controlling which region to generate the STS credential from. This changes the behavior of the flag so it controls the STS credentials region, and it also adds two new flags, `aws_kinesis_region` and `aws_firehose_region` to control the relative services regions.