### PR TITLE
Downgrade sqlite to 3.42 to prevent a regression with required columns

### DIFF
--- a/libraries/cmake/source/sqlite/CMakeLists.txt
+++ b/libraries/cmake/source/sqlite/CMakeLists.txt
@@ -6,8 +6,38 @@
 # SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
 
 function(sqliteMain)
-  set(SQLITE_GENERATE_INSTALL_TARGET false CACHE BOOL "" FORCE)
-  add_subdirectory(src)
+
+  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+  set(parameter_list
+    "SQLITE_MAX_VARIABLE_NUMBER=250000"
+  )
+
+  set(option_list
+    SQLITE_ENABLE_COLUMN_METADATA
+    SQLITE_SECURE_DELETE
+    SQLITE_ENABLE_DBSTAT_VTAB
+    SQLITE_SOUNDEX
+    SQLITE_ENABLE_EXPLAIN_COMMENTS
+  )
+
+  add_library(thirdparty_sqlite
+    "${library_root}/src/sqlite3.c"
+  )
+
+  target_compile_definitions(thirdparty_sqlite PRIVATE
+    ${parameter_list}
+  )
+
+  foreach(option ${option_list})
+    target_compile_definitions(thirdparty_sqlite PRIVATE
+      "${option}=1"
+    )
+  endforeach()
+
+  target_include_directories(thirdparty_sqlite INTERFACE
+    "${library_root}/src"
+  )
 
   target_link_libraries(thirdparty_sqlite PRIVATE
     thirdparty_c_settings

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -275,9 +275,11 @@
   "sqlite": {
     "product": "sqlite",
     "vendor": "sqlite",
-    "version": "3.45.0",
-    "commit": "b172c2880dbee89a62379ab35a10d0c89626c885",
-    "ignored-cves": []
+    "version": "3.42.0",
+    "commit": "3341b40a45585b7854b20a8acff944c7668cf7e8",
+    "ignored-cves": [
+      "CVE-2023-7104"
+    ]
   },
   "thrift": {
     "product": "thrift",


### PR DESCRIPTION
See https://github.com/osquery/osquery/issues/8291

This also moves the logic to build in osquery, so that's future proof if we ever want to patch sqlite.

CVE-2023-7104 is fully resolved by not compiling in the session extension, which was anyway unused.

Note that CVE-2024-0232 is not yet present in this version, since the json code is different, given that it didn't yet receive the rework to make it more performant.

I'm not closing the issue since this is a hotfix, we should be properly fixing this issue on our side.