### PR TITLE
Fix version collate returning incorrect value when last character is a delimiter

### DIFF
--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -77,8 +77,12 @@ static int compareRemainder(std::string_view l_ver,
   //
   // When remainder_precedence = false, this will return the segment value diff
   // if there is any, before falling through to return length diff.
-  if (comp_remaining) {
-    if (l_ver.size() == pos) {
+  //
+  // When the next character of a semver comparison of the longer version is a
+  // delimiter, this will return the segment value diff, otherwise it falls
+  // through to return length diff.
+  if (l_ver.size() == pos) {
+    if (comp_remaining) {
       switch (r_ver[pos]) {
       case '~':
         return 1;
@@ -91,9 +95,13 @@ static int compareRemainder(std::string_view l_ver,
           return diff;
         }
       }
+    } else if (delimiterPrecedence(r_ver[pos]) > 0) {
+      return diff;
     }
+  }
 
-    if (r_ver.size() == pos) {
+  if (r_ver.size() == pos) {
+    if (comp_remaining) {
       switch (l_ver[pos]) {
       case '~':
         return -1;
@@ -106,6 +114,8 @@ static int compareRemainder(std::string_view l_ver,
           return diff;
         }
       }
+    } else if (delimiterPrecedence(l_ver[pos]) > 0) {
+      return diff;
     }
   }
 

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -78,9 +78,9 @@ static int compareRemainder(std::string_view l_ver,
   // When remainder_precedence = false, this will return the segment value diff
   // if there is any, before falling through to return length diff.
   //
-  // When the next character of a semver comparison of the longer version is a
-  // delimiter, this will return the segment value diff, otherwise it falls
-  // through to return length diff.
+  // When comp_remaining = false and the next character of the version with the
+  // remainder is a delimiter, this will return the segment value diff if there
+  // is any, otherwise it falls through to return length diff.
   if (l_ver.size() == pos) {
     if (comp_remaining) {
       switch (r_ver[pos]) {

--- a/osquery/sql/sqlite_version.cpp
+++ b/osquery/sql/sqlite_version.cpp
@@ -95,7 +95,7 @@ static int compareRemainder(std::string_view l_ver,
           return diff;
         }
       }
-    } else if (delimiterPrecedence(r_ver[pos]) > 0) {
+    } else if (diff != 0 && delimiterPrecedence(r_ver[pos]) > 0) {
       return diff;
     }
   }
@@ -114,7 +114,7 @@ static int compareRemainder(std::string_view l_ver,
           return diff;
         }
       }
-    } else if (delimiterPrecedence(l_ver[pos]) > 0) {
+    } else if (diff != 0 && delimiterPrecedence(l_ver[pos]) > 0) {
       return diff;
     }
   }

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -520,7 +520,8 @@ TEST_F(SQLTests, test_collate_version_lt) {
               '1.1' < '1.a' collate version as t1, \
               '50.4.1b' < '50.4.1c' collate version as t2, \
               '1.0.0' < '1.0.0-2' collate version as t3, \
-              '1.0.0-2' < '1:0.0.3' collate version as t4",
+              '1.0.0-2' < '1:0.0.3' collate version as t4, \
+              '1.12.1' < '1.13' collate version as t5",
       d);
   ASSERT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["t0"], "1");
@@ -528,6 +529,7 @@ TEST_F(SQLTests, test_collate_version_lt) {
   EXPECT_EQ(d[0]["t2"], "1");
   EXPECT_EQ(d[0]["t3"], "1");
   EXPECT_EQ(d[0]["t4"], "1");
+  EXPECT_EQ(d[0]["t5"], "1");
 }
 
 TEST_F(SQLTests, test_collate_version_gt) {
@@ -537,7 +539,8 @@ TEST_F(SQLTests, test_collate_version_gt) {
               '190.10a' > '20.10a' collate version as t1, \
               '20.10a' > '20.102' collate version as t2, \
               '57:4' > '6.87.5' collate version as t3, \
-              '98.100.21-1b' > '98.100.21-1a' collate version as t4",
+              '98.100.21-1b' > '98.100.21-1a' collate version as t4, \
+              '8.11' > '8.10.24' collate version as t5",
       d);
   ASSERT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["t0"], "1");
@@ -545,6 +548,7 @@ TEST_F(SQLTests, test_collate_version_gt) {
   EXPECT_EQ(d[0]["t2"], "1");
   EXPECT_EQ(d[0]["t3"], "1");
   EXPECT_EQ(d[0]["t4"], "1");
+  EXPECT_EQ(d[0]["t5"], "1");
 }
 
 /*


### PR DESCRIPTION
There's a small bug in the version collations where the difference in length of the versions is returned when the next character of the longer version is a delimiter, which it should return any segment value difference before length difference.