### PR TITLE
improvement: refactor readFile

### DIFF
--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -124,6 +124,7 @@ function(generateOsqueryFilesystemTest)
   if(DEFINED PLATFORM_POSIX)
     list(APPEND source_files
       tests/posix/xattrs.cpp
+      tests/posix/filesystem_tests.cpp
     )
   endif()
 
@@ -137,6 +138,12 @@ function(generateOsqueryFilesystemTest)
   if(DEFINED PLATFORM_LINUX)
     list(APPEND source_files
       tests/linux/proc_tests.cpp
+    )
+  endif()
+
+  if (DEFINED PLATFORM_WINDOWS)
+    list(APPEND source_files
+      tests/windows/filesystem_tests.cpp
     )
   endif()
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -33,11 +33,9 @@
 #if WIN32
 #include <osquery/utils/conversions/windows/strings.h>
 #endif
+#include <osquery/utils/json/json.h>
 #include <osquery/utils/system/system.h>
 
-#include <osquery/utils/json/json.h>
-
-namespace pt = boost::property_tree;
 namespace fs = boost::filesystem;
 namespace errc = boost::system::errc;
 
@@ -48,7 +46,27 @@ FLAG(uint64, read_max, 50 * 1024 * 1024, "Maximum file read size");
 /// See reference #1382 for reasons why someone would allow unsafe.
 HIDDEN_FLAG(bool, allow_unsafe, false, "Allow unsafe executable permissions");
 
