### PR TITLE
When extension cannot be loaded due to duplicate item/extension name,…

### DIFF
--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -111,7 +111,7 @@ Status ExtensionManagerInterface::registerExtension(
     const ExtensionRegistry& registry,
     RouteUUID& uuid) {
   if (exists(info.name)) {
-    LOG(WARNING) << "Refusing to register duplicate extension " << info.name;
+    LOG(ERROR) << "Refusing to register duplicate extension " << info.name;
     return Status((int)ExtensionCode::EXT_FAILED,
                   "Duplicate extension registered");
   }
@@ -140,8 +140,8 @@ Status ExtensionManagerInterface::registerExtension(
 
   auto status = RegistryFactory::get().addBroadcast(uuid, registry);
   if (!status.ok()) {
-    LOG(WARNING) << "Could not add extension " << info.name << ": "
-                 << status.getMessage();
+    LOG(ERROR) << "Could not add extension " << info.name << ": "
+               << status.getMessage();
     kUuidGenerator.removeUuid(uuid);
     return Status((int)ExtensionCode::EXT_FAILED,
                   "Failed adding registry: " + status.getMessage());

--- a/osquery/registry/registry_factory.cpp
+++ b/osquery/registry/registry_factory.cpp
@@ -89,7 +89,9 @@ Status RegistryFactory::addBroadcast(const RouteUUID& uuid,
           VLOG(1) << "Extension " << uuid
                   << " has duplicate plugin name: " << item.first
                   << " in registry: " << registry.first;
-          return Status(1, "Duplicate registry item: " + item.first);
+          return Status(1,
+                        "Registry item " + item.first +
+                            " conflicts with another item of the same name.");
         }
       }
     }


### PR DESCRIPTION
Fixes #8254 

When an extension cannot be loaded due to a duplicate item/extension name, print error instead of warning. Also, print clearer message for duplicate item.


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
