### PR TITLE
Update table `alf_explicit_auths` as not supported on macOS 15

### DIFF
--- a/osquery/tables/system/darwin/firewall.mm
+++ b/osquery/tables/system/darwin/firewall.mm
@@ -228,6 +228,18 @@ QueryData parseALFExplicitAuthsTree(const pt::ptree& tree) {
 }
 
 QueryData genALFExplicitAuths(QueryContext& context) {
+  const auto& qd = SQL::selectAllFrom("os_version");
+  if (qd.size() != 1) {
+    LOG(ERROR) << "Couldn't determine macOS version";
+    return {};
+  }
+
+  if (qd.front().at("major") >= "15") {
+    // Currently not supported on macOS 15+.
+    VLOG(1) << "alf_explicit_auths is currently not supported on macOS 15";
+    return {};
+  }
+
   pt::ptree tree;
   auto s = genALFTreeFromFilesystem(tree);
   if (!s.ok()) {

--- a/specs/darwin/alf_explicit_auths.table
+++ b/specs/darwin/alf_explicit_auths.table
@@ -1,5 +1,5 @@
 table_name("alf_explicit_auths")
-description("ALF services explicitly allowed to perform networking.")
+description("ALF services explicitly allowed to perform networking. Not supported on macOS 15+ (returns no results).")
 schema([
     Column("process", TEXT, "Process name that is explicitly allowed"),
 ])

--- a/tests/integration/tables/alf_explicit_auths.cpp
+++ b/tests/integration/tables/alf_explicit_auths.cpp
@@ -36,7 +36,7 @@ TEST_F(alfExplicitAuths, test_sanity) {
   }
 
   ValidationMap row_map = {
-    {"process", NormalType},
+      {"process", NormalType},
   };
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/alf_explicit_auths.cpp
+++ b/tests/integration/tables/alf_explicit_auths.cpp
@@ -23,20 +23,22 @@ class alfExplicitAuths : public testing::Test {
 };
 
 TEST_F(alfExplicitAuths, test_sanity) {
-  // 1. Query data
   auto const data = execute_query("select * from alf_explicit_auths");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for available flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"process", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+
+  const auto& qd = SQL::selectAllFrom("os_version");
+  ASSERT_EQ(qd.size(), 1ul);
+
+  const auto macOS15Plus = qd.front().at("major") >= "15";
+
+  if (macOS15Plus) {
+    ASSERT_EQ(data.size(), 0ul);
+    return;
+  }
+
+  ValidationMap row_map = {
+    {"process", NormalType},
+  };
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
#8433

Looks like there's no "explict auths" in macOS 15 (yet). So let's document it as not supported.