### PR TITLE
Replacing ssid column description and adding spaces for ssid hexadeci…

### DIFF
--- a/osquery/tables/networking/darwin/wifi_utils.mm
+++ b/osquery/tables/networking/darwin/wifi_utils.mm
@@ -61,7 +61,7 @@ std::string extractSsid(const CFDataRef& data) {
       ss << " ";
     }
     ss << std::setfill('0') << std::setw(2) << std::hex
-       << (unsigned int)bytes[i];
+       << (unsigned int)bytes[i] << " ";
   }
   return ss.str();
 }

--- a/specs/darwin/wifi_networks.table
+++ b/specs/darwin/wifi_networks.table
@@ -1,7 +1,7 @@
 table_name("wifi_networks")
 description("macOS known/remembered Wi-Fi networks list.")
 schema([
-    Column("ssid", TEXT, "SSID octets of the network"),
+    Column("ssid", TEXT, "Raw bytes of the network name (aka SSID) as a hexadecimal string, for network names with non-printable Unicode characters"),
     Column("network_name", TEXT, "Name of the network"),
     Column("security_type", TEXT, "Type of security on this network"),
     Column("last_connected", INTEGER, "Last time this network was connected to as a unix_time", hidden=True),

--- a/specs/darwin/wifi_scan.table
+++ b/specs/darwin/wifi_scan.table
@@ -2,7 +2,7 @@ table_name("wifi_survey")
 description("Scan for nearby WiFi networks.")
 schema([
     Column("interface", TEXT, "Name of the interface"),
-    Column("ssid", TEXT, "SSID octets of the network"),
+    Column("ssid", TEXT, "Raw bytes of the network name (aka SSID) as a hexadecimal string, for network names with non-printable Unicode characters"),
     Column("bssid", TEXT, "The current basic service set identifier"),
     Column("network_name", TEXT, "Name of the network"),
     Column("country_code", TEXT, "The country code (ISO/IEC 3166-1:1997) for the network"),

--- a/specs/darwin/wifi_status.table
+++ b/specs/darwin/wifi_status.table
@@ -2,7 +2,7 @@ table_name("wifi_status")
 description("macOS current WiFi status.")
 schema([
     Column("interface", TEXT, "Name of the interface"),
-    Column("ssid", TEXT, "SSID octets of the network"),
+    Column("ssid", TEXT, "Raw bytes of the network name (aka SSID) as a hexadecimal string, for network names with non-printable Unicode characters"),
     Column("bssid", TEXT, "The current basic service set identifier"),
     Column("network_name", TEXT, "Name of the network"),
     Column("country_code", TEXT, "The country code (ISO/IEC 3166-1:1997) for the network"),


### PR DESCRIPTION
…mal string

<!-- Thank you for contributing to osquery! -->

- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

Resolves #8515 

Changed column description for ssid in wifi related tables and added spacing between bytes for ssid value.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
