### PR TITLE
test: re-enable tools_tests_testrelease

### DIFF
--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -97,8 +97,7 @@ function(generatePythonTests)
     "--verbose"
   )
 
-  # TODO: Add back this test once the zlib .so is no longer linked by the BPF libraries
-  # addPythonTest(NAME tools_tests_testrelease SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_release.py" ARGS ${release_test_args})
+  addPythonTest(NAME tools_tests_testrelease SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_release.py" ARGS ${release_test_args})
 
   # TODO: Uncomment me when the query packs test is fully fixed
   # addPythonTest(NAME tools_tests_testquerypacks SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/test_query_packs.py")


### PR DESCRIPTION
This was disabled in the past due to a bug in the build, where on Linux with BPF we would link zlib.so.
This has since been solved, so re-enable the test.