### PR TITLE
ci: Fix Linux build

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -259,7 +259,7 @@ jobs:
       run: |
         run_on_host="nsenter -t 1 -m -u -n -i"
         packages_to_remove=$($run_on_host dpkg-query -f '${Package}\n' -W | grep "^clang-.*\|^llvm-.*\|^php.*\|^mono-.*\|^mongodb-.*\
-        \|^libmono-.*\|^temurin-.*\|^dotnet-.*\|^google-chrome-stable\|^microsoft-edge-stable\|^google-cloud-sdk\|^firefox\|^hhvm\|^snapd")
+        \|^libmono-.*\|^temurin-8-jdk\|^temurin-11-jdk\|^temurin-17-jdk\|^dotnet-.*\|^google-chrome-stable\|^microsoft-edge-stable\|^google-cloud-sdk\|^firefox\|^hhvm\|^snapd")
         $run_on_host apt purge $packages_to_remove
 
     - name: Clone the osquery repository


### PR DESCRIPTION
When removing packages to get more space,
don't cause other packages to be installed;
keep one version of temurin Java sdk.

This is necessary because the apt mirrors that the install tries to access are out of date, and this makes the Linux job fail. To update them we would need to call `apt update`, but we really don't want to.