### PR TITLE
Add Windows platform optimized columns

### DIFF
--- a/specs/windows/authenticode.table
+++ b/specs/windows/authenticode.table
@@ -1,7 +1,7 @@
 table_name("authenticode")
 description("File (executable, bundle, installer, disk) code signing status.")
 schema([
-    Column("path", TEXT, "Must provide a path or directory", required=True),
+    Column("path", TEXT, "Must provide a path or directory", required=True, optimized=True),
     Column("original_program_name", TEXT, "The original program name that the publisher has signed"),
     Column("serial_number", TEXT, "The certificate serial number"),
     Column("issuer_name", TEXT, "The certificate issuer name"),

--- a/specs/windows/ntfs_acl_permissions.table
+++ b/specs/windows/ntfs_acl_permissions.table
@@ -1,7 +1,7 @@
 table_name("ntfs_acl_permissions")
 description("Retrieve NTFS ACL permission information for files and directories.")
 schema([
-  Column("path", TEXT, "Path to the file or directory.", required=True, index=True),
+  Column("path", TEXT, "Path to the file or directory.", required=True, index=True, optimized=True),
   Column("type", TEXT, "Type of access mode for the access control entry."),
   Column("principal", TEXT, "User or group to which the ACE applies."),
   Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),

--- a/specs/windows/prefetch.table
+++ b/specs/windows/prefetch.table
@@ -1,7 +1,7 @@
 table_name("prefetch")
 description("Prefetch files show metadata related to file execution.")
 schema([
-    Column("path", TEXT, "Prefetch file path.", additional=True),
+    Column("path", TEXT, "Prefetch file path.", additional=True, optimized=True),
     Column("filename", TEXT, "Executable filename."),
     Column("hash", TEXT, "Prefetch CRC hash."),
     Column("last_run_time", INTEGER, "Most recent time application was run."),

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -1,8 +1,8 @@
 table_name("registry")
 description("All of the Windows registry hives.")
 schema([
-    Column("key", TEXT, "Name of the key to search for", additional=True, collate="nocase"),
-    Column("path", TEXT, "Full path to the value", index=True),
+    Column("key", TEXT, "Name of the key to search for", additional=True, optimized=True, collate="nocase"),
+    Column("path", TEXT, "Full path to the value", index=True, optimized=True),
     Column("name", TEXT, "Name of the registry value entry"),
     Column("type", TEXT, "Type of the registry value, or 'subkey' if item is a subkey"),
     Column("data", TEXT, "Data content of registry value"),


### PR DESCRIPTION
This PR extends the optimized columns for the Windows platform. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on Windows 11 Pro: `10.0.22631`.