### PR TITLE
Add Darwin platform optimized system-related columns

### DIFF
--- a/specs/darwin/authorization_mechanisms.table
+++ b/specs/darwin/authorization_mechanisms.table
@@ -1,7 +1,7 @@
 table_name("authorization_mechanisms")
 description("macOS Authorization mechanisms database.")
 schema([
-    Column("label", TEXT, "Label of the authorization right", index=True),
+    Column("label", TEXT, "Label of the authorization right", index=True, optimized=True),
     Column("plugin", TEXT, "Authorization plugin name"),
     Column("mechanism", TEXT, "Name of the mechanism that will be called"),
     Column("privileged", TEXT, "If privileged it will run as root, else as an anonymous user"),

--- a/specs/darwin/authorizations.table
+++ b/specs/darwin/authorizations.table
@@ -1,8 +1,7 @@
 table_name("authorizations")
 description("macOS Authorization rights database.")
 schema([
-    Column("label", TEXT, "Item name, usually in reverse domain format",
-      index=True),
+    Column("label", TEXT, "Item name, usually in reverse domain format", index=True, optimized=True),
     Column("modified", TEXT, "Label top-level key"),
     Column("allow_root", TEXT, "Label top-level key"),
     Column("timeout", TEXT, "Label top-level key"),

--- a/specs/darwin/power_sensors.table
+++ b/specs/darwin/power_sensors.table
@@ -1,7 +1,7 @@
 table_name("power_sensors")
 description("Machine power (currents, voltages, wattages, etc) sensors.")
 schema([
-    Column("key", TEXT, "The SMC key on macOS", index=True),
+    Column("key", TEXT, "The SMC key on macOS", index=True, optimized=True),
     Column("category", TEXT, "The sensor category: currents, voltage, wattage"),
     Column("name", TEXT, "Name of power source"),
     Column("value", TEXT, "Power in Watts"),

--- a/specs/darwin/smc_keys.table
+++ b/specs/darwin/smc_keys.table
@@ -1,7 +1,7 @@
 table_name("smc_keys")
 description("Apple's system management controller keys.")
 schema([
-    Column("key", TEXT, "4-character key", additional=True, index=True),
+    Column("key", TEXT, "4-character key", additional=True, index=True, optimized=True),
     Column("type", TEXT, "SMC-reported type literal type"),
     Column("size", INTEGER, "Reported size of data in bytes"),
     Column("value", TEXT, "A type-encoded representation of the key value"),

--- a/specs/darwin/temperature_sensors.table
+++ b/specs/darwin/temperature_sensors.table
@@ -1,7 +1,7 @@
 table_name("temperature_sensors")
 description("Machine's temperature sensors.")
 schema([
-    Column("key", TEXT, "The SMC key on macOS", index=True),
+    Column("key", TEXT, "The SMC key on macOS", index=True, optimized=True),
     Column("name", TEXT, "Name of temperature source"),
     Column("celsius", DOUBLE, "Temperature in Celsius"),
     Column("fahrenheit", DOUBLE, "Temperature in Fahrenheit"),


### PR DESCRIPTION
This PR extends the optimized columns for the Darwin platform. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the `IN` optimization.

I've confirmed that the columns can support these changes by querying the tables with an `IN` constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before `IN` optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a `NULL`, `''` (empty string), and some non-existent values in my `IN` constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`.