### PR TITLE
Clear performance stats when modifying scheduled/pack query

### DIFF
--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -376,6 +376,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
   FRIEND_TEST(ConfigTests, test_nondenylist_query);
   FRIEND_TEST(ConfigTests, test_config_cli_flags);
+  FRIEND_TEST(ConfigTests, test_pack_stats);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option_first);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_add_view);

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -404,6 +404,40 @@ TEST_F(ConfigTests, test_pack_restrictions) {
   }));
 }
 
+TEST_F(ConfigTests, test_pack_stats) {
+  auto doc = getExamplePacksConfig();
+  auto& packs = doc.doc()["packs"];
+  for (const auto& pack : packs.GetObject()) {
+    get().addPack(pack.name.GetString(), "", pack.value);
+  }
+
+  // Add performance stats for a query.
+  auto fullName = "pack_unrestricted_pack_process_events";
+  Row row;
+  row["user_time"] = "";
+  row["system_time"] = "";
+  row["resident_size"] = "";
+  get().recordQueryPerformance(fullName, 10, 10, row, row);
+  bool statFound = false;
+  Config::get().getPerformanceStats(fullName,
+                                    [&statFound](const QueryPerformance& perf) {
+                                      ASSERT_EQ(perf.executions, 1U);
+                                      statFound = true;
+                                    });
+  ASSERT_TRUE(statFound);
+
+  // Update the query SQL and make sure performance stats were cleared.
+  get().updateSource("", R"({"packs": {"unrestricted_pack": {"queries": {
+    "process_events": {"query": "select * from processes", "interval": 10}}}}})");
+  statFound = false;
+  Config::get().getPerformanceStats(fullName,
+                                    [&statFound](const QueryPerformance& perf) {
+                                      ASSERT_EQ(perf.executions, 0U);
+                                      statFound = true;
+                                    });
+  ASSERT_TRUE(statFound);
+}
+
 TEST_F(ConfigTests, test_pack_removal) {
   size_t pack_count = 0;
   get().packs(([&pack_count](const Pack& pack) { pack_count++; }));


### PR DESCRIPTION
Fixes #8209 

When updating scheduled/pack queries dynamically, the performance stats will be cleared for deleted queries and for queries with updated SQL.

This is done by creating a map of pack/query/SQL of old queries and comparing it to the map for new/updated queries.

I'd like to merge this fix before starting work on a related issue https://github.com/osquery/osquery/issues/7694

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
