### PR TITLE
Fixing real precision by limiting precision to 15 digits.

### DIFF
--- a/osquery/utils/conversions/castvariant.h
+++ b/osquery/utils/conversions/castvariant.h
@@ -29,9 +29,11 @@ class CastVisitor : public boost::static_visitor<std::string> {
   std::string operator()(const double& d) const {
     std::ostringstream ss;
     // SQLite supports 15 significant digits.
-    // The value of std::numeric_limits<T>::digits10 is the number of base-10 digits that can be represented by the
-    // type T without change, that is, any number with this many significant decimal digits can be converted to a value
-    // of type T and back to decimal form, without change due to rounding or overflow. (from cppreference.com)
+    // The value of std::numeric_limits<T>::digits10 is the number of base-10
+    // digits that can be represented by the type T without change, that is, any
+    // number with this many significant decimal digits can be converted to a
+    // value of type T and back to decimal form, without change due to rounding
+    // or overflow. (from cppreference.com)
     ss << std::setprecision(std::numeric_limits<double>::digits10) << d;
     std::string s = ss.str();
     if (s.find('.') == std::string::npos) {

--- a/osquery/utils/conversions/castvariant.h
+++ b/osquery/utils/conversions/castvariant.h
@@ -28,7 +28,11 @@ class CastVisitor : public boost::static_visitor<std::string> {
 
   std::string operator()(const double& d) const {
     std::ostringstream ss;
-    ss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << d;
+    // SQLite supports 15 significant digits.
+    // The value of std::numeric_limits<T>::digits10 is the number of base-10 digits that can be represented by the
+    // type T without change, that is, any number with this many significant decimal digits can be converted to a value
+    // of type T and back to decimal form, without change due to rounding or overflow. (from cppreference.com)
+    ss << std::setprecision(std::numeric_limits<double>::digits10) << d;
     std::string s = ss.str();
     if (s.find('.') == std::string::npos) {
       s += ".0";


### PR DESCRIPTION
Fixes #8301 

The previous fix was incomplete -- there were still some numbers that were being improperly converted into string.

<img width="152" alt="image" src="https://github.com/osquery/osquery/assets/2685025/29f74ff6-e826-4f19-a128-8b13723ff96c">

This fix limits double-to-string conversion to significant digits only, without an extra non-significant digit.


<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
