### PR TITLE
tls_logger backoff

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -288,6 +288,10 @@ Use this only in emergency situations as size violations are dropped. It is extr
 
 This configures the max number of log lines to send every period (meaning every `logger_tls_period`).
 
+`--logger_tls_backoff_max=3600`
+
+Maximum seconds to wait before flushing logs over TLS/HTTPS. The exponential backoff kicks in when regular flush of buffered logs fails. Should be a multiple of `logger_tls_period`. 0 disables backoff. The max backoff time can be updated dynamically via `config_tls_endpoint`.
+
 `--distributed_tls_read_endpoint=`
 
 The URI path which will be used, in conjunction with `--tls_hostname`, to create the remote URI for retrieving distributed queries when using the **tls** distributed plugin.

--- a/plugins/logger/buffered.cpp
+++ b/plugins/logger/buffered.cpp
@@ -213,6 +213,7 @@ void BufferedLogForwarder::start() {
       // Apply any updates to configuration options, such as disabling of
       // backoff.
       applyNewConfiguration();
+      // Update backoff timers.
       backoffTick();
     } while (!interrupted() &&
              results_backoff_period_ > std::chrono::seconds::zero() &&

--- a/plugins/logger/buffered.cpp
+++ b/plugins/logger/buffered.cpp
@@ -50,7 +50,7 @@ Status BufferedLogForwarder::setUp() {
   return Status(0);
 }
 
-void BufferedLogForwarder::check() {
+void BufferedLogForwarder::check(bool send_results, bool send_statuses) {
   // Get a list of all the buffered log items, with a max of 1024 lines.
   std::vector<std::string> indexes;
   auto status = scanDatabaseKeys(kLogs, indexes, index_name_, max_log_lines_);
@@ -66,13 +66,25 @@ void BufferedLogForwarder::check() {
           }));
 
   // If any results/statuses were found in the flushed buffer, send.
-  if (results.size() > 0) {
+  if (send_results && !results.empty()) {
     status = send(results, "result");
     if (!status.ok()) {
       VLOG(1) << "Error sending results to logger: " << status.getMessage();
 
       if (interrupted()) {
         return;
+      }
+      if (max_backoff_period_ > std::chrono::seconds::zero()) {
+        results_backoff_++;
+        // Apply exponential backoff time.
+        results_backoff_period_ +=
+            log_period_ * results_backoff_ * results_backoff_;
+        if (results_backoff_period_ > max_backoff_period_) {
+          results_backoff_period_ = max_backoff_period_;
+          results_backoff_--;
+        }
+        VLOG(1) << "Will attempt to send results again in "
+                << results_backoff_period_.count() << " seconds";
       }
     } else {
       // Clear the results logs once they were sent.
@@ -82,16 +94,30 @@ void BufferedLogForwarder::check() {
                 }
                 deleteValueWithCount(kLogs, index);
               }));
+      results_backoff_ = 0;
+      results_backoff_period_ = std::chrono::seconds::zero();
     }
   }
 
-  if (statuses.size() > 0) {
+  if (send_statuses && !statuses.empty()) {
     status = send(statuses, "status");
     if (!status.ok()) {
       VLOG(1) << "Error sending status to logger: " << status.getMessage();
 
       if (interrupted()) {
         return;
+      }
+      if (max_backoff_period_ > std::chrono::seconds::zero()) {
+        statuses_backoff_++;
+        // Apply exponential backoff time.
+        statuses_backoff_period_ +=
+            log_period_ * statuses_backoff_ * statuses_backoff_;
+        if (statuses_backoff_period_ > max_backoff_period_) {
+          statuses_backoff_period_ = max_backoff_period_;
+          statuses_backoff_--;
+        }
+        VLOG(1) << "Will attempt to send status again in "
+                << statuses_backoff_period_.count() << " seconds";
       }
     } else {
       // Clear the status logs once they were sent.
@@ -101,6 +127,8 @@ void BufferedLogForwarder::check() {
                 }
                 deleteValueWithCount(kLogs, index);
               }));
