### PR TITLE
ci: Reduce scheduled builds amount

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -15,9 +15,9 @@
 name: build_x86
 
 on:
-  # Run this workflow once every 6 hours against the master branch
+  # Run this workflow once every day against the master branch
   schedule:
-   - cron: "0 */6 * * *"
+   - cron: "0 7 * * *"
 
   push:
     branches:

--- a/.github/workflows/self_hosted_runners.yml
+++ b/.github/workflows/self_hosted_runners.yml
@@ -14,9 +14,9 @@
 name: build_aarch64
 
 on:
-  # Run this workflow once every 6 hours against the master branch
+  # Run this workflow once every day against the master branch
   schedule:
-   - cron: "0 */6 * * *"
+   - cron: "0 7 * * *"
 
   # Do not run this on pull requests
   push:


### PR DESCRIPTION
As discussed during office hours we want to reduce the amount of scheduled builds to once a day, during a low activity time.