### PR TITLE
build: Silence deprecation warnings about non standard extensions on VS2022

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -355,6 +355,9 @@ function(setupBuildFlags)
       "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>"
       _WIN32_WINNT=_WIN32_WINNT_WIN7
       NTDDI_VERSION=NTDDI_WIN7
+      # VS2022 warns about this; the AWS SDK uses this non standard extension.
+      # Updating the SDK and switching to C++20 should fix this.
+      _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
     )
 
     set(windows_cxx_compile_options


### PR DESCRIPTION
The AWS SDK makes uses of a non standard extension on Windows, which is being deprecated. Updating the SDK and switching to C++20 will fix this.
We silence the warnings for now, because we have to first update the Linux toolchain to a newer compiler.