### PR TITLE
process_open_sockets: Mark pid column as additional instead of index

### DIFF
--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -1,7 +1,7 @@
 table_name("process_open_sockets")
 description("Processes which have open network sockets on the system.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID", index=True),
+    Column("pid", INTEGER, "Process (or thread) ID", additional=True),
     Column("fd", BIGINT, "Socket file descriptor number"),
     Column("socket", BIGINT, "Socket handle or inode number"),
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),


### PR DESCRIPTION
The `pid` column values are not unique, so it should not be an index.
