### PR TITLE
utils: Optimize default status message constructor

### DIFF
--- a/osquery/utils/status/status.cpp
+++ b/osquery/utils/status/status.cpp
@@ -15,6 +15,8 @@ namespace osquery {
 
 constexpr int Status::kSuccessCode;
 
+const std::string Status::okMessage("OK");
+
 Status Status::failure(int code, std::string message) {
   assert(code != Status::kSuccessCode &&
          "Using 'failure' to create Status object with a kSuccessCode");

--- a/osquery/utils/status/status.cpp
+++ b/osquery/utils/status/status.cpp
@@ -15,8 +15,6 @@ namespace osquery {
 
 constexpr int Status::kSuccessCode;
 
-const std::string Status::okMessage("OK");
-
 Status Status::failure(int code, std::string message) {
   assert(code != Status::kSuccessCode &&
          "Using 'failure' to create Status object with a kSuccessCode");

--- a/osquery/utils/status/status.h
+++ b/osquery/utils/status/status.h
@@ -34,14 +34,13 @@ namespace osquery {
 class Status {
  public:
   static constexpr int kSuccessCode = 0;
-  static const std::string okMessage;
   /**
    * @brief Default constructor
    *
    * Note that the default constructor initialized an osquery::Status instance
    * to a state such that a successful operation is indicated.
    */
-  explicit Status(int c = Status::kSuccessCode) : code_(c), message_(okMessage) {}
+  explicit Status(int c = Status::kSuccessCode) : code_(c), message_("OK") {}
 
   /**
    * @brief A constructor which can be used to concisely express the status of

--- a/osquery/utils/status/status.h
+++ b/osquery/utils/status/status.h
@@ -34,13 +34,14 @@ namespace osquery {
 class Status {
  public:
   static constexpr int kSuccessCode = 0;
+  static const std::string okMessage;
   /**
    * @brief Default constructor
    *
    * Note that the default constructor initialized an osquery::Status instance
    * to a state such that a successful operation is indicated.
    */
-  explicit Status(int c = Status::kSuccessCode) : code_(c), message_("OK") {}
+  explicit Status(int c = Status::kSuccessCode) : code_(c), message_(okMessage) {}
 
   /**
    * @brief A constructor which can be used to concisely express the status of

--- a/osquery/utils/status/status.h
+++ b/osquery/utils/status/status.h
@@ -34,13 +34,15 @@ namespace osquery {
 class Status {
  public:
   static constexpr int kSuccessCode = 0;
+  static const std::string okMessage;
   /**
    * @brief Default constructor
    *
    * Note that the default constructor initialized an osquery::Status instance
    * to a state such that a successful operation is indicated.
    */
-  explicit Status(int c = Status::kSuccessCode) : code_(c), message_("OK") {}
+  explicit Status(int c = Status::kSuccessCode)
+      : code_(c), message_(okMessage) {}
 
   /**
    * @brief A constructor which can be used to concisely express the status of


### PR DESCRIPTION
Watching `perf` tool shows large amount of `strlen` calls. The reason is in often default message construction that requires calculation of the constant string "OK" length.

Here we move this calculation on program start stage.