### PR TITLE
fix: Add stricter checks to JSON parsing

### DIFF
--- a/osquery/worker/ipc/include/table_ipc_base.h
+++ b/osquery/worker/ipc/include/table_ipc_base.h
@@ -94,6 +94,10 @@ class TableIPCBase {
       return status;
     }
 
+    if (!json_message.doc().IsObject()) {
+      return Status::failure("JSON root is not an object");
+    }
+
     if (!json_message.doc().HasMember("Type")) {
       return Status::failure("No Type member");
     }

--- a/plugins/config/tls_config.cpp
+++ b/plugins/config/tls_config.cpp
@@ -14,14 +14,14 @@
 // clang-format on
 
 #include <osquery/config/config.h>
-#include <osquery/dispatcher/dispatcher.h>
-#include <osquery/remote/enroll/enroll.h>
 #include <osquery/core/flags.h>
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/registry/registry.h>
+#include <osquery/remote/enroll/enroll.h>
 #include <osquery/remote/requests.h>
 #include <osquery/remote/serializers/json.h>
-#include <osquery/utils/json/json.h>
 #include <osquery/utils/chars.h>
+#include <osquery/utils/json/json.h>
 #include <plugins/config/tls_config.h>
 
 #include <sstream>
@@ -78,6 +78,12 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
       Status parse_status = tree.fromString(json);
       if (!parse_status.ok()) {
         VLOG(1) << "Could not parse JSON from TLS config node API";
+        return Status::failure("Could not parse JSON from TLS config node API");
+      }
+
+      if (!tree.doc().IsObject()) {
+        return Status::failure(
+            "Root of the JSON from TLS config node API is not an object");
       }
 
       // Re-encode the config key into JSON.

--- a/plugins/logger/kafka_producer.cpp
+++ b/plugins/logger/kafka_producer.cpp
@@ -24,10 +24,10 @@
 
 #include <osquery/config/config.h>
 #include <osquery/core/core.h>
-#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/core/flags.h>
-#include <osquery/registry/registry_factory.h>
 #include <osquery/core/system.h>
+#include <osquery/dispatcher/dispatcher.h>
+#include <osquery/registry/registry_factory.h>
 #include <osquery/utils/json/json.h>
 
 #include <plugins/config/parsers/kafka_topics.h>
@@ -121,7 +121,7 @@ inline std::string getMsgName(const std::string& payload) {
   // If failed to parse as JSON, or JSON object doesn't have "name" top-level
   // key, return base topic
   if (!doc.fromString(payload, JSON::ParseMode::Iterative) ||
-      !doc.doc().HasMember(fieldName)) {
+      !doc.doc().IsObject() || !doc.doc().HasMember(fieldName)) {
     return "";
   }
   auto& name = doc.doc()[fieldName];


### PR DESCRIPTION
I went through or uses of `fromString` and checked where we weren't making sure that the correct root node of the JSON tree was of the correct type.

We should also go through all uses of rapidjson and see if all the proper checks when accessing the rest of the JSON nodes are correct (checking that something IsString before doing GetString and so on).