### PR TITLE
Add Darwin platform optimized miscellaneous columns

### DIFF
--- a/specs/darwin/homebrew_packages.table
+++ b/specs/darwin/homebrew_packages.table
@@ -5,7 +5,7 @@ schema([
     Column("path", TEXT, "Package install path"),
     Column("version", TEXT, "Current 'linked' version", collate="version"),
     Column("type", TEXT, "Package type ('formula' or 'cask')"),
-    Column("prefix", TEXT, "Homebrew install prefix", hidden=True, additional=True),
+    Column("prefix", TEXT, "Homebrew install prefix", hidden=True, additional=True, optimized=True),
 ])
 attributes(cacheable=True)
 implementation("system/homebrew_packages@genHomebrewPackages")

--- a/specs/darwin/mdfind.table
+++ b/specs/darwin/mdfind.table
@@ -2,7 +2,7 @@ table_name("mdfind")
 description("Run searches against the spotlight database.")
 schema([
     Column("path", TEXT, "Path of the file returned from spotlight"),
-    Column("query", TEXT, "The query that was run to find the file", required=True),
+    Column("query", TEXT, "The query that was run to find the file", required=True, optimized=True),
 ])
 implementation("mdfind@genMdfindResults")
 fuzz_paths([])

--- a/specs/darwin/nvram.table
+++ b/specs/darwin/nvram.table
@@ -1,7 +1,7 @@
 table_name("nvram")
 description("Apple NVRAM variable listing.")
 schema([
-    Column("name", TEXT, "Variable name", additional=True, index=True),
+    Column("name", TEXT, "Variable name", additional=True, index=True, optimized=True),
     Column("type", TEXT, "Data type (CFData, CFString, etc)"),
     Column("value", TEXT, "Raw variable data"),
 ])

--- a/specs/darwin/password_policy.table
+++ b/specs/darwin/password_policy.table
@@ -1,7 +1,7 @@
 table_name("password_policy")
 description("Password Policies for macOS.")
 schema([
-    Column("uid", BIGINT, "User ID for the policy, -1 for policies that are global", index=True),
+    Column("uid", BIGINT, "User ID for the policy, -1 for policies that are global", index=True, optimized=True),
     Column("policy_identifier", TEXT, "Policy Identifier"),
     Column("policy_content", TEXT, "Policy content"),
     Column("policy_description", TEXT, "Policy description"),

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -1,8 +1,7 @@
 table_name("preferences")
 description("macOS defaults and managed preferences.")
 schema([
-    Column("domain", TEXT, "Application ID usually in com.name.product format",
-      index=True),
+    Column("domain", TEXT, "Application ID usually in com.name.product format", index=True, optimized=True),
     Column("key", TEXT, "Preference top-level key", index=True),
     Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -1,8 +1,7 @@
 table_name("safari_extensions")
 description("Safari browser extension details for all users. This table requires Full Disk Access (FDA) permission.")
 schema([
-    Column("uid", BIGINT, "The local user that owns the extension",
-      index=True),
+    Column("uid", BIGINT, "The local user that owns the extension", index=True, optimized=True),
     Column("name", TEXT, "Extension display name"),
     Column("identifier", TEXT, "Extension identifier"),
     Column("version", TEXT, "Extension long version", collate="version"),


### PR DESCRIPTION
This PR extends the optimized columns for the Darwin platform. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the `IN` optimization.

I've confirmed that the columns can support these changes by querying the tables with an `IN` constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before `IN` optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a `NULL`, `''` (empty string), and some non-existent values in my `IN` constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`.