+      statuses_backoff_ = 0;
+      statuses_backoff_period_ = std::chrono::seconds::zero();
     }
   }
 
@@ -174,10 +202,34 @@ void BufferedLogForwarder::purge() {
 
 void BufferedLogForwarder::start() {
   while (!interrupted()) {
-    check();
+    bool send_results = results_backoff_period_ <= std::chrono::seconds::zero();
+    bool send_statuses =
+        statuses_backoff_period_ <= std::chrono::seconds::zero();
+    check(send_results, send_statuses);
 
-    // Cool off and time wait the configured period.
-    pause(std::chrono::milliseconds(log_period_));
+    do {
+      // Cool off and time wait the configured period.
+      pause(std::chrono::milliseconds(log_period_));
+      // Apply any updates to configuration options, such as disabling of
+      // backoff.
+      applyNewConfiguration();
+      // Check if backoff was cancelled.
+      if (max_backoff_period_ <= log_period_) {
+        results_backoff_period_ = std::chrono::seconds::zero();
+        statuses_backoff_period_ = std::chrono::seconds::zero();
+        results_backoff_ = 0;
+        statuses_backoff_ = 0;
+      } else {
+        // Otherwise keep backing off, but reduce the amount of time left.
+        if (results_backoff_period_ > std::chrono::seconds::zero()) {
+          results_backoff_period_ -= log_period_;
+        }
+        if (statuses_backoff_period_ > std::chrono::seconds::zero()) {
+          statuses_backoff_period_ -= log_period_;
+        }
+      }
+    } while (results_backoff_period_ > std::chrono::seconds::zero() &&
+             statuses_backoff_period_ > std::chrono::seconds::zero());
   }
 }
 

--- a/plugins/logger/buffered.h
+++ b/plugins/logger/buffered.h
@@ -155,6 +155,9 @@ class BufferedLogForwarder : public InternalRunnable {
   /// Apply any new configuration changes.
   virtual void applyNewConfiguration() {}
 
+  /// Reduce backoff time, if needed.
+  void backoffTick();
+
  protected:
   /// Return whether the string is a result index
   bool isResultIndex(const std::string& index);
@@ -213,6 +216,12 @@ class BufferedLogForwarder : public InternalRunnable {
    */
   std::string index_name_;
 
+  /// Control the exponential backoff for sending results and statuses.
+  uint64_t results_backoff_ = 0;
+  uint64_t statuses_backoff_ = 0;
+  std::chrono::seconds results_backoff_period_ = std::chrono::seconds::zero();
+  std::chrono::seconds statuses_backoff_period_ = std::chrono::seconds::zero();
+
  private:
   /// Hold an incrementing index for buffering logs
   std::atomic<size_t> log_index_{0};
@@ -223,10 +232,5 @@ class BufferedLogForwarder : public InternalRunnable {
   /// Protects the count of buffered logs
   RecursiveMutex count_mutex_;
 
-  /// Control the exponential backoff for sending results and statuses.
-  uint64_t results_backoff_;
-  uint64_t statuses_backoff_;
-  std::chrono::seconds results_backoff_period_;
-  std::chrono::seconds statuses_backoff_period_;
 };
 }

--- a/plugins/logger/buffered.h
+++ b/plugins/logger/buffered.h
@@ -231,6 +231,5 @@ class BufferedLogForwarder : public InternalRunnable {
 
   /// Protects the count of buffered logs
   RecursiveMutex count_mutex_;
-
 };
 }

--- a/plugins/logger/tests/buffered_tests.cpp
+++ b/plugins/logger/tests/buffered_tests.cpp
@@ -643,9 +643,7 @@ TEST_F(BufferedLogForwarderTests, test_backoff) {
   // Fail to send.
   EXPECT_CALL(runner, send(ElementsAre("foo"), "result"))
       .WillOnce(Return(Status(1, "fail")));
-  EXPECT_CALL(
-      runner,
-      send(ElementsAre(MatchesStatus(log1)), "status"))
+  EXPECT_CALL(runner, send(ElementsAre(MatchesStatus(log1)), "status"))
       .WillOnce(Return(Status(1)));
   runner.check();
   ASSERT_EQ(runner.results_backoff_, 1);
@@ -677,9 +675,7 @@ TEST_F(BufferedLogForwarderTests, test_backoff) {
   ASSERT_EQ(runner.statuses_backoff_period_, std::chrono::seconds::zero());
 
   // Only send statuses.
-  EXPECT_CALL(
-      runner,
-      send(ElementsAre(MatchesStatus(log1)), "status"))
+  EXPECT_CALL(runner, send(ElementsAre(MatchesStatus(log1)), "status"))
       .WillOnce(Return(Status(1)));
   runner.check(false, true);
   ASSERT_EQ(runner.results_backoff_, 2);
@@ -690,9 +686,7 @@ TEST_F(BufferedLogForwarderTests, test_backoff) {
   // Fail to send again, hitting the max backoff.
   EXPECT_CALL(runner, send(ElementsAre("foo"), "result"))
       .WillOnce(Return(Status(1, "fail")));
-  EXPECT_CALL(
-      runner,
-      send(ElementsAre(MatchesStatus(log1)), "status"))
+  EXPECT_CALL(runner, send(ElementsAre(MatchesStatus(log1)), "status"))
       .WillOnce(Return(Status(1)));
   runner.check();
   ASSERT_EQ(runner.results_backoff_, 2);
@@ -703,9 +697,7 @@ TEST_F(BufferedLogForwarderTests, test_backoff) {
   // Allow send() to succeed.
   EXPECT_CALL(runner, send(ElementsAre("foo"), "result"))
       .WillOnce(Return(Status(0, "OK")));
-  EXPECT_CALL(
-      runner,
-      send(ElementsAre(MatchesStatus(log1)), "status"))
+  EXPECT_CALL(runner, send(ElementsAre(MatchesStatus(log1)), "status"))
       .WillOnce(Return(Status(0)));
   runner.check();
   ASSERT_EQ(runner.results_backoff_, 0);
@@ -725,12 +717,11 @@ TEST_F(BufferedLogForwarderTests, test_backoff) {
   ASSERT_EQ(runner.statuses_backoff_, 0);
   ASSERT_EQ(runner.statuses_backoff_period_, std::chrono::seconds::zero());
 
-  // Test letting backoff duration period attempt to go negative, which should be impossible based on std::chrono library implementation.
+  // Test letting backoff duration period attempt to go negative,
+  // which should be impossible based on std::chrono library implementation.
   runner.results_backoff_period_ = std::chrono::seconds(1);
   runner.log_period_ = std::chrono::seconds(2);
   runner.backoffTick();
   ASSERT_TRUE(runner.results_backoff_period_ <= std::chrono::seconds::zero());
-
 }
-
 } // namespace osquery

--- a/plugins/logger/tests/buffered_tests.cpp
+++ b/plugins/logger/tests/buffered_tests.cpp
@@ -282,6 +282,8 @@ TEST_F(BufferedLogForwarderTests, test_async) {
   runner->logString("foo");
 
   Dispatcher::addService(runner);
+  // Yield to allow runner to do its work.
+  std::this_thread::yield();
   runner->interrupt();
   Dispatcher::joinServices();
 }

--- a/plugins/logger/tls_logger.cpp
+++ b/plugins/logger/tls_logger.cpp
@@ -42,6 +42,13 @@ FLAG(uint64,
      "Seconds between flushing logs over TLS/HTTPS");
 
 FLAG(uint64,
+     logger_tls_backoff_max,
+     60 * 60,
+     "Maximum seconds to wait before flushing logs over TLS/HTTPS. Backoff "
+     "kicks in when regular flush fails. Should be a multiple of "
+     "logger_tls_period. 0 disables backoff");
+
+FLAG(uint64,
      logger_tls_max_linesize,
      1 * 1024 * 1024,
      "Max size in bytes allowed per log line");
@@ -59,7 +66,8 @@ TLSLogForwarder::TLSLogForwarder()
     : BufferedLogForwarder("TLSLogForwarder",
                            "tls",
                            std::chrono::seconds(FLAGS_logger_tls_period),
-                           FLAGS_logger_tls_max_lines) {
+                           FLAGS_logger_tls_max_lines,
+                           std::chrono::seconds(FLAGS_logger_tls_backoff_max)) {
   uri_ = TLSRequestHelper::makeURI(FLAGS_logger_tls_endpoint);
 }
 
@@ -94,6 +102,17 @@ Status TLSLoggerPlugin::setUp() {
 void TLSLoggerPlugin::init(const std::string& name,
                            const std::vector<StatusLogLine>& log) {
   logStatus(log);
+}
+
+void TLSLoggerPlugin::configure() {
+  forwarder_->configuration_updated = true;
+  forwarder_->updated_uri =
+      TLSRequestHelper::makeURI(FLAGS_logger_tls_endpoint);
+  forwarder_->updated_log_period =
+      std::chrono::seconds(FLAGS_logger_tls_period);
+  forwarder_->updated_max_log_lines = FLAGS_logger_tls_max_lines;
+  forwarder_->updated_max_backoff_period =
+      std::chrono::seconds(FLAGS_logger_tls_backoff_max);
 }
 
 Status TLSLogForwarder::send(std::vector<std::string>& log_data,
@@ -139,4 +158,15 @@ Status TLSLogForwarder::send(std::vector<std::string>& log_data,
   }
   return TLSRequestHelper::go<JSONSerializer>(uri_, params, response);
 }
+
+void TLSLogForwarder::applyNewConfiguration() {
+  if (configuration_updated) {
+    uri_ = updated_uri;
+    log_period_ = updated_log_period;
+    max_log_lines_ = updated_max_log_lines;
+    max_backoff_period_ = updated_max_backoff_period;
+  }
+  configuration_updated = false;
+}
+
 } // namespace osquery

--- a/plugins/logger/tls_logger.h
+++ b/plugins/logger/tls_logger.h
@@ -27,9 +27,19 @@ class TLSLogForwarder : public BufferedLogForwarder {
  public:
   explicit TLSLogForwarder();
 
+  /// Flag indicating whether configuration was updated.
+  bool configuration_updated = false;
+  /// Updated configs to be applied on the next applyNewConfiguration() call:
+  std::string updated_uri;
+  std::chrono::seconds updated_log_period;
+  std::chrono::seconds updated_max_backoff_period;
+  uint64_t updated_max_log_lines;
+
  protected:
   Status send(std::vector<std::string>& log_data,
               const std::string& log_type) override;
+
+  void applyNewConfiguration() override;
 
   /// Endpoint URI
   std::string uri_;
@@ -54,6 +64,9 @@ class TLSLoggerPlugin : public LoggerPlugin {
 
   /// Setup node key and worker thread for sending logs.
   Status setUp() override;
+
+  //// React to configuration updates.
+  void configure() override;
 
   bool usesLogStatus() override {
     return true;

--- a/plugins/logger/tls_logger.h
+++ b/plugins/logger/tls_logger.h
@@ -27,6 +27,8 @@ class TLSLogForwarder : public BufferedLogForwarder {
  public:
   explicit TLSLogForwarder();
 
+  /// Mutex for ensuring only one thread is reading/writing configuration.
+  std::mutex configuration_mutex;
   /// Flag indicating whether configuration was updated.
   bool configuration_updated = false;
   /// Updated configs to be applied on the next applyNewConfiguration() call:


### PR DESCRIPTION
Fixes #8219 

Added exponential backoff for tls_logger when results and/or status logs are unsuccessfully sent. The results and status logs have separate independent backoff timers, but their maximum backoff time config is the same.

The following tls_logger config values can now be updated dynamically via config_tls_endpoint without restarting osquery:
- logger_tls_endpoint
- logger_tls_period
- logger_tls_max_lines
- logger_tls_backoff_max (new)

QA Instructions:
1. Configure logger_tls_endpoint and start osquery.
2. Kill the server that was servicing the endpoint, and watch log requests start to back off.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
