### PR TITLE
ATC tables - Registry call after adding the plugins to the registry

### DIFF
--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -227,9 +227,6 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
-    PluginResponse resp;
-    Registry::call(
-        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
     LOG(INFO) << "ATC table: " << table_name << " Registered";
 
     s = tables->add(
@@ -239,6 +236,10 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       deleteDatabaseValue(kPersistentSettings, kDatabaseKeyPrefix + table_name);
       continue;
     }
+
+    PluginResponse resp;
+    Registry::call(
+        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
   }
 
   if (registered.size() > 0) {


### PR DESCRIPTION
It seems there was a slight bug introduced in #8233 where the atc table isn't created after being successfully registered:

```
I0429 13:56:57.628793 -251938112 init.cpp:413] osquery initialized [version=5.11.0-16-g47af2b035-dirty]
I0429 13:56:58.012014 -251938112 auto_constructed_tables.cpp:241] ATC table: atc_test Registered
osquery> SELECT * FROM atc_test LIMIT 1;
+-----------------------------------+-----------------------------------------------------------------------+
| service                           | path                                                                  |
+-----------------------------------+-----------------------------------------------------------------------+
| kTCCServiceAccessibility          | /System/Volumes/Data/Library/Application Support/com.apple.TCC/TCC.db |
+-----------------------------------+-----------------------------------------------------------------------+

I0429 13:54:13.307732 -251938112 init.cpp:413] osquery initialized [version=5.11.0-17-gc5145f0bf-dirty]
I0429 13:54:13.667146 -251938112 auto_constructed_tables.cpp:233] ATC table: atc_test Registered
osquery> SELECT * FROM atc_test LIMIT 1;
Error: no such table: atc_test
```

I'm still learning osquery's registry code, but this seems to be because of the `Registry::call`, when it reaches the point to get the plugin, it isn't there since the call was placed before the `Registry::add` and fails.

After moving the `Registry::call` back to after the `Registry::add`:

```
I0429 14:44:11.254305 -251938112 init.cpp:413] osquery initialized [version=5.12.1-2-gf298485c9-dirty]
I0429 14:44:11.635435 -251938112 auto_constructed_tables.cpp:230] ATC table: atc_test Registered
osquery> SELECT * FROM atc_test LIMIT 1;
+-----------------------------------+-----------------------------------------------------------------------+
| service                           | path                                                                  |
+-----------------------------------+-----------------------------------------------------------------------+
| kTCCServiceAccessibility          | /System/Volumes/Data/Library/Application Support/com.apple.TCC/TCC.db |
+-----------------------------------+-----------------------------------------------------------------------+
```