### PR TITLE
Refactor macOS system profile report retrieval

### DIFF
--- a/osquery/tables/applications/CMakeLists.txt
+++ b/osquery/tables/applications/CMakeLists.txt
@@ -67,6 +67,7 @@ function(generateOsqueryTablesApplications)
   if(DEFINED PLATFORM_MACOS)
     target_link_libraries(osquery_tables_applications PRIVATE
       osquery_utils_plist
+      osquery_utils_system_profiler
     )
   endif()
 

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -293,6 +293,7 @@ function(generateOsqueryTablesSystemSystemtable)
   elseif(DEFINED PLATFORM_MACOS)
     target_link_libraries(osquery_tables_system_systemtable PUBLIC
       osquery_utils_plist
+      osquery_utils_system_profiler
       thirdparty_openssl
     )
 

--- a/osquery/tables/system/darwin/secureboot.mm
+++ b/osquery/tables/system/darwin/secureboot.mm
@@ -12,19 +12,12 @@
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
-#include <osquery/utils/scope_guard.h>
+#include <osquery/utils/darwin/system_profiler.h>
 
-#import <AppKit/NSDocument.h>
 #include <CoreFoundation/CoreFoundation.h>
-#import <Foundation/Foundation.h>
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOKitLib.h>
 #include <mach/mach_error.h>
