### PR TITLE
ci: Update Linux Docker image to Ubuntu 20.04 

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -40,8 +40,8 @@ concurrency:
 # Please remember to update values for both x86 and aarch64 workflows.
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
-  PACKAGING_COMMIT: 4caa2c54f0d893c1efa47932571046bbce156c52
-  SUBMODULE_CACHE_VERSION: 2
+  PACKAGING_COMMIT: c089fb2d3d796d976e3b2fbea7ee69a1616b9576
+  SUBMODULE_CACHE_VERSION: 3
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
@@ -54,24 +54,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
+      image: osquery/builder20.04:7e9ee0339
+      options: --user 1001
 
     steps:
-
-    # We are using checkout@v1 because the checkout@v2 action downloads
-    # the source code without cloning if the installed git is < v2.18.
-    # Once we update the image we will also be able to select the clone
-    # destination; right now we are moving the .git folder manually.
-    - name: Clone the osquery repository
-      uses: actions/checkout@v1
-
-    # This script makes sure that the copyright headers have been correctly
-    # placed on all the source code files
-    - name: Check the copyright headers
-      run: |
-        ./tools/ci/scripts/check_copyright_headers.py
-
     - name: Setup the build paths
       shell: bash
       id: build_paths
@@ -80,10 +66,23 @@ jobs:
         rel_source_path="workspace/src"
 
         mkdir -p "${rel_build_path}"
-        ln -sf "$(pwd)" "${rel_source_path}"
+        mkdir -p "${rel_source_path}"
 
         echo "SOURCE=$(realpath ${rel_source_path})" >> $GITHUB_OUTPUT
         echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
+
+    - name: Clone the osquery repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ steps.build_paths.outputs.SOURCE }}
+        fetch-depth: 0
+
+    # This script makes sure that the copyright headers have been correctly
+    # placed on all the source code files
+    - name: Check the copyright headers
+      working-directory: ${{ steps.build_paths.outputs.SOURCE }}
+      run: |
+        ./tools/ci/scripts/check_copyright_headers.py
 
     - name: Configure the project
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
@@ -110,7 +109,7 @@ jobs:
 
     steps:
     - name: Clone the osquery repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install python pre-requisites
       run: |
@@ -127,13 +126,9 @@ jobs:
     needs: [check_code_style, check_libraries_manifest]
     runs-on: ubuntu-20.04
 
-    container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
-
     steps:
     - name: Clone the osquery repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: genwebsitejson.py
       run: python3 tools/codegen/genwebsitejson.py --specs=specs/
@@ -146,17 +141,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
+      image: osquery/builder20.04:7e9ee0339
+      options: --user 1001
 
     strategy:
       matrix:
         os: [ubuntu-20.04]
 
     steps:
-    - name: Clone the osquery repository
-      uses: actions/checkout@v1
-
     - name: Setup the build paths
       shell: bash
       id: build_paths
@@ -169,12 +161,15 @@ jobs:
                  ${rel_source_path} \
                  ${rel_install_path}
 
-        mv .git "${rel_source_path}"
-        ( cd "${rel_source_path}" && git reset --hard )
-
         echo "SOURCE=$(realpath ${rel_source_path})" >> $GITHUB_OUTPUT
         echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
         echo "REL_BINARY=${rel_build_path}" >> $GITHUB_OUTPUT
+
+    - name: Clone the osquery repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ steps.build_paths.outputs.SOURCE }}
+        fetch-depth: 0
 
     - name: Update the cache (git submodules)
       uses: actions/cache@v3
@@ -261,8 +256,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock --pid=host
+      image: osquery/builder20.04:7e9ee0339
+      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock --pid=host --user 1001
 
     strategy:
       matrix:
@@ -273,13 +268,45 @@ jobs:
     - name: Make space uninstalling packages
       shell: bash
       run: |
-        run_on_host="nsenter -t 1 -m -u -n -i"
+        run_on_host="sudo nsenter -t 1 -m -u -n -i"
         packages_to_remove=$($run_on_host dpkg-query -f '${Package}\n' -W | grep "^clang-.*\|^llvm-.*\|^php.*\|^mono-.*\|^mongodb-.*\
         \|^libmono-.*\|^temurin-8-jdk\|^temurin-11-jdk\|^temurin-17-jdk\|^dotnet-.*\|^google-chrome-stable\|^microsoft-edge-stable\|^google-cloud-sdk\|^firefox\|^hhvm\|^snapd")
         $run_on_host apt purge $packages_to_remove
 
