### PR TITLE
Add new file path for alf plist

### DIFF
--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -25,7 +25,9 @@ namespace tables {
  * This plist contains all of the details about the ALF.
  * It is used to populate all of the tables here.
  */
-const std::string kALFPlistPath{"/Library/Preferences/com.apple.alf.plist"};
+const std::vector<std::string> kALFPlistPaths{
+    "/Library/Preferences/com.apple.alf.plist",
+    "/usr/libexec/ApplicationFirewall/com.apple.alf.plist"};
 
 /// Well known keys within the plist containing settings.
 const std::map<std::string, std::string> kTopLevelIntKeys{
@@ -44,10 +46,17 @@ const std::map<std::string, std::string> kTopLevelStringKeys{
 };
 
 Status genALFTreeFromFilesystem(pt::ptree& tree) {
-  Status s = osquery::parsePlist(kALFPlistPath, tree);
-  if (!s.ok()) {
-    TLOG << "Error parsing " << kALFPlistPath << ": " << s.toString();
+  Status s;
+
+  for (const auto& path : kALFPlistPaths) {
+    s = osquery::parsePlist(path, tree);
+    if (s.ok()) {
+      break;
+    }
+
+    TLOG << "Error parsing " << path << ": " << s.toString();
   }
+
   return s;
 }
 

--- a/osquery/tables/system/darwin/firewall.h
+++ b/osquery/tables/system/darwin/firewall.h
@@ -34,8 +34,8 @@ osquery::QueryData parseALFExplicitAuthsTree(const pt::ptree& tree);
 // parseALFTree parses out the top level string and int keys
 osquery::QueryData parseALFTree(const pt::ptree& tree);
 
-// kALFPlistPath is the path of the com.apple.alf.plist path
-extern const std::string kALFPlistPath;
+// kALFPlistPaths are the possible paths of the com.apple.alf.plist path
+extern const std::vector<std::string> kALFPlistPaths;
 
 // kTopLevelIntKeys is a map of keys and columns which are used while parsing
 // in the function parseALFTree
@@ -44,5 +44,5 @@ extern const std::map<std::string, std::string> kTopLevelIntKeys;
 // kTopLevelStringKeys is a map of keys and columns which are used while
 // parsing in the function parseALFTree
 extern const std::map<std::string, std::string> kTopLevelStringKeys;
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/darwin/firewall_tests.cpp
+++ b/osquery/tables/system/tests/darwin/firewall_tests.cpp
@@ -114,7 +114,15 @@ TEST_F(FirewallTests, test_errors) {
 
 TEST_F(FirewallTests, test_on_disk_format) {
   pt::ptree tree;
-  auto s = osquery::parsePlist(kALFPlistPath, tree);
+  Status s;
+
+  for (const auto& path : kALFPlistPaths) {
+    s = osquery::parsePlist(path, tree);
+    if (s.ok()) {
+      break;
+    }
+  }
+
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   for (const auto& it : kTopLevelIntKeys) {


### PR DESCRIPTION
Fixes #8349 

In macOS 15 the alf plist has moved to the `/usr/libexec/ApplicationFirewall/` directory.

To fix this I've added the path into a plist path array, then enumerate it for the plist parser.

```
osquery> SELECT os_version.version AS os_version, alf.* FROM os_version, alf;
          os_version = 15.0
allow_signed_enabled = 1
     firewall_unload = 0
        global_state = 0
     logging_enabled = 1
      logging_option = 0
     stealth_enabled = 0
             version = 1.7
```