### PR TITLE
Add missing path separator in Safari Extensions table generator

### DIFF
--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -59,7 +59,7 @@ inline void jsonBoolAsInt(std::string& s) {
 
 /// Safari App Extensions Plist path
 #define kSafariAppExtensionsPlistPath                                          \
-  "Contents/PlugIns/%.appex/Contents/Info.plist"
+  "/Contents/PlugIns/%.appex/Contents/Info.plist"
 
 /// User Safari extension path
 #define kUserSafariExtensionsPath                                              \


### PR DESCRIPTION
Fixes #8210 

Simple one line change to correct the file path(s) `genSafariSandboxedExtensions` iterates over. I'm unsure if `listDirectoriesInDirectory` previously returned the path with the ending separator, but it currently does not seem to do so. Since `kSafariAppExtensionsPlistPath` is isolated I decided to just add the path separator instead of digging further.

Example:

```
Pre PR:

/Applications/AdBlock.appContents/PlugIns/%.appex/Contents/Info.plist

Post PR:

/Applications/AdBlock.app/Contents/PlugIns/%.appex/Contents/Info.plist
```