### PR TITLE
Check path exists first in `vscode_extensions`

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -26,6 +26,10 @@ namespace tables {
 void genReadJSONAndAddExtensionRows(const std::string& uid,
                                     const std::string& path,
                                     QueryData& results) {
+  if (!pathExists(path).ok()) {
+    return;
+  }
+
   std::string json;
   if (!readFile(path, json).ok()) {
     LOG(INFO) << "Could not read vscode extensions.json from " << path;


### PR DESCRIPTION
The following was being logged as INFO every time `vscode_extensions` was being queried.
Adding the usual pathExists check to avoid spamming status logs.

Linux host:
```
54038 I0305 15:05:32.666677 210071552 vscode_extensions.cpp:31] Could not read vscode extensions.json from /Users/luk/.vscode-server/extensions/extensions.json
54039 I0305 15:05:32.669131 210071552 vscode_extensions.cpp:31] Could not read vscode extensions.json from /var/root/.vscode/extensions/extensions.json
54040 I0305 15:05:32.669243 210071552 vscode_extensions.cpp:31] Could not read vscode extensions.json from /var/root/.vscode-server/extensions/extensions.json
```
Windows host:
```
I0223 17:08:25.617586  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode\extensions\extensions.json
I0223 17:08:25.617586  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode-server\extensions\extensions.json
I0223 17:08:25.628171  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode\extensions\extensions.json
I0223 17:08:25.628171  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode-server\extensions\extensions.json
I0223 17:08:25.628826  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from C:\Users\foo\.vscode\extensions\extensions.json
I0223 17:08:25.629468  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from C:\Users\foo\.vscode-server\extensions\extensions.json
I0223 17:08:25.629468  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode\extensions\extensions.json
I0223 17:08:25.630856  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode-server\extensions\extensions.json
I0223 17:08:25.633971  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from C:\Users\Lucas Rodriguez\.vscode\extensions\extensions.json
I0223 17:08:25.634523  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from C:\Users\Lucas Rodriguez\.vscode-server\extensions\extensions.json
I0223 17:08:25.662871  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode\extensions\extensions.json
I0223 17:08:25.663738  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from .vscode-server\extensions\extensions.json
I0223 17:08:25.664433  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\system32\config\systemprofile\.vscode\extensions\extensions.json
I0223 17:08:25.664844  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\system32\config\systemprofile\.vscode-server\extensions\extensions.json
I0223 17:08:25.664844  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\ServiceProfiles\LocalService\.vscode\extensions\extensions.json
I0223 17:08:25.665738  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\ServiceProfiles\LocalService\.vscode-server\extensions\extensions.json
I0223 17:08:25.668351  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\ServiceProfiles\NetworkService\.vscode\extensions\extensions.json
I0223 17:08:25.670445  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %systemroot%\ServiceProfiles\NetworkService\.vscode-server\extensions\extensions.json
I0223 17:08:25.670445  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %SystemRoot%\ServiceProfiles\SQLTELEMETRY$SQLEXPRESS\.vscode\extensions\extensions.json
I0223 17:08:25.671221  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %SystemRoot%\ServiceProfiles\SQLTELEMETRY$SQLEXPRESS\.vscode-server\extensions\extensions.json
I0223 17:08:25.671804  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %SystemRoot%\ServiceProfiles\MSSQL$SQLEXPRESS\.vscode\extensions\extensions.json
I0223 17:08:25.671804  9348 vscode_extensions.cpp:31] Could not read vscode extensions.json from %SystemRoot%\ServiceProfiles\MSSQL$SQLEXPRESS\.vscode-server\extensions\extensions.json
```
macOS:
```
102726:I0306 13:57:25.063361 246038528 vscode_extensions.cpp:31] Could not read vscode extensions.json from /Users/luk/.vscode-server/extensions/extensions.json
102727:I0306 13:57:25.064962 246038528 vscode_extensions.cpp:31] Could not read vscode extensions.json from /var/root/.vscode/extensions/extensions.json
102728:I0306 13:57:25.065032 246038528 vscode_extensions.cpp:31] Could not read vscode extensions.json from /var/root/.vscode-server/extensions/extensions.json
```