### PR TITLE
[Windows] Switched to wmain to accept non-ascii characters from command line

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -297,6 +297,7 @@ function(setupBuildFlags)
 
     set(windows_common_link_options
       /SUBSYSTEM:CONSOLE
+      /ENTRY:wmainCRTStartup
       ntdll.lib
       ole32.lib
       oleaut32.lib

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -297,7 +297,6 @@ function(setupBuildFlags)
 
     set(windows_common_link_options
       /SUBSYSTEM:CONSOLE
-      /ENTRY:wmainCRTStartup
       ntdll.lib
       ole32.lib
       oleaut32.lib

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -56,6 +56,11 @@ function(generateOsqueryd)
   set(osquery_ext "")
   if(PLATFORM_WINDOWS)
     set(osquery_ext ".exe")
+
+    # Allows the use of wmain(...)
+    target_link_options(osqueryd INTERFACE
+      /ENTRY:wmainCRTStartup
+    )
   endif()
 
   add_custom_target(create_osqueryi ALL DEPENDS osqueryi${osquery_ext})

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -39,8 +39,12 @@ function(generateOsqueryd)
   # Upstream uses an empty executable that links to a library with a
   # a main() entry point; try to emulate this.
   set(source_file "${CMAKE_CURRENT_BINARY_DIR}/empty_osqueryd_target_source_file.cpp")
-  generateBuildTimeSourceFile(${source_file} "extern int main(int argc, char* argv[]);")
-
+  if(PLATFORM_WINDOWS)
+    generateBuildTimeSourceFile(${source_file} "extern int wmain(int argc, wchar_t* argv[]);")
+  else()
+    generateBuildTimeSourceFile(${source_file} "extern int main(int argc, char* argv[]);")
+  endif()
+  
   add_osquery_executable(osqueryd "${source_file}")
   set_target_properties(osqueryd PROPERTIES POSITION_INDEPENDENT_CODE true)
 

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -58,7 +58,7 @@ function(generateOsqueryd)
     set(osquery_ext ".exe")
 
     # Allows the use of wmain(...)
-    target_link_options(osqueryd INTERFACE
+    target_link_options(osqueryd PRIVATE
       /ENTRY:wmainCRTStartup
     )
   endif()

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -27,6 +27,8 @@
 #include <osquery/core/shutdown.h>
 #include <osquery/filesystem/filesystem.h>
 
+#include <osquery/utils/conversions/windows/strings.h>
+
 DECLARE_string(flagfile);
 
 namespace osquery {
@@ -367,4 +369,21 @@ int main(int argc, char* argv[]) {
     }
   }
   return retcode;
+}
+
+int wmain(int argc, wchar_t* wargv[]) {
+  std::vector<std::wstring> wargs(wargv, wargv + argc);
+  std::vector<std::string> copies;
+  std::vector<char*> argv;
+
+  copies.reserve(wargs.size());
+  argv.reserve(wargs.size());
+
+  for (auto& arg : wargs) {
+    auto str = osquery::wstringToString(arg);
+    copies.emplace_back(str);
+    argv.push_back(copies.back().data());
+  }
+
+  return main(argc, &argv[0]);
 }


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/7923

From this https://github.com/osquery/osquery/issues/7923#issuecomment-1654679368 I implemented solution 1, switching from main to wmain, as the quickest and cleanest to implement.