### PR TITLE
Use non-throw version of `fs::recursive_directory_iterator`

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -431,14 +431,23 @@ Status listFilesInDirectory(const fs::path& path,
 Status listDirectoriesInDirectory(const fs::path& path,
                                   std::vector<std::string>& results,
                                   bool recursive) {
-  if (path.empty() || !pathExists(path)) {
+  // We don't really need the error, but by passing it into
+  // recursive_directory_iterator we invoked the non-throw version.
+  boost::system::error_code ignored_ec;
+
+  if (path.empty() || !pathExists(path) ||
+      !fs::is_directory(path, ignored_ec)) {
     return Status(1, "Target directory is invalid");
   }
 
   if (recursive) {
-    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+    for (fs::recursive_directory_iterator entry(
+             path, fs::directory_options::skip_permission_denied, ignored_ec),
+         end;
+         entry != end;
+         entry.increment(ec)) {
       // Exclude symlinks that do not point at directories
-      if (fs::is_symlink(entry)) {
+      if (fs::is_symlink(entry, ignored_ec)) {
         boost::system::error_code ec;
         auto canonical = fs::canonical(entry, ec);
         if (ec.value() != errc::success) {
@@ -451,13 +460,17 @@ Status listDirectoriesInDirectory(const fs::path& path,
           continue;
         }
         results.push_back(entry.path().string());
-      } else if (fs::is_directory(entry)) {
+      } else if (fs::is_directory(entry, ignored_ec)) {
         results.push_back(entry.path().string());
       }
     }
   } else {
-    for (const auto& entry : fs::directory_iterator(path)) {
-      if (fs::is_symlink(entry)) {
+    for (fs::directory_iterator entry(
+             path, fs::directory_options::skip_permission_denied, ignored_ec),
+         end;
+         entry != end;
+         entry.increment(ec)) {
+      if (fs::is_symlink(entry, ignored_ec)) {
         boost::system::error_code ec;
         auto canonical = fs::canonical(entry, ec);
         if (ec.value() != errc::success) {
@@ -470,7 +483,7 @@ Status listDirectoriesInDirectory(const fs::path& path,
           continue;
         }
         results.push_back(entry.path().string());
-      } else if (fs::is_directory(entry)) {
+      } else if (fs::is_directory(entry, ignored_ec)) {
         results.push_back(entry.path().string());
       }
     }
@@ -486,8 +499,8 @@ Status isDirectory(const fs::path& path) {
   }
 
   // The success error code is returned for as a failure (undefined error)
-  // We need to flip that into an error, a success would have falling through
-  // in the above conditional.
+  // We need to flip that into an error, a success would have falling
+  // through in the above conditional.
   if (ec.value() == errc::success) {
     return Status(1, "Path is not a directory: " + path.string());
   }
@@ -549,8 +562,8 @@ bool safePermissions(const fs::path& dir,
 
   Status result = platformIsTmpDir(dir);
   if (!result.ok() && result.getCode() < 0) {
-    // An error has occurred in stat() on dir, most likely because the file path
-    // does not exist
+    // An error has occurred in stat() on dir, most likely because the file
+    // path does not exist
     return false;
   } else if (result.ok()) {
     // Do not load modules from /tmp-like directories.

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -445,11 +445,11 @@ Status listDirectoriesInDirectory(const fs::path& path,
              path, fs::directory_options::skip_permission_denied, ignored_ec),
          end;
          entry != end;
-         entry.increment(ec)) {
+         entry.increment(ignored_ec)) {
       // Exclude symlinks that do not point at directories
-      if (fs::is_symlink(entry, ignored_ec)) {
+      if (fs::is_symlink(entry->path(), ignored_ec)) {
         boost::system::error_code ec;
-        auto canonical = fs::canonical(entry, ec);
+        auto canonical = fs::canonical(entry->path(), ec);
         if (ec.value() != errc::success) {
           // The symlink is broken or points to a non-existent file.
           continue;
@@ -459,9 +459,9 @@ Status listDirectoriesInDirectory(const fs::path& path,
           // The symlink is not a directory.
           continue;
         }
-        results.push_back(entry.path().string());
-      } else if (fs::is_directory(entry, ignored_ec)) {
-        results.push_back(entry.path().string());
+        results.push_back(entry->path().string());
+      } else if (fs::is_directory(entry->path(), ignored_ec)) {
+        results.push_back(entry->path().string());
       }
     }
   } else {
@@ -469,10 +469,10 @@ Status listDirectoriesInDirectory(const fs::path& path,
              path, fs::directory_options::skip_permission_denied, ignored_ec),
          end;
          entry != end;
-         entry.increment(ec)) {
-      if (fs::is_symlink(entry, ignored_ec)) {
+         entry.increment(ignored_ec)) {
+      if (fs::is_symlink(entry->path(), ignored_ec)) {
         boost::system::error_code ec;
-        auto canonical = fs::canonical(entry, ec);
+        auto canonical = fs::canonical(entry->path(), ec);
         if (ec.value() != errc::success) {
           // The symlink is broken or points to a non-existent file.
           continue;
@@ -482,9 +482,9 @@ Status listDirectoriesInDirectory(const fs::path& path,
           // The symlink is not a directory.
           continue;
         }
-        results.push_back(entry.path().string());
-      } else if (fs::is_directory(entry, ignored_ec)) {
-        results.push_back(entry.path().string());
+        results.push_back(entry->path().string());
+      } else if (fs::is_directory(entry->path(), ignored_ec)) {
+        results.push_back(entry->path().string());
       }
     }
   }


### PR DESCRIPTION
Fixes #8391

Modifies the `recursive_directory_iterator` to the non throwing form

~Looking at our code, I notice that we call `fs::recursive_directory_iterator` in two places. One has a try/catch, one does not. The internet suggests some versions of boost have a bug that causes is_symlink to raise if there's no permissions. They reference https://svn.boost.org/trac/boost/ticket/4494 which doesn't exist any more~

