### PR TITLE
ci: Correct job order

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -125,7 +125,7 @@ jobs:
 
   # This job runs source code analysis tools (currently, just cppcheck)
   check_source_code:
-    needs: [check_libraries_manifest, check_libraries_manifest]
+    needs: [check_code_style, check_libraries_manifest]
 
     runs-on: ${{ matrix.os }}
 
@@ -240,7 +240,7 @@ jobs:
   # The Linux build will only start once we know that the code
   # has been properly formatted
   build_linux:
-    needs: check_code_style
+    needs: [check_code_style, check_libraries_manifest]
 
     runs-on: ${{ matrix.os }}
 
@@ -543,7 +543,7 @@ jobs:
   # The macOS build will only start once we know that the code
   # has been properly formatted
   build_macos:
-    needs: check_code_style
+    needs: [check_code_style, check_libraries_manifest]
 
     runs-on: ${{ matrix.os }}
 
@@ -938,7 +938,7 @@ jobs:
   # The Windows build will only start once we know that the code
   # has been properly formatted
   build_windows:
-    needs: check_code_style
+    needs: [check_code_style, check_libraries_manifest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The check_source_code job was waiting for the same job 2 times, while it should've also waited for the code style job.

Also add a dependency in the build jobs to the libraries manifest check. The general idea is to have quick checks go first and fail everything immediately if something is wrong.
