### PR TITLE
ci: Update all Github actions to a version using NodeJs 20

### DIFF
--- a/.github/workflows/cleanup_ec2_runners.yml
+++ b/.github/workflows/cleanup_ec2_runners.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v3
+              uses: aws-actions/configure-aws-credentials@v4
               with:
                 aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
                 aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cve_scan_runner.yml
+++ b/.github/workflows/cve_scan_runner.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone the osquery repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install python pre-requisites
         run: |

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -172,7 +172,7 @@ jobs:
         fetch-depth: 0
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -353,7 +353,7 @@ jobs:
         git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -364,7 +364,7 @@ jobs:
           ccache_${{ matrix.os }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -578,7 +578,7 @@ jobs:
         echo "PACKAGE_BUILD=$(pwd)/${rel_package_build_path}" >> $GITHUB_OUTPUT
 
     - name: Clone the osquery repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         path: ${{ steps.build_paths.outputs.REL_SOURCE }}
@@ -592,7 +592,7 @@ jobs:
         vm_stat
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -603,7 +603,7 @@ jobs:
           ccache_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 
@@ -614,7 +614,7 @@ jobs:
           gitmodules_${{ matrix.os }}_${{ matrix.architecture }}_${{env.SUBMODULE_CACHE_VERSION}}
 
     - name: Update the cache (downloads)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.DOWNLOADS }}
 
@@ -802,7 +802,7 @@ jobs:
 
     steps:
       - name: Clone the osquery repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -866,7 +866,7 @@ jobs:
 
     steps:
       - name: Clone the osquery repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -1019,7 +1019,7 @@ jobs:
         git config --global core.symlinks true
 
     - name: Clone the osquery repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         path: ${{ steps.build_paths.outputs.REL_SOURCE }}
@@ -1049,7 +1049,7 @@ jobs:
         git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}\.git\modules
 
@@ -1060,7 +1060,7 @@ jobs:
           gitmodules_${{ matrix.os }}_${{env.SUBMODULE_CACHE_VERSION}}
 
     - name: Update the cache (downloads)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.DOWNLOADS }}
 
@@ -1071,7 +1071,7 @@ jobs:
           downloads_${{ matrix.os }}
 
     - name: Initialize the Python 3 installation
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
         architecture: "x64"
@@ -1228,7 +1228,7 @@ jobs:
         echo "COMPILER_VERSION=$version" >> $env:GITHUB_OUTPUT
 
     - name: Update the cache (sccache)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SCCACHE }}
 

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}
@@ -117,7 +117,7 @@ jobs:
 
       - name: Start aarch64 EC2 runner for a Release build
         id: start_ec2_runner-Release
-        uses: osquery/ec2-github-runner@v2.3.3
+        uses: osquery/ec2-github-runner@v2.3.6
         with:
           mode: start
           github-token: ${{ secrets.EC2_GITHUB_RUNNER_GH_PERSONAL_ACCESS_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Start aarch64 EC2 runner for a RelWithDebInfo build
         id: start_ec2_runner-RelWithDebInfo
-        uses: osquery/ec2-github-runner@v2.3.3
+        uses: osquery/ec2-github-runner@v2.3.6
         with:
           mode: start
           github-token: ${{ secrets.EC2_GITHUB_RUNNER_GH_PERSONAL_ACCESS_TOKEN }}
@@ -152,14 +152,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.EC2_GITHUB_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EC2_GITHUB_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EC2_GITHUB_RUNNER_AWS_REGION }}
 
       - name: Stop aarch64 EC2 runner for Release mode build
-        uses: osquery/ec2-github-runner@v2.3.3
+        uses: osquery/ec2-github-runner@v2.3.6
         with:
           mode: stop
           github-token: ${{ secrets.EC2_GITHUB_RUNNER_GH_PERSONAL_ACCESS_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
           ec2-instance-id: ${{ needs.start_ec2_runners.outputs.ec2-instance-id-Release }}
 
       - name: Stop aarch64 EC2 runner for RelWithDebInfo mode build
-        uses: osquery/ec2-github-runner@v2.3.3
+        uses: osquery/ec2-github-runner@v2.3.6
         with:
           mode: stop
           github-token: ${{ secrets.EC2_GITHUB_RUNNER_GH_PERSONAL_ACCESS_TOKEN }}
@@ -282,7 +282,7 @@ jobs:
         git checkout ${{ env.PACKAGING_COMMIT }}
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.CCACHE }}
 
@@ -293,7 +293,7 @@ jobs:
           ccache_${{ matrix.cache_key }}_${{ matrix.build_type }}
 
     - name: Update the cache (git submodules)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.build_paths.outputs.SOURCE }}/.git/modules
 


### PR DESCRIPTION
All actions using NodeJs < 20 are being deprecated soon.
