### PR TITLE
Update `cpu_info` to include `load_percentage` on windows

### DIFF
--- a/osquery/tables/system/windows/cpu_info.cpp
+++ b/osquery/tables/system/windows/cpu_info.cpp
@@ -12,8 +12,8 @@
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
 
-#include <osquery/utils/conversions/tryto.h>
 #include "osquery/core/windows/wmi.h"
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
@@ -57,6 +57,9 @@ QueryData genCpuInfo(QueryContext& context) {
     (data.GetLong("MaxClockSpeed", number))
         ? r["max_clock_speed"] = INTEGER(number)
         : r["max_clock_speed"] = "-1";
+    (data.GetLong("LoadPercentage", number))
+        ? r["load_percentage"] = INTEGER(number)
+        : r["load_percentage"] = "-1";
     results.push_back(r);
   }
 

--- a/specs/cpu_info.table
+++ b/specs/cpu_info.table
@@ -15,7 +15,7 @@ schema([
   Column("socket_designation", TEXT, "The assigned socket on the board for the given CPU."),
 ])
 extended_schema(WINDOWS, [
-    Column("availability", TEXT, "The availability and status of the CPU.")
+    Column("availability", TEXT, "The availability and status of the CPU."),
     Column("load_percentage", INTEGER, "The current percentage of utilization of the CPU."),
 ])
 extended_schema(DARWIN, [

--- a/specs/cpu_info.table
+++ b/specs/cpu_info.table
@@ -16,6 +16,7 @@ schema([
 ])
 extended_schema(WINDOWS, [
     Column("availability", TEXT, "The availability and status of the CPU.")
+    Column("load_percentage", INTEGER, "The current percentage of utilization of the CPU."),
 ])
 extended_schema(DARWIN, [
     Column("number_of_efficiency_cores", INTEGER, "The number of efficiency cores of the CPU. Only available on Apple Silicon"),

--- a/tests/integration/tables/cpu_info.cpp
+++ b/tests/integration/tables/cpu_info.cpp
@@ -53,6 +53,7 @@ TEST_F(cpuInfo, test_sanity) {
 
   if (isPlatform(PlatformType::TYPE_WINDOWS)) {
     row_map.emplace("availability", NonNegativeOrErrorInt);
+    row_map.emplace("load_percentage", NonNegativeOrErrorInt);
   }
 
   validate_rows(data, row_map);


### PR DESCRIPTION
It looks like windows tracks this, and there was an old PR (#5307) for the update. As the code was simple enough I've ported it forward. 


Co-authored-by: Cameron Haupt <chaupt2013@my.fit.edu>
