### PR TITLE
Revert #8352 (darwin alf plist path change)

### DIFF
--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -25,9 +25,7 @@ namespace tables {
  * This plist contains all of the details about the ALF.
  * It is used to populate all of the tables here.
  */
-const std::vector<std::string> kALFPlistPaths{
-    "/Library/Preferences/com.apple.alf.plist",
-    "/usr/libexec/ApplicationFirewall/com.apple.alf.plist"};
+const std::string kALFPlistPath{"/Library/Preferences/com.apple.alf.plist"};
 
 /// Well known keys within the plist containing settings.
 const std::map<std::string, std::string> kTopLevelIntKeys{
@@ -46,17 +44,10 @@ const std::map<std::string, std::string> kTopLevelStringKeys{
 };
 
 Status genALFTreeFromFilesystem(pt::ptree& tree) {
-  Status s;
-
-  for (const auto& path : kALFPlistPaths) {
-    s = osquery::parsePlist(path, tree);
-    if (s.ok()) {
-      break;
-    }
-
-    TLOG << "Error parsing " << path << ": " << s.toString();
+  Status s = osquery::parsePlist(kALFPlistPath, tree);
+  if (!s.ok()) {
+    TLOG << "Error parsing " << kALFPlistPath << ": " << s.toString();
   }
-
   return s;
 }
 

--- a/osquery/tables/system/darwin/firewall.h
+++ b/osquery/tables/system/darwin/firewall.h
@@ -34,8 +34,8 @@ osquery::QueryData parseALFExplicitAuthsTree(const pt::ptree& tree);
 // parseALFTree parses out the top level string and int keys
 osquery::QueryData parseALFTree(const pt::ptree& tree);
 
-// kALFPlistPaths are the possible paths of the com.apple.alf.plist path
-extern const std::vector<std::string> kALFPlistPaths;
+// kALFPlistPath is the path of the com.apple.alf.plist path
+extern const std::string kALFPlistPath;
 
 // kTopLevelIntKeys is a map of keys and columns which are used while parsing
 // in the function parseALFTree

--- a/osquery/tables/system/tests/darwin/firewall_tests.cpp
+++ b/osquery/tables/system/tests/darwin/firewall_tests.cpp
@@ -114,15 +114,7 @@ TEST_F(FirewallTests, test_errors) {
 
 TEST_F(FirewallTests, test_on_disk_format) {
   pt::ptree tree;
-  Status s;
-
-  for (const auto& path : kALFPlistPaths) {
-    s = osquery::parsePlist(path, tree);
-    if (s.ok()) {
-      break;
-    }
-  }
-
+  auto s = osquery::parsePlist(kALFPlistPath, tree);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   for (const auto& it : kTopLevelIntKeys) {


### PR DESCRIPTION
With Beta 3 of macOS 15 there's been confirmation in Apples release notes that "Application Firewall settings are no longer contained in a property list.".

Instead, Apple says to use the command line tool `socketfilterfw`. The previous PR for the alf plist path change will not work and may result in false data being returned.

While this PR doesn't solve the issue, it'll revert the possibility of false data from the `libexec` plist. I'm responsible for not catching this in #8352, as my `libexec` plist mirrored my settings at the time and I didn't validate the solution enough.