### PR TITLE
Add all-platform path-based optimized columns

### DIFF
--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -15,7 +15,7 @@ schema([
     Column("subject_key_id", TEXT, "SKID an optionally included SHA1"),
     Column("authority_key_id", TEXT, "AKID an optionally included SHA1"),
     Column("sha1", TEXT, "SHA1 hash of the raw certificate contents"),
-    Column("path", TEXT, "Path to Keychain or PEM bundle", additional=True),
+    Column("path", TEXT, "Path to Keychain or PEM bundle", additional=True, optimized=True),
     Column("serial", TEXT, "Certificate serial number"),
 
 ])

--- a/specs/hash.table
+++ b/specs/hash.table
@@ -1,8 +1,8 @@
 table_name("hash")
 description("Filesystem hash data.")
 schema([
-    Column("path", TEXT, "Must provide a path or directory", index=True, required=True),
-    Column("directory", TEXT, "Must provide a path or directory", required=True),
+    Column("path", TEXT, "Must provide a path or directory", index=True, optimized=True, required=True),
+    Column("directory", TEXT, "Must provide a path or directory", required=True, optimized=True),
     Column("md5", TEXT, "MD5 hash of provided filesystem data"),
     Column("sha1", TEXT, "SHA1 hash of provided filesystem data"),
     Column("sha256", TEXT, "SHA256 hash of provided filesystem data"),

--- a/specs/npm_packages.table
+++ b/specs/npm_packages.table
@@ -8,7 +8,7 @@ schema([
     Column("license", TEXT, "License under which package is launched"),
     Column("homepage", TEXT, "Package supplied homepage"),
     Column("path", TEXT, "Path at which this module resides"),
-    Column("directory", TEXT, "Directory where node_modules are located", index=True)
+    Column("directory", TEXT, "Directory where node_modules are located", index=True, optimized=True)
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),

--- a/specs/python_packages.table
+++ b/specs/python_packages.table
@@ -7,7 +7,7 @@ schema([
     Column("author", TEXT, "Optional package author"),
     Column("license", TEXT, "License under which package is launched"),
     Column("path", TEXT, "Path at which this module resides"),
-    Column("directory", TEXT, "Directory where Python modules are located", index=True)
+    Column("directory", TEXT, "Directory where Python modules are located", index=True, optimized=True)
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -1,8 +1,8 @@
 table_name("file")
 description("Interactive filesystem attributes and metadata.")
 schema([
-    Column("path", TEXT, "Absolute file path", required=True, index=True),
-    Column("directory", TEXT, "Directory of file(s)", required=True),
+    Column("path", TEXT, "Absolute file path", required=True, index=True, optimized=True),
+    Column("directory", TEXT, "Directory of file(s)", required=True, optimized=True),
     Column("filename", TEXT, "Name portion of file path"),
     Column("inode", BIGINT, "Filesystem inode number"),
     Column("uid", BIGINT, "Owning user ID"),


### PR DESCRIPTION
This PR extends the optimized columns for all platforms. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`, Linux Ubuntu: `6.8.0-1018-gcp (Ubuntu 12.3.0-1ubuntu1~22.04)`, and Windows 11 Pro: `10.0.22631`.