### PR TITLE
Added python packages in user directories

### DIFF
--- a/specs/python_packages.table
+++ b/specs/python_packages.table
@@ -1,18 +1,22 @@
 table_name("python_packages")
-description("Python packages installed in a system.")
+description("Python packages installed in a system. NOTE: when querying on windows, even without a users cross join, all user installed python packages will be returned. This special behavior is to not break original functionality.")
 schema([
     Column("name", TEXT, "Package display name"),
+    Column("uid", BIGINT, "The local user that owns the python package", index=True),
     Column("version", TEXT, "Package-supplied version", collate="version"),
     Column("summary", TEXT, "Package-supplied summary"),
     Column("author", TEXT, "Optional package author"),
     Column("license", TEXT, "License under which package is launched"),
     Column("path", TEXT, "Path at which this module resides"),
-    Column("directory", TEXT, "Directory where Python modules are located", index=True, optimized=True)
+    Column("directory", TEXT, "Directory where Python modules are located", index=True, optimized=True),
+    ForeignKey(column="uid", table="users"),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
 ])
+attributes(user_data=True)
 implementation("system/linux/python_packages@genPythonPackages")
 examples([
-"select * from python_packages where directory='/usr/'",
+    "select * from python_packages where directory='/usr/'",
+    "select * from users cross join python_packages using (uid)"
 ])

--- a/tests/integration/tables/python_packages.cpp
+++ b/tests/integration/tables/python_packages.cpp
@@ -10,21 +10,37 @@
 // Sanity check integration test for python_packages
 // Spec file: specs/python_packages.table
 
+#include <osquery/dispatcher/dispatcher.h>
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
 
 namespace osquery {
 namespace table_tests {
 
 class pythonPackages : public testing::Test {
-  protected:
-    void SetUp() override {
-      setUpEnvironment();
-    }
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
 };
 
 TEST_F(pythonPackages, test_sanity) {
   ValidationMap row_map = {
       {"name", NormalType},
+      {"uid", IntType},
       {"version", NormalType},
       {"summary", NormalType},
       {"author", NormalType},


### PR DESCRIPTION
Added `uid` column to `python_packages`. This makes it easy to scan for packages in user directories. 

Fixes https://github.com/osquery/osquery/issues/8500
From Fleet: https://github.com/fleetdm/fleet/issues/24805

I included some user directories that were missing in the initial scan. `.pyenv` places its python packages in the user directory as well as doing a pip install with the `--user` [flag](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-user) with the homebrew installed python. Here are two example paths from my mac:
`/Users/ksykulev/.pyenv/versions/3.13.1/lib/python3.13/site-packages`
`/Users/ksykulev/Library/Python/3.13/lib/python/site-packages`