### PR TITLE
build: Temporary workaround to build with XCode 15

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -254,11 +254,6 @@ function(setupBuildFlags)
         "-weak_framework OSLog"
       )
 
-      # This is a workaround for XCode 15 and boost
-      set(macos_cxx_defines
-        _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION
-      )
-
       set(osquery_macos_common_defines
         APPLE=1
         DARWIN=1
@@ -276,9 +271,6 @@ function(setupBuildFlags)
       )
       target_link_libraries(cxx_settings INTERFACE
         ${macos_cxx_link_libraries}
-      )
-      target_compile_definitions(cxx_settings INTERFACE
-        ${macos_cxx_defines}
       )
 
       list(APPEND osquery_defines ${osquery_macos_common_defines})

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -254,6 +254,11 @@ function(setupBuildFlags)
         "-weak_framework OSLog"
       )
 
+      # This is a workaround for XCode 15 and boost
+      set(macos_cxx_defines
+        _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION
+      )
+
       set(osquery_macos_common_defines
         APPLE=1
         DARWIN=1
@@ -271,6 +276,9 @@ function(setupBuildFlags)
       )
       target_link_libraries(cxx_settings INTERFACE
         ${macos_cxx_link_libraries}
+      )
+      target_compile_definitions(cxx_settings INTERFACE
+        ${macos_cxx_defines}
       )
 
       list(APPEND osquery_defines ${osquery_macos_common_defines})

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -142,6 +142,10 @@ function(importBoostInterfaceLibraries)
     importBoostInterfaceLibrary("${library_name}" ${library_dependency_list})
   endforeach()
 
+  target_compile_definitions(thirdparty_boost_container_hash INTERFACE
+    BOOST_NO_CXX98_FUNCTION_BASE
+  )
+
   # Additional settings for the libraries we just imported
   if(PLATFORM_LINUX)
     target_compile_definitions(thirdparty_boost_uuid INTERFACE


### PR DESCRIPTION
std::unary_function has been removed from C++17,
but boost still needs it.
Only recently in XCode 15 it has been removed; asks Boost to stop using it.

Fixes #8196 
