### PR TITLE
cve: Update libexpat to 2.6.0

### DIFF
--- a/libraries/cmake/source/expat/config/aarch64/expat_config.h
+++ b/libraries/cmake/source/expat/config/aarch64/expat_config.h
@@ -64,13 +64,13 @@
 #define PACKAGE "expat"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+#define PACKAGE_BUGREPORT "https://github.com/libexpat/libexpat/issues"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.5.0"
+#define PACKAGE_STRING "expat 2.6.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -79,7 +79,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.5.0"
+#define PACKAGE_VERSION "2.6.0"
 
 /* Define to 1 if you have the ANSI C header files. */
 #ifndef STDC_HEADERS
@@ -104,6 +104,9 @@
 
 /* Define to make parameter entity parsing functionality available. */
 /* #undef XML_DTD */
+
+/* Define as 1/0 to enable/disable support for general entities. */
+#define XML_GE 1
 
 /* Define to make XML Namespaces functionality available. */
 /* #undef XML_NS */

--- a/libraries/cmake/source/expat/config/x86_64/expat_config.h
+++ b/libraries/cmake/source/expat/config/x86_64/expat_config.h
@@ -64,13 +64,13 @@
 #define PACKAGE "expat"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+#define PACKAGE_BUGREPORT "https://github.com/libexpat/libexpat/issues"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.5.0"
+#define PACKAGE_STRING "expat 2.6.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -79,10 +79,12 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.5.0"
+#define PACKAGE_VERSION "2.6.0"
 
 /* Define to 1 if you have the ANSI C header files. */
+#ifndef STDC_HEADERS
 #define STDC_HEADERS
+#endif
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */
@@ -92,7 +94,7 @@
 /* #undef XML_ATTR_INFO */
 
 /* Define to specify how much context to retain around the current parse
-   point. */
+   point, 0 to disable. */
 #define XML_CONTEXT_BYTES 1024
 
 #if ! defined(_WIN32)
@@ -102,6 +104,9 @@
 
 /* Define to make parameter entity parsing functionality available. */
 /* #undef XML_DTD */
+
+/* Define as 1/0 to enable/disable support for general entities. */
+#define XML_GE 1
 
 /* Define to make XML Namespaces functionality available. */
 /* #undef XML_NS */

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -105,8 +105,8 @@
   "expat": {
     "product": "libexpat",
     "vendor": "libexpat_project",
-    "version": "2.5.0",
-    "commit": "654d2de0da85662fcc7644a7acd7c2dd2cfb21f0",
+    "version": "2.6.0",
+    "commit": "849da3e3fe727fccef5e96ef35482d66447f06a2",
     "ignored-cves": []
   },
   "gflags": {


### PR DESCRIPTION
Also resolves CVE-2023-52425 and
CVE-2023-52426

Fixes #8268 
Fixes #8269 
