### PR TITLE
Add POSIX platforms optimized columns

### DIFF
--- a/specs/posix/extended_attributes.table
+++ b/specs/posix/extended_attributes.table
@@ -1,8 +1,8 @@
 table_name("extended_attributes")
 description("Returns the extended attributes for files (similar to Windows ADS).")
 schema([
-    Column("path", TEXT, "Absolute file path", required=True),
-    Column("directory", TEXT, "Directory of file(s)", required=True),
+    Column("path", TEXT, "Absolute file path", required=True, optimized=True),
+    Column("directory", TEXT, "Directory of file(s)", required=True, optimized=True),
     Column("key", TEXT, "Name of the value generated from the extended attribute"),
     Column("value", TEXT, "The parsed information from the attribute"),
     Column("base64", INTEGER, "1 if the value is base64 encoded else 0"),

--- a/specs/posix/known_hosts.table
+++ b/specs/posix/known_hosts.table
@@ -1,8 +1,7 @@
 table_name("known_hosts")
 description("A line-delimited known_hosts table.")
 schema([
-    Column("uid", BIGINT, "The local user that owns the known_hosts file",
-      index=True),
+    Column("uid", BIGINT, "The local user that owns the known_hosts file", index=True, optimized=True),
     Column("key", TEXT, "parsed authorized keys line"),
     Column("key_file", TEXT, "Path to known_hosts file"),
     ForeignKey(column="uid", table="users"),

--- a/specs/posix/process_envs.table
+++ b/specs/posix/process_envs.table
@@ -1,7 +1,7 @@
 table_name("process_envs")
 description("A key/value table of environment variables for each process.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID", index=True),
+    Column("pid", INTEGER, "Process (or thread) ID", index=True, optimized=True),
     Column("key", TEXT, "Environment variable name"),
     Column("value", TEXT, "Environment variable value"),
 ])

--- a/specs/posix/shell_history.table
+++ b/specs/posix/shell_history.table
@@ -1,7 +1,7 @@
 table_name("shell_history")
 description("A line-delimited (command) table of per-user .*_history data.")
 schema([
-    Column("uid", BIGINT, "Shell history owner", additional=True),
+    Column("uid", BIGINT, "Shell history owner", additional=True, optimized=True),
     Column("time", INTEGER, "Entry timestamp. It could be absent, default value is 0."),
     Column("command", TEXT, "Unparsed date/line/command history line"),
     Column("history_file", TEXT, "Path to the .*_history for this user"),


### PR DESCRIPTION
This PR extends the optimized columns for POSIX platforms. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)` and Linux Ubuntu: `6.8.0-1018-gcp (Ubuntu 12.3.0-1ubuntu1~22.04)`.