### PR TITLE
Add additional chrome extensions paths for Island browser (island.io)

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -61,7 +61,8 @@ const ChromePathSuffixMap kWindowsPathList = {
     {ChromeBrowserType::Edge, "AppData\\Local\\Microsoft\\Edge\\User Data"},
     {ChromeBrowserType::EdgeBeta, "AppData\\Local\\Microsoft\\Edge Beta\\User Data"},
     {ChromeBrowserType::Opera, "AppData\\Roaming\\Opera Software\\Opera Stable"},
-    {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"}};
+    {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"},
+    {ChromeBrowserType::Island, "AppData\\Local\\Island\\Island\\User Data"}};
 // clang-format on
 
 // clang-format off
@@ -76,7 +77,8 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::Edge, "Library/Application Support/Microsoft Edge"},
     {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
     {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"},
-    {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"}};
+    {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"},
+    {ChromeBrowserType::Island, "Library/Application Support/Island"}};
 // clang-format on
 
 const ChromePathSuffixMap kLinuxPathList = {
@@ -89,6 +91,7 @@ const ChromePathSuffixMap kLinuxPathList = {
     {ChromeBrowserType::Yandex, ".config/yandex-browser-beta"},
     {ChromeBrowserType::Opera, ".config/opera"},
     {ChromeBrowserType::Vivaldi, ".config/vivaldi"},
+    {ChromeBrowserType::Island, ".config/island"}
 };
 
 /// Maps ChromeBrowserType values to readable strings
@@ -105,6 +108,7 @@ const std::unordered_map<ChromeBrowserType, std::string>
         {ChromeBrowserType::Edge, "edge"},
         {ChromeBrowserType::Edge, "edge_beta"},
         {ChromeBrowserType::Vivaldi, "vivaldi"},
+        {ChromeBrowserType::Island, "island"}
 };
 
 /// Base paths for built-in extensions; used to silence warnings for

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -38,7 +38,8 @@ enum class ChromeBrowserType {
   Opera,
   Edge,
   EdgeBeta,
-  Vivaldi
+  Vivaldi,
+  Island
 };
 
 /// Converts the browser type to a printable string


### PR DESCRIPTION
This PR is nearly identical to https://github.com/osquery/osquery/pull/8170 (which added support for Vivaldi and Chrome Beta/Dev), the only difference being it adds support for the Chromium-based Island browser (island.io). 