### PR TITLE
Align ES functions with documented macOS versions

### DIFF
--- a/osquery/events/darwin/endpointsecurity_fim.cpp
+++ b/osquery/events/darwin/endpointsecurity_fim.cpp
@@ -88,7 +88,7 @@ void EndpointSecurityFileEventPublisher::configure() {
 
     for (const auto& p : muted_path_literals_) {
       es_return_t rc;
-      if (__builtin_available(macos 13.0, *)) {
+      if (__builtin_available(macos 12.0, *)) {
         rc =
             es_mute_path(es_file_client_, p.c_str(), ES_MUTE_PATH_TYPE_LITERAL);
       } else {
@@ -101,7 +101,7 @@ void EndpointSecurityFileEventPublisher::configure() {
 
     for (const auto& p : muted_path_prefixes_) {
       es_return_t rc;
-      if (__builtin_available(macos 13.0, *)) {
+      if (__builtin_available(macos 12.0, *)) {
         rc = es_mute_path(es_file_client_, p.c_str(), ES_MUTE_PATH_TYPE_PREFIX);
       } else {
         rc = es_mute_path_prefix(es_file_client_, p.c_str());
@@ -113,7 +113,7 @@ void EndpointSecurityFileEventPublisher::configure() {
 
     for (const auto& p : default_muted_path_literals_) {
       es_return_t rc;
-      if (__builtin_available(macos 13.0, *)) {
+      if (__builtin_available(macos 12.0, *)) {
         rc =
             es_mute_path(es_file_client_, p.c_str(), ES_MUTE_PATH_TYPE_LITERAL);
       } else {


### PR DESCRIPTION
Per the docs `es_mute_path_literal `and `es_mute_path_prefix` are deprecated since MacOS 12.0
And  `es_mute_path `is available since 12.0.
So Code needs to align with docs. 

[es_mute_path_literal](https://developer.apple.com/documentation/endpointsecurity/3366122-es_mute_path_literal?language=objc)
![image](https://github.com/osquery/osquery/assets/93097769/f5f584f7-b7cb-48d6-8f5a-d6fc05672ad0)
[es_mute_path_prefix](https://developer.apple.com/documentation/endpointsecurity/3366123-es_mute_path_prefix?language=objc)
![image](https://github.com/osquery/osquery/assets/93097769/c8294294-3364-4471-b63d-1bbe488a1275)

[es_mute_path](https://developer.apple.com/documentation/endpointsecurity/3763102-es_mute_path?language=objc)
![image](https://github.com/osquery/osquery/assets/93097769/7e67eb4e-4453-443a-9bfb-4245a3b8b6d9)
