### PR TITLE
Catching generic exception in order to avoid crashing when parsing windows events logs

### DIFF
--- a/osquery/events/windows/windowseventlogparser.cpp
+++ b/osquery/events/windows/windowseventlogparser.cpp
@@ -181,6 +181,9 @@ Status parseWindowsEventLogPTree(WELEvent& windows_event,
     property_list.add_child(node_name, event_data);
   };
 
+  /*
+   * Full Event schema description: https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventtype-complextype
+   */
   // Add the event & user data node to the property list
   getDataFromPtree("Event.EventData");
   getDataFromPtree("Event.UserData");
@@ -195,6 +198,10 @@ Status parseWindowsEventLogPTree(WELEvent& windows_event,
     return Status::failure(
         "Invalid Windows event object: the EventData tag is not valid: " +
         e.message());
+  } catch (const std::exception& e) {
+    return Status::failure(
+        "Invalid Windows event object: " +
+        std::string{ e.what() });
   }
 
   if (output.data.empty()) {

--- a/osquery/events/windows/windowseventlogparser.cpp
+++ b/osquery/events/windows/windowseventlogparser.cpp
@@ -182,7 +182,8 @@ Status parseWindowsEventLogPTree(WELEvent& windows_event,
   };
 
   /*
-   * Full Event schema description: https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventtype-complextype
+   * Full Event schema description:
+   * https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventtype-complextype
    */
   // Add the event & user data node to the property list
   getDataFromPtree("Event.EventData");
@@ -199,9 +200,8 @@ Status parseWindowsEventLogPTree(WELEvent& windows_event,
         "Invalid Windows event object: the EventData tag is not valid: " +
         e.message());
   } catch (const std::exception& e) {
-    return Status::failure(
-        "Invalid Windows event object: " +
-        std::string{ e.what() });
+    return Status::failure("Invalid Windows event object: " +
+                           std::string{e.what()});
   }
 
   if (output.data.empty()) {

--- a/osquery/tables/system/tests/windows/windows_eventlog_tests.cpp
+++ b/osquery/tables/system/tests/windows/windows_eventlog_tests.cpp
@@ -76,6 +76,35 @@ TEST_F(WindowsEventLogTests, parse_wel_xml) {
   EXPECT_EQ(row["data"], expect_data);
 }
 
+TEST_F(WindowsEventLogTests, parse_wel_xml_fails) {
+    std::string xml_event =
+        R"(<?xml version="1.0" encoding="UTF-8"?>
+               <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+                  <System>
+                         <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" EventSourceName="" />
+                         <EventID>1234</EventID>
+                         <Version>0</Version>
+                         <Level>0</Level>
+                         <Task>13569</Task>
+                         <Opcode>0</Opcode>
+                         <Keywords>0x8020000000000000</Keywords>
+                         <TimeCreated SystemTime="2021-07-09T17:42:21.9876643Z" />
+                         <EventRecordID>203</EventRecordID>
+                         <Correlation ActivityID="{5afc5725-7524-0001-8857-fc5a2475d701}" />
+                         <Execution ProcessID="624" ThreadID="728" />
+                         <Channel>Security</Channel>
+                         <Computer>DESKTOP-HFR8AR9</Computer>
+                         <Security />
+                  </System>
+               </Event>)";
+
+  QueryContext context;
+
+  Row row;
+  ASSERT_NO_THROW(parseWelXml(context, stringToWstring(xml_event), row));
+  EXPECT_TRUE(row.empty());
+}
+
 TEST_F(WindowsEventLogTests, gen_xfilter_test1) {
   QueryContext context;
   std::string xfilter;

--- a/osquery/tables/system/tests/windows/windows_eventlog_tests.cpp
+++ b/osquery/tables/system/tests/windows/windows_eventlog_tests.cpp
@@ -77,26 +77,24 @@ TEST_F(WindowsEventLogTests, parse_wel_xml) {
 }
 
 TEST_F(WindowsEventLogTests, parse_wel_xml_fails) {
-    std::string xml_event =
-        R"(<?xml version="1.0" encoding="UTF-8"?>
-               <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
-                  <System>
-                         <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" EventSourceName="" />
-                         <EventID>1234</EventID>
-                         <Version>0</Version>
-                         <Level>0</Level>
-                         <Task>13569</Task>
-                         <Opcode>0</Opcode>
-                         <Keywords>0x8020000000000000</Keywords>
-                         <TimeCreated SystemTime="2021-07-09T17:42:21.9876643Z" />
-                         <EventRecordID>203</EventRecordID>
-                         <Correlation ActivityID="{5afc5725-7524-0001-8857-fc5a2475d701}" />
-                         <Execution ProcessID="624" ThreadID="728" />
-                         <Channel>Security</Channel>
-                         <Computer>DESKTOP-HFR8AR9</Computer>
-                         <Security />
-                  </System>
-               </Event>)";
+  std::string xml_event =
+      "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>"
+      "<System>"
+      "<Provider Name='Microsoft-Windows-Security-Auditing' "
+      "Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}' EventSourceName='' />"
+      "<EventID>1234</EventID>"
+      "<Version>0</Version>"
+      "<Level>0</Level>"
+      "<Task>13569</Task>"
+      "<Opcode>0</Opcode>"
+      "<Keywords>0x8020000000000000</Keywords>"
+      "<TimeCreated SystemTime='2021-07-09T17:42:21.9876643Z' />"
+      "<EventRecordID>203</EventRecordID>"
+      "<Correlation ActivityID='{5afc5725-7524-0001-8857-fc5a2475d701}' />"
+      "<Execution ProcessID='624' ThreadID='728' />"
+      "<Channel>Security</Channel>"
+      "<Computer>DESKTOP-HFR8AR9</Computer>"
+      "<Security /></System></Event>";
 
   QueryContext context;
 


### PR DESCRIPTION
Fixes [#7340](https://github.com/osquery/osquery/issues/7340)

For the time being we are only catching the exception to avoid crashing the process.
The schema description is explained on this page [EventType Schema](https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventtype-complextype)

The downside of this solution is that we are going to miss the event. In order to get those events, it should be as easy as adding the parsing of xml elements: `DebugData`, `BinaryEventData` and `ProcessingErrorData`. The content of those elements will be flattened out and stored into `row["data"]`. 

E.g.
```
getDataFromPtree("Event.EventData");
getDataFromPtree("Event.UserData");

getDataFromPtree("Event.DebugData");
getDataFromPtree("Event.BinaryEventData");
getDataFromPtree("Event.ProcessingErrorData");
```

Happy to add those if you are happy to.