### PR TITLE
Fix signed/unsigned mismatch in powershell_events

### DIFF
--- a/osquery/events/windows/windowseventlogpublisher.cpp
+++ b/osquery/events/windows/windowseventlogpublisher.cpp
@@ -208,7 +208,7 @@ double WindowsEventLogPublisher::cosineSimilarity(
   std::vector<double> buffer_freqs(kCharFreqVectorLen, 0.0);
 
   auto buffer_size = buffer.size();
-  for (auto chr : buffer) {
+  for (unsigned char chr : buffer) {
     if (chr < kCharFreqVectorLen) {
       buffer_freqs[chr] += 1.0 / buffer_size;
     }


### PR DESCRIPTION
This fixes #8224 

cosine similarity calculation in powershell_events could rollover to using negative indices with special chars in script (#8224)
Converting `auto` type to `unsigned char` will force compiler to treat `chr` as unsigned value which is more in accordance with `size_t` type used for indices in `buffer_freqs` . 
 This also provides an accurate value of cosine-similarity of scripts with special characters. 
