### PR TITLE
Fix crash in socket table parsing

### DIFF
--- a/osquery/tables/networking/windows/process_open_sockets.cpp
+++ b/osquery/tables/networking/windows/process_open_sockets.cpp
@@ -97,15 +97,31 @@ void WinSockets::parseSocketTable(WinSockTableType sockType,
   unsigned int numEntries;
   switch (sockType) {
   case WinSockTableType::tcp:
+    if (tcpTable_ == nullptr) {
+      TLOG << "Error the TCP IPv4 socket table has not been allocated";
+      return;
+    }
     numEntries = tcpTable_->dwNumEntries;
     break;
   case WinSockTableType::tcp6:
+    if (tcp6Table_ == nullptr) {
+      TLOG << "Error the TCP IPv6 socket table has not been allocated";
+      return;
+    }
     numEntries = tcp6Table_->dwNumEntries;
     break;
   case WinSockTableType::udp:
+    if (udpTable_ == nullptr) {
+      TLOG << "Error the UDP IPv4 socket table has not been allocated";
+      return;
+    }
     numEntries = udpTable_->dwNumEntries;
     break;
   case WinSockTableType::udp6:
+    if (udp6Table_ == nullptr) {
+      TLOG << "Error the UDP IPv6 socket table has not been allocated";
+      return;
+    }
     numEntries = udp6Table_->dwNumEntries;
     break;
   default:


### PR DESCRIPTION
The socket tables are allocated in the constructor for WinSockets, but any failure to allocate is not subsequently checked before using the tables in the parsing routine. This was causing a crash in (possibly temporary) low-memory scenarios.

The fix is to simply check the tables are not null before using them. The fix is to the only location in the code where the tables are referenced.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
