### PR TITLE
Add support for Firefox addons for snap installations

### DIFF
--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -28,11 +28,11 @@ namespace {
 
 /// Each home directory will include custom extensions. Comma separated list of paths.
 #if defined(__APPLE__)
-#define kFirefoxPaths "/Library/Application Support/Firefox/Profiles/"
+const std::vector<std::string> kFirefoxPaths = {"/Library/Application Support/Firefox/Profiles/"};
 #elif defined(__linux__)
-#define kFirefoxPaths "/.mozilla/firefox/,/snap/firefox/common/.mozilla/firefox/"
+const std::vector<std::string> kFirefoxPaths = {"/.mozilla/firefox/,/snap/firefox/common/.mozilla/firefox/"};
 #elif defined(WIN32)
-#define kFirefoxPaths "\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"
+const std::vector<std::string> kFirefoxPaths = {"\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"};
 #endif
 
 #define kFirefoxExtensionsFile "/extensions.json"
@@ -184,10 +184,8 @@ QueryData genFirefoxAddons(QueryContext& context) {
   for (const auto& row : users) {
     if (row.count("uid") > 0 && row.count("directory") > 0) {
       // For each user, enumerate all of their Firefox profiles in each path.
-      std::istringstream paths_stream(kFirefoxPaths);
-      std::string path;
       std::vector<std::string> profiles;
-      while (std::getline(paths_stream, path, ',')) {
+      for (const auto& path : kFirefoxPaths) {
         auto directory = fs::path(row.at("directory")) / path;
         if (!listDirectoriesInDirectory(directory, profiles).ok()) {
           continue;

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -26,7 +26,7 @@ namespace tables {
 
 namespace {
 
-/// Each home directory will include custom extensions. Comma separated list of paths.
+/// Each home directory will include custom extensions.
 #if defined(__APPLE__)
 const std::vector<std::string> kFirefoxPaths = {"/Library/Application Support/Firefox/Profiles/"};
 #elif defined(__linux__)

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -28,11 +28,14 @@ namespace {
 
 /// Each home directory will include custom extensions.
 #if defined(__APPLE__)
-const std::vector<std::string> kFirefoxPaths = {"/Library/Application Support/Firefox/Profiles/"};
+const std::vector<std::string> kFirefoxPaths = {
+    "/Library/Application Support/Firefox/Profiles/"};
 #elif defined(__linux__)
-const std::vector<std::string> kFirefoxPaths = {"/.mozilla/firefox/", "/snap/firefox/common/.mozilla/firefox/"};
+const std::vector<std::string> kFirefoxPaths = {
+    "/.mozilla/firefox/", "/snap/firefox/common/.mozilla/firefox/"};
 #elif defined(WIN32)
-const std::vector<std::string> kFirefoxPaths = {"\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"};
+const std::vector<std::string> kFirefoxPaths = {
+    "\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"};
 #endif
 
 #define kFirefoxExtensionsFile "/extensions.json"

--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -30,7 +30,7 @@ namespace {
 #if defined(__APPLE__)
 const std::vector<std::string> kFirefoxPaths = {"/Library/Application Support/Firefox/Profiles/"};
 #elif defined(__linux__)
-const std::vector<std::string> kFirefoxPaths = {"/.mozilla/firefox/,/snap/firefox/common/.mozilla/firefox/"};
+const std::vector<std::string> kFirefoxPaths = {"/.mozilla/firefox/", "/snap/firefox/common/.mozilla/firefox/"};
 #elif defined(WIN32)
 const std::vector<std::string> kFirefoxPaths = {"\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"};
 #endif


### PR DESCRIPTION
`osquery` doesn't list my Firefox addons and I suspect that's because Ubuntu installs it via snap. This PR should add support for Firefox installations installed via snap.


To submit a PR please make sure to follow the next steps:

- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.