### PR TITLE
ci: Update xcode version for macos-14 from 14.3.1 to 15.4

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -668,7 +668,7 @@ jobs:
       id: xcode_selector
       run: |
         if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-          xcode_path="/Applications/Xcode_14.3.1.app/Contents/Developer"
+          xcode_path="/Applications/Xcode_15.4.app/Contents/Developer"
         elif [[ "${{ matrix.os }}" == "macos-15" ]]; then
           xcode_path="/Applications/Xcode_16.app/Contents/Developer"
         else


### PR DESCRIPTION
The older version has been removed on arm64 runners.
Builds are currently failing: https://github.com/osquery/osquery/actions/runs/11725838783/job/32663117635

Just updating should not be a problem since the deployment target is what drives the compatibility.
