### PR TITLE
Fix `unified_log` handling of timestamp formats

### DIFF
--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -260,14 +260,20 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
       if (isSequential) {
         latest_timestamp = sc.timestamp;
       }
+
+      bool using_greather_than_constraint = false;
+
       for (const auto& constraint :
            queryContext.constraints["timestamp"].getAll(GREATER_THAN)) {
         double provided_timestamp =
             [[NSString stringWithUTF8String:constraint.c_str()] doubleValue];
+
         if (provided_timestamp > latest_timestamp) {
           latest_timestamp = provided_timestamp;
+          using_greather_than_constraint = true;
         }
       }
+
       for (const auto& constraint :
            queryContext.constraints["timestamp"].getAll(
                GREATER_THAN_OR_EQUALS)) {
@@ -275,11 +281,23 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
             [[NSString stringWithUTF8String:constraint.c_str()] doubleValue];
         if (provided_timestamp > latest_timestamp) {
           latest_timestamp = provided_timestamp;
+          using_greather_than_constraint = false;
         }
       }
+
       if (latest_timestamp > -1) {
+        /* We are summing 1 because with a > constraint we want entries with a
+          time that's at least one second after the constraint value we passed,
+          but the log entries have a higher precision, so the underlying library
+          will also return entries few milliseconds after. If we don't do this
+          then these will be filtered out by sqlite and will count
+          towards the max_rows limit */
+        double search_timestamp = using_greather_than_constraint
+                                      ? latest_timestamp + 1
+                                      : latest_timestamp;
+
         NSDate* provided_date =
-            [NSDate dateWithTimeIntervalSince1970:latest_timestamp];
+            [NSDate dateWithTimeIntervalSince1970:search_timestamp];
         position = [logstore positionWithDate:provided_date];
       }
 
@@ -380,8 +398,9 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
 
         Row r;
 
-        r["timestamp"] = BIGINT(
-            static_cast<std::uint32_t>([[entry date] timeIntervalSince1970]));
+        double entry_timestamp = [[entry date] timeIntervalSince1970];
+        r["timestamp"] = BIGINT(static_cast<std::uint32_t>(entry_timestamp));
+        r["timestamp_double"] = SQL_TEXT(entry_timestamp);
         r["message"] = SQL_TEXT(
             std::string([[entry composedMessage] UTF8String],
                         [[entry composedMessage]

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -286,12 +286,12 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
       }
 
       if (latest_timestamp > -1) {
-        /* We are summing 1 because with a > constraint we want entries with a
-          time that's at least one second after the constraint value we passed,
-          but the log entries have a higher precision, so the underlying library
-          will also return entries few milliseconds after. If we don't do this
-          then these will be filtered out by sqlite and will count
-          towards the max_rows limit */
+        /* We are summing 1 because with a > integer constraint we want entries
+          with a time that's at least one second after the constraint value we
+          passed, but the log entries have a higher precision, so the underlying
+          library will also return entries few milliseconds after. If we don't
+          do this then these will count towards the max_rows limit but end up
+          being filtered out by sqlite */
         double search_timestamp = using_greather_than_constraint
                                       ? latest_timestamp + 1
                                       : latest_timestamp;

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -380,7 +380,8 @@ QueryData genUnifiedLog(QueryContext& queryContext) {
 
         Row r;
 
-        r["timestamp"] = BIGINT([[entry date] timeIntervalSince1970]);
+        r["timestamp"] = BIGINT(
+            static_cast<std::uint32_t>([[entry date] timeIntervalSince1970]));
         r["message"] = SQL_TEXT(
             std::string([[entry composedMessage] UTF8String],
                         [[entry composedMessage]

--- a/specs/darwin/unified_log.table
+++ b/specs/darwin/unified_log.table
@@ -10,6 +10,7 @@ description("Queries the OSLog framework for entries in the system log. "
 
 schema([
   Column("timestamp", BIGINT, "unix timestamp associated with the entry", additional=True),
+  Column("timestamp_double", TEXT, "floating point timestamp associated with the entry"),
   Column("storage", INTEGER, "the storage category for the entry", additional=True),
   Column("message", TEXT, "composed message", additional=True),
   Column("activity", BIGINT, "the activity ID associate with the entry", additional=True),

--- a/tests/integration/tables/unified_log.cpp
+++ b/tests/integration/tables/unified_log.cpp
@@ -48,6 +48,7 @@ TEST_F(UnifiedLogTest, test_sanity) {
 
   ValidationMap row_map = {
       {"timestamp", IntType},
+      {"timestamp_double", NonEmptyString},
       {"level", NormalType},
       {"storage", IntType},
       {"message", NormalType},


### PR DESCRIPTION
The log entries timestamp is a double, we need to ensure that it's cast to an integer when returning it as a result to sqlite and using a timestamp constraint, otherwise sqlite will filter out all the entries that have the decimal part in them.
