### PR TITLE
cmake: Pass the osquery python path to googletest

### DIFF
--- a/libraries/cmake/source/googletest/CMakeLists.txt
+++ b/libraries/cmake/source/googletest/CMakeLists.txt
@@ -29,6 +29,7 @@ function(googleTestMain)
   endforeach()
 
   set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set(Python_EXECUTABLE "${OSQUERY_PYTHON_EXECUTABLE}")
   add_subdirectory("${library_root}" "${CMAKE_CURRENT_BINARY_DIR}/submodule" EXCLUDE_FROM_ALL)
 
   set(target_list


### PR DESCRIPTION
Although googletest uses python only for its own tests, it still searches for it and the search cannot be removed.
In some configuration, like when using pyenv, CMake requires a shell to be able to find Python; this might not be present if run via the VsCode CMake extension.
While we can pass the Python3_EXECUTABLE path to osquery, googletest will still attempt to search Python in the system, slowing down the configuration phase.