### PR TITLE
Boost 1.86 compatibility

### DIFF
--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -197,7 +197,7 @@ Status procEnumerateProcesses(UserData& user_data,
       }
 
       // See #792: std::regex is incomplete until GCC 4.9
-      const auto pid = it->path().leaf().string();
+      const auto pid = it->path().filename().string();
       if (std::atoll(pid.data()) <= 0) {
         continue;
       }
@@ -248,7 +248,7 @@ Status procEnumerateProcessDescriptors(const std::string& pid,
     boost::filesystem::directory_iterator it(descriptors_path), end;
 
     for (; it != end; ++it) {
-      auto fd = it->path().leaf().string();
+      auto fd = it->path().filename().string();
 
       std::string link;
       Status status = procReadDescriptor(pid, fd, link);

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -952,7 +952,7 @@ TEST_F(FilesystemTests, test_directory_listing_with_file_symlink) {
   const fs::path test_root_dir = fs::temp_directory_path() / genRandomName();
   ASSERT_TRUE(fs::create_directory(test_root_dir));
 
-  fs::ofstream test_file(test_root_dir / "test_file.txt");
+  std::ofstream test_file((test_root_dir / "test_file.txt").string());
   test_file.close();
 
   // Create symlink

--- a/osquery/tables/applications/chrome/tests/utils.cpp
+++ b/osquery/tables/applications/chrome/tests/utils.cpp
@@ -154,8 +154,8 @@ const std::unordered_map<std::string, std::string>
         {"description", "Description"},
         {"permissions", "1, 2"},
         {"optional_permissions", "3, 4"},
-        {"permissions_json", "{\"\":\"1\",\"\":\"2\"}\n"},
-        {"optional_permissions_json", "{\"\":\"3\",\"\":\"4\"}\n"},
+        {"permissions_json", "{\"\":\"1\",\"\":\"2\"}"},
+        {"optional_permissions_json", "{\"\":\"3\",\"\":\"4\"}"},
 };
 
 const std::string kExpectedComputedExtensionIdentifier{
@@ -208,6 +208,11 @@ TEST_F(ChromeUtilsTests, getExtensionContentScriptsMatches) {
   }
 }
 
+std::string trim_trailing_newline(const std::string& str) {
+  auto end = str.find_last_not_of('\n');
+  return (end == std::string::npos) ? "" : str.substr(0, end + 1);
+}
+
 TEST_F(ChromeUtilsTests, getExtensionProperties) {
   pt::iptree parsed_manifest;
 
@@ -230,7 +235,8 @@ TEST_F(ChromeUtilsTests, getExtensionProperties) {
     ASSERT_TRUE(property_it != properties.end());
 
     const auto& value = property_it->second;
-    EXPECT_EQ(value, expected_value);
+    std::string trimmed_value = trim_trailing_newline(value);
+    EXPECT_EQ(trimmed_value, expected_value);
   }
 }
 

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -229,7 +229,7 @@ std::string NormalizePath(const std::string& cwd,
   */
 
   boostfs::path normalized_path(translated_path);
-  normalized_path = normalized_path.normalize();
+  normalized_path = normalized_path.lexically_normal();
 
   return normalized_path.string();
 };

--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -206,7 +206,7 @@ Status PowershellEventSubscriber::parseScriptMessageEvent(
 
       if (!output.script_path.empty()) {
         output.script_name =
-            boost::filesystem::path(output.script_path).leaf().string();
+            boost::filesystem::path(output.script_path).filename().string();
       }
     }
   }

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -170,7 +170,7 @@ void DeviceHelper::generateFile(const std::string& partition,
   r["device"] = device_path_;
   r["partition"] = partition;
   r["path"] = path;
-  r["filename"] = fs::path(path).leaf().string();
+  r["filename"] = fs::path(path).filename().string();
 
   if (fs != nullptr) {
     r["block_size"] = BIGINT(fs->getBlockSize());

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -732,7 +732,7 @@ Status appendLogTypeToJson(const std::string& log_type, std::string& log) {
   log = output.str();
 
   // Get rid of newline
-  if (!log.empty()) {
+  if (!log.empty() && log.back() == '\n') {
     log.pop_back();
   }
   return Status::success();

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -39,7 +39,7 @@ TEST_F(Mdfind, test_sanity) {
 
   auto file_path = rows[0]["path"];
   boost::filesystem::path path(file_path);
-  auto filename = path.leaf().string();
+  auto filename = path.filename().string();
 
   rows =
       execute_query("select * from mdfind where query = 'kMDItemFSName = \"" +
@@ -49,7 +49,7 @@ TEST_F(Mdfind, test_sanity) {
 
   for (auto row : rows) {
     boost::filesystem::path retrieved_path(row["path"]);
-    EXPECT_EQ(retrieved_path.leaf().string(), filename);
+    EXPECT_EQ(retrieved_path.filename().string(), filename);
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->

Hey again,

This PR contains changes required for compatibility with [Boost 1.86.0](https://www.boost.org/users/history/version_1_86_0.html).

For context, the complete WIP patchset for the [Arch Linux package for osquery](https://archlinux.org/packages/extra/x86_64/osquery/) is maintained in this branch: https://github.com/carlsmedstad/osquery/tree/build-on-archlinux