+    # Due to how the RPM packaging tools work, we have to adhere to some
+    # character count requirements in the build path vs source path.
+    #
+    # Failing to do so, will break the debuginfo RPM package.
+    - name: Setup the build paths
+      id: build_paths
+      run: |
+        rel_build_path="workspace/usr/src/debug/osquery/build"
+        rel_src_path="workspace/padding-required-by-rpm-packages/src"
+        rel_ccache_path="workspace/ccache"
+        rel_package_data_path="workspace/package_data"
+        rel_packaging_path="workspace/osquery-packaging"
+        rel_package_build_path="workspace/package-build"
+
+        mkdir -p ${rel_build_path} \
+                 ${rel_src_path} \
+                 ${rel_ccache_path} \
+                 ${rel_src_path} \
+                 ${rel_package_data_path} \
+                 ${rel_package_build_path}
+
+        echo "SOURCE=$(realpath ${rel_src_path})" >> $GITHUB_OUTPUT
+        echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
+        echo "CCACHE=$(realpath ${rel_ccache_path})" >> $GITHUB_OUTPUT
+        echo "PACKAGING=$(realpath ${rel_packaging_path})" >> $GITHUB_OUTPUT
+        echo "PACKAGE_DATA=$(realpath ${rel_package_data_path})" >> $GITHUB_OUTPUT
+        echo "REL_PACKAGE_BUILD=${rel_package_build_path}" >> $GITHUB_OUTPUT
+        echo "PACKAGE_BUILD=$(realpath ${rel_package_build_path})" >> $GITHUB_OUTPUT
+
     - name: Clone the osquery repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
+      with:
+        path: ${{ steps.build_paths.outputs.SOURCE }}
+        fetch-depth: 0
 
     - name: Select the build job count
       shell: bash
@@ -318,63 +345,12 @@ jobs:
           echo "VALUE=OFF" >> $GITHUB_OUTPUT
         fi
 
-    # When we spawn in the container, we are root; create an unprivileged
-    # user now so that we can later use it to launch the normal user tests
-    - name: Create a non-root user
-      if: matrix.build_type != 'RelWithDebInfo'
-      id: unprivileged_user
-      run: |
-        useradd -m -s /bin/bash unprivileged_user
-        echo "NAME=unprivileged_user" >> $GITHUB_OUTPUT
-
-    # Due to how the RPM packaging tools work, we have to adhere to some
-    # character count requirements in the build path vs source path.
-    #
-    # Failing to do so, will break the debuginfo RPM package.
-    - name: Setup the build paths
-      id: build_paths
-      run: |
-        rel_build_path="workspace/usr/src/debug/osquery/build"
-        rel_src_path="workspace/padding-required-by-rpm-packages/src"
-        rel_ccache_path="workspace/ccache"
-        rel_package_data_path="workspace/package_data"
-        rel_packaging_path="workspace/osquery-packaging"
-        rel_package_build_path="workspace/package-build"
-
-        mkdir -p ${rel_build_path} \
-                 ${rel_src_path} \
-                 ${rel_ccache_path} \
-                 ${rel_src_path} \
-                 ${rel_package_data_path} \
-                 ${rel_package_build_path}
-
-        chown -R ${{ steps.unprivileged_user.outputs.NAME }}:${{ steps.unprivileged_user.outputs.NAME }} .
-
-        mv .git "${rel_src_path}"
-        ( cd "${rel_src_path}" && git reset --hard )
-
-        echo "SOURCE=$(realpath ${rel_src_path})" >> $GITHUB_OUTPUT
-        echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
-        echo "CCACHE=$(realpath ${rel_ccache_path})" >> $GITHUB_OUTPUT
-        echo "PACKAGING=$(realpath ${rel_packaging_path})" >> $GITHUB_OUTPUT
-        echo "PACKAGE_DATA=$(realpath ${rel_package_data_path})" >> $GITHUB_OUTPUT
-        echo "REL_PACKAGE_BUILD=${rel_package_build_path}" >> $GITHUB_OUTPUT
-        echo "PACKAGE_BUILD=$(realpath ${rel_package_build_path})" >> $GITHUB_OUTPUT
-
     - name: Clone the osquery-packaging repository
       run: |
         git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         cd ${{ steps.build_paths.outputs.PACKAGING }}
         git checkout ${{ env.PACKAGING_COMMIT }}
