### PR TITLE
ci: Update nvdlib to use the latest NVD APIs

### DIFF
--- a/.github/workflows/cleanup_ec2_runners.yml
+++ b/.github/workflows/cleanup_ec2_runners.yml
@@ -18,6 +18,8 @@ on:
 jobs:
     cleanup:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
+
         steps:
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/cve_scan_runner.yml
+++ b/.github/workflows/cve_scan_runner.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   scan-and-open-issues:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
 
     steps:
       - name: Clone the osquery repository
@@ -32,5 +33,5 @@ jobs:
           --repository .
 
           ./tools/ci/scripts/cve/third_party_libraries_cves_scanner.py --manifest libraries/third_party_libraries_manifest.json \
-          --create_issues \
+          --create-issues \
           --debug

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -3,9 +3,7 @@
     "product": "openssl",
     "vendor": "openssl",
     "version": "3.1.3",
-    "ignored-cves": [
-      "CVE-2019-0190"
-    ]
+    "ignored-cves": []
   },
   "augeas": {
     "product": "augeas",

--- a/tools/ci/scripts/cve/requirements.txt
+++ b/tools/ci/scripts/cve/requirements.txt
@@ -1,2 +1,2 @@
-nvdlib==0.6.1
-pygit2==1.10.1
+nvdlib==0.7.6
+pygit2==1.13.3


### PR DESCRIPTION
- Update nvdlib to use the latest NVD APIs

- Use isVulnerable in the request to only get CVEs for the CPE we are searching for, where the CPE is vulnerable, not all the CVEs that are connected to the CPE.

- Put a limit to the CVE scan and EC2 cleanup workflow.

- Change the create_issues option to create-issues, using the same format for the other options.

- Formatting

The `isVulnerable` parameter fixes the issue where for instance `openldap` has a CVE that reference `openssl`, because the CVE is due to an incorrect usage of `openssl`, but it's **not** a bug/CVE of `openssl`, and the API returns that when searching CVEs for `openssl`.
We then had to ignore those in the manifest. Now they will not be returned instead.

A run can be seen on my repo: https://github.com/Smjert/osquery/actions/runs/7062714699

Fixes #8123 
