### PR TITLE
Revert #8233

### DIFF
--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -227,11 +227,6 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
-    PluginResponse resp;
-    Registry::call(
-        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
-    LOG(INFO) << "ATC table: " << table_name << " Registered";
-
     s = tables->add(
         table_name, std::make_shared<ATCPlugin>(path, columns, query), true);
     if (!s.ok()) {
@@ -239,6 +234,11 @@ Status ATCConfigParserPlugin::update(const std::string& source,
       deleteDatabaseValue(kPersistentSettings, kDatabaseKeyPrefix + table_name);
       continue;
     }
+
+    PluginResponse resp;
+    Registry::call(
+        "sql", "sql", {{"action", "attach"}, {"table", table_name}}, resp);
+    LOG(INFO) << "ATC table: " << table_name << " Registered";
   }
 
   if (registered.size() > 0) {


### PR DESCRIPTION
Reverting #8233 as it made ATC tables unable to attach properly which revealed a race condition between extensions and ATC tables #8323. A fix is in the works with #8324.