### PR TITLE
fix IO objects refcounting

### DIFF
--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/utils/scope_guard.h>
 #include <IOKit/IOMessage.h>
+#include <osquery/utils/scope_guard.h>
 
 #include <osquery/core/tables.h>
 #include <osquery/events/darwin/iokit.h>
@@ -24,9 +24,10 @@ struct DeviceTracker : private boost::noncopyable {
  public:
   explicit DeviceTracker(IOKitEventPublisher* p) : publisher(p) {}
   ~DeviceTracker() {
-    if(notification)
+    if (notification)
       IOObjectRelease(notification);
   }
+
  public:
   IOKitEventPublisher* publisher{nullptr};
   io_object_t notification{0};
@@ -160,12 +161,13 @@ void IOKitEventPublisher::deviceAttach(void* refcon, io_iterator_t iterator) {
 
       // Create a notification tracker.
       auto tracker = std::make_shared<struct DeviceTracker>(self);
-      auto kr = IOServiceAddInterestNotification(self->port_,
-                                       device,
-                                       kIOGeneralInterest,
-                                       (IOServiceInterestCallback)deviceDetach,
-                                       tracker.get(),
-                                       &(tracker->notification));
+      auto kr = IOServiceAddInterestNotification(
+          self->port_,
+          device,
+          kIOGeneralInterest,
+          (IOServiceInterestCallback)deviceDetach,
+          tracker.get(),
+          &(tracker->notification));
       if (KERN_SUCCESS != kr) {
         continue;
       }

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <osquery/utils/scope_guard.h>
 #include <IOKit/IOMessage.h>
 
 #include <osquery/core/tables.h>
@@ -22,7 +23,10 @@ REGISTER(IOKitEventPublisher, "event_publisher", "iokit");
 struct DeviceTracker : private boost::noncopyable {
  public:
   explicit DeviceTracker(IOKitEventPublisher* p) : publisher(p) {}
-
+  ~DeviceTracker() {
+    if(notification)
+      IOObjectRelease(notification);
+  }
  public:
   IOKitEventPublisher* publisher{nullptr};
   io_object_t notification{0};
@@ -147,26 +151,29 @@ void IOKitEventPublisher::deviceAttach(void* refcon, io_iterator_t iterator) {
   // It is possible to reiterate devices, but that will cause duplicate events.
   while ((device = IOIteratorNext(iterator))) {
     {
+      // release reference obtained by IOIteratorNext
+      auto release = scope_guard::create([&]() { IOObjectRelease(device); });
       WriteLock lock(self->mutex_);
       if (self->port_ == nullptr) {
-        IOObjectRelease(device);
         continue;
       }
 
       // Create a notification tracker.
       auto tracker = std::make_shared<struct DeviceTracker>(self);
-      self->devices_.push_back(tracker);
-      IOServiceAddInterestNotification(self->port_,
+      auto kr = IOServiceAddInterestNotification(self->port_,
                                        device,
                                        kIOGeneralInterest,
                                        (IOServiceInterestCallback)deviceDetach,
                                        tracker.get(),
                                        &(tracker->notification));
+      if (KERN_SUCCESS != kr) {
+        continue;
+      }
+      self->devices_.push_back(tracker);
     }
     if (self->publisher_started_) {
       self->newEvent(device, IOKitEventContext::Action::DEVICE_ATTACH);
     }
-    IOObjectRelease(device);
   }
 }
 
@@ -184,20 +191,17 @@ void IOKitEventPublisher::deviceDetach(void* refcon,
   // The device tracker allows us to emit using the publisher and release the
   // notification created for this device.
   self->newEvent(device, IOKitEventContext::Action::DEVICE_DETACH);
-  IOObjectRelease(device);
 
   {
     WriteLock lock(self->mutex_);
     // Remove the device tracker.
-    IOObjectRelease(tracker->notification);
     auto it = self->devices_.begin();
     while (it != self->devices_.end()) {
       if ((*it)->notification == tracker->notification) {
-        IOObjectRelease((*it)->notification);
         self->devices_.erase(it);
         break;
       }
-      it++;
+      ++it;
     }
   }
 }
@@ -251,9 +255,6 @@ void IOKitEventPublisher::stop() {
   }
 
   // Clear all devices and their notifications.
-  for (const auto& device : devices_) {
-    IOObjectRelease(device->notification);
-  }
   devices_.clear();
 }
 


### PR DESCRIPTION
Experiencing random crashes in iokit thread on USB unplug. 
```
Crashed Thread:        22  iokit

Exception Type:        EXC_GUARD (SIGKILL)
Exception Codes:       GUARD_TYPE_MACH_PORT
Exception Codes:       0x0000000000005c03, 0x0000000000000000
...
Thread 22 Crashed:: iokit
0   libsystem_kernel.dylib        	       0x18da69ce4 _kernelrpc_mach_port_deallocate_trap + 8
1   libsystem_kernel.dylib        	       0x18da6b11c mach_port_deallocate + 28
2   IOKit                         	       0x191536678 IODispatchCalloutFromCFMessage + 396
3   CoreFoundation                	       0x18dbbf1d0 __CFMachPortPerform + 296
4   CoreFoundation                	       0x18db922c8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 60
5   CoreFoundation                	       0x18db921e8 __CFRunLoopDoSource1 + 524
6   CoreFoundation                	       0x18db90b48 __CFRunLoopRun + 2248
7   CoreFoundation                	       0x18db8fbc4 CFRunLoopRunSpecific + 588
8   CoreFoundation                	       0x18dc0ae50 CFRunLoopRun + 64
```

This PR aims to fix couple of refcounting issues in iokit.cpp:
1. `IOObjectRelease(device)` is called in some paths of `DeleteDevice`. The callback operates on a "borrowed" reference and shouldn't release it.
2. `IOReleaseObject(notification)` is called twice. Converting to RAII style management of notification object.