### PR TITLE
Add support for Apple Silicon in secureboot table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -152,7 +152,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/running_apps.mm
       darwin/sandboxes.cpp
       darwin/screenlock.mm
-      darwin/secureboot.cpp
+      darwin/secureboot.mm
       darwin/shared_folders.mm
       darwin/sharing_preferences.cpp
       darwin/signature.mm

--- a/osquery/tables/system/darwin/secureboot.mm
+++ b/osquery/tables/system/darwin/secureboot.mm
@@ -212,7 +212,7 @@ Status getAarch64SecureBootSetting(Row& r) {
     });
 
     if (!CFBundleLoadExecutable(bundle)) {
-      return Status::failure("SPSupport load executable failed")
+      return Status::failure("SPSupport load executable failed");
     }
 
 #pragma clang diagnostic push

--- a/osquery/tables/system/darwin/secureboot.mm
+++ b/osquery/tables/system/darwin/secureboot.mm
@@ -12,11 +12,19 @@
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
+#include <osquery/utils/scope_guard.h>
 
+#import <AppKit/NSDocument.h>
 #include <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOKitLib.h>
 #include <mach/mach_error.h>
+
+@interface SPDocument : NSDocument {
+}
+- (id)reportForDataType:(id)arg1;
+@end
 
 namespace osquery::tables {
 
@@ -137,7 +145,7 @@ Status getSecureBootModeFromValue(UniqueCFTypeRef& value,
   return Status::success();
 }
 
-Status getSecureBootSetting(Row& row) {
+Status getIntelSecureBootSetting(Row& row) {
   SecureBootMode mode{SecureBootMode::NoSecurity};
 
   UniqueIoRegistryEntry options_entry;
@@ -176,17 +184,120 @@ Status getSecureBootSetting(Row& row) {
   return Status::success();
 }
 
+Status getAarch64SecureBootSetting(Row& r) {
+  @autoreleasepool {
+    // BEWARE: Because of the dynamic nature of the calls in this function, we
+    // must be careful to properly clean up the memory. Any future modifications
+    // to this function should attempt to ensure there are no leaks (and test
+    // with ./tools/analysis/profile.py --leaks).
+    CFURLRef bundle_url = CFURLCreateWithFileSystemPath(
+        kCFAllocatorDefault,
+        CFSTR("/System/Library/PrivateFrameworks/SPSupport.framework"),
+        kCFURLPOSIXPathStyle,
+        true);
+
+    if (bundle_url == nullptr) {
+      return Status::failure("Error parsing SPSupport bundle URL");
+    }
+
+    CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, bundle_url);
+    CFRelease(bundle_url);
+    if (bundle == nullptr) {
+      return Status::failure("Error opening SPSupport bundle");
+    }
+
+    CFBundleLoadExecutable(bundle);
+
+    auto cleanup_bundle = scope_guard::create([&]() {
+      CFBundleUnloadExecutable(bundle);
+      CFRelease(bundle);
+    });
+
+#pragma clang diagnostic push
+// We are silencing here because we don't know the selector beforehand
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+
+    id cls = NSClassFromString(@"SPDocument");
+    if (cls == nullptr) {
+      return Status::failure("Could not load SPDocument class");
+    }
+
+    SEL sel = @selector(new);
+    if (![cls respondsToSelector:sel]) {
+      return Status::failure("SPDocument does not respond to new selector");
+    }
+
+    id document = [cls performSelector:sel];
+    if (document == nullptr) {
+      return Status::failure("[SPDocument new] returned null");
+    }
+
+    auto cleanup_document =
+        scope_guard::create([&]() { CFRelease((__bridge CFTypeRef)document); });
+
+#pragma clang diagnostic pop
+
+    NSDictionary* report = [[[document reportForDataType:@"SPiBridgeDataType"]
+        objectForKey:@"_items"] lastObject];
+
+    if ([report valueForKey:@"ibridge_secure_boot"]) {
+      r["description"] =
+          SQL_TEXT([[report valueForKey:@"ibridge_secure_boot"] UTF8String]);
+      if (r["description"] == "Full Security" ||
+          r["description"] == "Reduced Security") {
+        r["secure_boot"] = "1";
+      } else if (r["description"] == "Permissive Security") {
+        r["secure_boot"] = "0";
+      }
+    }
+
+    if ([report valueForKey:@"ibridge_sb_other_kext"]) {
+      auto value = std::string(
+          [[report valueForKey:@"ibridge_sb_other_kext"] UTF8String]);
+      if (value == "Yes") {
+        r["allow_kernel_extensions"] = "1";
+      } else if (value == "No") {
+        r["allow_kernel_extensions"] = "0";
+      }
+    }
+
+    // Combine both MDM values into a single column (since devices should be in
+    // *either* DEP or Manual enrollment)
+    if ([report valueForKey:@"ibridge_sb_manual_mdm"] ||
+        [report valueForKey:@"ibridge_sb_device_mdm"]) {
+      r["allow_mdm_operations"] = "0";
+
+      if ([report valueForKey:@"ibridge_sb_manual_mdm"]) {
+        auto value = std::string(
+            [[report valueForKey:@"ibridge_sb_manual_mdm"] UTF8String]);
+        if (value == "Yes") {
+          r["allow_mdm_operations"] = "1";
+        }
+      }
+
+      if ([report valueForKey:@"ibridge_sb_device_mdm"]) {
+        auto value = std::string(
+            [[report valueForKey:@"ibridge_sb_device_mdm"] UTF8String]);
+        if (value == "Yes") {
+          r["allow_mdm_operations"] = "1";
+        }
+      }
+    }
+  }
+
+  return Status::success();
+}
+
 } // namespace
 
 QueryData genSecureBoot(QueryContext& context) {
   Row row;
 
 #ifdef __aarch64__
-  LOG(INFO) << "secure_boot unsupported on ARM macOS";
-  return {};
+  auto status = getAarch64SecureBootSetting(row);
+#else
+  auto status = getIntelSecureBootSetting(row);
 #endif
-
-  auto status = getSecureBootSetting(row);
   if (!status.ok()) {
     LOG(ERROR) << "secureboot error: " << status.toString();
     return {};

--- a/specs/secureboot.table
+++ b/specs/secureboot.table
@@ -7,8 +7,8 @@ schema([
 extended_schema(DARWIN, [
     Column("secure_mode", INTEGER, "(Intel) Secure mode: 0 disabled, 1 full security, 2 medium security"),
     Column("description", TEXT, "(Apple Silicon) Human-readable description: 'Full Security', 'Reduced Security', or 'Permissive Security'"),
-    Column("allow_kernel_extensions", INTEGER, "(Apple Silicon) Allow user management of kernel extensions from identified developers"),
-    Column("allow_mdm_operations", INTEGER, "(Apple Silicon) Allow remote (MDM) management of kernel extensions and automatic software updates"),
+    Column("kernel_extensions", INTEGER, "(Apple Silicon) Allow user management of kernel extensions from identified developers (1 if allowed)"),
+    Column("mdm_operations", INTEGER, "(Apple Silicon) Allow remote (MDM) management of kernel extensions and automatic software updates (1 if allowed)"),
 ])
 
 extended_schema(LINUX + WINDOWS, [

--- a/specs/secureboot.table
+++ b/specs/secureboot.table
@@ -5,7 +5,10 @@ schema([
 ])
 
 extended_schema(DARWIN, [
-    Column("secure_mode", INTEGER, "Secure mode for Intel-based macOS: 0 disabled, 1 full security, 2 medium security"),
+    Column("secure_mode", INTEGER, "(Intel) Secure mode: 0 disabled, 1 full security, 2 medium security"),
+    Column("description", TEXT, "(Apple Silicon) Human-readable description: 'Full Security', 'Reduced Security', or 'Permissive Security'"),
+    Column("allow_kernel_extensions", INTEGER, "(Apple Silicon) Allow user management of kernel extensions from identified developers"),
+    Column("allow_mdm_operations", INTEGER, "(Apple Silicon) Allow remote (MDM) management of kernel extensions and automatic software updates"),
 ])
 
 extended_schema(LINUX + WINDOWS, [


### PR DESCRIPTION
Add the additional columns "description", "allow_kernel_extensions", and "allow_mdm_operations". These correspond to the options presented in the Startup Security Utility.

This has been tested across all the possible configurations on a M2 MacBook Pro with Manual MDM enrollment.

Closes #8195
