### PR TITLE
table: Remove support for deprecated Safari Legacy Extensions

### DIFF
--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -7,14 +7,10 @@ schema([
     Column("identifier", TEXT, "Extension identifier"),
     Column("version", TEXT, "Extension long version", collate="version"),
     Column("sdk", TEXT, "Bundle SDK used to compile extension", collate="version"),
-    Column("update_url", TEXT, "Extension-supplied update URI"),
-    Column("author", TEXT, "Optional extension author"),
-    Column("developer_id", TEXT, "Optional developer identifier"),
     Column("description", TEXT, "Optional extension description text"),
-    Column("path", TEXT, "Path to extension XAR bundle"),
+    Column("path", TEXT, "Path to the Info.plist describing the extension"),
     Column("bundle_version", TEXT, "The version of the build that identifies an iteration of the bundle"),
     Column("copyright", TEXT, "A human-readable copyright notice for the bundle"),
-    Column("extension_type", TEXT, "Extension Type: WebOrAppExtension or LegacyExtension"),	
     ForeignKey(column="uid", table="users")
 ])
 attributes(user_data=True)


### PR DESCRIPTION
Also removes columns which will not have data anymore,
like "author", "update_url", "developer_id" and
"extension_type" since there's no more differentiation necessary.

Updated "path" to reflect its current meaning.

We target macOS 10.15 and updated Safari there is version 15.x.

Since Safari version 13 there's no more support for legacy extensions (.safariextz): https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes#Removed-Features
