### PR TITLE
Removing manufacture_date from battery table

### DIFF
--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -155,7 +155,6 @@ BOOL genAdvancedBatteryInfo(Row& r) {
     [components setYear:year];
     NSDate* date = [calendar dateFromComponents:components];
 
-    r["manufacture_date"] = INTEGER([date timeIntervalSince1970]);
   }
   if ([advancedBatteryInfo objectForKey:@kIOPMDeviceNameKey]) {
     r["model"] = SQL_TEXT(

--- a/specs/macwin/battery.table
+++ b/specs/macwin/battery.table
@@ -23,6 +23,5 @@ extended_schema(WINDOWS, [
 extended_schema(DARWIN, [
     Column("health", TEXT, "One of the following: \"Good\" describes a well-performing battery, \"Fair\" describes a functional battery with limited capacity, or \"Poor\" describes a battery that's not capable of providing power"),
     Column("condition", TEXT, "One of the following: \"Normal\" indicates the condition of the battery is within normal tolerances, \"Service Needed\" indicates that the battery should be checked out by a licensed Mac repair service, \"Permanent Failure\" indicates the battery needs replacement"),
-    Column("manufacture_date", INTEGER, "The date the battery was manufactured UNIX Epoch"),
 ])
 implementation("battery@genBatteryInfo")

--- a/tests/integration/tables/battery.cpp
+++ b/tests/integration/tables/battery.cpp
@@ -34,7 +34,6 @@ TEST_F(battery, test_sanity) {
   // Or use custom DataCheck object
   // ValidationMap row_map = {
   //      {"manufacturer", NormalType}
-  //      {"manufacture_date", IntType}
   //      {"model", NormalType}
   //      {"serial_number", NormalType}
   //      {"cycle_count", IntType}


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->


- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

Resolves #8266 

Removed the `manufacture_date` from `battery` table for macOS.
<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
