### PR TITLE
Add `sha256` hash to `apparmor_profiles` table

### DIFF
--- a/osquery/tables/system/linux/apparmor_profiles.cpp
+++ b/osquery/tables/system/linux/apparmor_profiles.cpp
@@ -22,7 +22,7 @@ struct AppArmorProfile final {
   std::string name;
   std::string attach;
   std::string mode;
-  std::string sha1;
+  std::string sha256;
 };
 
 using AppArmorProfileList = std::vector<AppArmorProfile>;
@@ -58,12 +58,12 @@ Status generateProfile(AppArmorProfile& profile,
 
   boost::trim(profile.name);
 
-  status = readFile(profile_path + "/sha1", profile.sha1);
+  status = readFile(profile_path + "/sha256", profile.sha256);
   if (!status.ok()) {
     return status;
   }
 
-  boost::trim(profile.sha1);
+  boost::trim(profile.sha256);
 
   profile.path = parent_name;
   if (!profile.path.empty()) {
@@ -171,7 +171,7 @@ QueryData genAppArmorProfiles(QueryContext& context) {
     row["name"] = profile.name;
     row["mode"] = profile.mode;
     row["attach"] = profile.attach;
-    row["sha1"] = profile.sha1;
+    row["sha256"] = profile.sha256;
     row["path"] = profile.path;
 
     row_list.push_back(std::move(row));

--- a/osquery/tables/system/linux/apparmor_profiles.cpp
+++ b/osquery/tables/system/linux/apparmor_profiles.cpp
@@ -22,6 +22,7 @@ struct AppArmorProfile final {
   std::string name;
   std::string attach;
   std::string mode;
+  std::string sha1;
   std::string sha256;
 };
 
@@ -58,11 +59,17 @@ Status generateProfile(AppArmorProfile& profile,
 
   boost::trim(profile.name);
 
+  // AppArmor switched to sha256 after Linux 6.8; fallback to sha1 if the read
+  // fails.
   status = readFile(profile_path + "/sha256", profile.sha256);
   if (!status.ok()) {
-    return status;
+    status = readFile(profile_path + "/sha1", profile.sha1);
+    if (!status.ok()) {
+      return status;
+    }
   }
 
+  boost::trim(profile.sha1);
   boost::trim(profile.sha256);
 
   profile.path = parent_name;
@@ -171,6 +178,7 @@ QueryData genAppArmorProfiles(QueryContext& context) {
     row["name"] = profile.name;
     row["mode"] = profile.mode;
     row["attach"] = profile.attach;
+    row["sha1"] = profile.sha1;
     row["sha256"] = profile.sha256;
     row["path"] = profile.path;
 

--- a/specs/linux/apparmor_profiles.table
+++ b/specs/linux/apparmor_profiles.table
@@ -5,7 +5,7 @@ schema([
     Column("name", TEXT, "Policy name."),
     Column("attach", TEXT, "Which executable(s) a profile will attach to."),
     Column("mode", TEXT, "How the policy is applied."),
-    Column("sha1", TEXT, "A unique hash that identifies this policy."),
+    Column("sha256", TEXT, "A unique hash that identifies this policy."),
 ])
 implementation("system/apparmor_profiles@genAppArmorProfiles")
 examples([

--- a/specs/linux/apparmor_profiles.table
+++ b/specs/linux/apparmor_profiles.table
@@ -5,6 +5,7 @@ schema([
     Column("name", TEXT, "Policy name."),
     Column("attach", TEXT, "Which executable(s) a profile will attach to."),
     Column("mode", TEXT, "How the policy is applied."),
+    Column("sha1", TEXT, "A unique hash that identifies this policy."),
     Column("sha256", TEXT, "A unique hash that identifies this policy."),
 ])
 implementation("system/apparmor_profiles@genAppArmorProfiles")


### PR DESCRIPTION
AppArmor changed the `SECURITY_APPARMOR_HASH` from sha1 to sha256 on the Linux kernel 6.8, thus breaking the `apparmor_profiles` table (#8344):

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=237c31cb5d83b3f77715f6d6a185f46a5ee4ec88

This adds a new `sha256` column to the `apparmor_profiles` table to address this change.