### PR TITLE
Updated Time Machine table documentation to require FDA.

### DIFF
--- a/specs/darwin/time_machine_backups.table
+++ b/specs/darwin/time_machine_backups.table
@@ -1,5 +1,5 @@
 table_name("time_machine_backups")
-description("Backups to drives using TimeMachine.")
+description("Backups to drives using TimeMachine. This table requires Full Disk Access (FDA) permission.")
 schema([
     Column("destination_id", TEXT, "Time Machine destination ID"),
     Column("backup_date", INTEGER, "Backup Date"),

--- a/specs/darwin/time_machine_destinations.table
+++ b/specs/darwin/time_machine_destinations.table
@@ -1,5 +1,5 @@
 table_name("time_machine_destinations")
-description("Locations backed up to using Time Machine.")
+description("Locations backed up to using Time Machine. This table requires Full Disk Access (FDA) permission.")
 schema([
     Column("alias", TEXT, "Human readable name of drive"),
     Column("destination_id", TEXT, "Time Machine destination ID"),


### PR DESCRIPTION
Updated Time Machine table documentation to require FDA, which is needed to read `/Library/Preferences/com.apple.TimeMachine.plist`