### PR TITLE
Add Linux platform optimized columns

### DIFF
--- a/specs/linux/deb_packages.table
+++ b/specs/linux/deb_packages.table
@@ -11,7 +11,7 @@ schema([
     Column("maintainer", TEXT, "Package maintainer"),
     Column("section", TEXT, "Package section"),
     Column("priority", TEXT, "Package priority"),
-    Column("admindir", TEXT, "libdpkg admindir. Defaults to /var/lib/dpkg", additional=True),
+    Column("admindir", TEXT, "libdpkg admindir. Defaults to /var/lib/dpkg", additional=True, optimized=True),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),

--- a/specs/linux/process_namespaces.table
+++ b/specs/linux/process_namespaces.table
@@ -1,7 +1,7 @@
 table_name("process_namespaces")
 description("Linux namespaces for processes running on the host system.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID", index=True),
+    Column("pid", INTEGER, "Process (or thread) ID", index=True, optimized=True),
     Column("cgroup_namespace", TEXT, "cgroup namespace inode"),
     Column("ipc_namespace", TEXT, "ipc namespace inode"),
     Column("mnt_namespace", TEXT, "mnt namespace inode"),

--- a/specs/linux/shadow.table
+++ b/specs/linux/shadow.table
@@ -10,7 +10,7 @@ schema([
     Column("inactive", BIGINT, "Number of days after password expires until account is blocked"),
     Column("expire", BIGINT, "Number of days since UNIX epoch date until account is disabled"),
     Column("flag", BIGINT, "Reserved"),
-    Column("username", TEXT, "Username", index=True),
+    Column("username", TEXT, "Username", index=True, optimized=True),
 ])
 implementation("system/shadow@genShadow")
 examples([


### PR DESCRIPTION
This PR extends the optimized columns for Linux platforms. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on Linux Ubuntu: `6.8.0-1018-gcp (Ubuntu 12.3.0-1ubuntu1~22.04)`.