### PR TITLE
Add support for `alf_exceptions`to macOS 15

### DIFF
--- a/osquery/tables/system/darwin/firewall.h
+++ b/osquery/tables/system/darwin/firewall.h
@@ -26,7 +26,7 @@ namespace tables {
 // parseALFExceptionsTree parses out the "exceptions" key
 osquery::QueryData parseALFExceptionsTree(const pt::ptree& tree);
 
-// Currently on macOS 15+ osquery supports the following 'alf' columns:
+// Currently, on macOS 15+ osquery supports the following 'alf' columns:
 //
 // 'global_state', 'stealth_enabled', 'logging_enabled', and 'version'.
 // These columns are populated from information gathered from system_profiler's
@@ -47,6 +47,16 @@ osquery::QueryData parseALFExceptionsTree(const pt::ptree& tree);
 //  "SPFirewallDataType"
 //    or the socketfilterfw command.
 osquery::QueryData genALFFromSystemProfiler();
+
+// Currently, on macOS 15+:
+//  - `alf_exceptions` returns only a subset of the exceptions (only signed apps
+//  it seems). The full list of exceptions can be gathered only by executing
+//  `/usr/libexec/ApplicationFirewall/socketfilterfw --listapps`.
+//  - `path` contains the bundle identifier and not the file path.
+//  - The column `state` currently has two values "0" and "2". It attempts to
+//  follow the semantic value as macOS < 15, "0" means "allow incoming
+//  connections" and "2" means "block incoming connections".
+osquery::QueryData genALFExceptionsFromSystemProfiler();
 
 // Given a property tree of the parsed content of com.apple.alf.plist,
 // parseALFExplicitAuthsTree parses out the "explicitauth" key

--- a/specs/darwin/alf_exceptions.table
+++ b/specs/darwin/alf_exceptions.table
@@ -1,7 +1,7 @@
 table_name("alf_exceptions")
 description("macOS application layer firewall (ALF) service exceptions.")
 schema([
-    Column("path", TEXT, "Path to the executable that is excepted"),
-    Column("state", INTEGER, "Firewall exception state"),
+    Column("path", TEXT, "Path to the executable that is excepted. On macOS 15+ this can also be a bundle identifier"),
+    Column("state", INTEGER, "Firewall exception state. 0 if the application is configured to allow incoming connections, 2 if the application is configured to block incoming connections and 3 if the application is configuted to allow incoming connections but with additional restrictions."),
 ])
 implementation("firewall@genALFExceptions")


### PR DESCRIPTION
#8432

```
osquery> SELECT * FROM alf_exceptions;
+------------------------------------------+-------+
| path                                     | state |
+------------------------------------------+-------+
| io.tailscale.ipn.macos.network-extension | 0     |
| com.apple.sharingd                       | 0     |
| com.allowthistraffic.cmd                 | 0     |
| com.apple.rpcbind                        | 0     |
| com.spotify.client                       | 0     |
| com.apple.cupsd                          | 0     |
| <REDACTED>.com.docker.docker             | 0     |
| com.blockthistraffic.cmd                 | 2     |
| <REDACTED>.com.vmware.fusion             | 0     |
| com.docker.docker                        | 0     |
| com.apple.dt.xcode_select.tool-shim      | 0     |
| com.apple.remoted                        | 0     |
| com.apple.sshd-keygen-wrapper            | 0     |
| org.python.python                        | 0     |
| com.apple.InternetSharing                | 0     |
| com.apple.universalcontrol               | 0     |
| com.apple.rpc                            | 0     |
| com.apple.smbd                           | 0     |
| <REDACTED>.com.google.Chrome             | 0     |
| com.apple.ruby                           | 0     |
| com.apple.controlcenter                  | 0     |
+------------------------------------------+-------+
```