-
-    # One of the tests in the test suit will spawn a Docker container
-    # using this socket. Allow the unprivileged user we created
-    # to access it.
-    - name: Update the Docker socket permissions
-      if: matrix.build_type != 'RelWithDebInfo'
-      run: |
-        chmod 666 /var/run/docker.sock
 
     - name: Update the cache (ccache)
       uses: actions/cache@v3
@@ -439,7 +415,7 @@ jobs:
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
       if: matrix.build_type != 'RelWithDebInfo'
       run: |
-        sudo -u ${{ steps.unprivileged_user.outputs.NAME }} ctest --build-nocmake -LE "root-required" -V
+        ctest --build-nocmake -LE "root-required" -V
 
     - name: Run the tests as root user
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
@@ -460,14 +436,6 @@ jobs:
           --build . \
           --target install \
           -j ${{ steps.build_job_count.outputs.VALUE }}
-
-    # Since we need to run CMake to create the packages with osquery-packaging, the
-    # configuration will fail unless the C and C++ compilers are found
-    - name: Install packaging dependencies
-      if: matrix.build_type == 'RelWithDebInfo'
-      run: |
-        sudo apt update
-        sudo apt install build-essential gcc g++ -y
 
     - name: Create the packages
       if: matrix.build_type == 'RelWithDebInfo'

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -29,8 +29,8 @@ on:
 # Please remember to update values for both x86 and aarch64 workflows.
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
-  PACKAGING_COMMIT: 4caa2c54f0d893c1efa47932571046bbce156c52
-  SUBMODULE_CACHE_VERSION: 2
+  PACKAGING_COMMIT: c089fb2d3d796d976e3b2fbea7ee69a1616b9576
+  SUBMODULE_CACHE_VERSION: 3
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery
@@ -43,24 +43,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
+      image: osquery/builder20.04:7e9ee0339
+      options: --user 1001
 
     steps:
-
-    # We are using checkout@v1 because the checkout@v2 action downloads
-    # the source code without cloning if the installed git is < v2.18.
-    # Once we update the image we will also be able to select the clone
-    # destination; right now we are moving the .git folder manually.
-    - name: Clone the osquery repository
-      uses: actions/checkout@v1
-
-    # This script makes sure that the copyright headers have been correctly
-    # placed on all the source code files
-    - name: Check the copyright headers
-      run: |
-        ./tools/ci/scripts/check_copyright_headers.py
-
     - name: Setup the build paths
       shell: bash
       id: build_paths
@@ -69,10 +55,23 @@ jobs:
         rel_source_path="workspace/src"
 
         mkdir -p "${rel_build_path}"
-        ln -sf "$(pwd)" "${rel_source_path}"
+        mkdir -p "${rel_source_path}"
 
         echo "SOURCE=$(realpath ${rel_source_path})" >> $GITHUB_OUTPUT
         echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
+
+    - name: Clone the osquery repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ steps.build_paths.outputs.SOURCE }}
+        fetch-depth: 0
+
+    # This script makes sure that the copyright headers have been correctly
+    # placed on all the source code files
+    - name: Check the copyright headers
+      working-directory: ${{ steps.build_paths.outputs.SOURCE }}
+      run: |
+        ./tools/ci/scripts/check_copyright_headers.py
 
     - name: Configure the project
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
@@ -186,8 +185,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     container:
-      image: osquery/builder18.04:c7a9d706d
-      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock
+      image: osquery/builder20.04:7e9ee0339
+      options: --privileged --init -v /var/run/docker.sock:/var/run/docker.sock --pid=host --user root
 
     strategy:
       matrix:
@@ -201,8 +200,43 @@ jobs:
           cache_key: ubuntu-20.04_aarch64
 
     steps:
