### PR TITLE
cve: Update openssl to 3.2.1

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "3.2.0")
-set(OPENSSL_ARCHIVE_SHA256 "14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e")
+set(OPENSSL_VERSION "3.2.1")
+set(OPENSSL_ARCHIVE_SHA256 "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "ignored-cves": []
   },
   "augeas": {


### PR DESCRIPTION
Also fix CVE-2023-6129

Fixes #8255 
