### PR TITLE
Add `symlink_target_path` to `files` tables

### DIFF
--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -386,7 +386,7 @@ void genFileInfoPosix(const fs::path& path,
   if (S_ISLNK(link_stat.st_mode)) {
     r["symlink"] = "1";
     fs::path symlink_target = fs::read_symlink(path);
-    r["symlink_target"] = symlink_target.string();
+    r["symlink_target_path"] = symlink_target.string();
   }
 
   if (stat(path.string().c_str(), &file_stat)) {

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -385,6 +385,8 @@ void genFileInfoPosix(const fs::path& path,
   }
   if (S_ISLNK(link_stat.st_mode)) {
     r["symlink"] = "1";
+    fs::path symlink_target = fs::read_symlink(path);
+    r["symlink_target"] = symlink_target.string();
   }
 
   if (stat(path.string().c_str(), &file_stat)) {

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -18,6 +18,7 @@ schema([
     Column("hard_links", INTEGER, "Number of hard links"),
     Column("symlink", INTEGER, "1 if the path is a symlink, otherwise 0"),
     Column("type", TEXT, "File status"),
+    Column("symlink_target", TEXT, "Full path of the symlink target if any")
 ])
 extended_schema(WINDOWS, [
     Column("attributes", TEXT, "File attrib string. See: https://ss64.com/nt/attrib.html"),

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -18,7 +18,7 @@ schema([
     Column("hard_links", INTEGER, "Number of hard links"),
     Column("symlink", INTEGER, "1 if the path is a symlink, otherwise 0"),
     Column("type", TEXT, "File status"),
-    Column("symlink_target", TEXT, "Full path of the symlink target if any")
+    Column("symlink_target_path", TEXT, "Full path of the symlink target if any")
 ])
 extended_schema(WINDOWS, [
     Column("attributes", TEXT, "File attrib string. See: https://ss64.com/nt/attrib.html"),

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -165,7 +165,8 @@ TEST_F(FileTests, test_sanity) {
                            {"btime", NonNegativeInt},
                            {"hard_links", IntType},
                            {"symlink", IntType},
-                           {"type", NonEmptyString}};
+                           {"type", NonEmptyString},
+                           {"symlink_target", NormalType}};
 #ifdef WIN32
   row_map["attributes"] = NormalType;
   row_map["volume_serial"] = NormalType;

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -166,7 +166,7 @@ TEST_F(FileTests, test_sanity) {
                            {"hard_links", IntType},
                            {"symlink", IntType},
                            {"type", NonEmptyString},
-                           {"symlink_target", NormalType}};
+                           {"symlink_target_path", NormalType}};
 #ifdef WIN32
   row_map["attributes"] = NormalType;
   row_map["volume_serial"] = NormalType;


### PR DESCRIPTION
Add an empty by default column `symlink_target` that will show the target in case of a symlink.

This is one of many small patches that should help drive #8476  ahead.

