### PR TITLE
Extend timeout for test HTTP server

### DIFF
--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -28,7 +28,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # Default values for global variables
 HTTP_SERVER_USE_TLS = False
 HTTP_SERVER_PERSIST = False
-HTTP_SERVER_TIMEOUT = 30
+HTTP_SERVER_TIMEOUT = 120
 HTTP_SERVER_VERBOSE = False
 HTTP_SERVER_CERT = "test_server.pem"
 HTTP_SERVER_KEY = "test_server.key"

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -28,7 +28,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # Default values for global variables
 HTTP_SERVER_USE_TLS = False
 HTTP_SERVER_PERSIST = False
-HTTP_SERVER_TIMEOUT = 10
+HTTP_SERVER_TIMEOUT = 30
 HTTP_SERVER_VERBOSE = False
 HTTP_SERVER_CERT = "test_server.pem"
 HTTP_SERVER_KEY = "test_server.key"


### PR DESCRIPTION
In some CI runs (eg. https://github.com/osquery/osquery/actions/runs/11383780628/job/31670155405?pr=8421#step:19:2925) the server seems to shut down before the test completes. This is intended to improve reliability by increasing the timeout.
