### PR TITLE
Fixed eBPF's parsing of parent pid

### DIFF
--- a/osquery/events/linux/bpf/processcontextfactory.cpp
+++ b/osquery/events/linux/bpf/processcontextfactory.cpp
@@ -240,12 +240,12 @@ bool ProcessContextFactory::getParentPidFromStatFile(IFilesystem& fs,
     return false;
   }
 
-  auto parent_pid_r_it = std::find(buffer.rbegin(), buffer.rend(), ')');
-  if (parent_pid_r_it == buffer.rend()) {
+  auto parent_pid_it = std::find(buffer.begin(), buffer.end(), ')');
+  if (parent_pid_it == buffer.end()) {
     return false;
   }
 
-  auto parent_pid_it = std::next(parent_pid_r_it.base(), 4);
+  parent_pid_it = std::next(parent_pid_it, 4);
   if (parent_pid_it >= buffer.end()) {
     return false;
   }

--- a/osquery/events/linux/bpf/processcontextfactory.cpp
+++ b/osquery/events/linux/bpf/processcontextfactory.cpp
@@ -240,12 +240,12 @@ bool ProcessContextFactory::getParentPidFromStatFile(IFilesystem& fs,
     return false;
   }
 
-  auto parent_pid_it = std::find(buffer.begin(), buffer.end(), ')');
-  if (parent_pid_it == buffer.end()) {
+  auto parent_pid_r_it = std::find(buffer.rbegin(), buffer.rend(), ')');
+  if (parent_pid_r_it == buffer.rend()) {
     return false;
   }
 
-  parent_pid_it = std::next(parent_pid_it, 4);
+  auto parent_pid_it = std::next(parent_pid_r_it.base(), 3);
   if (parent_pid_it >= buffer.end()) {
     return false;
   }

--- a/osquery/events/tests/linux/bpf/processcontextfactory.cpp
+++ b/osquery/events/tests/linux/bpf/processcontextfactory.cpp
@@ -30,7 +30,7 @@ TEST_F(ProcessContextFactoryTests, captureSingleProcess) {
 
   EXPECT_TRUE(succeeded);
 
-  EXPECT_EQ(process_context.parent_process_id, 3616);
+  EXPECT_EQ(process_context.parent_process_id, 33616);
   EXPECT_EQ(process_context.binary_path, "/usr/bin/zsh");
 
   ASSERT_EQ(process_context.argv.size(), 3U);


### PR DESCRIPTION

Fixes eBPF's parent process pid parsing. The unit test https://github.com/osquery/osquery/blob/6ac7ffb1941703cd1317822c89357fe823b353d2/osquery/events/tests/linux/bpf/processcontextfactory.cpp#L33 should be `33616`, accordingly to the mock data
https://github.com/osquery/osquery/blob/6ac7ffb1941703cd1317822c89357fe823b353d2/osquery/events/tests/linux/bpf/mockedfilesystem.cpp#L20 