### PR TITLE
Using std::setprecision to get the right precision for double to string conversion.

### DIFF
--- a/osquery/utils/conversions/castvariant.h
+++ b/osquery/utils/conversions/castvariant.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include <boost/lexical_cast.hpp>
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 namespace osquery {
@@ -23,7 +25,9 @@ class CastVisitor : public boost::static_visitor<std::string> {
   }
 
   std::string operator()(const double& d) const {
-    std::string s{boost::lexical_cast<std::string>(d)};
+    std::ostringstream ss;
+    ss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << d;
+    std::string s = ss.str();
     if (s.find('.') == std::string::npos) {
       s += ".0";
     }

--- a/osquery/utils/conversions/castvariant.h
+++ b/osquery/utils/conversions/castvariant.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
-#include <boost/lexical_cast.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/variant.hpp>
 #include <iomanip>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/8301

boost::lexical_cast was not using the right precision for double-to-string conversion.
Switched to using std::ostringstream.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
