### PR TITLE
CI: Fix macOS python dependencies install step

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -658,20 +658,22 @@ jobs:
           coreutils \
           gnu-sed
 
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+
     - name: Install tests dependencies
       id: install_test_deps
       run: |
-        python_root="/usr/local/Frameworks/Python.framework/Versions/Current"
-
-        ${python_root}/bin/pip3 install setuptools \
-                     pexpect==3.3 \
-                     psutil \
-                     timeout_decorator \
-                     six \
-                     thrift==0.11.0 \
-                     osquery
-
-        echo "PYTHON_ROOT=${python_root}" >> $GITHUB_OUTPUT
+        pip3 install setuptools \
+                      pexpect==3.3 \
+                      psutil \
+                      timeout_decorator \
+                      six \
+                      thrift==0.11.0 \
+                      osquery
 
     - name: Install CMake
       shell: bash
@@ -721,7 +723,6 @@ jobs:
           -DCMAKE_BUILD_TYPE:STRING="${{ matrix.build_type }}" \
           -DOSQUERY_BUILD_TESTS=ON \
           -DOSQUERY_NO_DEBUG_SYMBOLS=${{ steps.debug_symbols_settings.outputs.VALUE }} \
-          -DPython3_ROOT_DIR=${{ steps.install_test_deps.outputs.PYTHON_ROOT }} \
           ${{ steps.build_paths.outputs.SOURCE }}
 
     - name: Build the project
@@ -823,17 +824,22 @@ jobs:
         with:
           name: macos_tests_Debug
 
-      - name: Install tests dependencies
-        run: |
-          python_root="/usr/local/Frameworks/Python.framework/Versions/Current"
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
 
-          ${python_root}/bin/pip3 install setuptools \
-                       pexpect==3.3 \
-                       psutil \
-                       timeout_decorator \
-                       six \
-                       thrift==0.11.0 \
-                       osquery
+      - name: Install tests dependencies
+        id: install_test_deps
+        run: |
+          pip3 install setuptools \
+                        pexpect==3.3 \
+                        psutil \
+                        timeout_decorator \
+                        six \
+                        thrift==0.11.0 \
+                        osquery
 
       - name: Install CMake
         shell: bash

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -661,7 +661,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.12.2'
         architecture: 'x64'
 
     - name: Install tests dependencies
@@ -827,7 +827,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12.2'
           architecture: 'x64'
 
       - name: Install tests dependencies

--- a/osquery/process/posix/process.cpp
+++ b/osquery/process/posix/process.cpp
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <iostream>
 #include <vector>
 
 #include <osquery/core/system.h>
@@ -185,7 +186,8 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     ::execve(arguments[0], argv, ::environ);
 
     // Code should never reach this point
-    LOG(ERROR) << "Could not start extension process: " << exec_path;
+    std::cerr << "Could not start extension process: " << exec_path
+              << ", error: " << errno << std::endl;
     ::exit(EXIT_FAILURE);
     return std::shared_ptr<PlatformProcess>();
   }
@@ -227,7 +229,13 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchTestPythonScript(
   if (process_pid == 0) {
     // Start a Python script
     ::execvp(osquery_python_path.c_str(), argv);
-    ::exit(0);
+
+    std::string args = boost::algorithm::join(args_array, " ");
+
+    // Should not reach this if everything executes correctly
+    std::cerr << "Could not start process at " << osquery_python_path
+              << ", args: " << args << ", error: " << errno << std::endl;
+    ::exit(EXIT_FAILURE);
   } else if (process_pid > 0) {
     process.reset(new PlatformProcess(process_pid));
   }

--- a/tools/ci/scripts/macos/package_tests.sh
+++ b/tools/ci/scripts/macos/package_tests.sh
@@ -29,7 +29,7 @@ main() {
   local launcher_path="${destination}/run.sh"
 
   printf '#!/usr/bin/env bash\n\n' > "${launcher_path}"
-  printf 'export _OSQUERY_PYTHON_INTERPRETER_PATH="/usr/local/Frameworks/Python.framework/Versions/Current/bin/python3"\n' >> "${launcher_path}"
+  printf 'export _OSQUERY_PYTHON_INTERPRETER_PATH=`where python`\n' >> "${launcher_path}"
   printf 'export RUNNER_ROOT_FOLDER="$(pwd)"\n\n' >> "${launcher_path}"
   printf 'ctest --build-nocmake -V\n' >> "${launcher_path}"
   chmod 755 "${launcher_path}" || return 1


### PR DESCRIPTION
Don't use the OS python to install dependencies,
but use the one that's installed for the runner itself. Select it with the python action.