### PR TITLE
Add double quotes in Windows installation documentation

### DIFF
--- a/docs/wiki/installation/install-windows.md
+++ b/docs/wiki/installation/install-windows.md
@@ -45,7 +45,7 @@ The recommended way to set these ACLs is with PowerShell, and we've written a he
 C:\Users\Thor\work\repos\osquery [master ≡]
 λ  . .\tools\deployment\chocolatey\tools\osquery_utils.ps1
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  Set-SafePermissions C:\Program Files\osquery\osqueryd\
+λ  Set-SafePermissions "C:\Program Files\osquery\osqueryd\"
 True
 ```
 
@@ -66,14 +66,14 @@ C:\Program Files\osquery
 
 ```PowerShell
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  New-Service -Name "osqueryd" -BinaryPathName "C:\Program Files\osquery\osqueryd\osqueryd.exe --flagfile=C:\Program Files\osquery\osquery.flags"
+λ  New-Service -Name "osqueryd" -BinaryPathName "`"C:\Program Files\osquery\osqueryd\osqueryd.exe`" --flagfile=`"C:\Program Files\osquery\osquery.flags`""
 ```
 
 * Lastly, if you'd prefer to use the Windows service utility `sc.exe` you can use:
 
 ```PowerShell
 C:\Users\Thor\work\repos\osquery [master ≡]
-λ  sc.exe create osqueryd type= own start= auto error= normal binpath= "C:\Program Files\osquery\osqueryd\osqueryd.exe --flagfile=\Program Files\osquery\osquery.flags" displayname= 'osqueryd'
+λ  sc.exe create osqueryd type= own start= auto error= normal binpath= "`"C:\Program Files\osquery\osqueryd\osqueryd.exe`" --flagfile=`"C:\Program Files\osquery\osquery.flags`"" displayname= 'osqueryd'
 ```
 
 ## Running osquery
@@ -97,8 +97,8 @@ If you'd like to create your own osquery Chocolatey package, you can run [`.\too
 
 In order to enable support for the Windows Event Log, you first have to install the manifest file. To install and uninstall it manually, you can use the built-in `wevtutil` command:
 
-* **Install**: `wevtutil im C:\Program Files\osquery\osquery.man`
-* **Uninstall**: `wevtutil um C:\Program Files\osquery\osquery.man`
+* **Install**: `wevtutil im "C:\Program Files\osquery\osquery.man"`
+* **Uninstall**: `wevtutil um "C:\Program Files\osquery\osquery.man"`
 
 The same operation can be performed using the osquery manager (`C:\Program Files\osquery\manage-osqueryd.ps1`):
 

--- a/docs/wiki/installation/install-windows.md
+++ b/docs/wiki/installation/install-windows.md
@@ -59,7 +59,7 @@ For example:
 
 ````PowerShell
 C:\Program Files\osquery
-λ  .\manage-osqueryd.ps1 -install -startupArgs "C:\Program Files\osquery\osquery.flags"
+λ  .\manage-osqueryd.ps1 -install -startupArgs "--flagfile=`"C:\Program Files\osquery\osquery.flags`""
 ````
 
 * If you'd rather use Powershell to manually create the service you can run:
@@ -99,7 +99,6 @@ In order to enable support for the Windows Event Log, you first have to install 
 
 * **Install**: `wevtutil im "C:\Program Files\osquery\osquery.man"`
 * **Uninstall**: `wevtutil um "C:\Program Files\osquery\osquery.man"`
-
 The same operation can be performed using the osquery manager (`C:\Program Files\osquery\manage-osqueryd.ps1`):
 
 * **Install**: `.\manage-osqueryd.ps1 -installWelManifest`


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->


- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

solves #7368 

the issue is that installation-windows.md misses double quotes in the path which results in unexpected behavior during installation on Windows.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
