### PR TITLE
Add arc path to `chrome_extensions` on macOS

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -76,7 +76,8 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::Edge, "Library/Application Support/Microsoft Edge"},
     {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
     {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"},
-    {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"}};
+    {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"},
+    {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"}};
 // clang-format on
 
 const ChromePathSuffixMap kLinuxPathList = {
@@ -105,6 +106,7 @@ const std::unordered_map<ChromeBrowserType, std::string>
         {ChromeBrowserType::Edge, "edge"},
         {ChromeBrowserType::Edge, "edge_beta"},
         {ChromeBrowserType::Vivaldi, "vivaldi"},
+        {ChromeBrowserType::Arc, "arc"},
 };
 
 /// Base paths for built-in extensions; used to silence warnings for

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -38,7 +38,8 @@ enum class ChromeBrowserType {
   Opera,
   Edge,
   EdgeBeta,
-  Vivaldi
+  Vivaldi,
+  Arc,
 };
 
 /// Converts the browser type to a printable string


### PR DESCRIPTION
Adds additional chrome_extensions path for Arc on Mac, closing #8377.

This does not add Windows, as I can't test that, and I'm not to sure I find the correct path for it, closest is `%LOCALAPPDATA%\Packages\TheBrowserCompany.Arc_ttt1ap7aakyb4` from https://resources.arc.net/hc/en-us/articles/22353769256471-How-To-Set-Arc-Group-Policies, which _looks_ random.

You may notice the trailing `User Data` on the path, that as far as I can tell is just a quirk of Arcs chromium use, but correct. (The link above mentions plist use on Windows too, so I guess it leaks in both directions (?))

