### PR TITLE
Update tests for `unified_log` table to work around slowness

### DIFF
--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -364,10 +364,14 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
         return {};
       }
 
+      // auto blah = enumerator.countByEnumerating
+
       int skip_counter = 0;
       bool first = isSequential;
       OSLogEntryLog* entry;
-      while (entry = [enumerator nextObject]) {
+      //while (entry = [enumerator nextObject]) {
+          for (entry in enumerator){
+
         if (first) {
           // Skips the log entries that have been already extracted
           double load_date = [[entry date] timeIntervalSince1970];
@@ -380,10 +384,12 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
         }
 
         // Escape if the rows number reached the limit
-        if (++rows_counter > max_rows)
+        if (++rows_counter > max_rows) {
+                 //TLOG << "  seph skip";
           // Free OSLogEnumerator by enumerating all remaining objects before
           // escaping
           continue;
+        }
 
         if (isSequential) {
           // Save timestamp and count

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -364,14 +364,10 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
         return {};
       }
 
-      // auto blah = enumerator.countByEnumerating
-
       int skip_counter = 0;
       bool first = isSequential;
       OSLogEntryLog* entry;
-      //while (entry = [enumerator nextObject]) {
-          for (entry in enumerator){
-
+      while (entry = [enumerator nextObject]) {
         if (first) {
           // Skips the log entries that have been already extracted
           double load_date = [[entry date] timeIntervalSince1970];
@@ -384,12 +380,10 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
         }
 
         // Escape if the rows number reached the limit
-        if (++rows_counter > max_rows) {
-                 //TLOG << "  seph skip";
+        if (++rows_counter > max_rows)
           // Free OSLogEnumerator by enumerating all remaining objects before
           // escaping
           continue;
-        }
 
         if (isSequential) {
           // Save timestamp and count

--- a/tests/integration/tables/unified_log.cpp
+++ b/tests/integration/tables/unified_log.cpp
@@ -62,18 +62,26 @@ TEST_F(UnifiedLogTest, test_sanity) {
   };
   validate_rows(rows, row_map);
 
+  // NOTE: Because of https://github.com/osquery/osquery/pull/8274 the
+  // unified_log behavior without a timestamp is horrific. As a workaround, we
+  // impose a short timestamp. Better would be to fix the underlying issue
+
   // max rows test
-  QueryData const r1 =
-      execute_query("select * from unified_log where max_rows = 50");
+  QueryData const r1 = execute_query(
+      "select * from unified_log where max_rows = 50 and timestamp > (select "
+      "unix_time - 120 from time)");
   ASSERT_EQ(r1.size(), 50ul);
-  QueryData const r2 =
-      execute_query("select * from unified_log where max_rows = 1");
+  QueryData const r2 = execute_query(
+      "select * from unified_log where max_rows = 1 and timestamp > (select "
+      "unix_time - 60 from time)");
   ASSERT_EQ(r2.size(), 1ul);
-  QueryData const r3 =
-      execute_query("select * from unified_log where max_rows = 0");
+  QueryData const r3 = execute_query(
+      "select * from unified_log where max_rows = 0 and timestamp > (select "
+      "unix_time - 60 from time)");
   ASSERT_EQ(r3.size(), 0ul);
-  QueryData const r4 =
-      execute_query("select * from unified_log where max_rows = -1");
+  QueryData const r4 = execute_query(
+      "select * from unified_log where max_rows = -1 and timestamp > (select "
+      "unix_time - 60 from time)");
   ASSERT_EQ(r4.size(), 0ul);
 
   // Sequential test: checks the pointer is increased and the data extracted

--- a/tests/integration/tables/unified_log.cpp
+++ b/tests/integration/tables/unified_log.cpp
@@ -95,7 +95,7 @@ TEST_F(UnifiedLogTest, test_sanity) {
   dc2.load();
   EXPECT_TRUE(dc1 < dc2);
   QueryData const r6 = execute_query(
-      "select * from unified_log where max_rows = 1 and timestamp > -1 "
+      "select * from unified_log where max_rows = 1 and timestamp > -1 and "
       "category = 'General'");
   ASSERT_EQ(r5.size(), 1ul);
   ASSERT_EQ(r6.size(), 1ul);

--- a/tests/integration/tables/unified_log.cpp
+++ b/tests/integration/tables/unified_log.cpp
@@ -65,6 +65,7 @@ TEST_F(UnifiedLogTest, test_sanity) {
   // NOTE: Because of https://github.com/osquery/osquery/pull/8274 the
   // unified_log behavior without a timestamp is horrific. As a workaround, we
   // impose a short timestamp. Better would be to fix the underlying issue
+  // Where that's not possible, we limit the category
 
   // max rows test
   QueryData const r1 = execute_query(
@@ -89,11 +90,13 @@ TEST_F(UnifiedLogTest, test_sanity) {
   DeltaContext dc1, dc2;
   dc1.load();
   QueryData const r5 = execute_query(
-      "select * from unified_log where max_rows = 1 and timestamp > -1");
+      "select * from unified_log where max_rows = 1 and timestamp > -1 and "
+      "category = 'General'");
   dc2.load();
   EXPECT_TRUE(dc1 < dc2);
   QueryData const r6 = execute_query(
-      "select * from unified_log where max_rows = 1 and timestamp > -1");
+      "select * from unified_log where max_rows = 1 and timestamp > -1 "
+      "category = 'General'");
   ASSERT_EQ(r5.size(), 1ul);
   ASSERT_EQ(r6.size(), 1ul);
   bool sequential_queries_diff = false;


### PR DESCRIPTION
To fix a memory leak,  https://github.com/osquery/osquery/pull/8274 added a lot of excess enumeration work. This, unfortunately, is a horrific performance regression for all `unified_log` usage without a timestamp constraint. 

This adds a somewhat cumbersome additional `WHERE` clause to most of the tests. It's not ideal, but it should cut down on the run time significantly. 