### PR TITLE
Add all-platform user-based optimized columns

### DIFF
--- a/specs/chrome_extension_content_scripts.table
+++ b/specs/chrome_extension_content_scripts.table
@@ -2,7 +2,7 @@ table_name("chrome_extension_content_scripts")
 description("Chrome browser extension content scripts.")
 schema([
     Column("browser_type", TEXT, "The browser type (Valid values: chrome, chromium, opera, yandex, brave)"),
-    Column("uid", BIGINT, "The local user that owns the extension", index=True),
+    Column("uid", BIGINT, "The local user that owns the extension", index=True, optimized=True),
     Column("identifier", TEXT, "Extension identifier"),
     Column("version", TEXT, "Extension-supplied version"),
     Column("script", TEXT, "The content script used by the extension"),

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -2,7 +2,7 @@ table_name("chrome_extensions")
 description("Chrome-based browser extensions.")
 schema([
     Column("browser_type", TEXT, "The browser type (Valid values: chrome, chromium, opera, yandex, brave, edge, edge_beta)"),
-    Column("uid", BIGINT, "The local user that owns the extension", index=True),
+    Column("uid", BIGINT, "The local user that owns the extension", index=True, optimized=True),
     Column("name", TEXT, "Extension display name"),
     Column("profile", TEXT, "The name of the Chrome profile that contains this extension"),
     Column("profile_path", TEXT, "The profile path"),

--- a/specs/firefox_addons.table
+++ b/specs/firefox_addons.table
@@ -1,8 +1,7 @@
 table_name("firefox_addons")
 description("Firefox browser extensions, webapps, and addons.")
 schema([
-    Column("uid", BIGINT, "The local user that owns the addon",
-        additional=True),
+    Column("uid", BIGINT, "The local user that owns the addon", additional=True, optimized=True),
     Column("name", TEXT, "Addon display name"),
     Column("identifier", TEXT, "Addon identifier", index=True),
     Column("creator", TEXT, "Addon-supported creator string"),

--- a/specs/ssh_configs.table
+++ b/specs/ssh_configs.table
@@ -1,8 +1,7 @@
 table_name("ssh_configs")
 description("A table of parsed ssh_configs.")
 schema([
-    Column("uid", BIGINT, "The local owner of the ssh_config file",
-      additional=True),
+    Column("uid", BIGINT, "The local owner of the ssh_config file", additional=True, optimized=True),
     Column("block",TEXT,"The host or match block"),
     Column("option", TEXT, "The option and value"),
     Column("ssh_config_file", TEXT, "Path to the ssh_config file"),

--- a/specs/user_groups.table
+++ b/specs/user_groups.table
@@ -1,7 +1,7 @@
 table_name("user_groups")
 description("Local system user group relationships.")
 schema([
-    Column("uid", BIGINT, "User ID", index=True),
+    Column("uid", BIGINT, "User ID", index=True, optimized=True),
     Column("gid", BIGINT, "Group ID", index=True)
 ])
 implementation("user_groups@genUserGroups")

--- a/specs/user_ssh_keys.table
+++ b/specs/user_ssh_keys.table
@@ -1,8 +1,7 @@
 table_name("user_ssh_keys")
 description("Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted.")
 schema([
-    Column("uid", BIGINT, "The local user that owns the key file",
-      additional=True),
+    Column("uid", BIGINT, "The local user that owns the key file", additional=True, optimized=True),
     Column("path", TEXT, "Path to key file", index=True),
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
     Column("key_type", TEXT, "The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string."),

--- a/specs/vscode_extensions.table
+++ b/specs/vscode_extensions.table
@@ -9,8 +9,7 @@ schema([
     Column("publisher_id", TEXT, "Publisher ID"),
     Column("installed_at", BIGINT, "Installed Timestamp"),
     Column("prerelease", INTEGER, "Pre release version"),
-    Column("uid", BIGINT, "The local user that owns the plugin",
-      additional=True),
+    Column("uid", BIGINT, "The local user that owns the plugin", additional=True, optimized=True),
 ])
 attributes(user_data=True)
 implementation("applications/vscode_extensions@genVSCodeExtensions")


### PR DESCRIPTION
This PR extends the optimized columns for all platforms. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`, Linux Ubuntu: `6.8.0-1018-gcp (Ubuntu 12.3.0-1ubuntu1~22.04)`, and Windows 11 Pro: `10.0.22631`.