### PR TITLE
Add Darwin platform optimized path columns

### DIFF
--- a/specs/darwin/apps.table
+++ b/specs/darwin/apps.table
@@ -2,7 +2,7 @@ table_name("apps")
 description("macOS applications installed in known search paths (e.g., /Applications).")
 schema([
     Column("name", TEXT, "Name of the Name.app folder"),
-    Column("path", TEXT, "Absolute and full Name.app path", index=True),
+    Column("path", TEXT, "Absolute and full Name.app path", index=True, optimized=True),
     Column("bundle_executable", TEXT,
         "Info properties CFBundleExecutable label"),
     Column("bundle_identifier", TEXT,

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -9,6 +9,6 @@ schema([
     Column("modified", TEXT, "Date of last modification"),
     Column("type", TEXT, "Keychain item type (class)"),
     Column("pk_hash", TEXT, "Hash of associated public key (SHA1 of subjectPublicKey, see RFC 8520 4.2.1.2)"),
-    Column("path", TEXT, "Path to keychain containing item", additional=True),
+    Column("path", TEXT, "Path to keychain containing item", additional=True, optimized=True),
 ])
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/mdls.table
+++ b/specs/darwin/mdls.table
@@ -1,7 +1,7 @@
 table_name("mdls")
 description("Query file metadata in the Spotlight database.")
 schema([
-    Column("path", TEXT, "Path of the file", required=True),
+    Column("path", TEXT, "Path of the file", required=True, optimized=True),
     Column("key", TEXT, "Name of the metadata key"),
     Column("value", TEXT, "Value stored in the metadata key"),
     Column("valuetype", TEXT, "CoreFoundation type of data stored in value", hidden=True),

--- a/specs/darwin/package_bom.table
+++ b/specs/darwin/package_bom.table
@@ -7,7 +7,7 @@ schema([
     Column("mode", INTEGER, "Expected permissions"),
     Column("size", BIGINT, "Expected file size"),
     Column("modified_time", INTEGER, "Timestamp the file was installed"),
-    Column("path", TEXT, "Path of package bom", required=True),
+    Column("path", TEXT, "Path of package bom", required=True, optimized=True),
 ])
 implementation("packages@genPackageBOM")
 examples([

--- a/specs/darwin/plist.table
+++ b/specs/darwin/plist.table
@@ -4,8 +4,7 @@ schema([
     Column("key", TEXT, "Preference top-level key"),
     Column("subkey", TEXT, "Intermediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),
-    Column("path", TEXT, "(required) read preferences from a plist",
-      required=True),
+    Column("path", TEXT, "(required) read preferences from a plist", required=True, optimized=True),
 ])
 implementation("system/darwin/preferences@genOSXPlist")
 examples([

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -1,8 +1,7 @@
 table_name("signature")
 description("File (executable, bundle, installer, disk) code signing status.")
 schema([
-    Column("path", TEXT, "Must provide a path or directory",
-       index=True, required=True),
+    Column("path", TEXT, "Must provide a path or directory", index=True, optimized=True, required=True),
     Column("hash_resources", INTEGER,
        "Set to 1 to also hash resources, or 0 otherwise. Default is 1",
        additional=True),


### PR DESCRIPTION
This PR extends the optimized columns for the Darwin platform. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the `IN` optimization.

I've confirmed that the columns can support these changes by querying the tables with an `IN` constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before `IN` optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a `NULL`, `''` (empty string), and some non-existent values in my `IN` constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`.