+    # Due to how the RPM packaging tools work, we have to adhere to some
+    # character count requirements in the build path vs source path.
+    #
+    # Failing to do so, will break the debuginfo RPM package.
+    - name: Setup the build paths
+      id: build_paths
+      run: |
+        # The group for the docker socket doesn't have gid docker
+        sudo chown root:docker /var/run/docker.sock
+
+        rel_build_path="workspace/usr/src/debug/osquery/build"
+        rel_src_path="workspace/padding-required-by-rpm-packages/src"
+        rel_ccache_path="workspace/ccache"
+        rel_package_data_path="workspace/package_data"
+        rel_packaging_path="workspace/osquery-packaging"
+        rel_package_build_path="workspace/package-build"
+
+        mkdir -p ${rel_build_path} \
+                 ${rel_src_path} \
+                 ${rel_ccache_path} \
+                 ${rel_src_path} \
+                 ${rel_package_data_path} \
+                 ${rel_package_build_path}
+
+        echo "SOURCE=$(realpath ${rel_src_path})" >> $GITHUB_OUTPUT
+        echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
+        echo "CCACHE=$(realpath ${rel_ccache_path})" >> $GITHUB_OUTPUT
+        echo "PACKAGING=$(realpath ${rel_packaging_path})" >> $GITHUB_OUTPUT
+        echo "PACKAGE_DATA=$(realpath ${rel_package_data_path})" >> $GITHUB_OUTPUT
+        echo "REL_PACKAGE_BUILD=${rel_package_build_path}" >> $GITHUB_OUTPUT
+        echo "PACKAGE_BUILD=$(realpath ${rel_package_build_path})" >> $GITHUB_OUTPUT
+
     - name: Clone the osquery repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
+      with:
+        path: ${{ steps.build_paths.outputs.SOURCE }}
+        fetch-depth: 0
 
     - name: Select the build job count
       shell: bash
@@ -240,61 +274,12 @@ jobs:
           echo "VALUE=OFF" >> $GITHUB_OUTPUT
         fi
 
-    # When we spawn in the container, we are root; create an unprivileged
-    # user now so that we can later use it to launch the normal user tests
-    - name: Create a non-root user
-      id: unprivileged_user
-      run: |
-        useradd -m -s /bin/bash unprivileged_user
-        echo "NAME=unprivileged_user" >> $GITHUB_OUTPUT
-
-    # Due to how the RPM packaging tools work, we have to adhere to some
-    # character count requirements in the build path vs source path.
-    #
-    # Failing to do so, will break the debuginfo RPM package.
-    - name: Setup the build paths
-      id: build_paths
-      run: |
-        rel_build_path="workspace/usr/src/debug/osquery/build"
-        rel_src_path="workspace/padding-required-by-rpm-packages/src"
-        rel_ccache_path="workspace/ccache"
-        rel_package_data_path="workspace/package_data"
-        rel_packaging_path="workspace/osquery-packaging"
-        rel_package_build_path="workspace/package-build"
-
-        mkdir -p ${rel_build_path} \
-                 ${rel_src_path} \
-                 ${rel_ccache_path} \
-                 ${rel_src_path} \
-                 ${rel_package_data_path} \
-                 ${rel_package_build_path}
-
-        chown -R ${{ steps.unprivileged_user.outputs.NAME }}:${{ steps.unprivileged_user.outputs.NAME }} .
-
-        mv .git "${rel_src_path}"
-        ( cd "${rel_src_path}" && git reset --hard )
-
-        echo "SOURCE=$(realpath ${rel_src_path})" >> $GITHUB_OUTPUT
-        echo "BINARY=$(realpath ${rel_build_path})" >> $GITHUB_OUTPUT
-        echo "CCACHE=$(realpath ${rel_ccache_path})" >> $GITHUB_OUTPUT
-        echo "PACKAGING=$(realpath ${rel_packaging_path})" >> $GITHUB_OUTPUT
-        echo "PACKAGE_DATA=$(realpath ${rel_package_data_path})" >> $GITHUB_OUTPUT
-        echo "REL_PACKAGE_BUILD=${rel_package_build_path}" >> $GITHUB_OUTPUT
-        echo "PACKAGE_BUILD=$(realpath ${rel_package_build_path})" >> $GITHUB_OUTPUT
-
     - name: Clone the osquery-packaging repository
       run: |
         git clone ${{ env.PACKAGING_REPO }} \
           ${{ steps.build_paths.outputs.PACKAGING }}
         cd ${{ steps.build_paths.outputs.PACKAGING }}
         git checkout ${{ env.PACKAGING_COMMIT }}
