### PR TITLE
Copy keychain files.

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -163,18 +163,24 @@ QueryData genCerts(QueryContext& context) {
       }));
 
   // All files will be copied to a temp directory before being processed.
-  // This attempts to fix the keychain corruption seen in https://github.com/osquery/osquery/issues/7780
+  // This attempts to fix the keychain corruption seen in
+  // https://github.com/osquery/osquery/issues/7780
   KeychainMap keychain_map;
   // Base temp directory that we will need to delete.
-  keychain_map.temp_base = boost::filesystem::canonical(boost::filesystem::temp_directory_path()) / boost::filesystem::unique_path();
+  keychain_map.temp_base =
+      boost::filesystem::canonical(boost::filesystem::temp_directory_path()) /
+      boost::filesystem::unique_path();
 
   @autoreleasepool {
     if (!paths.empty()) {
       for (const auto& path : paths) {
         boost::filesystem::path source(path);
-        if (is_regular_file(source) && keychain_map.actual_to_temp.count(source) == 0) {
-          // Make a copy. Using a unique subdirectory to prevent filename conflicts.
-          auto temp_dir = keychain_map.temp_base / boost::filesystem::unique_path();
+        if (is_regular_file(source) &&
+            keychain_map.actual_to_temp.count(source) == 0) {
+          // Make a copy. Using a unique subdirectory to prevent filename
+          // conflicts.
+          auto temp_dir =
+              keychain_map.temp_base / boost::filesystem::unique_path();
           boost::filesystem::create_directories(temp_dir);
           boost::filesystem::path dest = temp_dir / source.filename();
           boost::filesystem::copy_file(source, dest);
@@ -184,7 +190,8 @@ QueryData genCerts(QueryContext& context) {
           SecKeychainStatus keychain_status;
           auto status = SecKeychainOpen(dest.c_str(), &keychain);
           if (status != errSecSuccess || keychain == nullptr ||
-              SecKeychainGetStatus(keychain, &keychain_status) != errSecSuccess) {
+              SecKeychainGetStatus(keychain, &keychain_status) !=
+                  errSecSuccess) {
             if (keychain != nullptr) {
               CFRelease(keychain);
             }

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -24,7 +24,8 @@ extern const std::vector<std::string> kSystemKeychainPaths;
 extern const std::vector<std::string> kUserKeychainPaths;
 
 // KeychainMap tracks the temporary copies of keychain files.
-// We make a copy of every keychain file before interacting with it via Apple APIs.
+// We make a copy of every keychain file before interacting with it via Apple
+// APIs.
 class KeychainMap {
  public:
   boost::filesystem::path temp_base;

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -23,12 +23,26 @@ namespace tables {
 extern const std::vector<std::string> kSystemKeychainPaths;
 extern const std::vector<std::string> kUserKeychainPaths;
 
+// KeychainMap tracks the temporary copies of keychain files.
+// We make a copy of every keychain file before interacting with it via Apple APIs.
+class KeychainMap {
+ public:
+  boost::filesystem::path temp_base;
+  std::map<boost::filesystem::path, boost::filesystem::path> actual_to_temp;
+  std::map<boost::filesystem::path, boost::filesystem::path> temp_to_actual;
+  void Insert(boost::filesystem::path actual, boost::filesystem::path temp) {
+    actual_to_temp.insert({actual, temp});
+    temp_to_actual.insert({temp, actual});
+  }
+};
+
 void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
 std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Generate a list of keychain items for a given item type.
 CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
-                               const CFTypeRef& item_type);
+                               const CFTypeRef& item_type,
+                               KeychainMap& keychain_map);
 
 std::set<std::string> getKeychainPaths();
 }

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -46,7 +46,9 @@ const std::map<SecItemClass, std::string> kKeychainItemClasses = {
     {kSecPrivateKeyItemClass, "private key"},
     {kSecSymmetricKeyItemClass, "symmetric key"}};
 
-void genKeychainItem(const SecKeychainItemRef& item, const KeychainMap& keychain_map, QueryData& results) {
+void genKeychainItem(const SecKeychainItemRef& item,
+                     const KeychainMap& keychain_map,
+                     QueryData& results) {
   Row r;
 
   // Create an info structure with 1 tag, then iterate over setting the tag
@@ -129,19 +131,24 @@ QueryData genKeychainItems(QueryContext& context) {
   }
 
   // All files will be copied to a temp directory before being processed.
-  // This attempts to fix the keychain corruption seen in https://github.com/osquery/osquery/issues/7780
+  // This attempts to fix the keychain corruption seen in
+  // https://github.com/osquery/osquery/issues/7780
   KeychainMap keychain_map;
   // Base temp directory that we will need to delete.
-  keychain_map.temp_base = boost::filesystem::canonical(boost::filesystem::temp_directory_path()) / boost::filesystem::unique_path();
+  keychain_map.temp_base =
+      boost::filesystem::canonical(boost::filesystem::temp_directory_path()) /
+      boost::filesystem::unique_path();
 
   for (const auto& item_type : kKeychainItemTypes) {
-    CFArrayRef items = CreateKeychainItems(keychain_paths, item_type, keychain_map);
+    CFArrayRef items =
+        CreateKeychainItems(keychain_paths, item_type, keychain_map);
     if (items == nullptr) {
       continue;
     }
     auto count = CFArrayGetCount(items);
     for (CFIndex i = 0; i < count; i++) {
-      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i), keychain_map,
+      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),
+                      keychain_map,
                       results);
     }
 

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -46,7 +46,7 @@ const std::map<SecItemClass, std::string> kKeychainItemClasses = {
     {kSecPrivateKeyItemClass, "private key"},
     {kSecSymmetricKeyItemClass, "symmetric key"}};
 
-void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
+void genKeychainItem(const SecKeychainItemRef& item, const KeychainMap& keychain_map, QueryData& results) {
   Row r;
 
   // Create an info structure with 1 tag, then iterate over setting the tag
@@ -108,7 +108,12 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
     r["type"] = kKeychainItemClasses.at(item_class);
   }
 
-  r["path"] = getKeychainPath(item);
+  auto temp_path = boost::filesystem::path(getKeychainPath(item));
+  auto it = keychain_map.temp_to_actual.find(temp_path);
+  if (it != keychain_map.temp_to_actual.end()) {
+    r["path"] = it->second.string();
+  }
+  // TODO: Log error if needed.
   results.push_back(r);
 }
 
@@ -123,19 +128,28 @@ QueryData genKeychainItems(QueryContext& context) {
     keychain_paths = getKeychainPaths();
   }
 
+  // All files will be copied to a temp directory before being processed.
+  // This attempts to fix the keychain corruption seen in https://github.com/osquery/osquery/issues/7780
+  KeychainMap keychain_map;
+  // Base temp directory that we will need to delete.
+  keychain_map.temp_base = boost::filesystem::canonical(boost::filesystem::temp_directory_path()) / boost::filesystem::unique_path();
+
   for (const auto& item_type : kKeychainItemTypes) {
-    CFArrayRef items = CreateKeychainItems(keychain_paths, item_type);
+    CFArrayRef items = CreateKeychainItems(keychain_paths, item_type, keychain_map);
     if (items == nullptr) {
       continue;
     }
     auto count = CFArrayGetCount(items);
     for (CFIndex i = 0; i < count; i++) {
-      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),
+      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i), keychain_map,
                       results);
     }
 
     CFRelease(items);
   }
+
+  // Clean up temp directory
+  remove_all(keychain_map.temp_base);
 
   return results;
 }

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -31,7 +31,9 @@ const std::vector<std::string> kUserKeychainPaths = {
     "/Library/Keychains",
 };
 
-void genKeychains(const std::string& path, CFMutableArrayRef& keychains, KeychainMap& keychain_map) {
+void genKeychains(const std::string& path,
+                  CFMutableArrayRef& keychains,
+                  KeychainMap& keychain_map) {
   std::vector<std::string> paths;
 
   // Support both a directory and explicit path search.
@@ -50,7 +52,8 @@ void genKeychains(const std::string& path, CFMutableArrayRef& keychains, Keychai
     if (is_regular_file(source)) {
       boost::filesystem::path dest;
       if (keychain_map.actual_to_temp.count(source) == 0) {
-        auto temp_dir = keychain_map.temp_base / boost::filesystem::unique_path();
+        auto temp_dir =
+            keychain_map.temp_base / boost::filesystem::unique_path();
         boost::filesystem::create_directories(temp_dir);
         dest = temp_dir / source.filename();
         boost::filesystem::copy_file(source, dest);


### PR DESCRIPTION
Fixes `certificates` and `keychain_items` tables from #7780
Related issue: https://github.com/fleetdm/fleet/issues/13065

Updating `certificates` and `keychain_items` tables to make a copy of keychain files before working on them.
We hope that fixes the corruption of login keychains seen by some users.

The `keychain_acl` table does not work with copied keychains because the copies fail authentication.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
