### PR TITLE
Add missing includes causing compilation error with Clang 18.1.8

### DIFF
--- a/osquery/core/core.h
+++ b/osquery/core/core.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <osquery/utils/macros/macros.h>

--- a/osquery/core/shutdown.cpp
+++ b/osquery/core/shutdown.cpp
@@ -11,6 +11,7 @@
 #include <osquery/logger/data_logger.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
 #include <string>
 

--- a/osquery/core/sql/query_data.cpp
+++ b/osquery/core/sql/query_data.cpp
@@ -9,6 +9,8 @@
 
 #include "query_data.h"
 
+#include <algorithm>
+
 namespace rj = rapidjson;
 
 namespace osquery {

--- a/osquery/core/sql/scheduled_query.h
+++ b/osquery/core/sql/scheduled_query.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <boost/format.hpp>
+#include <fstream>
 
 #include <gtest/gtest.h>
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <iomanip>
 #include <thread>
 
 #include <math.h>

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <future>
+#include <iomanip>
 #include <optional>
 #include <queue>
 #include <thread>

--- a/osquery/remote/uri.h
+++ b/osquery/remote/uri.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/osquery/tables/system/posix/openssl_utils.cpp
+++ b/osquery/tables/system/posix/openssl_utils.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <ctime>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
 

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <fstream>
 #include <future>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>

--- a/osquery/utils/pidfile/tests/pidfile.cpp
+++ b/osquery/utils/pidfile/tests/pidfile.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <cstdlib>
+#include <fstream>
 #include <string>
 
 #include <gtest/gtest.h>

--- a/osquery/utils/system/posix/time.cpp
+++ b/osquery/utils/system/posix/time.cpp
@@ -9,6 +9,7 @@
 
 #include <osquery/utils/system/time.h>
 
+#include <cstdint>
 #include <string.h>
 
 namespace osquery {

--- a/osquery/utils/system/time.h
+++ b/osquery/utils/system/time.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 

--- a/osquery/utils/tests/scope_guard.cpp
+++ b/osquery/utils/tests/scope_guard.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <chrono>
+#include <fstream>
 #include <string>
 #include <thread>
 

--- a/tests/integration/tables/process_open_files.cpp
+++ b/tests/integration/tables/process_open_files.cpp
@@ -16,6 +16,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <fstream>
 #include <unistd.h>
 
 namespace osquery {


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->

Hey :wave:

These are some includes I had to add to make the project buildable on Arch Linux using Clang 18.1.8.

For context I'm currently in the process of updating the [Arch Linux package for osquery](https://archlinux.org/packages/extra/x86_64/osquery/) and will attempt to upstream as many of the required patches as possible. The complete WIP patchset can be found in this branch: https://github.com/carlsmedstad/osquery/tree/build-on-archlinux

Cheers!