### PR TITLE
Add all platform process based and curl optimized columns

### DIFF
--- a/specs/curl.table
+++ b/specs/curl.table
@@ -1,7 +1,7 @@
 table_name("curl")
 description("Perform an http request and return stats about it.")
 schema([
-    Column("url", TEXT, "The url for the request", required=True, index=True),
+    Column("url", TEXT, "The url for the request", required=True, index=True, optimized=True),
     Column("method", TEXT, "The HTTP method for the request"),
     Column("user_agent", TEXT, "The user-agent string to use for the request",
        additional=True),

--- a/specs/process_memory_map.table
+++ b/specs/process_memory_map.table
@@ -1,7 +1,7 @@
 table_name("process_memory_map")
 description("Process memory mapped files and pseudo device/regions.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID", index=True),
+    Column("pid", INTEGER, "Process (or thread) ID", index=True, optimized=True),
     Column("start", TEXT, "Virtual start address (hex)"),
     Column("end", TEXT, "Virtual end address (hex)"),
     Column("permissions", TEXT, "r=read, w=write, x=execute, p=private (cow)"),

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -1,7 +1,7 @@
 table_name("processes")
 description("All running processes on the host system.")
 schema([
-    Column("pid", BIGINT, "Process (or thread) ID", index=True),
+    Column("pid", BIGINT, "Process (or thread) ID", index=True, optimized=True),
     Column("name", TEXT, "The process path or shorthand argv[0]"),
     Column("path", TEXT, "Path to executed binary"),
     Column("cmdline", TEXT, "Complete argv"),


### PR DESCRIPTION
This PR extends the optimized columns for all platforms. I've split up the optimized changes into multiple PRs to make it easier to validate the table generation methods. I've only added tables where I believe and tested the generate methods support the IN optimization.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on macOS Sequoia: `Version 15.2 Beta (24C5079e)`, Linux Ubuntu: `6.8.0-1018-gcp (Ubuntu 12.3.0-1ubuntu1~22.04)`, and Windows 11 Pro: `10.0.22631`.