### PR TITLE
Extend `homebrew_packages` table to include Casks

### DIFF
--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -82,7 +82,7 @@ void packagesFromPrefix(QueryData& results,
   }
 
   std::tuple<std::string, fs::path> typesList[2] = {
-      std::make_tuple("formulae", fs::path(prefix) / "Cellar"),
+      std::make_tuple("formula", fs::path(prefix) / "Cellar"),
       std::make_tuple("cask", fs::path(prefix) / "Caskroom")};
 
   for (const auto& typeTuple : typesList) {

--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -92,7 +92,7 @@ void packagesFromPrefix(QueryData& results,
         LOG(WARNING) << "Error reading homebrew " << type << " path "
                      << typePath.native();
       }
-      return;
+      continue;
     }
 
     for (const auto& path :

--- a/specs/darwin/homebrew_packages.table
+++ b/specs/darwin/homebrew_packages.table
@@ -4,7 +4,7 @@ schema([
     Column("name", TEXT, "Package name"),
     Column("path", TEXT, "Package install path"),
     Column("version", TEXT, "Current 'linked' version", collate="version"),
-    Column("type", TEXT, "Package type"),
+    Column("type", TEXT, "Package type ('formula' or 'cask')"),
     Column("prefix", TEXT, "Homebrew install prefix", hidden=True, additional=True),
 ])
 attributes(cacheable=True)

--- a/specs/darwin/homebrew_packages.table
+++ b/specs/darwin/homebrew_packages.table
@@ -4,6 +4,7 @@ schema([
     Column("name", TEXT, "Package name"),
     Column("path", TEXT, "Package install path"),
     Column("version", TEXT, "Current 'linked' version", collate="version"),
+    Column("type", TEXT, "Package type"),
     Column("prefix", TEXT, "Homebrew install prefix", hidden=True, additional=True),
 ])
 attributes(cacheable=True)


### PR DESCRIPTION
Resolves https://github.com/osquery/osquery/issues/5327

PR adds the dir `/Caskroom` to the `homebrew_packages` table so it includes any [casks](https://formulae.brew.sh/cask/) installed by the user.
It also adds a new column `type` to distinguish between formulae and casks.

This is important since some binaries will end up in `/usr/local/bin` thus not being reported by any Osquery table.
```
$ which ngrok
/usr/local/bin/ngrok
```

Example query:
```
$ osqueryi "select * from homebrew_packages order by type limit 5;"
+---------------+-----------------------------------+---------------------+----------+
| name          | path                              | version             | type     |
+---------------+-----------------------------------+---------------------+----------+
| ngrok         | /usr/local/Caskroom/ngrok         | 3.6.0,eZcX4as7yeX,a | cask     |
| vagrant       | /usr/local/Caskroom/vagrant       | 2.3.7               | cask     |
| 1password-cli | /usr/local/Caskroom/1password-cli | 2.20.0              | cask     |
| rubberband    | /usr/local/Cellar/rubberband      | 3.3.0               | formula |
| libpsl        | /usr/local/Cellar/libpsl          | 0.21.2_2            | formula |
+---------------+-----------------------------------+---------------------+----------+
```