### PR TITLE
Fix crash when carve size is stored as string

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -204,7 +204,7 @@ Status Carver::carve() {
   }
 
   PlatformFile uploadFile(uploadPath, PF_OPEN_EXISTING | PF_READ);
-  updateCarveValue(carveGuid_, "size", std::to_string(uploadFile.size()));
+  updateCarveValue(carveGuid_, "size", uploadFile.size());
 
   std::string uploadHash =
       (uploadFile.size() > FLAGS_read_max)

--- a/osquery/carver/carver_utils.cpp
+++ b/osquery/carver/carver_utils.cpp
@@ -29,38 +29,6 @@ CLI_FLAG(bool,
 
 std::atomic<bool> kCarverPendingCarves{true};
 
-/// Helper function to update values related to a carve
-void updateCarveValue(const std::string& guid,
-                      const std::string& key,
-                      const std::string& value) {
-  std::string carve;
-  auto s = getDatabaseValue(kCarves, kCarverDBPrefix + guid, carve);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to update status of carve in database " << guid;
-    return;
-  }
-
-  JSON tree;
-  s = tree.fromString(carve);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to parse carve entries: " << s.what();
-    return;
-  }
-
-  tree.add(key, value);
-
-  std::string out;
-  s = tree.toString(out);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to serialize carve entries: " << s.what();
-  }
-
-  s = setDatabaseValue(kCarves, kCarverDBPrefix + guid, out);
-  if (!s.ok()) {
-    VLOG(1) << "Failed to update status of carve in database " << guid;
-  }
-}
-
 std::string createCarveGuid() {
   return boost::uuids::to_string(boost::uuids::random_generator()());
 }

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -54,7 +54,14 @@ void enumerateCarves(QueryData& results, const std::string& new_guid) {
     }
 
     if (tree.doc().HasMember("size")) {
-      r["size"] = INTEGER(tree.doc()["size"].GetInt());
+      // In some instances, it was observed that the size is stored as a JSON
+      // string rather than number, resulting in an exception if GetInt was
+      // called. Check for the type for backwards compatibility.
+      if (tree.doc()["size"].IsInt()) {
+        r["size"] = INTEGER(tree.doc()["size"].GetInt());
+      } else {
+        r["size"] = INTEGER(tree.doc()["size"].GetString());
+      }
     }
 
     stringToRow("sha256", r, tree);
@@ -108,5 +115,5 @@ QueryData genCarves(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
In some instances, it was observed that the size is stored as a JSON string rather than number, resulting in an exception if GetInt was called. Check for the type for backwards compatibility.

Fixes #7756.
