### PR TITLE
add additional details for OpenSSL-style keys

### DIFF
--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -58,8 +58,8 @@ bool isOpenSSHKeyEncrypted(const std::string& keys_content) {
 bool parsePrivateKey(const std::string& keys_content,
                      int& key_type,
                      std::string& key_group_name,
-                     std::string& key_length,
-                     std::string& key_security_bits,
+                     int& key_length,
+                     int& key_security_bits,
                      bool& is_encrypted) {
   BIO* bio_stream = BIO_new(BIO_s_mem());
   auto const bio_stream_guard =
@@ -104,8 +104,8 @@ bool parsePrivateKey(const std::string& keys_content,
     return false;
   }
   key_type = EVP_PKEY_base_id(pkey);
-  key_length = std::to_string(EVP_PKEY_bits(pkey));
-  key_security_bits = std::to_string(EVP_PKEY_security_bits(pkey));
+  key_length = EVP_PKEY_bits(pkey);
+  key_security_bits = EVP_PKEY_security_bits(pkey);
   // openssl group names are all under 24 chars today, leave some extra room
   char groupname[32];
   size_t gname_len;
@@ -168,8 +168,8 @@ void genSSHkeyForHosts(const std::string& uid,
     }
     int key_type;
     std::string key_group_name;
-    std::string key_length;
-    std::string key_security_bits;
+    int key_length = -1;
+    int key_security_bits = -1;
     bool encrypted;
     bool parsed = parsePrivateKey(keys_content,
                                   key_type,
@@ -185,8 +185,8 @@ void genSSHkeyForHosts(const std::string& uid,
       r["encrypted"] = encrypted ? "1" : "0";
       r["key_type"] = keyTypeAsString(key_type);
       r["key_group_name"] = key_group_name;
-      r["key_length"] = key_length;
-      r["key_security_bits"] = key_security_bits;
+      r["key_length"] = INTEGER(key_length);
+      r["key_security_bits"] = INTEGER(key_security_bits);
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -57,6 +57,9 @@ bool isOpenSSHKeyEncrypted(const std::string& keys_content) {
 // if it's an openssh key.
 bool parsePrivateKey(const std::string& keys_content,
                      int& key_type,
+                     std::string& key_group_name,
+                     std::string& key_length,
+                     std::string& key_security_bits,
                      bool& is_encrypted) {
   BIO* bio_stream = BIO_new(BIO_s_mem());
   auto const bio_stream_guard =
@@ -101,6 +104,17 @@ bool parsePrivateKey(const std::string& keys_content,
     return false;
   }
   key_type = EVP_PKEY_base_id(pkey);
+  key_length = std::to_string(EVP_PKEY_bits(pkey));
+  key_security_bits = std::to_string(EVP_PKEY_security_bits(pkey));
+  // openssl group names are all under 24 chars today, leave some extra room
+  char groupname[32];
+  size_t gname_len;
+  int status;
+  status =
+      EVP_PKEY_get_group_name(pkey, groupname, sizeof(groupname), &gname_len);
+  if (status) {
+    key_group_name.assign(groupname, gname_len);
+  }
   return true;
 }
 
@@ -153,8 +167,16 @@ void genSSHkeyForHosts(const std::string& uid,
       continue;
     }
     int key_type;
+    std::string key_group_name;
+    std::string key_length;
+    std::string key_security_bits;
     bool encrypted;
-    bool parsed = parsePrivateKey(keys_content, key_type, encrypted);
+    bool parsed = parsePrivateKey(keys_content,
+                                  key_type,
+                                  key_group_name,
+                                  key_length,
+                                  key_security_bits,
+                                  encrypted);
     if (parsed) {
       Row r;
       r["pid_with_namespace"] = "0";
@@ -162,6 +184,9 @@ void genSSHkeyForHosts(const std::string& uid,
       r["path"] = kfile;
       r["encrypted"] = encrypted ? "1" : "0";
       r["key_type"] = keyTypeAsString(key_type);
+      r["key_group_name"] = key_group_name;
+      r["key_length"] = key_length;
+      r["key_security_bits"] = key_security_bits;
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
+++ b/osquery/tables/system/tests/posix/ssh_keys_tests.cpp
@@ -175,6 +175,9 @@ TEST_F(SshKeysTests, rsa_key_unencrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "0");
   EXPECT_EQ(row.at("key_type"), "rsa");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "1024");
+  EXPECT_EQ(row.at("key_security_bits"), "80");
 }
 
 TEST_F(SshKeysTests, rsa_key_encrypted) {
@@ -197,6 +200,9 @@ TEST_F(SshKeysTests, rsa_key_encrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "1");
   EXPECT_EQ(row.at("key_type"), "");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "-1");
+  EXPECT_EQ(row.at("key_security_bits"), "-1");
 }
 
 TEST_F(SshKeysTests, dsa_unencrypted) {
@@ -219,6 +225,9 @@ TEST_F(SshKeysTests, dsa_unencrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "0");
   EXPECT_EQ(row.at("key_type"), "dsa");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "1024");
+  EXPECT_EQ(row.at("key_security_bits"), "80");
 }
 
 TEST_F(SshKeysTests, dsa_encrypted) {
@@ -241,6 +250,9 @@ TEST_F(SshKeysTests, dsa_encrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "1");
   EXPECT_EQ(row.at("key_type"), "");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "-1");
+  EXPECT_EQ(row.at("key_security_bits"), "-1");
 }
 
 TEST_F(SshKeysTests, ed25519_unencrypted) {
@@ -263,6 +275,9 @@ TEST_F(SshKeysTests, ed25519_unencrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "0");
   EXPECT_EQ(row.at("key_type"), "");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "-1");
+  EXPECT_EQ(row.at("key_security_bits"), "-1");
 }
 
 TEST_F(SshKeysTests, ed25519_encrypted) {
@@ -285,6 +300,9 @@ TEST_F(SshKeysTests, ed25519_encrypted) {
   EXPECT_EQ(row.at("path"), fs::canonical(filepath).native());
   EXPECT_EQ(row.at("encrypted"), "1");
   EXPECT_EQ(row.at("key_type"), "");
+  EXPECT_EQ(row.at("key_group_name"), "");
+  EXPECT_EQ(row.at("key_length"), "-1");
+  EXPECT_EQ(row.at("key_security_bits"), "-1");
 }
 
 } // namespace tables

--- a/specs/user_ssh_keys.table
+++ b/specs/user_ssh_keys.table
@@ -6,6 +6,9 @@ schema([
     Column("path", TEXT, "Path to key file", index=True),
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
     Column("key_type", TEXT, "The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string."),
+    Column("key_group_name", TEXT, "The group of the private key. Supported for a subset of key_types implemented by OpenSSL"),
+    Column("key_length", INTEGER, "The cryptographic length of the cryptosystem to which the private key belongs, in bits. Definition of cryptographic length is specific to cryptosystem"),
+    Column("key_security_bits", INTEGER, "The number of security bits of the private key, bits of security as defined in NIST SP800-57"),
     ForeignKey(column="uid", table="users"),
 ])
 extended_schema(LINUX, [

--- a/specs/user_ssh_keys.table
+++ b/specs/user_ssh_keys.table
@@ -7,8 +7,8 @@ schema([
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
     Column("key_type", TEXT, "The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string."),
     Column("key_group_name", TEXT, "The group of the private key. Supported for a subset of key_types implemented by OpenSSL"),
-    Column("key_length", INTEGER, "The cryptographic length of the cryptosystem to which the private key belongs, in bits. Definition of cryptographic length is specific to cryptosystem"),
-    Column("key_security_bits", INTEGER, "The number of security bits of the private key, bits of security as defined in NIST SP800-57"),
+    Column("key_length", INTEGER, "The cryptographic length of the cryptosystem to which the private key belongs, in bits. Definition of cryptographic length is specific to cryptosystem. -1 if unavailable"),
+    Column("key_security_bits", INTEGER, "The number of security bits of the private key, bits of security as defined in NIST SP800-57. -1 if unavailable"),
     ForeignKey(column="uid", table="users"),
 ])
 extended_schema(LINUX, [

--- a/tests/integration/tables/user_ssh_keys.cpp
+++ b/tests/integration/tables/user_ssh_keys.cpp
@@ -41,19 +41,21 @@ TEST_F(userSshKeys, test_sanity) {
   // 1. Query data
   auto const data = execute_query("select * from user_ssh_keys");
   // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
+  ASSERT_GE(data.size(), 0ul);
   // ASSERT_EQ(data.size(), 1ul);
   // ASSERT_EQ(data.size(), 0ul);
   // 3. Build validation map
   // See helper.h for available flags
   // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"uid", IntType}
-  //      {"path", NormalType}
-  //      {"encrypted", IntType}
-  //}
+  ValidationMap row_map = {{"uid", IntType},
+                           {"path", NormalType},
+                           {"encrypted", IntType},
+                           {"key_type", NormalType},
+                           {"key_group_name", NormalType},
+                           {"key_length", IntType},
+                           {"key_security_bits", IntType}};
   // 4. Perform validation
-  // validate_rows(data, row_map);
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
This PR introduces additional columns which use OpenSSL macros to get additional details about PEM keys in user .ssh/ directories. 
- "key_length" uses OpenSSL's EVP_PKEY_bits to get the cryptographic length of the cryptosystem to which the private key belongs, in bits. Definition of cryptographic length is specific to cryptosystem.
- "key_security_bits" uses OpenSSL's EVP_PKEY_security_bits to get the number of security bits of the given key (bits of security as defined in NIST SP800-57).
- "key_group_name" uses OpenSSL's EVP_PKEY_get_group_name to get the group of the private key. Supported for a subset of key_types implemented by OpenSSL.


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
