### PR TITLE
Fix `process_open_sockets` to correctly displays `family` and `protocol` on macOS

### DIFF
--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -178,8 +178,8 @@ void genSocketDescriptor(int pid, int descriptor, QueryData& results) {
 
     r["pid"] = INTEGER(pid);
     r["socket"] = INTEGER(descriptor);
-    r["family"] = "0";
-    r["protocol"] = "0";
+    r["family"] = INTEGER(si.psi.soi_family);
+    r["protocol"] = INTEGER(si.psi.soi_protocol);
     r["local_address"] = "";
     r["local_port"] = "0";
     r["remote_address"] = "";


### PR DESCRIPTION
Fixes #8296 