### PR TITLE
cve: Update openssl to 3.2.0

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "3.1.3")
-set(OPENSSL_ARCHIVE_SHA256 "f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6")
+set(OPENSSL_VERSION "3.2.0")
+set(OPENSSL_ARCHIVE_SHA256 "14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "3.1.3",
+    "version": "3.2.0",
     "ignored-cves": []
   },
   "augeas": {


### PR DESCRIPTION
This also resolves CVE-2023-5363,
CVE-2023-5678.

Fixes #8187
Fixes #8193 
