### PR TITLE
Fix invalid memory access in `curl_certificates` table

### DIFF
--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -114,14 +114,14 @@ static std::string certificate_extensions(X509* cert, int nid) {
 
   // remove the ending newline from the extension value
   auto length = bio_buf->length;
-  if (bio_buf->data[length - 1] == '\n' || bio_buf->data[length - 1] == '\r') {
-    bio_buf->data[length - 1] = '\0';
+  for (auto i = 0; length > 0 && i < 2; i++) {
+    if (bio_buf->data[length - 1] == '\n' ||
+        bio_buf->data[length - 1] == '\r') {
+      length--;
+    }
   }
 
-  if (bio_buf->data[length] == '\n' || bio_buf->data[length] == '\r') {
-    bio_buf->data[length] = '\0';
-  }
-  auto ident = std::string(bio_buf->data, bio_buf->length);
+  auto ident = std::string(bio_buf->data, length);
 
   // Replace the newline character with the comma
   std::replace(ident.begin(), ident.end(), '\n', ';');


### PR DESCRIPTION
While running valgrind on osquery it reported an invalid memory access in the curl_certificates table. There is a read and potential write 1 byte past the end of a memory buffer when stripping trailing newline from the end of the formatted X509 extension name. In this PR I remove the spurious check past the end of the buffer and also fix an issue where, if a newline had been found at the end of the buffer, the output included a NIL byte at the end instead of actually shrinking the string as intended.