### PR TITLE
Add missing SSH key types that support FIDO2 authentication

### DIFF
--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -26,11 +26,14 @@ namespace tables {
 const std::vector<std::string> kSSHAuthorizedkeys = {".ssh/authorized_keys",
                                                      ".ssh/authorized_keys2"};
 const std::string kKeyRingLabelOptionPrefix = "zos-key-ring-label=";
-const std::vector<std::string> kSSHKeyTypes = {"ssh-rsa",
-                                               "ssh-ed25519",
-                                               "ecdsa-sha2-nistp256",
-                                               "ecdsa-sha2-nistp384",
-                                               "ecdsa-sha2-nistp521"};
+const std::vector<std::string> kSSHKeyTypes = {
+    "ssh-rsa",
+    "ssh-ed25519",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "sk-ecdsa-sha2-nistp256@openssh.com",
+    "sk-ssh-ed25519@openssh.com"};
 const std::string kWhitespace{"\t "};
 
 bool KeyRingLabelOptExists(const std::string& line) {


### PR DESCRIPTION
Fixes #8313 