### PR TITLE
Don't add ATC table name to registry until after sqlite DB initialization

### DIFF
--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -227,6 +227,11 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
+    PluginResponse resp;
+    Registry::call(
+        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
+    LOG(INFO) << "ATC table: " << table_name << " Registered";
+
     s = tables->add(
         table_name, std::make_shared<ATCPlugin>(path, columns, query), true);
     if (!s.ok()) {
@@ -234,11 +239,6 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       deleteDatabaseValue(kPersistentSettings, kDatabaseKeyPrefix + table_name);
       continue;
     }
-
-    PluginResponse resp;
-    Registry::call(
-        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
-    LOG(INFO) << "ATC table: " << table_name << " Registered";
   }
 
   if (registered.size() > 0) {


### PR DESCRIPTION
Fixes #8232

I'm not sure if there are nuances I'm missing or if there is a good way to test this section of code, but this fixes a bug where the _first_ ATC table specified in a conf file is attached twice and the second attempt fails. 
