### PR TITLE
`listDirectoriesInDirectory` fix -- check if symlinks point to directories

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -435,9 +435,11 @@ Status listDirectoriesInDirectory(const fs::path& path,
     return Status(1, "Target directory is invalid");
   }
 
+  boost::system::error_code ec;
   if (recursive) {
     for (const auto& entry : fs::recursive_directory_iterator(path)) {
-      if (fs::is_symlink(entry)) {
+      // Exclude symlinks that do not point at directories
+      if (fs::is_symlink(entry) && fs::is_directory(fs::canonical(entry, ec))) {
         results.push_back(entry.path().string());
       } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());
@@ -445,7 +447,7 @@ Status listDirectoriesInDirectory(const fs::path& path,
     }
   } else {
     for (const auto& entry : fs::directory_iterator(path)) {
-      if (fs::is_symlink(entry)) {
+      if (fs::is_symlink(entry) && fs::is_directory(fs::canonical(entry, ec))) {
         results.push_back(entry.path().string());
       } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -435,11 +435,21 @@ Status listDirectoriesInDirectory(const fs::path& path,
     return Status(1, "Target directory is invalid");
   }
 
-  boost::system::error_code ec;
   if (recursive) {
     for (const auto& entry : fs::recursive_directory_iterator(path)) {
       // Exclude symlinks that do not point at directories
-      if (fs::is_symlink(entry) && fs::is_directory(fs::canonical(entry, ec))) {
+      if (fs::is_symlink(entry)) {
+        boost::system::error_code ec;
+        auto canonical = fs::canonical(entry, ec);
+        if (ec.value() != errc::success) {
+          // The symlink is broken or points to a non-existent file.
+          continue;
+        }
+        auto is_dir = fs::is_directory(canonical, ec);
+        if (ec.value() != errc::success || !is_dir) {
+          // The symlink is not a directory.
+          continue;
+        }
         results.push_back(entry.path().string());
       } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());
@@ -447,7 +457,18 @@ Status listDirectoriesInDirectory(const fs::path& path,
     }
   } else {
     for (const auto& entry : fs::directory_iterator(path)) {
-      if (fs::is_symlink(entry) && fs::is_directory(fs::canonical(entry, ec))) {
+      if (fs::is_symlink(entry)) {
+        boost::system::error_code ec;
+        auto canonical = fs::canonical(entry, ec);
+        if (ec.value() != errc::success) {
+          // The symlink is broken or points to a non-existent file.
+          continue;
+        }
+        auto is_dir = fs::is_directory(canonical, ec);
+        if (ec.value() != errc::success || !is_dir) {
+          // The symlink is not a directory.
+          continue;
+        }
         results.push_back(entry.path().string());
       } else if (fs::is_directory(entry)) {
         results.push_back(entry.path().string());

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -985,7 +985,8 @@ TEST_F(FilesystemTests, test_directory_listing_with_bad_symlinks) {
 
   // Create symlink that points to non-existent file.
   try {
-    fs::create_symlink(test_root_dir / "not_exists.txt", test_root_dir / "link2");
+    fs::create_symlink(test_root_dir / "not_exists.txt",
+                       test_root_dir / "link2");
   } catch (const fs::filesystem_error& e) {
     FAIL() << "Error creating symlink: " << e.what();
   }

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -965,7 +965,11 @@ TEST_F(FilesystemTests, test_directory_listing_with_file_symlink) {
   std::vector<std::string> found_directories;
   ASSERT_TRUE(
       listDirectoriesInDirectory(test_root_dir, found_directories, false));
+  ASSERT_TRUE(found_directories.empty());
 
+  // Test with recursive=true
+  ASSERT_TRUE(
+      listDirectoriesInDirectory(test_root_dir, found_directories, true));
   ASSERT_TRUE(found_directories.empty());
 
   deleteDirectoryContent(test_root_dir);
@@ -994,7 +998,11 @@ TEST_F(FilesystemTests, test_directory_listing_with_bad_symlinks) {
   std::vector<std::string> found_directories;
   ASSERT_TRUE(
       listDirectoriesInDirectory(test_root_dir, found_directories, false));
+  ASSERT_TRUE(found_directories.empty());
 
+  // Test with recursive=true
+  ASSERT_TRUE(
+      listDirectoriesInDirectory(test_root_dir, found_directories, true));
   ASSERT_TRUE(found_directories.empty());
 
   deleteDirectoryContent(test_root_dir);

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -874,8 +874,6 @@ TEST_F(FilesystemTests, test_directory_listing_with_recursive_junction) {
   // This test verifies that a recursive directory junction can be handled by
   // listDirectoriesInDirectory logic
 
-  const unsigned int EXPECTED_NR_OF_DIRECTORIES = 1;
-
   const fs::path test_root_raw = fs::temp_directory_path() / genRandomName();
   ASSERT_TRUE(fs::create_directory(test_root_raw));
   const fs::path junction_dir = test_root_raw / genRandomName();
@@ -892,9 +890,7 @@ TEST_F(FilesystemTests, test_directory_listing_with_recursive_junction) {
   std::vector<std::string> found_directories;
   ASSERT_TRUE(
       listDirectoriesInDirectory(test_root_raw, found_directories, false));
-  ASSERT_TRUE(!found_directories.empty());
-
-  ASSERT_TRUE(found_directories.size() == EXPECTED_NR_OF_DIRECTORIES);
+  ASSERT_TRUE(found_directories.empty());
 
   deleteDirectoryContent(test_root_raw);
 }
@@ -949,6 +945,58 @@ TEST_F(FilesystemTests, test_directory_listing_with_legacy_logic) {
 
   deleteDirectoryContent(test_root_raw_dirs);
   deleteDirectoryContent(test_root_work_dirs);
+}
+
+TEST_F(FilesystemTests, test_directory_listing_with_file_symlink) {
+  // This test verifies that a file symlink is not mistaken for a directory.
+  const fs::path test_root_dir = fs::temp_directory_path() / genRandomName();
+  ASSERT_TRUE(fs::create_directory(test_root_dir));
+
+  fs::ofstream test_file(test_root_dir / "test_file.txt");
+  test_file.close();
+
+  // Create symlink
+  try {
+    fs::create_symlink(test_root_dir / "test_file.txt", test_root_dir / "link");
+  } catch (const fs::filesystem_error& e) {
+    FAIL() << "Error creating symlink: " << e.what();
+  }
+
+  std::vector<std::string> found_directories;
+  ASSERT_TRUE(
+      listDirectoriesInDirectory(test_root_dir, found_directories, false));
+
+  ASSERT_TRUE(found_directories.empty());
+
+  deleteDirectoryContent(test_root_dir);
+}
+
+TEST_F(FilesystemTests, test_directory_listing_with_bad_symlinks) {
+  // This test verifies that bad symlinks are not mistaken for a directory.
+  const fs::path test_root_dir = fs::temp_directory_path() / genRandomName();
+  ASSERT_TRUE(fs::create_directory(test_root_dir));
+
+  // Create symlink that points to itself.
+  try {
+    fs::create_symlink(test_root_dir / "link", test_root_dir / "link");
+  } catch (const fs::filesystem_error& e) {
+    FAIL() << "Error creating symlink: " << e.what();
+  }
+
+  // Create symlink that points to non-existent file.
+  try {
+    fs::create_symlink(test_root_dir / "not_exists.txt", test_root_dir / "link2");
+  } catch (const fs::filesystem_error& e) {
+    FAIL() << "Error creating symlink: " << e.what();
+  }
+
+  std::vector<std::string> found_directories;
+  ASSERT_TRUE(
+      listDirectoriesInDirectory(test_root_dir, found_directories, false));
+
+  ASSERT_TRUE(found_directories.empty());
+
+  deleteDirectoryContent(test_root_dir);
 }
 
 } // namespace osquery


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/8354: inotify treats symlinks to individual files as directories.

Demo video of the fix: https://www.loom.com/share/c7044edec1ff47158fd93f49a1b0af63

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
