### PR TITLE
Fix: `safari_extensions` not returning results

### DIFF
--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -402,14 +402,14 @@ inline bool isUserExtension(const fs::path& app_extension_plist,
   // extension identifier
   getPtreeFromPlist(app_extension_plist, app_extension_ptree);
   for (const auto& entry : app_extension_ptree) {
-    if (!boost::algorithm::contains(entry.first, ext_data.identifier)) {
+    if (boost::algorithm::contains(entry.first, ext_data.identifier)) {
       return true;
     }
   }
 
   getPtreeFromPlist(web_extension_plist, web_extension_ptree);
   for (const auto& entry : web_extension_ptree) {
-    if (!boost::algorithm::contains(entry.first, ext_data.identifier)) {
+    if (boost::algorithm::contains(entry.first, ext_data.identifier)) {
       return true;
     }
   }


### PR DESCRIPTION
We want to have the extension identifier be present in the Extensions.plist, not the opposite.

With a couple of test extensions:
```
osquery> select * from safari_extensions;
           uid = 501
          name = Safari Extension
    identifier = com.1password.safari.extension
       version = 8.10.46
           sdk = 6.0
    update_url =
        author =
  developer_id =
   description =
          path = /Applications/1Password for Safari.app/Contents/PlugIns/%.appex/Contents/Info.plist
bundle_version = 81046034
     copyright =
extension_type = WebOrAppExtension

           uid = 501
          name = Ghostery Privacy Ad Blocker Extension
    identifier = com.ghostery.extension.safari
       version = 10.4.6
           sdk = 6.0
    update_url =
        author =
  developer_id =
   description =
          path = /Applications/Ghostery Privacy Ad Blocker.app/Contents/PlugIns/%.appex/Contents/Info.plist
bundle_version = 29
     copyright =
extension_type = WebOrAppExtension
```