-
-    # One of the tests in the test suit will spawn a Docker container
-    # using this socket. Allow the unprivileged user we created
-    # to access it.
-    - name: Update the Docker socket permissions
-      run: |
-        chmod 666 /var/run/docker.sock
 
     - name: Update the cache (ccache)
       uses: actions/cache@v3
@@ -357,7 +342,8 @@ jobs:
     - name: Run the tests as normal user
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
       run: |
-        sudo -u ${{ steps.unprivileged_user.outputs.NAME }} ctest --build-nocmake -LE "root-required" -V
+        sudo chown -R runner:runner .
+        sudo -u runner ctest --build-nocmake -LE "root-required" -V
 
     - name: Run the tests as root user
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
@@ -382,14 +368,6 @@ jobs:
         # we are unfortunately out of space otherwise.
         find . -name "*.a" -exec rm {} \;
         find . -name "*.o" -exec rm {} \;
-
-    # Since we need to run CMake to create the packages with osquery-packaging, the
-    # configuration will fail unless the C and C++ compilers are found
-    - name: Install packaging dependencies
-      if: matrix.build_type == 'RelWithDebInfo'
-      run: |
-        sudo apt update
-        sudo apt install build-essential gcc g++ -y
 
     - name: Create the packages
       if: matrix.build_type == 'RelWithDebInfo'

--- a/tools/ci/Makefile
+++ b/tools/ci/Makefile
@@ -7,16 +7,16 @@ all:
 # instance. Thus, these targets are for building and pushing to the
 # remote, and building some test images locally.
 container:
-	docker buildx build --platform linux/amd64,linux/arm64 -f osquery-ubuntu18.04-toolchain.dockerfile .
+	docker buildx build --platform linux/amd64,linux/arm64 -f osquery-ubuntu20.04-toolchain.dockerfile .
 
 # push uses the cached builds from `container`
 push: TAG = $(shell git rev-parse --short HEAD)
 push: container
-	docker buildx build --platform linux/amd64,linux/arm64 --push -t osquery/builder18.04:$(TAG) -f osquery-ubuntu18.04-toolchain.dockerfile .
+	docker buildx build --platform linux/amd64,linux/arm64 --push -t osquery/builder20.04:$(TAG) -f osquery-ubuntu20.04-toolchain.dockerfile .
 
 # These targets use --load, which pushes to the local docker
 # install. Only a single platform is supported.
 arm:
-	docker buildx build --platform linux/arm64 --load -t osquerybuilder:$@  -f osquery-ubuntu18.04-toolchain.dockerfile .
+	docker buildx build --platform linux/arm64 --load -t osquerybuilder:$@  -f osquery-ubuntu20.04-toolchain.dockerfile .
 x86:
-	docker buildx build --platform linux/amd64 --load -t osquerybuilder:$@ -f osquery-ubuntu18.04-toolchain.dockerfile .
+	docker buildx build --platform linux/amd64 --load -t osquerybuilder:$@ -f osquery-ubuntu20.04-toolchain.dockerfile .

--- a/tools/ci/osquery-ubuntu20.04-toolchain.dockerfile
+++ b/tools/ci/osquery-ubuntu20.04-toolchain.dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04 AS ubuntubase
+FROM ubuntu:20.04 AS ubuntubase
 RUN apt update -q -y
-RUN apt upgrade -q -y
-RUN apt install -q -y --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt upgrade -q -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -q -y --no-install-recommends \
 	git \
 	make \
 	ccache \
@@ -64,6 +64,10 @@ RUN rm -rf /var/lib/apt/lists/*
 
 FROM base3 AS base4
 COPY --from=cppcheck /root/cppcheck/install/usr/local/ /usr/local/
+# Add user for the Github Actions CI
+RUN groupadd --gid 127 docker
+RUN useradd runner --uid 1001 -G docker -s /bin/bash
+RUN echo 'runner ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Squash all layers down using a giant COPY. It's kinda gross, but it
 # works. Though the layers are only adding about 50 megs on a 1gb


### PR DESCRIPTION
You can see a successful run on aarch64 here: https://github.com/osquery/osquery/actions/runs/9812533295

This fixes a problem with some actions that started using Node.js 20, which is not compatible with the Linux Docker images we are using.
It's also a base for a soon to be happening update of all our actions to the latest version, to use Node.js 20+, since the previous versions will be deprecated.