### PR TITLE
Add windows UBR to `os_version` table

### DIFF
--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -48,7 +48,7 @@ QueryData genOSVersion(QueryContext& context) {
   std::string cimInstallDate{""};
   wmiResults[0].GetString("InstallDate", cimInstallDate);
   r["install_date"] = BIGINT(cimDatetimeToUnixtime(cimInstallDate));
- 
+
   wmiResults[0].GetString("Version", version_string);
   auto version = osquery::split(version_string, ".");
 
@@ -69,7 +69,7 @@ QueryData genOSVersion(QueryContext& context) {
   r["platform"] = "windows";
   r["platform_like"] = "windows";
   r["version"] = r["major"] + "." + r["minor"] + "." + r["build"];
-  
+
   QueryData regResults;
   queryKey(
       "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
@@ -82,7 +82,7 @@ QueryData genOSVersion(QueryContext& context) {
       break;
     }
   }
-  
+
   r["revision"] = INTEGER(updateBuildRevision);
 
   return {r};

--- a/specs/os_version.table
+++ b/specs/os_version.table
@@ -19,6 +19,7 @@ extended_schema(DARWIN, [
 
 extended_schema(WINDOWS, [
     Column("install_date", BIGINT, "The install date of the OS."),
+    Column("revision", INTEGER, "Update Build Revision, refers to the specific revision number of a Windows update"),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),

--- a/tests/integration/tables/os_version.cpp
+++ b/tests/integration/tables/os_version.cpp
@@ -41,6 +41,7 @@ TEST_F(OsVersion, test_sanity) {
       {"arch", NonEmptyString},
 #ifdef OSQUERY_WINDOWS
       {"install_date", NonEmptyString},
+      {"revision", NonNegativeInt},
 #endif
 #ifdef OSQUERY_DARWIN
       {"extra", NormalType},


### PR DESCRIPTION
Fixes #7908 and #7663 
The purpose of this PR is to include the build revision to the build number on windows.

**Rationale for this change:**
On executing the query `“select build from os_version;”` the build does not display the full build number including what is called the updated build revision (UBR) , the implementation of os_version uses the Win32_OperatingSystem WMI class to get all the build information, but it does not have any property that returns the UBR.

**How is this fixed:**
Get this information from windows registry and concatenate it to the build value.

Below screen shot shows, how this would look post fix 
![issue_7663](https://github.com/osquery/osquery/assets/38827245/811873c2-be2b-45a3-9ba6-f6ead1748007)