-static const size_t kMaxRecursiveGlobs = 64;
+namespace {
+const size_t kMaxRecursiveGlobs = 64;
+
+constexpr std::size_t kBlockSize = 16384;
+
+Status checkFileReadLimit(std::size_t file_size,
+                          const fs::path& path,
+                          bool shouldLog) {
+  if (file_size > FLAGS_read_max) {
+    auto error_message = "Cannot read " + path.string() +
+                         " size exceeds limit: " + std::to_string(file_size) +
+                         " > " + std::to_string(FLAGS_read_max);
+    if (shouldLog) {
+      LOG(WARNING) << error_message;
+    }
+    return Status::failure(error_message);
+  }
+
+  return Status::success();
+}
+} // namespace
 
 Status writeTextFile(const fs::path& path,
                      const std::string& content,
@@ -80,24 +98,6 @@ Status writeTextFile(const fs::path& path,
   return Status::success();
 }
 
-struct OpenReadableFile : private boost::noncopyable {
- public:
-  explicit OpenReadableFile(const fs::path& path, bool blocking = false)
-      : blocking_io(blocking) {
-    int mode = PF_OPEN_EXISTING | PF_READ;
-    if (!blocking) {
-      mode |= PF_NONBLOCK;
-    }
-
-    // Open the file descriptor and allow caller to perform error checking.
-    fd = std::make_unique<PlatformFile>(path, mode);
-  }
-
- public:
-  std::unique_ptr<PlatformFile> fd{nullptr};
-  bool blocking_io;
-};
-
 void initializeFilesystemAPILocale() {
 #if defined(WIN32)
   setlocale(LC_ALL, ".UTF-8");
@@ -108,111 +108,135 @@ void initializeFilesystemAPILocale() {
 }
 
 Status readFile(const fs::path& path,
-                size_t size,
-                size_t block_size,
-                bool dry_run,
-                std::function<void(std::string& buffer, size_t size)> predicate,
-                bool blocking,
-                bool log) {
-  OpenReadableFile handle(path, blocking);
+                std::function<void(std::string_view)> predicate,
+                bool shouldLog) {
+  PlatformFile file_handle(path, PF_OPEN_EXISTING | PF_READ | PF_NONBLOCK);
 
-  if (handle.fd == nullptr || !handle.fd->isValid()) {
-    return Status::failure("Cannot open file for reading: " + path.string());
+  if (!file_handle.isValid()) {
+    return Status::failure("Cannot open file for reading: " +
+                           file_handle.getFilePath().string());
   }
 
-  off_t file_size = static_cast<off_t>(handle.fd->size());
+  const std::uint64_t file_size = file_handle.size();
 
-  if (size > 0 &&
-      (handle.fd->isSpecialFile() || static_cast<off_t>(size) < file_size)) {
-    file_size = static_cast<off_t>(size);
+  // Fail to read if the file is bigger than the configured limit.
+  auto status = checkFileReadLimit(file_size, path, shouldLog);
+  if (!status.ok()) {
+    return status;
   }
 
-  // Apply the max byte-read based on file/link target ownership.
-  auto read_max = static_cast<off_t>(FLAGS_read_max);
-  if (file_size > read_max) {
-    if (!dry_run) {
-      auto s =
-          Status::failure("Cannot read " + path.string() +
-                          " size exceeds limit: " + std::to_string(file_size) +
-                          " > " + std::to_string(read_max));
-      if (log) {
-        LOG(WARNING) << s.getMessage();
-      }
-      return s;
+  const bool isSpecialFile = file_handle.isSpecialFile();
+
+  /* If the file is a regular file on disk and has no data,
+     do not attempt to read */
+  if (!isSpecialFile && file_size == 0) {
+    return Status::success();
+  }
+
+  ssize_t res = 0;
+  std::size_t total_bytes = 0;
+  char buffer[kBlockSize];
+
+  do {
+    res = file_handle.read(buffer, kBlockSize);
+
+    // EOF
+    if (res == 0) {
+      break;
     }
-    return Status::failure("File exceeds read limits");
-  }
 
-  if (dry_run) {
-    // The caller is only interested in performing file read checks.
-    boost::system::error_code ec;
-    try {
-      return Status(0, fs::canonical(path, ec).string());
-    } catch (const boost::filesystem::filesystem_error& err) {
-      return Status::failure(err.what());
+    if (res > 0) {
+      total_bytes += res;
+      status = checkFileReadLimit(total_bytes, path, shouldLog);
+
+      if (!status.ok()) {
+        return status;
+      }
+
+      predicate({buffer, static_cast<std::size_t>(res)});
     }
-  }
+  } while (res > 0 || (!isSpecialFile && file_handle.hasPendingIo()));
 
-  off_t total_bytes = 0;
-  if (handle.blocking_io || handle.fd->isSpecialFile()) {
-    // Reset block size to a sane minimum.
-    block_size = (block_size < 4096) ? 4096 : block_size;
-    ssize_t part_bytes = 0;
-    bool overflow = false;
-    do {
-      std::string part(block_size, '\0');
-      part_bytes = handle.fd->read(&part[0], block_size);
-      if (part_bytes > 0) {
-        total_bytes += static_cast<off_t>(part_bytes);
-        if (total_bytes >= read_max) {
-          return Status::failure("File exceeds read limits");
-        }
-        if (file_size > 0 && total_bytes > file_size) {
-          overflow = true;
-          part_bytes -= (total_bytes - file_size);
-        }
-        predicate(part, part_bytes);
-      }
-    } while (part_bytes > 0 && !overflow);
-  } else {
-    std::string content(file_size, '\0');
-    do {
-      auto part_bytes =
-          handle.fd->read(&content[total_bytes], file_size - total_bytes);
-      if (part_bytes > 0) {
-        total_bytes += static_cast<off_t>(part_bytes);
-      }
-    } while (handle.fd->hasPendingIo());
-    predicate(content, file_size);
+  if (res < 0) {
+    return Status::failure("Failed to read " + path.string());
   }
 
   return Status::success();
-} // namespace osquery
-
-Status readFile(const fs::path& path,
-                std::string& content,
-                size_t size,
-                bool dry_run,
-                bool blocking,
-                bool log) {
-  return readFile(path,
-                  size,
-                  4096,
-                  dry_run,
-                  ([&content](std::string& buffer, size_t _size) {
-                    if (buffer.size() == _size) {
-                      content += std::move(buffer);
-                    } else {
-                      content += buffer.substr(0, _size);
-                    }
-                  }),
-                  blocking,
-                  log);
 }
 
-Status readFile(const fs::path& path, bool blocking) {
-  std::string blank;
-  return readFile(path, blank, 0, true, false, blocking);
+Status readFile(const fs::path& path, std::string& content, bool shouldLog) {
+  PlatformFile file_handle(path, PF_OPEN_EXISTING | PF_READ | PF_NONBLOCK);
+
+  if (!file_handle.isValid()) {
+    return Status::failure("Cannot open file for reading: " +
+                           file_handle.getFilePath().string());
+  }
+
+  const std::uint64_t file_size = file_handle.size();
+
+  // Fail to read if the file is bigger than the configured limit
+  auto status = checkFileReadLimit(file_size, path, shouldLog);
+
+  if (!status.ok()) {
+    return status;
+  }
+
+  const bool isSpecialFile = file_handle.isSpecialFile();
+
+  /* If the file is a regular file on disk and has no data,
+   do not attempt to read */
+  if (!isSpecialFile && file_size == 0) {
+    return Status::success();
+  }
+
+  /* We read in blocks only if we don't know the file size;
+     otherwise use the file size for efficiency */
+  std::size_t read_size = 0;
+  if (file_size > 0) {
+    read_size = file_size;
+    content.resize(file_size);
+  } else {
+    read_size = kBlockSize;
+    content.resize(kBlockSize);
+  }
+
+  std::size_t offset = 0;
+  ssize_t res = 0;
+
+  do {
+    res = file_handle.read(&content[offset], read_size);
+
+    // EOF
+    if (res == 0) {
+      break;
+    }
+
+    if (res > 0) {
+      offset += res;
+      auto status = checkFileReadLimit(offset, path, shouldLog);
+
+      if (!status.ok()) {
+        content.clear();
+        return status;
+      }
+
+      if (file_size > 0) {
+        read_size = file_size - offset;
+      } else {
+        content.resize(content.size() + kBlockSize);
+      }
+    }
+  } while (read_size > 0 &&
+           (res > 0 || (!isSpecialFile && file_handle.hasPendingIo())));
+
+  if (res < 0) {
+    content.clear();
+    return Status::failure("Failed to read " + path.string());
+  }
+
+  content.resize(offset);
+
+  return Status::success();
 }
 
 Status isWritable(const fs::path& path, bool effective) {

--- a/osquery/filesystem/tests/linux/proc_tests.cpp
+++ b/osquery/filesystem/tests/linux/proc_tests.cpp
@@ -8,6 +8,9 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+
 #include <osquery/filesystem/linux/proc.h>
 
 #ifndef ETH_P_ALL
@@ -17,6 +20,8 @@
 #ifndef ETH_P_LLDP
 #define ETH_P_LLDP 0x88cc
 #endif
+
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace {
@@ -121,6 +126,26 @@ TEST_F(LinuxProc, testProcGetSocketListPacketValidInvalidContent) {
   EXPECT_EQ(ETH_P_ALL, socket_list[0].protocol);
   EXPECT_EQ("154955523", socket_list[0].socket);
   EXPECT_EQ("NONE", socket_list[0].state);
+}
+
+TEST_F(LinuxProc, test_user_namespace_parser) {
+  auto unique_path = fs::temp_directory_path() /
+                     fs::unique_path("osquery.tests.user_ns_parser.%%%%.%%%%");
+
+  auto temp_path = unique_path.native();
+
+  boost::system::error_code error_code;
+  EXPECT_EQ(fs::create_directory(temp_path, error_code), true);
+
+  auto symlink_path = temp_path + "/namespace";
+  EXPECT_EQ(symlink("namespace:[112233]", symlink_path.data()), 0);
+
+  ino_t namespace_inode;
+  auto status = procGetNamespaceInode(namespace_inode, "namespace", temp_path);
+  EXPECT_TRUE(status.ok());
+
+  removePath(temp_path);
+  EXPECT_EQ(namespace_inode, static_cast<ino_t>(112233));
 }
 
 } // namespace

--- a/osquery/filesystem/tests/posix/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/posix/filesystem_tests.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <boost/filesystem.hpp>
+
+#include <gtest/gtest.h>
+
+#include <osquery/filesystem/filesystem.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+class PosixFilesystemTests : public testing::Test {
+ protected:
+  fs::path test_working_dir_;
+
+  void SetUp() override {
+    test_working_dir_ = fs::temp_directory_path() /
+                        fs::unique_path("osquery.test_working_dir.%%%%.%%%%");
+    fs::create_directories(test_working_dir_);
+  }
+
+  void TearDown() override {
+    fs::remove_all(test_working_dir_);
+  }
+};
+
+TEST_F(PosixFilesystemTests, test_read_unopened_fifo) {
+  // This test verifies that open and read operations do not hang when using
+  // non-blocking mode for pipes.
+  auto test_file = test_working_dir_ / "fifo";
+  ASSERT_EQ(::mkfifo(test_file.c_str(), S_IRUSR | S_IWUSR), 0);
+
+  std::string content;
+  ASSERT_TRUE(readFile(test_file, content));
+  ASSERT_TRUE(content.empty());
+  ::unlink(test_file.c_str());
+}
+} // namespace osquery

--- a/osquery/filesystem/tests/windows/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/windows/filesystem_tests.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+
+#include <gtest/gtest.h>
+
+#include <osquery/filesystem/filesystem.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+class WindowsFilesystemTests : public testing::Test {
+ protected:
+  fs::path test_working_dir_;
+
+  void SetUp() override {
+    test_working_dir_ = fs::temp_directory_path() /
+                        fs::unique_path("osquery.test_working_dir.%%%%.%%%%");
+    fs::create_directories(test_working_dir_);
+  }
+
+  void TearDown() override {}
+};
+
+TEST_F(WindowsFilesystemTests, test_read_empty_named_pipe) {
+  // This test verifies that open and read operations do not hang when using
+  // non-blocking mode for pipes.
+  std::wstring pipe_name = LR"(\\.\pipe\osquery_test_pipe)";
+  HANDLE pipe_handle = CreateNamedPipe(pipe_name.c_str(),
+                                       PIPE_ACCESS_DUPLEX,
+                                       PIPE_WAIT,
+                                       PIPE_UNLIMITED_INSTANCES,
+                                       0,
+                                       0,
+                                       1000,
+                                       0);
+  std::string content;
+  ASSERT_NE(pipe_handle, INVALID_HANDLE_VALUE) << GetLastError();
+  ASSERT_FALSE(readFile(pipe_name, content));
+  ASSERT_TRUE(content.empty());
+  CloseHandle(pipe_handle);
+}
+
+} // namespace osquery

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1105,6 +1105,16 @@ ssize_t PlatformFile::getOverlappedResultForRead(void* buf,
       has_pending_io_ = true;
       last_read_.is_active_ = true;
       nret = -1;
+    } else if (last_error == ERROR_HANDLE_EOF) {
+      // We arrived at the end of the file. This normally happens only with
+      // empty files, or when over reading. In the other case where the last
+      // read gets all the final bytes, GetOverlappedResult will succeed and
+      // report no further pending data.
+
+      has_pending_io_ = false;
+      last_read_.is_active_ = false;
+      last_read_.buffer_.reset(nullptr);
+      nret = 0;
     } else {
       // Error has occurred, just in case, cancel all IO
       ::CancelIo(handle_);

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -243,11 +243,6 @@ QueryData genKnownWifiNetworks(QueryContext& context) {
   auto dropper = DropPrivileges::get();
   dropper->dropToParent(path);
 
-  if (!readFile(path)) {
-    VLOG(1) << "Unable to read file: " << p;
-    return {};
-  }
-
   if (isBigSurOrHigher()) {
     return parseBigSur(p);
   }
@@ -288,5 +283,5 @@ QueryData genKnownWifiNetworks(QueryContext& context) {
   }
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -66,7 +66,7 @@ QueryData genEtcHostsImpl(QueryContext& context, Logger& logger) {
   std::string content;
   QueryData qres = {};
 
-  auto s = readFile(kEtcHosts, content, 0, false, false, false);
+  auto s = readFile(kEtcHosts, content);
   if (s.ok()) {
     qres = parseEtcHostsContent(content);
   } else {

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -143,7 +143,7 @@ void genAptUrl(const std::string& source,
   }
 
   std::string content;
-  auto s = readFile(cache_files[0], content, 0, false, false, false);
+  auto s = readFile(cache_files[0], content);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return;
@@ -183,7 +183,7 @@ static void genAptSource(const std::string& source,
                          Logger& logger) {
   std::string content;
 
-  auto s = readFile(source, content, 0, false, false, false);
+  auto s = readFile(source, content);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return;

--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -104,7 +104,7 @@ void genSSHkeysForUser(const std::string& uid,
       continue;
     }
 
-    auto s = readFile(keys_file, keys_content, false, false, false);
+    auto s = readFile(keys_file, keys_content);
     if (!s.ok()) {
       // Cannot read a specific keys file.
       logger.log(google::GLOG_ERROR, s.getMessage());

--- a/osquery/tables/system/posix/crontab.cpp
+++ b/osquery/tables/system/posix/crontab.cpp
@@ -38,7 +38,7 @@ std::vector<std::string> cronFromFile(const std::string& path, Logger& logger) {
     return cron_lines;
   }
 
-  auto s = readFile(path, content, false, false, false);
+  auto s = readFile(path, content);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     return cron_lines;

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -54,7 +54,7 @@ const std::string kWinPythonInstallKey =
 
 void genPackage(const std::string& path, Row& r, Logger& logger) {
   std::string content;
-  auto s = readFile(path, content, false, false);
+  auto s = readFile(path, content);
   if (!s.ok()) {
     logger.log(google::GLOG_WARNING, s.getMessage());
     logger.vlog(1, "Cannot find info file: " + path);

--- a/osquery/tables/system/ssh_keys.cpp
+++ b/osquery/tables/system/ssh_keys.cpp
@@ -160,7 +160,7 @@ void genSSHkeyForHosts(const std::string& uid,
   // Go through each file
   for (const auto& kfile : files_list) {
     std::string keys_content;
-    auto s = readFile(kfile, keys_content, false, false, false);
+    auto s = readFile(kfile, keys_content);
     if (!s.ok()) {
       // Cannot read a specific keys file.
       logger.log(google::GLOG_WARNING, s.getMessage());

--- a/osquery/utils/status/status.h
+++ b/osquery/utils/status/status.h
@@ -75,7 +75,7 @@ class Status {
    * success or failure of an operation. On successful operations, the idiom
    * is for the message to be "OK"
    */
-  std::string getMessage() const {
+  const std::string& getMessage() const {
     return message_;
   }
 


### PR DESCRIPTION
- Simplify readFile interface to only support reading full files

- Remove the choice of reading in a blocking way, since we want to prevent hanging

- Remove the dry run read, since it was not useful

- Split the implementation between two overloads, where one supports returning the whole file contents in one go, while the other calls back a predicate everytime some data is read, up to a fixed block size (as with the previous implementation)
