### PR TITLE
Fix: Check and free cert context creation in windows certificates table

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -603,8 +603,16 @@ void findUserPersonalCertsOnDisk(const std::string& username,
           encodedCert.data(),
           static_cast<unsigned long>(encodedCert.size()));
 
+      if (ctx == nullptr) {
+        VLOG(1) << "Failed to create certificate context with (" << GetLastError()
+                << ")";
+        continue;
+      }
+
       addCertRow(
           ctx, storeId, sid, storeName, username, storeLocation, results);
+
+      CertFreeCertificateContext(ctx);
     }
   } catch (const fs::filesystem_error& e) {
     VLOG(1) << "Error traversing " << certsPath.str() << ": " << e.what();

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -604,8 +604,8 @@ void findUserPersonalCertsOnDisk(const std::string& username,
           static_cast<unsigned long>(encodedCert.size()));
 
       if (ctx == nullptr) {
-        VLOG(1) << "Failed to create certificate context with (" << GetLastError()
-                << ")";
+        VLOG(1) << "Failed to create certificate context with ("
+                << GetLastError() << ")";
         continue;
       }
 


### PR DESCRIPTION
There are 2 bugs in the findUserPersonalCertsOnDisk method:-

- The return from CertCreateCertificateContext is not checked, which leads to a subsequent crash in addCertRow etc. should the call fail
- The certificate context, if created, is not freed after use

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
