### PR TITLE
Include VSCode Insiders extensions in vscode_extensions table

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -25,7 +25,7 @@ namespace tables {
 
 void genReadJSONAndAddExtensionRows(const std::string& uid,
                                     const std::string& path,
-                                    const std::string& version_type,
+                                    const std::string& vscode_edition,
                                     QueryData& results) {
   if (!pathExists(path).ok()) {
     return;
@@ -60,7 +60,7 @@ void genReadJSONAndAddExtensionRows(const std::string& uid,
 
     Row r;
     r["uid"] = uid;
-    r["version_type"] = version_type;
+    r["vscode_edition"] = vscode_edition;
 
     rapidjson::Value::ConstMemberIterator it = identifier.FindMember("id");
     if (it != identifier.MemberEnd() && it->value.IsString()) {
@@ -109,11 +109,11 @@ void genReadJSONAndAddExtensionRows(const std::string& uid,
 struct ConfDir {
   std::string uid;
   fs::path path;
-  std::string version_type;
+  std::string vscode_edition;
 
   bool operator<(const ConfDir& other) const {
-    return std::tie(uid, path, version_type) <
-           std::tie(other.uid, other.path, other.version_type);
+    return std::tie(uid, path, vscode_edition) <
+           std::tie(other.uid, other.path, other.vscode_edition);
   }
 };
 
@@ -148,7 +148,7 @@ QueryData genVSCodeExtensions(QueryContext& context) {
   for (const auto& conf_dir : conf_dirs) {
     auto path = conf_dir.path / "extensions" / "extensions.json";
     genReadJSONAndAddExtensionRows(
-        conf_dir.uid, path.string(), conf_dir.version_type, results);
+        conf_dir.uid, path.string(), conf_dir.vscode_edition, results);
   }
 
   return results;

--- a/specs/vscode_extensions.table
+++ b/specs/vscode_extensions.table
@@ -11,7 +11,7 @@ schema([
     Column("prerelease", INTEGER, "Pre release version"),
     Column("uid", BIGINT, "The local user that owns the plugin",
       additional=True),
-    Column("version_type", TEXT, "VSCode or VSCode Insiders")
+    Column("vscode_edition", TEXT, "VSCode or VSCode Insiders")
 ])
 attributes(user_data=True)
 implementation("applications/vscode_extensions@genVSCodeExtensions")

--- a/specs/vscode_extensions.table
+++ b/specs/vscode_extensions.table
@@ -11,6 +11,7 @@ schema([
     Column("prerelease", INTEGER, "Pre release version"),
     Column("uid", BIGINT, "The local user that owns the plugin",
       additional=True),
+    Column("version_type", TEXT, "VSCode or VSCode Insiders")
 ])
 attributes(user_data=True)
 implementation("applications/vscode_extensions@genVSCodeExtensions")

--- a/tests/integration/tables/vscode_extensions.cpp
+++ b/tests/integration/tables/vscode_extensions.cpp
@@ -57,7 +57,7 @@ TEST_F(vscodeExtensions, test_sanity) {
       {"installed_at", NonNegativeInt},
       {"prerelease", Bool | EmptyOk},
       {"uid", NonNegativeInt},
-      {"version_type", NormalType},
+      {"vscode_edition", NormalType},
   };
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/vscode_extensions.cpp
+++ b/tests/integration/tables/vscode_extensions.cpp
@@ -57,6 +57,7 @@ TEST_F(vscodeExtensions, test_sanity) {
       {"installed_at", NonNegativeInt},
       {"prerelease", Bool | EmptyOk},
       {"uid", NonNegativeInt},
+      {"version_type", NormalType},
   };
   validate_rows(data, row_map);
 }


### PR DESCRIPTION
# Include VSCode Insiders extensions in vscode_extensions table

## Background

As per this issue -> https://github.com/osquery/osquery/issues/8350 <- this PR introduces VSCode insiders extensions in the `vscode_extensions` table.

## Changes

This changes:

- `osquery/tables/applications/vscode_extensions.cpp` - Add path for `.vscode-server-insiders` and `.vscode-insiders` `/extensions/extensions.json` files, and also adds a new column named `version_type` to differentiate between `vscode` or `vscode_insiders`.
- Also updates `specs/vscode_extensions.table` and `tests/integration/tables/vscode_extensions.cpp` to include the new column.