### PR TITLE
Add support for accept to macOS table `socket_events`

### DIFF
--- a/osquery/tables/events/darwin/socket_events.cpp
+++ b/osquery/tables/events/darwin/socket_events.cpp
@@ -18,6 +18,7 @@
 
 #include <osquery/core/flags.h>
 #include <osquery/events/darwin/openbsm.h>
+#include <osquery/logger/logger.h>
 #include <osquery/registry/registry_factory.h>
 #include <osquery/utils/system/uptime.h>
 
@@ -70,7 +71,7 @@ Status OpenBSMNetEvSubscriber::init() {
 }
 
 void OpenBSMNetEvSubscriber::configure() {
-  std::vector<size_t> event_ids{AUE_CONNECT, AUE_BIND};
+  std::vector<size_t> event_ids{AUE_CONNECT, AUE_BIND, AUE_ACCEPT};
   for (const auto& evid : event_ids) {
     auto sc = createSubscriptionContext();
     sc->event_id = evid;
@@ -92,6 +93,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["action"] = "connect";
         } else if (tok.tt.hdr32.e_type == AUE_BIND) {
           r["action"] = "bind";
+        } else if (tok.tt.hdr32.e_type == AUE_ACCEPT) {
+          r["action"] = "accept";
         } else {
           continue;
         }
@@ -102,6 +105,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["action"] = "connect";
         } else if (tok.tt.hdr32_ex.e_type == AUE_BIND) {
           r["action"] = "bind";
+        } else if (tok.tt.hdr32.e_type == AUE_ACCEPT) {
+          r["action"] = "accept";
         } else {
           continue;
         }
@@ -113,6 +118,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["action"] = "connect";
         } else if (tok.tt.hdr64_ex.e_type == AUE_BIND) {
           r["action"] = "bind";
+        } else if (tok.tt.hdr32.e_type == AUE_ACCEPT) {
+          r["action"] = "accept";
         } else {
           continue;
         }
@@ -176,6 +183,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["remote_port"] = "0";
           r["local_address"] = getIpFromToken(tok);
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
+        } else if (r["action"] == "accept") {
+          r["remote_address"] = getIpFromToken(tok);
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
@@ -197,6 +206,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["remote_port"] = "0";
           r["local_address"] = getIpFromToken(tok);
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
+        } else if (r["action"] == "accept") {
+          r["remote_address"] = getIpFromToken(tok);
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));

--- a/osquery/tables/events/darwin/socket_events.cpp
+++ b/osquery/tables/events/darwin/socket_events.cpp
@@ -185,6 +185,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
         } else if (r["action"] == "accept") {
           r["remote_address"] = getIpFromToken(tok);
+          // The message does contain a port value but it does not seem to
+          // correspond to either the local or the remote port.
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
@@ -208,6 +210,8 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
         } else if (r["action"] == "accept") {
           r["remote_address"] = getIpFromToken(tok);
+          // The message does contain a port value but it does not seem to
+          // correspond to either the local or the remote port.
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));

--- a/osquery/tables/events/darwin/socket_events.cpp
+++ b/osquery/tables/events/darwin/socket_events.cpp
@@ -118,7 +118,7 @@ Status OpenBSMNetEvSubscriber::Callback(
           r["action"] = "connect";
         } else if (tok.tt.hdr64_ex.e_type == AUE_BIND) {
           r["action"] = "bind";
-        } else if (tok.tt.hdr32.e_type == AUE_ACCEPT) {
+        } else if (tok.tt.hdr64.e_type == AUE_ACCEPT) {
           r["action"] = "accept";
         } else {
           continue;

--- a/specs/posix/socket_events.table
+++ b/specs/posix/socket_events.table
@@ -1,7 +1,7 @@
 table_name("socket_events")
-description("Track network socket opens and closes.")
+description("Track network socket bind, connect, and accepts.")
 schema([
-    Column("action", TEXT, "The socket action (bind, listen, close)"),
+    Column("action", TEXT, "The socket action (bind, connect, accept)"),
     Column("pid", BIGINT, "Process (or thread) ID"),
     Column("path", TEXT, "Path of executed file"),
     Column("fd", TEXT, "The file description for the process socket"),


### PR DESCRIPTION
This is useful for seeing when a new incoming connection is accepted on a listening socket. Includes the remote IP.

Closes #8379.
