### PR TITLE
Add support for metalink and store repo config file name in table

### DIFF
--- a/osquery/tables/system/linux/yum_sources.cpp
+++ b/osquery/tables/system/linux/yum_sources.cpp
@@ -25,7 +25,8 @@ const std::string kYumConf{"/etc/yum.conf"};
 const std::string kYumReposDir{"/etc/yum.repos.d"};
 const std::string kYumConfigFileExtension{".repo"};
 
-void parseYumConf(std::istream& source,
+void parseYumConf(const std::string& source_filename,
+                  std::istream& source,
                   QueryData& results,
                   std::string& repos_dir) {
   boost::property_tree::ptree tree;
@@ -39,11 +40,13 @@ void parseYumConf(std::istream& source,
     }
 
     Row r;
+    r["source"] = source_filename;
     for (auto it2 : it1.second) {
       // Option
       if ("baseurl" == it2.first || "enabled" == it2.first ||
           "gpgcheck" == it2.first || "name" == it2.first ||
-          "gpgkey" == it2.first || "mirrorlist" == it2.first) {
+          "gpgkey" == it2.first || "mirrorlist" == it2.first ||
+          "metalink" == it2.first) {
         r[it2.first] = it2.second.data();
       }
     }
@@ -64,7 +67,7 @@ void parseYumConf(const std::string& source,
   }
 
   try {
-    parseYumConf(stream, results, repos_dir);
+    parseYumConf(source, stream, results, repos_dir);
   } catch (boost::property_tree::ini_parser::ini_parser_error& e) {
     logger.vlog(
         1,

--- a/osquery/tables/system/tests/linux/yum_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/yum_sources_tests.cpp
@@ -16,15 +16,19 @@
 namespace osquery {
 namespace tables {
 
-void parseYumConf(std::istream&, QueryData& ults, std::string& repos_dir);
+void parseYumConf(const std::string&,
+                  std::istream&,
+                  QueryData& ults,
+                  std::string& repos_dir);
 
 class YumSourcesTests : public testing::Test {};
 
 TEST_F(YumSourcesTests, parse_empty_yum_conf) {
   QueryData results;
   std::string repos_dir;
+  const std::string& repo_file_name = "/etc/yum.conf";
   std::istringstream stream1("");
-  parseYumConf(stream1, results, repos_dir);
+  parseYumConf(repo_file_name, stream1, results, repos_dir);
   // Default is used when no main.reposdir is set
   ASSERT_EQ(repos_dir, "/etc/yum.repos.d");
   ASSERT_EQ(results.size(), (unsigned long)0);
@@ -33,6 +37,7 @@ TEST_F(YumSourcesTests, parse_empty_yum_conf) {
 TEST_F(YumSourcesTests, parse_yum_conf) {
   QueryData results;
   std::string repos_dir;
+  const std::string& repo_file_name = "/etc/local/yum.repos.d/example.repo";
   std::istringstream stream2(R"STRLIT(
 # Some comment
 
@@ -47,6 +52,7 @@ enabled=1
 name=My personal repo
 reposdir=/ignored/path
 mirrorlist=http://url.to.mirror.list
+metalink=http://url.to.metalink
 
 [math]
 baseurl=http://some.math.repo.url
@@ -55,23 +61,28 @@ name=Mathematic library repo
 gpgcheck=0
 gpgkey=ftp://repokeys/mykey
 mirrorlist=http://url.to.mirror.list
+metalink=http://url.to.metalink
 )STRLIT");
 
-  parseYumConf(stream2, results, repos_dir);
+  parseYumConf(repo_file_name, stream2, results, repos_dir);
   ASSERT_EQ(repos_dir, "/etc/local/yum.repos.d");
   ASSERT_EQ(results.size(), (unsigned long)2);
 
   ASSERT_EQ(results.at(0).at("baseurl"), "http://my.repo.url/1/v2/3");
   ASSERT_EQ(results.at(0).at("mirrorlist"), "http://url.to.mirror.list");
+  ASSERT_EQ(results.at(0).at("metalink"), "http://url.to.metalink");
   ASSERT_EQ(results.at(0).at("enabled"), "1");
   ASSERT_EQ(results.at(0).at("name"), "My personal repo");
+  ASSERT_EQ(results.at(0).at("source"), "/etc/local/yum.repos.d/example.repo");
   ASSERT_EQ(results.at(0).find("gpgcheck"), results.at(0).end());
   ASSERT_EQ(results.at(0).find("gpgkey"), results.at(0).end());
 
   ASSERT_EQ(results.at(1).at("baseurl"), "http://some.math.repo.url");
   ASSERT_EQ(results.at(1).at("mirrorlist"), "http://url.to.mirror.list");
+  ASSERT_EQ(results.at(1).at("metalink"), "http://url.to.metalink");
   ASSERT_EQ(results.at(1).at("enabled"), "0");
   ASSERT_EQ(results.at(1).at("name"), "Mathematic library repo");
+  ASSERT_EQ(results.at(1).at("source"), "/etc/local/yum.repos.d/example.repo");
   ASSERT_EQ(results.at(1).at("gpgcheck"), "0");
   ASSERT_EQ(results.at(1).at("gpgkey"), "ftp://repokeys/mykey");
 }

--- a/specs/linux/yum_sources.table
+++ b/specs/linux/yum_sources.table
@@ -2,8 +2,10 @@ table_name("yum_sources")
 description("Current list of Yum repositories or software channels.")
 schema([
     Column("name", TEXT, "Repository name"),
+    Column("source", TEXT, "Source file"),
     Column("baseurl", TEXT, "Repository base URL"),
     Column("mirrorlist", TEXT, "Mirrorlist URL"),
+    Column("metalink", TEXT, "Metalink URL"),
     Column("enabled", TEXT, "Whether the repository is used"),
     Column("gpgcheck", TEXT, "Whether packages are GPG checked"),
     Column("gpgkey", TEXT, "URL to GPG key"),


### PR DESCRIPTION
The configuration of yum repository, may use the metalink parameter in addition to the baseurl and mirrorlist parameters.
The value of this parameter has now been added to the yum_sources table.
In addition, the path to the repository config file also added to table, similar to the apt_sources table.
