### PR TITLE
fix: Fix a crash in firefox_addons

### DIFF
--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <optional>
+
 #include <boost/property_tree/json_parser.hpp>
 
 #include <osquery/core/tables.h>

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -113,6 +113,12 @@ void genFirefoxAddonsFromExtensions(const std::string& uid,
     }
   }
 
+  if (!extensions.doc().IsObject()) {
+    TLOG << "Failed to parse the JSON extensions file at: " << extensions_path
+         << ", the document root is not an object";
+    return;
+  }
+
   const auto addons_it = extensions.doc().FindMember("addons");
 
   if (addons_it == extensions.doc().MemberEnd()) {


### PR DESCRIPTION
Add a return when the "addons" member in the extensions JSON is present but it's not an array, to avoid accessing uninitialized memory.

Also check that the "addons" member elements are all objects when trying to access its nested members.

Should fix #8226 
