### PR TITLE
Replace usage of libaudit function removed in v3.0.7

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -434,8 +434,10 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
   audit_rule_data rule = {};
 
   // Attempt to add each one of the rules we collected
+  int machine = audit_detect_machine();
   for (int syscall_number : monitored_syscall_list_) {
-    audit_rule_syscall_data(&rule, syscall_number);
+    const char* syscall_name = audit_syscall_to_name(syscall_number, machine);
+    audit_rule_syscallbyname_data(&rule, syscall_name);
     if (FLAGS_audit_debug) {
       VLOG(1) << "Audit rule queued for syscall " << syscall_number;
     }


### PR DESCRIPTION
Hey :wave:

The function `audit_rule_syscall_data` is since https://github.com/linux-audit/audit-userspace/commit/24fa18cfea484b0e58ab02e71b9cc0bea87f6b00 not part of libaudit's interface.

For context I'm currently in the process of updating the [Arch Linux package for osquery](https://archlinux.org/packages/extra/x86_64/osquery/) and will attempt to upstream as many of the required patches as possible. The complete WIP patchset can be found in this branch: https://github.com/carlsmedstad/osquery/tree/build-on-archlinux

Cheers!