### PR TITLE
Fix for `windows_crashes` missing information on user mode memory dumps

### DIFF
--- a/osquery/tables/system/windows/windows_crashes.cpp
+++ b/osquery/tables/system/windows/windows_crashes.cpp
@@ -615,40 +615,53 @@ void processDebugEngine(const std::string& fileName, Row& r) {
 QueryData genCrashLogs(QueryContext& context) {
   const std::string kDumpFileExtension = ".dmp";
   QueryData results;
-  std::string dumpFolderLocation{""};
+  std::string userModeDumpFolderLocation{""};
+  std::vector<std::string> dumpFolderLocations;
 
   // Query registry for crash dump folder
-  std::string dumpFolderQuery =
+  std::string userModeDumpFolderQuery =
       "SELECT data FROM registry WHERE path = \"" + kLocalDumpsRegKey + "\"";
-  SQL dumpFolderResults(dumpFolderQuery);
-  if (!dumpFolderResults.rows().empty()) {
-    dumpFolderLocation = dumpFolderResults.rows()[0].at("data");
-  } else {
-    auto tempDumpLoc = getEnvVar("TMP");
-    dumpFolderLocation = tempDumpLoc.is_initialized() ? *tempDumpLoc : "";
+
+  SQL userModeDumpFolderResults(userModeDumpFolderQuery);
+  if (!userModeDumpFolderResults.rows().empty()) {
+    dumpFolderLocations.push_back(
+        userModeDumpFolderResults.rows()[0].at("data"));
   }
 
-  if (const auto expandedPath = expandEnvString(dumpFolderLocation)) {
-    dumpFolderLocation = *expandedPath;
+  auto tempDumpLoc = getEnvVar("LOCALAPPDATA");
+  userModeDumpFolderLocation = tempDumpLoc.is_initialized() ? *tempDumpLoc : "";
+
+  if (!userModeDumpFolderLocation.empty()) {
+    const std::string crashDumpFolder = "CrashDumps";
+    userModeDumpFolderLocation += "\\";
+    userModeDumpFolderLocation += crashDumpFolder;
+    dumpFolderLocations.push_back(userModeDumpFolderLocation);
   }
 
-  if (!fs::exists(dumpFolderLocation) ||
-      !fs::is_directory(dumpFolderLocation)) {
-    VLOG(1) << "No crash dump directory found";
-    return results;
-  }
+  // Process each potential dump folder
+  for (auto& dumpFolderLocation : dumpFolderLocations) {
+    if (const auto expandedPath = expandEnvString(dumpFolderLocation)) {
+      dumpFolderLocation = *expandedPath;
+    }
 
-  // Enumerate and process crash dumps
-  std::vector<std::string> files;
-  if (listFilesInDirectory(dumpFolderLocation, files)) {
-    for (const auto& lf : files) {
-      if (alg::iends_with(lf, kDumpFileExtension) && fs::is_regular_file(lf)) {
-        Row r;
-        processDebugEngine(lf, r);
-        if (!r.empty()) {
-          results.push_back(r);
+    if (fs::exists(dumpFolderLocation) &&
+        fs::is_directory(dumpFolderLocation)) {
+      std::vector<std::string> files;
+      if (listFilesInDirectory(dumpFolderLocation, files)) {
+        for (const auto& lf : files) {
+          if (alg::iends_with(lf, kDumpFileExtension) &&
+              fs::is_regular_file(lf)) {
+            Row r;
+            processDebugEngine(lf, r);
+            if (!r.empty()) {
+              results.push_back(r);
+            }
+          }
         }
       }
+    } else {
+      VLOG(1) << "Dump folder not found or not a directory: "
+              << dumpFolderLocation;
     }
   }
 


### PR DESCRIPTION
Fixes #8381 

**Issue:** 
Fix for an issue in the 'windows_crashes' table that prevents displaying information related to user mode memory dumps.

**Root Cause:**

1. To display information related to user mode crash dumps, the user has to configure the following on the system, if not done, then no crash dumps are created for user mode application crashes.  The below link has the detailed information, so it could be possible the user has not configured this on end user systems and hence no data related to crash dumps are displayed.
https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps

 2. The default location for user mode crash dumps if the user has not configured the step (1) as mentioned above is 
 **C:\Users\<username>\AppData\Local\CrashDumps** , which can be accessed  using the **%LOCALAPPDATA%** environment variable
 
 The current implementation in windows_crashes.cpp (https://github.com/osquery/osquery/blob/master/osquery/tables/system/windows/windows_crashes.cpp)
fist checks the item (1) mentioned above and if that condition fails then it checks the item(2) , here the code is looking for user mode crash dumps in the %TMP% folder which in my opinion is not correct, the location should %LOCALAPPDATA%\CrashDumps

3. Moreover the application should try to aggregate all possible user mode crash dumps paths, instead of looking into one specific location and if that check fails, it will start searching in other location, when the objective is to display information about crash dumps, then it should also look into other locations and aggregate all found paths for a comprehensive data collection.

 
 **What changed:**
The default path where the user mode memory dumps are stored is changed from **%TMP%** folder path  to %LOCALAPPDATA%\CrashDumps and a vector of file paths is created so that it can aggregate all possible locations where user mode memory dumps can be found. 

**Tests:**
All Unit test cases passed and query to fetch the user mode memory dumps worked post the fix. 
