### PR TITLE
Use empty columns instead of zeroes when undefined in socket_events

### DIFF
--- a/osquery/tables/events/darwin/socket_events.cpp
+++ b/osquery/tables/events/darwin/socket_events.cpp
@@ -172,15 +172,11 @@ Status OpenBSMNetEvSubscriber::Callback(
       }
       case AUT_SOCKINET32: {
         if (r["action"] == "bind") {
-          r["remote_address"] = "0";
-          r["remote_port"] = "0";
           r["local_address"] = getIpFromToken(tok);
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
-          r["local_address"] = "0";
-          r["local_port"] = "0";
         }
         if (tok.tt.sockinet_ex32.family == 2) {
           r["family"] = INTEGER(2);
@@ -193,15 +189,11 @@ Status OpenBSMNetEvSubscriber::Callback(
       }
       case AUT_SOCKINET128: {
         if (r["action"] == "bind") {
-          r["remote_address"] = "0";
-          r["remote_port"] = "0";
           r["local_address"] = getIpFromToken(tok);
           r["local_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
         } else {
           r["remote_address"] = getIpFromToken(tok);
           r["remote_port"] = INTEGER(ntohs(tok.tt.sockinet_ex32.port));
-          r["local_address"] = "0";
-          r["local_port"] = "0";
         }
         if (tok.tt.sockinet_ex32.family == 2) {
           r["family"] = INTEGER(2);

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -57,15 +57,9 @@ bool SocketEventSubscriber::parseSockAddr(const std::string& saddr,
   if (row["action"] == "bind") {
     address_column = "local_address";
     port_column = "local_port";
-
-    row["remote_address"] = "0";
-    row["remote_port"] = "0";
   } else {
     address_column = "remote_address";
     port_column = "remote_port";
-
-    row["local_address"] = "0";
-    row["local_port"] = "0";
   }
 
   // The protocol is not included in the audit message.


### PR DESCRIPTION
I think it is easier to understand the results when the values that are not relevant are set to empty/null rather than explicitly set to zero. I think that explicitly setting to zero might be a leftover from the time when osquery couldn't handle empty column values.
