### PR TITLE
Rename `hvci_status` to `deviceguard_status` to better reflect the data collected.

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -232,7 +232,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/wmi_event_filters.cpp
       windows/wmi_filter_consumer_binding.cpp
       windows/wmi_script_event_consumers.cpp
-      windows/hvci_status.cpp
+      windows/deviceguard_status.cpp
       windows/tpm_info.cpp
       windows/prefetch.cpp
     )

--- a/osquery/tables/system/windows/deviceguard_status.cpp
+++ b/osquery/tables/system/windows/deviceguard_status.cpp
@@ -16,7 +16,7 @@
 namespace osquery {
 namespace tables {
 
-QueryData genHVCIStatus(QueryContext& context) {
+QueryData genDeviceGuardStatus(QueryContext& context) {
   QueryData results;
 
   std::vector<std::string> vbs_methods = {"VBS_NOT_ENABLED",
@@ -42,18 +42,18 @@ QueryData genHVCIStatus(QueryContext& context) {
     long vbs_status;
     data.GetLong("VirtualizationBasedSecurityStatus", vbs_status);
     r["vbs_status"] =
-        vbs_methods.size() < vbs_status ? vbs_methods[vbs_status] : "UNKNOWN";
+        vbs_methods.size() > vbs_status ? vbs_methods[vbs_status] : "UNKNOWN";
 
     long code_policy_status;
     data.GetLong("CodeIntegrityPolicyEnforcementStatus", code_policy_status);
     r["code_integrity_policy_enforcement_status"] =
-        enforcement_methods.size() < code_policy_status
+        enforcement_methods.size() > code_policy_status
             ? enforcement_methods[vbs_status]
             : "UNKNOWN";
 
     long umci_status;
     data.GetLong("UsermodeCodeIntegrityPolicyEnforcementStatus", umci_status);
-    r["umci_policy_status"] = enforcement_methods.size() < umci_status
+    r["umci_policy_status"] = enforcement_methods.size() > umci_status
                                   ? enforcement_methods[umci_status]
                                   : "UNKNOWN";
 

--- a/osquery/tables/system/windows/deviceguard_status.cpp
+++ b/osquery/tables/system/windows/deviceguard_status.cpp
@@ -48,7 +48,7 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
     data.GetLong("CodeIntegrityPolicyEnforcementStatus", code_policy_status);
     r["code_integrity_policy_enforcement_status"] =
         enforcement_methods.size() > code_policy_status
-            ? enforcement_methods[vbs_status]
+            ? enforcement_methods[code_policy_status]
             : "UNKNOWN";
 
     long umci_status;

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -299,7 +299,7 @@ function(generateNativeTables)
     "windows/windows_firewall_rules.table:windows"
     "windows/userassist.table:windows"
     "windows/dns_cache.table:windows"
-    "windows/hvci_status.table:windows"
+    "windows/deviceguard_status.table:windows"
     "windows/shimcache.table:windows"
     "windows/shellbags.table:windows"
     "windows/prefetch.table:windows"

--- a/specs/windows/deviceguard_status.table
+++ b/specs/windows/deviceguard_status.table
@@ -1,4 +1,4 @@
-table_name("deviceguard_status")
+table_name("deviceguard_status", aliases=["hvci_status"])
 description("Retrieve DeviceGuard info of the machine.")
 schema([
   Column("version", TEXT, "The version number of the Device Guard build.", collate="version"),

--- a/specs/windows/deviceguard_status.table
+++ b/specs/windows/deviceguard_status.table
@@ -1,5 +1,5 @@
-table_name("hvci_status")
-description("Retrieve HVCI info of the machine.")
+table_name("deviceguard_status")
+description("Retrieve DeviceGuard info of the machine.")
 schema([
   Column("version", TEXT, "The version number of the Device Guard build.", collate="version"),
   Column("instance_identifier", TEXT, "The instance ID of Device Guard."),
@@ -7,4 +7,4 @@ schema([
   Column("code_integrity_policy_enforcement_status", TEXT, "The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered."),
   Column("umci_policy_status", TEXT, "The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered."), 
 ])
-implementation("system/windows/hvci_status@genHVCIStatus")
+implementation("system/windows/deviceguard_status@genDeviceGuardStatus")

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -334,7 +334,7 @@ function(generateTestsIntegrationTablesTestsTest)
       wmi_event_filters.cpp
       wmi_filter_consumer_binding.cpp
       wmi_script_event_consumers.cpp
-      hvci_status.cpp
+      deviceguard_status.cpp
       yara.cpp
       tpm_info.cpp
       security_profile_info.cpp

--- a/tests/integration/tables/deviceguard_status.cpp
+++ b/tests/integration/tables/deviceguard_status.cpp
@@ -7,23 +7,23 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-// Integration test for hvci_status
-// Spec file: specs/windows/hvci_status.table
+// Integration test for deviceguard_status
+// Spec file: specs/windows/deviceguard_status.table
 
 #include <osquery/tests/integration/tables/helper.h>
 
 namespace osquery {
 namespace table_tests {
 
-class HVCIStatus : public testing::Test {
+class DeviceGuardStatus : public testing::Test {
  protected:
   void SetUp() override {
     setUpEnvironment();
   }
 };
 
-TEST_F(HVCIStatus, test_sanity) {
-  QueryData data = execute_query("select * from hvci_status");
+TEST_F(DeviceGuardStatus, test_sanity) {
+  QueryData data = execute_query("select * from deviceguard_status");
 
   ASSERT_GE(data.size(), 1ul);
 


### PR DESCRIPTION
Also fix incorrect comparison causing status data to always return `UNKNOWN`.