### PR TITLE
build: Correct xz submodule url and openssl download url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/arangodb/linenoise-ng
 [submodule "libraries/cmake/source/lzma/src"]
 	path = libraries/cmake/source/lzma/src
-	url = https://git.tukaani.org/xz.git
+	url = https://github.com/tukaani-project/xz
 [submodule "libraries/cmake/source/rapidjson/src"]
 	path = libraries/cmake/source/rapidjson/src
 	url = https://github.com/Tencent/rapidjson

--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -187,12 +187,9 @@ function(opensslMain)
   list(APPEND openssl_c_flags ${OSQUERY_FORMULA_CFLAGS})
   string(REPLACE ";" " " openssl_c_flags "${openssl_c_flags}")
 
-  string(REGEX MATCH "[0-9]\.[0-9]\.[0-9]" OPENSSL_VERSION_NO_PATCH "${OPENSSL_VERSION}")
-
   if("${OSQUERY_OPENSSL_ARCHIVE_PATH}" STREQUAL "")
     set(openssl_urls
-      "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
-      "https://www.openssl.org/source/old/${OPENSSL_VERSION_NO_PATCH}/openssl-${OPENSSL_VERSION}.tar.gz"
+      "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
     )
   else()
     if(NOT EXISTS "${OSQUERY_OPENSSL_ARCHIVE_PATH}" OR IS_DIRECTORY "${OSQUERY_OPENSSL_ARCHIVE_PATH}")


### PR DESCRIPTION
- Upstream xz has disabled cloning from their own repo.
   Go back to the Github repository instead,
   they have been reinstated a while ago.

- Openssl has updated their website and their downloads moved
   totally on Github too. Update the url.

Fixes #8382 