-
-@interface SPDocument : NSDocument {
-}
-- (id)reportForDataType:(id)arg1;
-@end
 
 namespace osquery::tables {
 
@@ -186,61 +179,14 @@ Status getIntelSecureBootSetting(Row& row) {
 
 Status getAarch64SecureBootSetting(Row& r) {
   @autoreleasepool {
-    // BEWARE: Because of the dynamic nature of the calls in this function, we
-    // must be careful to properly clean up the memory. Any future modifications
-    // to this function should attempt to ensure there are no leaks (and test
-    // with ./tools/analysis/profile.py --leaks).
-    CFURLRef bundle_url = CFURLCreateWithFileSystemPath(
-        kCFAllocatorDefault,
-        CFSTR("/System/Library/PrivateFrameworks/SPSupport.framework"),
-        kCFURLPOSIXPathStyle,
-        true);
-
-    if (bundle_url == nullptr) {
-      return Status::failure("Error parsing SPSupport bundle URL");
+    NSDictionary* __autoreleasing result;
+    Status status = getSystemProfilerReport("SPiBridgeDataType", result);
+    if (!status.ok()) {
+      return Status::failure("failed to get secureboot config: " +
+                             status.getMessage());
     }
 
-    CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, bundle_url);
-    CFRelease(bundle_url);
-    if (bundle == nullptr) {
-      return Status::failure("Error opening SPSupport bundle");
-    }
-
-    auto cleanup_bundle = scope_guard::create([&]() {
-      CFBundleUnloadExecutable(bundle);
-      CFRelease(bundle);
-    });
-
-    if (!CFBundleLoadExecutable(bundle)) {
-      return Status::failure("SPSupport load executable failed");
-    }
-
-#pragma clang diagnostic push
-// We are silencing here because we don't know the selector beforehand
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-
-    id cls = NSClassFromString(@"SPDocument");
-    if (cls == nullptr) {
-      return Status::failure("Could not load SPDocument class");
-    }
-
-    SEL sel = @selector(new);
-    if (![cls respondsToSelector:sel]) {
-      return Status::failure("SPDocument does not respond to new selector");
-    }
-
-    id document = [cls performSelector:sel];
-    if (document == nullptr) {
-      return Status::failure("[SPDocument new] returned null");
-    }
-
-    auto cleanup_document =
-        scope_guard::create([&]() { CFRelease((__bridge CFTypeRef)document); });
-
-#pragma clang diagnostic pop
-
-    NSDictionary* report = [[[document reportForDataType:@"SPiBridgeDataType"]
-        objectForKey:@"_items"] lastObject];
+    NSDictionary* report = [[result objectForKey:@"_items"] lastObject];
 
     if ([report valueForKey:@"ibridge_secure_boot"]) {
       r["description"] =

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(osqueryTablesSystemTestsMain)
-
   if(DEFINED PLATFORM_LINUX)
     generateOsqueryTablesSystemLinuxTests()
   endif()
@@ -136,6 +135,7 @@ function(generateOsqueryTablesSystemDarwinTests)
     osquery_utils
     osquery_utils_conversions
     osquery_utils_plist
+    osquery_utils_system_profiler
     tests_helper
     thirdparty_googletest
   )
@@ -169,20 +169,20 @@ endfunction()
 
 function(generateOsqueryTablesSystemDarwinKeychainTests)
   set(source_files
-          darwin/keychain_test.cpp
+    darwin/keychain_test.cpp
   )
 
   add_osquery_executable(osquery_tables_system_darwin_keychain_tests-test ${source_files})
 
   target_link_libraries(osquery_tables_system_darwin_keychain_tests-test PRIVATE
-          osquery_cxx_settings
-          osquery_filesystem
-          osquery_hashing
-          osquery_tables_system_systemtable
-          osquery_extensions
-          osquery_extensions_implthrift
-          tests_helper
-          thirdparty_googletest
+    osquery_cxx_settings
+    osquery_filesystem
+    osquery_hashing
+    osquery_tables_system_systemtable
+    osquery_extensions
+    osquery_extensions_implthrift
+    tests_helper
+    thirdparty_googletest
   )
 endfunction()
 

--- a/osquery/utils/CMakeLists.txt
+++ b/osquery/utils/CMakeLists.txt
@@ -35,8 +35,10 @@ function(osqueryUtilsMain)
   endif()
 
   generateOsqueryUtils()
+
   if(DEFINED PLATFORM_MACOS)
     generateOsqueryUtilsPlist()
+    generateOsqueryUtilsSystemProfiler()
   endif()
 endfunction()
 
@@ -111,11 +113,9 @@ function(generateOsqueryUtils)
   generateIncludeNamespace(osquery_utils_attribute "osquery/utils" "FILE_ONLY" ${attribute_public_header_files})
 
   add_test(NAME osquery_utils_utilstests-test COMMAND osquery_utils_utilstests-test)
-
 endfunction()
 
 function(generateOsqueryUtilsPlist)
-
   list(APPEND source_files
     darwin/plist.mm
   )
@@ -133,7 +133,26 @@ function(generateOsqueryUtilsPlist)
   )
 
   generateIncludeNamespace(osquery_utils "osquery/utils" "FULL_PATH" ${platform_public_header_files})
+endfunction()
 
+function(generateOsqueryUtilsSystemProfiler)
+  list(APPEND source_files
+    darwin/system_profiler.mm
+  )
+
+  add_osquery_library(osquery_utils_system_profiler ${source_files})
+
+  target_link_libraries(osquery_utils_system_profiler PRIVATE
+    osquery_cxx_settings
+    osquery_filesystem
+    thirdparty_boost
+  )
+
+  set(platform_public_header_files
+    darwin/system_profiler.h
+  )
+
+  generateIncludeNamespace(osquery_utils "osquery/utils" "FULL_PATH" ${platform_public_header_files})
 endfunction()
 
 function(generateOsqueryUtilsUtilstestsTest)
@@ -150,6 +169,12 @@ function(generateOsqueryUtilsUtilstestsTest)
       tests/windows/env.cpp
       tests/windows/filetime.cpp
       tests/windows/shellitems.cpp
+    )
+  endif()
+
+  if(DEFINED PLATFORM_DARWIN)
+    list(APPEND source_files
+      tests/darwin/system_profiler.mm
     )
   endif()
 

--- a/osquery/utils/darwin/system_profiler.h
+++ b/osquery/utils/darwin/system_profiler.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <osquery/utils/status/status.h>
+
+#import <Foundation/Foundation.h>
+
+namespace osquery {
+
+/**
+ * @brief Retrieve data from the macOS System Profiler/System Information
+ * utility.
+ *
+ * This could be called from within an @autoreleasepool.
+ *
+ * @param datatype the data type to request (see `system_profiler
+ * -listDataTypes`).
+ * @param result the NSDictionary pointer for returning results.
+ *
+ * @return an instance of Status, indicating success or failure.
+ */
+Status getSystemProfilerReport(const std::string& datatype,
+                               NSDictionary*& result);
+
+} // namespace osquery

--- a/osquery/utils/darwin/system_profiler.mm
+++ b/osquery/utils/darwin/system_profiler.mm
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include "system_profiler.h"
+
+#include <memory>
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/scope_guard.h>
+
+#import <AppKit/NSDocument.h>
+#include <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#include <IOKit/IOKitKeys.h>
+#include <IOKit/IOKitLib.h>
+#include <mach/mach_error.h>
+
+@interface SPDocument : NSDocument {
+}
+- (NSMutableDictionary*)reportForDataType:(NSString*)datatype;
+@end
+
+namespace osquery {
+
+Status getSystemProfilerReport(const std::string& datatype,
+                               NSDictionary*& result) {
+  // BEWARE: Because of the dynamic nature of the calls in this function, we
+  // must be careful to properly clean up the memory. Any future modifications
+  // to this function should attempt to ensure there are no leaks (and test
+  // with ./tools/analysis/profile.py --leaks).
+  CFURLRef bundle_url = CFURLCreateWithFileSystemPath(
+      kCFAllocatorDefault,
+      CFSTR("/System/Library/PrivateFrameworks/SPSupport.framework"),
+      kCFURLPOSIXPathStyle,
+      true);
+
+  if (bundle_url == nullptr) {
+    return Status::failure("Error parsing SPSupport bundle URL");
+  }
+
+  CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, bundle_url);
+  CFRelease(bundle_url);
+  if (bundle == nullptr) {
+    return Status::failure("Error opening SPSupport bundle");
+  }
+
+  auto cleanup_bundle = scope_guard::create([&]() {
+    CFBundleUnloadExecutable(bundle);
+    CFRelease(bundle);
+  });
+
+  if (!CFBundleLoadExecutable(bundle)) {
+    return Status::failure("SPSupport load executable failed");
+  }
+
+#pragma clang diagnostic push
+// We are silencing here because we don't know the selector beforehand
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+
+  id cls = NSClassFromString(@"SPDocument");
+  if (cls == nullptr) {
+    return Status::failure("Could not load SPDocument class");
+  }
+
+  SEL sel = @selector(new);
+  if (![cls respondsToSelector:sel]) {
+    return Status::failure("SPDocument does not respond to new selector");
+  }
+
+  id document = [cls performSelector:sel];
+  if (document == nullptr) {
+    return Status::failure("[SPDocument new] returned null");
+  }
+
+  auto cleanup_document =
+      scope_guard::create([&]() { CFRelease((__bridge CFTypeRef)document); });
+
+#pragma clang diagnostic pop
+
+  result = [document
+      reportForDataType:[NSString stringWithUTF8String:datatype.c_str()]];
+
+  return Status::success();
+}
+
+} // namespace osquery

--- a/osquery/utils/tests/darwin/system_profiler.mm
+++ b/osquery/utils/tests/darwin/system_profiler.mm
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/utils/darwin/system_profiler.h>
+
+namespace osquery {
+
+class DarwinSystemProfilerTests : public testing::Test {};
+
+TEST_F(DarwinSystemProfilerTests, test_getSystemProfilerReport) {
+  NSDictionary* __autoreleasing result;
+  Status status = getSystemProfilerReport("SPEthernetDataType", result);
+  EXPECT_TRUE(status.ok())
+  EXPECT_NE([result count], 0U);
+}
+
+} // namespace osquery


### PR DESCRIPTION
Move the report retrieval into a utility file and then refactor the two current tables that use it (`connected_displays` and `secureboot`) to use the new helper.

Tested that the tables continue to work on both Intel and ARM64.
