### PR TITLE
Fix linux `groups` table to handle larger group sets by increasing buffer size

### DIFF
--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -31,10 +31,7 @@ QueryData genGroupsImpl(QueryContext& context, Logger& logger) {
   struct group* grp_result{nullptr};
   struct group grp;
 
-  size_t bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
-  if (bufsize > 16384) { /* Value was indeterminate */
-    bufsize = 16384; /* Should be more than enough */
-  }
+  size_t bufsize = 16384;
   auto buf = std::make_unique<char[]>(bufsize);
   if (context.constraints["gid"].exists(EQUALS)) {
     auto gids = context.constraints["gid"].getAll<long long>(EQUALS);


### PR DESCRIPTION
This PR 
- sets initial buffer size as 16KB
- bumps buffer size when exceeded

Fixes https://github.com/osquery/osquery/issues/8356

<!-- Thank you for contributing to osquery! -->

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
