### PR TITLE
In `wifi_networks` convert `ssid` from hex string to ascii string

### DIFF
--- a/osquery/tables/networking/darwin/wifi_utils.mm
+++ b/osquery/tables/networking/darwin/wifi_utils.mm
@@ -53,17 +53,13 @@ std::string extractSsid(const CFDataRef& data) {
   if (data == nil) {
     return "";
   }
-  std::stringstream ss;
   auto bytes = CFDataGetBytePtr(data);
   auto length = CFDataGetLength(data);
+  std::string s;
   for (CFIndex i = 0; i < length; i++) {
-    if (i > 0 && i % 4 == 0) {
-      ss << " ";
-    }
-    ss << std::setfill('0') << std::setw(2) << std::hex
-       << (unsigned int)bytes[i];
+    s += static_cast<char>(bytes[i]);
   }
-  return ss.str();
+  return s;
 }
 
 std::string getSecurityName(const CWSecurity cw) {


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->


- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

Resolves #8515 

added code for conversion of hexadecimal string to ascii valued string

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
