### PR TITLE
Boost 1.87 compatibility

### DIFF
--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -29,7 +29,7 @@
 // Keep it on top of all other includes to fix double include WinSock.h header file
 // which is windows specific boost build problem
 #include <boost/asio/deadline_timer.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
 // clang-format on


### PR DESCRIPTION
I'm currently rebuilding osquery for Boost 1.87 on Arch Linux and have produced this compatibility patch.

These changes are not backwards compatible with Boost 1.86, but that could be fixed with some `#if BOOST_VERSION` checks if needed. Let me know if that's the case.

Thanks!