### PR TITLE
Fixes crash with non-null-terminated values in registry enumeration

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -331,7 +331,8 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
 
     std::unique_ptr<BYTE[]> bpDataBuff = std::make_unique<BYTE[]>(lpData);
 
-    // Read the registry value data ensuring correct handling of non-terminated strings
+    // Read the registry value data ensuring correct handling of non-terminated
+    // strings
     retCode = RegGetValueW(hRegistryHandle.get(),
                            nullptr,
                            achValue.get(),


### PR DESCRIPTION
A crash occurs when a string registry value is not null-terminated and this value is the longest in a given key.

This PR substitutes the use of RegQueryValueEx API to RegGetValue which correctly handles non null-terminated string values in the registry.

RegQueryInfoKey API will return the maximum length of a value in a specified key as it exists in the registry, so any string value (REG_SZ etc.) which has been written without a null terminator will result in a cbMaxValueData value for the data only which is incorrect. So, if the non-terminated string value also happens to be the longest value in the given key, the current allocation is not sufficient. 

This change allocates a buffer per-value rather than one buffer based on the size of the largest reported value, which would be wrong.

On encountering a non-terminated string RegGetValue will return the required length (including space for a null) in the lpData out parameter and a status of ERROR_MORE_DATA.

There are also some minor (e.g. REG_BINARY) changes required to accommodate this fix in this PR.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
