### PR TITLE
Upgrade rocksdb; add more AWS logger logging

### DIFF
--- a/libraries/cmake/source/rocksdb/README.md
+++ b/libraries/cmake/source/rocksdb/README.md
@@ -92,7 +92,7 @@ cmake \
   -DWITH_PERF_CONTEXT=OFF \
   -DPORTABLE=ON \
   -DFORCE_SSE42=ON \
-  -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
+  -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
   -DCMAKE_OSX_ARCHITECTURES=x86_64
 ```
@@ -117,7 +117,7 @@ cmake \
   -DPORTABLE=ON \
   -DHAVE_SSE42:BOOL=OFF \
   -DWITH_IOSTATS_CONTEXT=OFF \
-  -DCMAKE_OSX_SYSROOT=/Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk \
+  -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
   -DCMAKE_OSX_ARCHITECTURES=arm64
 ```

--- a/libraries/cmake/source/rocksdb/version/build_version.cc
+++ b/libraries/cmake/source/rocksdb/version/build_version.cc
@@ -7,8 +7,8 @@
 
 // The build script may replace these values with real values based
 // on whether or not GIT is available and the platform settings
-static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:51b540921dd7495c9cf2265eb58942dad1f2ef72";
-static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v6.22.1";
+static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:da11a59034584ea2d0911268b8136e5249d6b692";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v6.29.5";
 #define HAS_GIT_CHANGES 0
 #if HAS_GIT_CHANGES == 0
 // If HAS_GIT_CHANGES is 0, the GIT date is used.

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -268,8 +268,8 @@
   "rocksdb": {
     "product": "rocksdb",
     "vendor": "facebook",
-    "version": "6.22.1",
-    "commit": "51b540921dd7495c9cf2265eb58942dad1f2ef72",
+    "version": "6.29.5",
+    "commit": "da11a59034584ea2d0911268b8136e5249d6b692",
     "ignored-cves": []
   },
   "sleuthkit": {

--- a/plugins/logger/aws_kinesis.cpp
+++ b/plugins/logger/aws_kinesis.cpp
@@ -147,7 +147,7 @@ size_t KinesisLogForwarder::getMaxBytesPerBatch() const {
 }
 
 size_t KinesisLogForwarder::getMaxRetryCount() const {
-  return 100U;
+  return 10U;
 }
 
 size_t KinesisLogForwarder::getInitialRetryDelay() const {


### PR DESCRIPTION
- Update rocksdb to a new version
- reduce the retries the AWS Kinesis logger will attempt
- cap the retry delay to 15 seconds down from 103!
- add more logging of failures

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
