### PR TITLE
Added cache and throttling for `certificates`, `keychain_acls`, and `keychain_items` tables.

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -379,7 +379,7 @@ function(generateOsqueryTablesSystemSystemtable)
       PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
     )
   elseif(DEFINED PLATFORM_MACOS)
-    add_test(NAME osquery_keychain_tests-test COMMAND osquery_keychain_tests-test)
+    add_test(NAME osquery_tables_system_darwin_keychain_tests-test COMMAND osquery_tables_system_darwin_keychain_tests-test)
     add_test(NAME osquery_tables_system_darwin_tests-test COMMAND osquery_tables_system_darwin_tests-test)
 
     set_tests_properties(

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -379,6 +379,7 @@ function(generateOsqueryTablesSystemSystemtable)
       PROPERTIES ENVIRONMENT "TEST_CONF_FILES_DIR=${TEST_CONFIGS_DIR}"
     )
   elseif(DEFINED PLATFORM_MACOS)
+    add_test(NAME osquery_keychain_tests-test COMMAND osquery_keychain_tests-test)
     add_test(NAME osquery_tables_system_darwin_tests-test COMMAND osquery_tables_system_darwin_tests-test)
 
     set_tests_properties(

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -180,7 +180,7 @@ QueryData genCerts(QueryContext& context) {
         }
 
         // Check cache
-        bool err;
+        bool err = false;
         std::string hash;
         bool hit =
             keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
@@ -251,7 +251,7 @@ QueryData genCerts(QueryContext& context) {
         }
 
         // Check cache
-        bool err;
+        bool err = false;
         bool hit =
             keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
         if (err) {

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -139,6 +139,9 @@ void genFileCertificate(const std::string& path, QueryData& results) {
 QueryData genCerts(QueryContext& context) {
   QueryData results;
 
+  // Lock keychain access to 1 table/thread at a time.
+  std::unique_lock<decltype(keychainMutex)> lock(keychainMutex);
+
   // Allow the caller to set both an explicit keychain search path
   // and certificate files on disk.
   std::set<std::string> keychain_paths;

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -29,7 +29,7 @@ DECLARE_bool(keychain_access_cache); // enable flag
 DECLARE_uint32(keychain_access_interval); // throttling flag
 
 // The tables supported by Keychain Cache
-enum class KeychainTable { KEYCHAIN_ACLS };
+enum class KeychainTable { CERTIFICATES, KEYCHAIN_ACLS };
 
 // The KeychainCache caches results associated with keychain files,
 // and throttles access to these files.
@@ -68,6 +68,10 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Generate a list of keychain items for a given item type.
 CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
+                               const CFTypeRef& item_type);
+
+/// Generate a list of keychain items for a given item type.
+CFArrayRef CreateKeychainItems(SecKeychainRef keychain,
                                const CFTypeRef& item_type);
 
 std::set<std::string> getKeychainPaths();

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -29,7 +29,7 @@ DECLARE_bool(keychain_access_cache); // enable flag
 DECLARE_uint32(keychain_access_interval); // throttling flag
 
 // The tables supported by Keychain Cache
-enum class KeychainTable { CERTIFICATES, KEYCHAIN_ACLS };
+enum class KeychainTable { CERTIFICATES, KEYCHAIN_ACLS, KEYCHAIN_ITEMS };
 
 // The KeychainCache caches results associated with keychain files,
 // and throttles access to these files.
@@ -51,27 +51,28 @@ class KeychainCache {
   // Read checks the hash and returns 1 for a cache hit or 0 for a cache miss.
   // If hit, results are populated. hash is the file hash
   bool Read(const boost::filesystem::path& path,
-            const KeychainTable table,
+            KeychainTable table,
             std::string& hash,
             QueryData& results,
             bool& err);
   // Write a cache entry.
   void Write(const boost::filesystem::path& path,
-             const KeychainTable table,
+             KeychainTable table,
              const std::string& hash,
              const QueryData& results);
+  size_t Size() {
+    return cache.size();
+  }
 };
 extern KeychainCache keychainCache;
 
-void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
+// Expand paths to individual files
+std::set<std::string> expandPaths(const std::set<std::string>& paths);
+
 std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Generate a list of keychain items for a given item type.
-CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
-                               const CFTypeRef& item_type);
-
-/// Generate a list of keychain items for a given item type.
-CFArrayRef CreateKeychainItems(SecKeychainRef keychain,
+CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
                                const CFTypeRef& item_type);
 
 std::set<std::string> getKeychainPaths();

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -46,6 +46,7 @@ class KeychainCache {
   std::map<std::pair<boost::filesystem::path, KeychainTable>,
            KeychainCacheEntry>
       cache;
+  std::mutex mutex;
 
  public:
   // Read checks the hash and returns 1 for a cache hit or 0 for a cache miss.

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -46,7 +46,6 @@ class KeychainCache {
   std::map<std::pair<boost::filesystem::path, KeychainTable>,
            KeychainCacheEntry>
       cache;
-  std::mutex mutex;
 
  public:
   // Read checks the hash and returns 1 for a cache hit or 0 for a cache miss.
@@ -66,6 +65,7 @@ class KeychainCache {
   }
 };
 extern KeychainCache keychainCache;
+extern std::mutex keychainMutex;
 
 // Expand paths to individual files
 std::set<std::string> expandPaths(const std::set<std::string>& paths);

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -39,7 +39,7 @@ class KeychainCache {
   // for a single keychain file.
   class KeychainCacheEntry {
    public:
-    std::time_t timestamp; // time of last access
+    std::chrono::system_clock::time_point timestamp; // time of last access
     std::string hash; // sha256 keychain file hash
     QueryData results; // the cached results
   };

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -299,7 +299,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
   QueryData new_results;
 
   SecKeychainRef keychain = nullptr;
-  OSStatus os_status = 0;
+  OSStatus os_status;
   OSQUERY_USE_DEPRECATED(os_status = SecKeychainOpen(path.c_str(), &keychain));
   if (os_status != noErr || keychain == nullptr) {
     if (keychain != nullptr) {
@@ -369,6 +369,10 @@ QueryData genKeychainACLApps(QueryContext& context) {
     }
   }
   OSQUERY_USE_DEPRECATED(SecKeychainSetUserInteractionAllowed(true));
+
+  if (FLAGS_keychain_access_cache) {
+    TLOG << "Total Keychain Cache entries: " << keychainCache.Size();
+  }
 
   return results;
 }

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -25,6 +25,9 @@
 namespace osquery {
 namespace tables {
 
+// The table key for Keychain cache access.
+static const KeychainTable KEYCHAIN_TABLE = KeychainTable::KEYCHAIN_ACLS;
+
 typedef struct {
   std::string keychain_path;
   std::string label;
@@ -284,8 +287,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
   // Check cache
   bool err;
   std::string hash;
-  bool hit = keychainCache.Read(
-      source, KeychainTable::KEYCHAIN_ACLS, hash, results, err);
+  bool hit = keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
   if (err) {
     return {2, "Could not open the file at " + path};
   }
@@ -304,7 +306,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
       CFRelease(keychain);
     }
     // Cache an empty result to prevent the above API call in the future.
-    keychainCache.Write(source, KeychainTable::KEYCHAIN_ACLS, hash, {});
+    keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
     return Status(os_status, "Could not open the keychain at " + path);
   }
 
@@ -318,7 +320,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
     }
     CFRelease(keychain);
     // Cache an empty result to prevent the above API call in the future.
-    keychainCache.Write(source, KeychainTable::KEYCHAIN_ACLS, hash, {});
+    keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
     return Status(os_status,
                   "Could not pull keychain items from the search API");
   }
@@ -341,7 +343,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
   CFRelease(keychain);
   CFRelease(search);
   // Write new results to the cache.
-  keychainCache.Write(source, KeychainTable::KEYCHAIN_ACLS, hash, new_results);
+  keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
   results.insert(results.end(), new_results.begin(), new_results.end());
   return Status::success();
 }

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -351,6 +351,9 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
 QueryData genKeychainACLApps(QueryContext& context) {
   QueryData results;
 
+  // Lock keychain access to 1 table/thread at a time.
+  std::unique_lock<decltype(keychainMutex)> lock(keychainMutex);
+
   OSQUERY_USE_DEPRECATED(SecKeychainSetUserInteractionAllowed(false));
   for (const auto& path : getKeychainPaths()) {
     std::vector<std::string> ls_results;

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -285,7 +285,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
   }
 
   // Check cache
-  bool err;
+  bool err = false;
   std::string hash;
   bool hit = keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
   if (err) {

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -130,7 +130,7 @@ QueryData genKeychainItems(QueryContext& context) {
     keychain_paths = getKeychainPaths();
   }
 
-  // Since we are used a cache for each keychain file, we must process
+  // Since we are using a cache for each keychain file, we must process
   // certificates one keychain file at a time.
   std::set<std::string> expanded_paths = expandPaths(keychain_paths);
   for (const auto& path : expanded_paths) {

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -122,6 +122,9 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
 QueryData genKeychainItems(QueryContext& context) {
   QueryData results;
 
+  // Lock keychain access to 1 table/thread at a time.
+  std::unique_lock<decltype(keychainMutex)> lock(keychainMutex);
+
   // Allow the caller to set an explicit certificate (keychain) search path.
   std::set<std::string> keychain_paths;
   if (context.constraints["path"].exists(EQUALS)) {

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -18,6 +18,9 @@
 namespace osquery {
 namespace tables {
 
+// The table key for Keychain cache access.
+static const KeychainTable KEYCHAIN_TABLE = KeychainTable::KEYCHAIN_ITEMS;
+
 const std::vector<CFTypeRef> kKeychainItemTypes = {
     kSecClassGenericPassword,
     kSecClassInternetPassword,
@@ -63,8 +66,11 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
   // Any tag that does not exist for the item will prevent the entire result.
   for (const auto& attr_tag : kKeychainItemAttrs) {
     tags[0] = attr_tag.first;
-    auto os_status = SecKeychainItemCopyAttributesAndData(
-        item, &info, &item_class, &attr_list, 0, nullptr);
+
+    OSStatus os_status;
+    OSQUERY_USE_DEPRECATED(
+        os_status = SecKeychainItemCopyAttributesAndData(
+            item, &info, &item_class, &attr_list, nullptr, nullptr));
 
     if (os_status == errSecNoSuchAttr) {
       // This attr does not exist, skip it.
@@ -98,7 +104,8 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
           r[attr_tag.second] = encoded;
         }
       }
-      SecKeychainItemFreeAttributesAndData(attr_list, nullptr);
+      OSQUERY_USE_DEPRECATED(
+          SecKeychainItemFreeAttributesAndData(attr_list, nullptr));
       attr_list = nullptr;
     }
   }
@@ -123,18 +130,74 @@ QueryData genKeychainItems(QueryContext& context) {
     keychain_paths = getKeychainPaths();
   }
 
-  for (const auto& item_type : kKeychainItemTypes) {
-    CFArrayRef items = CreateKeychainItems(keychain_paths, item_type);
-    if (items == nullptr) {
+  // Since we are used a cache for each keychain file, we must process
+  // certificates one keychain file at a time.
+  std::set<std::string> expanded_paths = expandPaths(keychain_paths);
+  for (const auto& path : expanded_paths) {
+    // Check whether path is valid
+    boost::system::error_code ec;
+    auto source =
+        boost::filesystem::canonical(boost::filesystem::path(path), ec);
+    if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
+      // File does not exist or user does not have access. Don't log here to
+      // reduce noise.
       continue;
     }
-    auto count = CFArrayGetCount(items);
-    for (CFIndex i = 0; i < count; i++) {
-      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),
-                      results);
+
+    // Check cache
+    bool err;
+    std::string hash;
+    bool hit = keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
+    if (err) {
+      TLOG << "Could not read the file at " << path << "" << ec.message();
+      continue;
+    }
+    if (hit) {
+      continue;
     }
 
-    CFRelease(items);
+    // Cache miss. We need to generate new results.
+    SecKeychainRef keychain = nullptr;
+    OSStatus status;
+    OSQUERY_USE_DEPRECATED(status = SecKeychainOpen(source.c_str(), &keychain));
+    if (status != errSecSuccess || keychain == nullptr) {
+      if (keychain != nullptr) {
+        CFRelease(keychain);
+      }
+      // Cache an empty result to prevent the above API call in the future.
+      keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+      continue;
+    }
+
+    auto keychains = CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
+    CFArrayAppendValue(keychains, keychain);
+    QueryData new_results;
+    for (const auto& item_type : kKeychainItemTypes) {
+      std::set<std::string> temp_paths;
+      temp_paths.insert(path);
+      CFArrayRef items = CreateKeychainItems(keychains, item_type);
+      if (items == nullptr) {
+        // Cache an empty result to prevent the above API calls in the future.
+        keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+        continue;
+      }
+      auto count = CFArrayGetCount(items);
+      for (CFIndex i = 0; i < count; i++) {
+        genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),
+                        new_results);
+      }
+
+      CFRelease(items);
+    }
+    CFRelease(keychains);
+
+    // Update cache and results
+    keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
+    results.insert(results.end(), new_results.begin(), new_results.end());
+  }
+
+  if (FLAGS_keychain_access_cache) {
+    TLOG << "Total Keychain Cache entries: " << keychainCache.Size();
   }
 
   return results;

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -145,7 +145,7 @@ QueryData genKeychainItems(QueryContext& context) {
     }
 
     // Check cache
-    bool err;
+    bool err = false;
     std::string hash;
     bool hit = keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
     if (err) {

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -36,6 +36,7 @@ FLAG(uint32,
      "be enabled to use")
 
 KeychainCache keychainCache = KeychainCache();
+std::mutex keychainMutex;
 
 const std::vector<std::string> kSystemKeychainPaths = {
     "/System/Library/Keychains",
@@ -147,9 +148,6 @@ bool KeychainCache::Read(const boost::filesystem::path& path,
     return false;
   }
 
-  // Lock cache access to this thread to make it thread-safe
-  std::unique_lock<decltype(mutex)> lock(mutex);
-
   // Check the cache.
   auto it = this->cache.find(std::make_pair(path, table));
   if (it == this->cache.end()) {
@@ -184,9 +182,6 @@ void KeychainCache::Write(const boost::filesystem::path& path,
     // Don't use the cache.
     return;
   }
-
-  // Lock cache access to this thread to make it thread-safe
-  std::unique_lock<decltype(mutex)> lock(mutex);
 
   // Make entry to insert.
   KeychainCacheEntry entry;

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -14,13 +14,28 @@
 #include <string>
 
 #include <osquery/core/core.h>
+#include <osquery/core/flags.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/hashing/hashing.h>
 #include <osquery/tables/system/darwin/keychain.h>
 #include <osquery/utils/conversions/join.h>
 
+#include <osquery/logger/logger.h>
+
 namespace osquery {
 namespace tables {
+
+FLAG(bool,
+     keychain_access_cache,
+     true,
+     "Use a cache for keychain accesses (default true)")
+FLAG(uint32,
+     keychain_access_interval,
+     5,
+     "Minimum minutes required between keychain accesses. Keychain cache must "
+     "be enabled to use")
+
+KeychainCache keychainCache = KeychainCache();
 
 const std::vector<std::string> kSystemKeychainPaths = {
     "/System/Library/Keychains",
@@ -124,5 +139,69 @@ std::set<std::string> getKeychainPaths() {
 
   return keychain_paths;
 }
+
+bool KeychainCache::Read(const boost::filesystem::path& path,
+                         const KeychainTable table,
+                         std::string& hash,
+                         QueryData& results,
+                         bool& err) {
+  if (!FLAGS_keychain_access_cache) {
+    // Don't use the cache.
+    return false;
+  }
+
+  // Get hash of the file.
+  hash = hashFromFile(HASH_TYPE_SHA256, path.string());
+  if (hash.empty()) {
+    err = true;
+    return false;
+  }
+
+  // Check the cache.
+  auto it = this->cache.find(std::make_pair(path, table));
+  if (it == this->cache.end()) {
+    // Cache miss. This always occurs on the first read.
+    return false;
+  }
+  KeychainCacheEntry& entry = it->second;
+  if (entry.hash == hash) {
+    // Exact cache hit. Append results from cache.
+    results.insert(results.end(), entry.results.begin(), entry.results.end());
+    return true;
+  }
+  TLOG << "Previous hash did not match. Modified file: " << path.string();
+
+  // Check the read interval -- are we allowed to update the cache. If not, we
+  // return the cached results.
+  if (std::time(nullptr) >
+      entry.timestamp + (60 * FLAGS_keychain_access_interval)) {
+    return false;
+  }
+  TLOG << "Access to keychain file throttled. Returning previous results for: "
+       << path.string();
+  results.insert(results.end(), entry.results.begin(), entry.results.end());
+  return true;
+}
+
+void KeychainCache::Write(const boost::filesystem::path& path,
+                          const KeychainTable table,
+                          const std::string& hash,
+                          const QueryData& results) {
+  if (!FLAGS_keychain_access_cache) {
+    // Don't use the cache.
+    return;
+  }
+
+  // Make entry to insert.
+  KeychainCacheEntry entry;
+  entry.timestamp = std::time(nullptr);
+  entry.hash = hash;
+  entry.results = results;
+
+  std::pair<boost::filesystem::path, KeychainTable> key =
+      std::make_pair(path, table);
+  this->cache.insert_or_assign(key, entry);
+}
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -163,7 +163,7 @@ bool KeychainCache::Read(const boost::filesystem::path& path,
 
   // Check the read interval -- are we allowed to update the cache. If not, we
   // return the cached results.
-  if (std::time(nullptr) >
+  if (std::time(nullptr) >=
       entry.timestamp + (60 * FLAGS_keychain_access_interval)) {
     return false;
   }

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -163,8 +163,8 @@ bool KeychainCache::Read(const boost::filesystem::path& path,
 
   // Check the read interval -- are we allowed to update the cache. If not, we
   // return the cached results.
-  if (std::time(nullptr) >=
-      entry.timestamp + (60 * FLAGS_keychain_access_interval)) {
+  if (std::chrono::system_clock::now() >=
+      entry.timestamp + std::chrono::minutes(FLAGS_keychain_access_interval)) {
     return false;
   }
   TLOG << "Access to keychain file throttled. Returning previous results for: "
@@ -184,7 +184,7 @@ void KeychainCache::Write(const boost::filesystem::path& path,
 
   // Make entry to insert.
   KeychainCacheEntry entry;
-  entry.timestamp = std::time(nullptr);
+  entry.timestamp = std::chrono::system_clock::now();
   entry.hash = hash;
   entry.results = results;
 

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -147,6 +147,9 @@ bool KeychainCache::Read(const boost::filesystem::path& path,
     return false;
   }
 
+  // Lock cache access to this thread to make it thread-safe
+  std::unique_lock<decltype(mutex)> lock(mutex);
+
   // Check the cache.
   auto it = this->cache.find(std::make_pair(path, table));
   if (it == this->cache.end()) {
@@ -181,6 +184,9 @@ void KeychainCache::Write(const boost::filesystem::path& path,
     // Don't use the cache.
     return;
   }
+
+  // Lock cache access to this thread to make it thread-safe
+  std::unique_lock<decltype(mutex)> lock(mutex);
 
   // Make entry to insert.
   KeychainCacheEntry entry;

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ function(osqueryTablesSystemTestsMain)
 
   if(DEFINED PLATFORM_MACOS)
     generateOsqueryTablesSystemDarwinTests()
+    generateOsqueryTablesSystemDarwinKeychainTests()
   endif()
 
   if(DEFINED PLATFORM_WINDOWS)
@@ -163,6 +164,22 @@ function(generateOsqueryTablesSystemDarwinTests)
   # Make sure that the data is built before the test
   add_dependencies(osquery_tables_system_darwin_tests-test
     unsigned_test_builder
+  )
+endfunction()
+
+function(generateOsqueryTablesSystemDarwinKeychainTests)
+  set(source_files
+          darwin/keychain_test.cpp
+  )
+
+  add_osquery_executable(osquery_keychain_tests-test ${source_files})
+
+  target_link_libraries(osquery_keychain_tests-test PRIVATE
+          osquery_cxx_settings
+          osquery_extensions_implthrift
+          osquery_tables_system_systemtable
+          tests_helper
+          thirdparty_googletest
   )
 endfunction()
 

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -172,15 +172,15 @@ function(generateOsqueryTablesSystemDarwinKeychainTests)
           darwin/keychain_test.cpp
   )
 
-  add_osquery_executable(osquery_keychain_tests-test ${source_files})
+  add_osquery_executable(osquery_tables_system_darwin_keychain_tests-test ${source_files})
 
-  target_link_libraries(osquery_keychain_tests-test PRIVATE
+  target_link_libraries(osquery_tables_system_darwin_keychain_tests-test PRIVATE
           osquery_cxx_settings
-          osquery_extensions_implthrift
           osquery_filesystem
+          osquery_hashing
           osquery_tables_system_systemtable
-          osquery_utils
-          osquery_utils_info
+          osquery_extensions
+          osquery_extensions_implthrift
           tests_helper
           thirdparty_googletest
   )

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -177,7 +177,10 @@ function(generateOsqueryTablesSystemDarwinKeychainTests)
   target_link_libraries(osquery_keychain_tests-test PRIVATE
           osquery_cxx_settings
           osquery_extensions_implthrift
+          osquery_filesystem
           osquery_tables_system_systemtable
+          osquery_utils
+          osquery_utils_info
           tests_helper
           thirdparty_googletest
   )

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -100,7 +100,6 @@ TEST_F(KeychainTest, keychain_cache) {
     EXPECT_FALSE(err);
     EXPECT_EQ(new_results.size(), 0);
   }
-
 }
 
 TEST_F(KeychainTest, keychain_cache_bad_path) {
@@ -114,4 +113,4 @@ TEST_F(KeychainTest, keychain_cache_bad_path) {
   EXPECT_EQ(results.size(), 0);
 }
 
-}
+} // namespace osquery::tables

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <boost/filesystem.hpp>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/tables/system/darwin/keychain.h>
@@ -43,6 +45,14 @@ TEST_F(KeychainTest, keychain_cache) {
   std::ofstream test_file(path.string());
   test_file.write(file_contents.c_str(), (long)file_contents.length());
   test_file.close();
+
+  // Sanity check to make sure the test file was actually created.
+  boost::system::error_code ec;
+  if (!is_regular_file(path, ec) || ec.failed()) {
+    GTEST_FAIL() << "Could not create a temporary file needed for the test: "
+                 << path.string();
+  }
+
   bool err;
   EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
   EXPECT_FALSE(err);
@@ -62,6 +72,7 @@ TEST_F(KeychainTest, keychain_cache) {
   {
     QueryData new_results;
     hash = "";
+    err = false;
     EXPECT_TRUE(keychainCache.Read(path, table, hash, new_results, err));
     EXPECT_FALSE(err);
     EXPECT_EQ(new_results.size(), 1);
@@ -91,6 +102,7 @@ TEST_F(KeychainTest, keychain_cache) {
   {
     QueryData new_results;
     hash = "";
+    err = false;
     EXPECT_TRUE(keychainCache.Read(path, table, hash, new_results, err));
     EXPECT_FALSE(err);
     EXPECT_EQ(new_results.size(), 1);
@@ -102,6 +114,7 @@ TEST_F(KeychainTest, keychain_cache) {
   {
     QueryData new_results;
     hash = "";
+    err = false;
     EXPECT_FALSE(keychainCache.Read(path, table, hash, new_results, err));
     EXPECT_FALSE(err);
     EXPECT_EQ(new_results.size(), 0);

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -38,8 +38,11 @@ TEST_F(KeychainTest, keychain_cache) {
   QueryData results;
 
   // Create a file and check cache.
+  std::string file_contents = "contents";
   boost::filesystem::path path = test_working_dir_ / "cache.keychain";
-  boost::filesystem::save_string_file(path, "contents");
+  std::ofstream test_file(path.string());
+  test_file.write(file_contents.c_str(), (long)file_contents.length());
+  test_file.close();
   bool err;
   EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
   EXPECT_FALSE(err);
@@ -80,7 +83,10 @@ TEST_F(KeychainTest, keychain_cache) {
   }
 
   // Read access throttled. Cached result returned.
-  boost::filesystem::save_string_file(path, "contents_modified");
+  file_contents = "contents_modified";
+  test_file = std::ofstream(path.string());
+  test_file.write(file_contents.c_str(), (long)file_contents.length());
+  test_file.close();
   FLAGS_keychain_access_interval = 1;
   {
     QueryData new_results;

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -1,0 +1,117 @@
+/**
+* Copyright (c) 2014-present, The osquery authors
+*
+* This source code is licensed as defined by the LICENSE file found in the
+* root directory of this source tree.
+*
+* SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+*/
+
+#include <gtest/gtest.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/tables/system/darwin/keychain.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery::tables {
+
+class KeychainTest : public testing::Test {
+ protected:
+  fs::path test_working_dir_;
+
+  void SetUp() override {
+    test_working_dir_ = fs::temp_directory_path() /
+                        fs::unique_path("osquery.test_working_dir.%%%%.%%%%");
+    fs::create_directories(test_working_dir_);
+  }
+
+  void TearDown() override {
+    fs::remove_all(test_working_dir_);
+  }
+};
+
+TEST_F(KeychainTest, keychain_cache) {
+  EXPECT_EQ(keychainCache.Size(), 0);
+
+  KeychainTable table = KeychainTable::CERTIFICATES;
+  std::string hash;
+  QueryData results;
+
+  // Create a file and check cache.
+  boost::filesystem::path path = test_working_dir_ / "cache.keychain";
+  boost::filesystem::save_string_file(path, "contents");
+  bool err;
+  EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
+  EXPECT_FALSE(err);
+  EXPECT_EQ(keychainCache.Size(), 0);
+
+  // Write to cache
+  {
+    QueryData new_results;
+    Row row;
+    row["foo"] = "bar";
+    new_results.push_back(row);
+    keychainCache.Write(path, table, hash, new_results);
+    EXPECT_EQ(keychainCache.Size(), 1);
+  }
+
+  // Read results.
+  {
+    QueryData new_results;
+    hash = "";
+    EXPECT_TRUE(keychainCache.Read(path, table, hash, new_results, err));
+    EXPECT_FALSE(err);
+    EXPECT_EQ(new_results.size(), 1);
+    EXPECT_EQ(new_results[0]["foo"], "bar");
+  }
+
+  // Overwrite cache results.
+  {
+    QueryData new_results;
+    Row row;
+    row["key"] = "value";
+    new_results.push_back(row);
+    keychainCache.Write(path, table, hash, new_results);
+    EXPECT_EQ(keychainCache.Size(), 1);
+    // Write results to another path for good measure
+    new_results.emplace_back();
+    keychainCache.Write("bozo", table, hash, new_results);
+    EXPECT_EQ(keychainCache.Size(), 2);
+  }
+
+  // Read access throttled. Cached result returned.
+  boost::filesystem::save_string_file(path, "contents_modified");
+  FLAGS_keychain_access_interval = 1;
+  {
+    QueryData new_results;
+    hash = "";
+    EXPECT_TRUE(keychainCache.Read(path, table, hash, new_results, err));
+    EXPECT_FALSE(err);
+    EXPECT_EQ(new_results.size(), 1);
+    EXPECT_EQ(new_results[0]["key"], "value");
+  }
+
+  // Read access NOT throttled. Cache miss.
+  FLAGS_keychain_access_interval = 0;
+  {
+    QueryData new_results;
+    hash = "";
+    EXPECT_FALSE(keychainCache.Read(path, table, hash, new_results, err));
+    EXPECT_FALSE(err);
+    EXPECT_EQ(new_results.size(), 0);
+  }
+
+}
+
+TEST_F(KeychainTest, keychain_cache_bad_path) {
+  boost::filesystem::path path = test_working_dir_ / "does_not_exist";
+  KeychainTable table = KeychainTable::KEYCHAIN_ITEMS;
+  std::string hash;
+  QueryData results;
+  bool err;
+  EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
+  EXPECT_TRUE(err);
+  EXPECT_EQ(results.size(), 0);
+}
+
+}

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <boost/filesystem.hpp>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <osquery/filesystem/filesystem.h>
@@ -53,7 +52,7 @@ TEST_F(KeychainTest, keychain_cache) {
                  << path.string();
   }
 
-  bool err;
+  bool err = false;
   EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
   EXPECT_FALSE(err);
   EXPECT_EQ(keychainCache.Size(), 0);
@@ -126,7 +125,7 @@ TEST_F(KeychainTest, keychain_cache_bad_path) {
   KeychainTable table = KeychainTable::KEYCHAIN_ITEMS;
   std::string hash;
   QueryData results;
-  bool err;
+  bool err = false;
   EXPECT_FALSE(keychainCache.Read(path, table, hash, results, err));
   EXPECT_TRUE(err);
   EXPECT_EQ(results.size(), 0);

--- a/osquery/tables/system/tests/darwin/keychain_test.cpp
+++ b/osquery/tables/system/tests/darwin/keychain_test.cpp
@@ -1,11 +1,11 @@
 /**
-* Copyright (c) 2014-present, The osquery authors
-*
-* This source code is licensed as defined by the LICENSE file found in the
-* root directory of this source tree.
-*
-* SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
-*/
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
 
 #include <gtest/gtest.h>
 #include <osquery/filesystem/filesystem.h>

--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -1,5 +1,5 @@
 table_name("certificates")
-description("Certificate Authorities installed in Keychains/ca-bundles.")
+description("Certificate Authorities installed in Keychains/ca-bundles. NOTE: osquery limits frequent access to keychain files on macOS. This limit is controlled by keychain_access_interval flag.")
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate distinguished name (deprecated, use subject2)"),

--- a/specs/darwin/keychain_acls.table
+++ b/specs/darwin/keychain_acls.table
@@ -1,5 +1,5 @@
 table_name("keychain_acls")
-description("Applications that have ACL entries in the keychain.")
+description("Applications that have ACL entries in the keychain. NOTE: osquery limits frequent access to keychain files. This limit is controlled by keychain_access_interval flag.")
 schema([
     Column("keychain_path", TEXT, "The path of the keychain"),
     Column("authorizations", TEXT, "A space delimited set of authorization attributes"),

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -1,5 +1,5 @@
 table_name("keychain_items")
-description("Generic details about keychain items.")
+description("Generic details about keychain items. NOTE: osquery limits frequent access to keychain files. This limit is controlled by keychain_access_interval flag.")
 schema([
     Column("label", TEXT, "Generic item name"),
     Column("description", TEXT, "Optional item description"),


### PR DESCRIPTION
Fixes #7780 
Related issue: https://github.com/fleetdm/fleet/issues/13065

Adding a cache for macOS keychain file accesses.

The cache checks whether a keychain file has been modified by comparing the file's SHA256 hash. If the file has been modified, the cache also checks whether the file has been accessed recently. If it has been accessed within the configured interval, the old cached results are returned.

The cache works independently for each table. This means that multiple tables can access the keychain files within the interval, but each one of them can only do so once.

The following feature flags have been added:
```
    --keychain_access_cache                          Use a cache for keychain accesses (default true)
    --keychain_access_interval VALUE                 Minimum minutes required between keychain accesses. Keychain cache must be enabled to use
```

Default `keychain_access_interval` is 5 minutes.

Old table results exactly match new table results when ordered by primary key.

Performance results for `certificates` for 10 rounds (old vs new):
```
 U:1  C:0  M:3  F:0  D:0  manual: utilization: 13.940000000000001 cpu_time: 0.14197365480000002 memory: 35979264.0 fds: 4.0 duration: 0.5259468078613281
 U:1  C:0  M:3  F:0  D:0  manual: utilization: 13.236666666666668 cpu_time: 0.13929492440000002 memory: 35386163.2 fds: 4.0 duration: 0.5783782720565795
```

Performance results for `certificates` for 10 counts (new is faster and less memory due to cache):
```
 U:2  C:1  M:3  F:0  D:2  manual: utilization: 44.29999999999999 cpu_time: 0.669130928 memory: 50331648.0 fds: 4.0 duration: 1.5303008556365967
 U:2  C:1  M:3  F:0  D:2  manual: utilization: 28.366666666666664 cpu_time: 0.42878788 memory: 40534016.0 fds: 4.0 duration: 1.0357069969177246
```

Performance results for `keychain_acls` for 10 rounds (old vs new):
```
 U:1  C:0  M:3  F:0  D:0  manual: utilization: 10.57 cpu_time: 0.10779758619999999 memory: 29374873.6 fds: 4.0 duration: 0.5254422664642334
 U:1  C:0  M:3  F:0  D:0  manual: utilization: 11.366666666666669 cpu_time: 0.1201387166 memory: 29420748.8 fds: 4.0 duration: 0.5800627708435059
```

Performance results for `keychain_acls` for 10 counts (new is faster and less memory due to cache):
```
 U:2  C:1  M:3  F:0  D:2  manual: utilization: 22.059999999999995 cpu_time: 0.557502384 memory: 77463552.0 fds: 4.0 duration: 2.0405030250549316
 U:2  C:1  M:3  F:0  D:2  manual: utilization: 26.733333333333334 cpu_time: 0.405785928 memory: 36782080.0 fds: 4.0 duration: 1.0386288166046143
```

Performance results for `keychain_items` for 10 rounds (old vs new). **New performance is better.** This is likely because the new code only opens each keychain file once, while old code opened each keychain file multiple times -- once for each keychain item type (password, certificate, etc.)
```
 U:2  C:1  M:3  F:0  D:1  manual: utilization: 30.510833333333334 cpu_time: 0.45226203760000006 memory: 29961420.8 fds: 4.0 duration: 0.9804916620254517
 U:2  C:0  M:3  F:0  D:0  manual: utilization: 20.805 cpu_time: 0.2112246234 memory: 26363494.4 fds: 4.0 duration: 0.5286885976791382
```

Performance results for `keychain_items` for 10 counts (new is way faster and less memory):
```
 U:3  C:2  M:3  F:0  D:3  manual: utilization: 78.25999999999999 cpu_time: 3.946559488 memory: 41320448.0 fds: 4.0 duration: 4.564563989639282
 U:2  C:1  M:3  F:0  D:2  manual: utilization: 25.474999999999998 cpu_time: 0.511153552 memory: 33996800.0 fds: 4.0 duration: 1.5302011966705322
```

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
