### PR TITLE
Add additional WMI data to `deviceguard_status` table

### DIFF
--- a/osquery/tables/system/windows/deviceguard_status.cpp
+++ b/osquery/tables/system/windows/deviceguard_status.cpp
@@ -23,6 +23,10 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
                                           "VBS_ENABLED_AND_NOT_RUNNING",
                                           "VBS_ENABLED_AND_RUNNING"};
 
+  std::vector<std::string> security_services = {
+      "NONE", "CREDENTIAL_GUARD", "MEMORY_INTEGRITY",
+      "SYSTEM_GUARD_SECURE_LAUNCH", "SMM_FIRMWARE_MEASUREMENT" };
+
   std::vector<std::string> enforcement_methods = {
       "OFF", "AUDIT_MODE", "ENFORCED_MODE"};
 
@@ -56,6 +60,24 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
     r["umci_policy_status"] = enforcement_methods.size() > umci_status
                                   ? enforcement_methods[umci_status]
                                   : "UNKNOWN";
+
+    std::vector<long> running_security_services;
+    data.GetVectorOfLongs("SecurityServicesRunning", running_security_services);
+    for (int i = 0; i < running_security_services.size(); i++) {
+        r["running_security_services"].append(security_services.size() > running_security_services[i] ? security_services[running_security_services[i]] : "UNKNOWN");
+        if (i < (running_security_services.size() - 1)) {
+            r["running_security_services"].append(", ");
+        }
+    }
+
+    std::vector<long> configured_security_services;
+    data.GetVectorOfLongs("SecurityServicesConfigured", configured_security_services);
+    for (int i = 0; i < configured_security_services.size(); i++) {
+        r["configured_security_services"].append(security_services.size() > configured_security_services[i] ? security_services[configured_security_services[i]] : "UNKNOWN");
+        if (i < (configured_security_services.size() - 1)) {
+            r["configured_security_services"].append(", ");
+        }
+    }
 
     results.push_back(r);
   }

--- a/osquery/tables/system/windows/deviceguard_status.cpp
+++ b/osquery/tables/system/windows/deviceguard_status.cpp
@@ -23,9 +23,11 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
                                           "VBS_ENABLED_AND_NOT_RUNNING",
                                           "VBS_ENABLED_AND_RUNNING"};
 
-  std::vector<std::string> security_services = {
-      "NONE", "CREDENTIAL_GUARD", "MEMORY_INTEGRITY",
-      "SYSTEM_GUARD_SECURE_LAUNCH", "SMM_FIRMWARE_MEASUREMENT" };
+  std::vector<std::string> security_services = {"NONE",
+                                                "CREDENTIAL_GUARD",
+                                                "MEMORY_INTEGRITY",
+                                                "SYSTEM_GUARD_SECURE_LAUNCH",
+                                                "SMM_FIRMWARE_MEASUREMENT"};
 
   std::vector<std::string> enforcement_methods = {
       "OFF", "AUDIT_MODE", "ENFORCED_MODE"};
@@ -64,19 +66,26 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
     std::vector<long> running_security_services;
     data.GetVectorOfLongs("SecurityServicesRunning", running_security_services);
     for (int i = 0; i < running_security_services.size(); i++) {
-        r["running_security_services"].append(security_services.size() > running_security_services[i] ? security_services[running_security_services[i]] : "UNKNOWN");
-        if (i < (running_security_services.size() - 1)) {
-            r["running_security_services"].append(", ");
-        }
+      r["running_security_services"].append(
+          security_services.size() > running_security_services[i]
+              ? security_services[running_security_services[i]]
+              : "UNKNOWN");
+      if (i < (running_security_services.size() - 1)) {
+        r["running_security_services"].append(", ");
+      }
     }
 
     std::vector<long> configured_security_services;
-    data.GetVectorOfLongs("SecurityServicesConfigured", configured_security_services);
+    data.GetVectorOfLongs("SecurityServicesConfigured",
+                          configured_security_services);
     for (int i = 0; i < configured_security_services.size(); i++) {
-        r["configured_security_services"].append(security_services.size() > configured_security_services[i] ? security_services[configured_security_services[i]] : "UNKNOWN");
-        if (i < (configured_security_services.size() - 1)) {
-            r["configured_security_services"].append(", ");
-        }
+      r["configured_security_services"].append(
+          security_services.size() > configured_security_services[i]
+              ? security_services[configured_security_services[i]]
+              : "UNKNOWN");
+      if (i < (configured_security_services.size() - 1)) {
+        r["configured_security_services"].append(", ");
+      }
     }
 
     results.push_back(r);

--- a/osquery/tables/system/windows/deviceguard_status.cpp
+++ b/osquery/tables/system/windows/deviceguard_status.cpp
@@ -71,7 +71,7 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
               ? security_services[running_security_services[i]]
               : "UNKNOWN");
       if (i < (running_security_services.size() - 1)) {
-        r["running_security_services"].append(", ");
+        r["running_security_services"].append(",");
       }
     }
 
@@ -84,7 +84,7 @@ QueryData genDeviceGuardStatus(QueryContext& context) {
               ? security_services[configured_security_services[i]]
               : "UNKNOWN");
       if (i < (configured_security_services.size() - 1)) {
-        r["configured_security_services"].append(", ");
+        r["configured_security_services"].append(",");
       }
     }
 

--- a/specs/windows/deviceguard_status.table
+++ b/specs/windows/deviceguard_status.table
@@ -5,6 +5,8 @@ schema([
   Column("instance_identifier", TEXT, "The instance ID of Device Guard."),
   Column("vbs_status", TEXT, "The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered."),
   Column("code_integrity_policy_enforcement_status", TEXT, "The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered."),
+  Column("configured_security_services", TEXT, "The list of configured Device Guard services. Returns UNKNOWN if an error is encountered."),
+  Column("running_security_services", TEXT, "The list of running Device Guard services. Returns UNKNOWN if an error is encountered."),
   Column("umci_policy_status", TEXT, "The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered."), 
 ])
 implementation("system/windows/deviceguard_status@genDeviceGuardStatus")

--- a/tests/integration/tables/deviceguard_status.cpp
+++ b/tests/integration/tables/deviceguard_status.cpp
@@ -33,6 +33,8 @@ TEST_F(DeviceGuardStatus, test_sanity) {
       {"vbs_status", NonEmptyString},
       {"code_integrity_policy_enforcement_status", NonEmptyString},
       {"umci_policy_status", NonEmptyString},
+      {"configured_security_services", NonEmptyString},
+      {"running_security_services", NonEmptyString},
   };
   validate_rows(data, row_map);
 }


### PR DESCRIPTION
This change imports the remaining useful fields presented by the `Win32_DeviceGuard` WMI table.
