### PR TITLE
Fix/startup items parsing

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -359,6 +359,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/windows_eventlog.h
       windows/windows_update_history.h
       windows/security_profile_info_utils.h
+      windows/startup_items.h
     )
   endif()
 

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -193,6 +193,7 @@ function(generateOsqueryTablesSystemWindowsTests)
     windows/windows_eventlog_tests.cpp
     windows/windows_optional_features_tests.cpp
     windows/windows_update_history_tests.cpp
+	windows/startup_items_tests.cpp
   )
 
   target_link_libraries(osquery_tables_system_windows_tests-test PRIVATE

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -193,7 +193,7 @@ function(generateOsqueryTablesSystemWindowsTests)
     windows/windows_eventlog_tests.cpp
     windows/windows_optional_features_tests.cpp
     windows/windows_update_history_tests.cpp
-	windows/startup_items_tests.cpp
+    windows/startup_items_tests.cpp
   )
 
   target_link_libraries(osquery_tables_system_windows_tests-test PRIVATE

--- a/osquery/tables/system/tests/windows/startup_items_tests.cpp
+++ b/osquery/tables/system/tests/windows/startup_items_tests.cpp
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+ 
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/tests/test_util.h>
+
+#include <osquery/tables/system/windows/startup_items.h>
+
+namespace osquery {
+namespace tables {
+
+  struct StartupItemsTests : testing::Test {
+
+        Row r;
+		std::error_code ec;
+        std::filesystem::path tmp;
+
+        void SetUp()
+        {
+            tmp = std::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("osquery-startup-items-%%%%%").string();
+            ASSERT_FALSE(ec);
+            std::filesystem::create_directories(tmp, ec);
+            ASSERT_FALSE(ec);
+        }
+
+        void TearDown()
+        {
+            // reset Row each test
+            r = {};
+            ec = {};
+            std::filesystem::remove_all(tmp, ec);
+        }
+    };
+
+    TEST_F(StartupItemsTests, test_no_path)
+    {
+        auto path = std::string{};
+        ASSERT_FALSE(parseStartupPath(path, r));
+        EXPECT_TRUE(r.empty());
+    }
+
+    TEST_F(StartupItemsTests, test_path_no_spaces)
+    {
+        auto path = std::string{ "C:\\Windows\\System32\\cmd.exe" };
+        ASSERT_TRUE(parseStartupPath(path, r));
+        EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
+    }
+
+    TEST_F(StartupItemsTests, test_path_no_spaces_with_argument)
+    {
+        auto path = std::string{ "C:\\Windows\\System32\\cmd.exe /r /c" };
+        ASSERT_TRUE(parseStartupPath(path, r));
+        EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
+        EXPECT_EQ(r["args"], "/r /c");
+    }
+
+    TEST_F(StartupItemsTests, test_path_with_spaces)
+    {
+        auto file = tmp / "path with spaces";
+        file.make_preferred();
+        std::filesystem::create_directories(file);
+
+        file /= "startup_item.exe";
+        file.make_preferred();
+        {
+            std::ofstream out(file);
+            ASSERT_TRUE(out.is_open());
+            out << "";
+        }
+        ASSERT_TRUE(parseStartupPath(file.string(), r));
+        EXPECT_EQ(r["path"], file.string());
+        EXPECT_EQ(r["args"], "");
+    }
+
+    TEST_F(StartupItemsTests, test_path_with_spaces_and_args)
+    {
+        auto file = tmp / "spaces in path";
+        file.make_preferred();
+        std::filesystem::create_directories(file);
+
+        file /= "startup_item.exe";
+        file.make_preferred();
+        {
+            std::ofstream out(file);
+            ASSERT_TRUE(out.is_open());
+            out << "";
+        }
+        ASSERT_TRUE(parseStartupPath(file.string() + " /a /b", r));
+        EXPECT_EQ(r["path"], file.string());
+        EXPECT_EQ(r["args"], "/a /b");
+    }
+
+    TEST_F(StartupItemsTests, test_quoted_path_with_spaces_and_args)
+    {
+        auto file = tmp / "spaces in path";
+        file.make_preferred();
+        std::filesystem::create_directories(file);
+
+        file /= "startup_item.exe";
+        file.make_preferred();
+        {
+            std::ofstream out(file);
+            ASSERT_TRUE(out.is_open());
+            out << "";
+        }
+        ASSERT_TRUE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
+        EXPECT_EQ(r["path"], file.string());
+        EXPECT_EQ(r["args"], "/g /h");
+    }
+
+    TEST_F(StartupItemsTests, test_non_existing_path)
+    {
+        auto file = tmp / "spaces in path" / "startup_item.exe";
+        file.make_preferred();
+
+        ASSERT_FALSE(parseStartupPath(file.string() + " /g /h", r));
+        EXPECT_TRUE(r.empty());
+    }
+
+    TEST_F(StartupItemsTests, test_quoted_non_existing_path)
+    {
+        auto file = tmp / "spaces in path" / "startup_item.exe";
+        file.make_preferred();
+
+        ASSERT_FALSE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
+        EXPECT_TRUE(r.empty());
+    }
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/windows/startup_items_tests.cpp
+++ b/osquery/tables/system/tests/windows/startup_items_tests.cpp
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
- 
+
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -20,121 +20,112 @@
 namespace osquery {
 namespace tables {
 
-  struct StartupItemsTests : testing::Test {
+struct StartupItemsTests : testing::Test {
+  Row r;
+  std::error_code ec;
+  std::filesystem::path tmp;
 
-        Row r;
-		std::error_code ec;
-        std::filesystem::path tmp;
+  void SetUp() {
+    tmp =
+        std::filesystem::temp_directory_path(ec) /
+        boost::filesystem::unique_path("osquery-startup-items-%%%%%").string();
+    ASSERT_FALSE(ec);
+    std::filesystem::create_directories(tmp, ec);
+    ASSERT_FALSE(ec);
+  }
 
-        void SetUp()
-        {
-            tmp = std::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("osquery-startup-items-%%%%%").string();
-            ASSERT_FALSE(ec);
-            std::filesystem::create_directories(tmp, ec);
-            ASSERT_FALSE(ec);
-        }
+  void TearDown() {
+    // reset Row each test
+    r = {};
+    ec = {};
+    std::filesystem::remove_all(tmp, ec);
+  }
+};
 
-        void TearDown()
-        {
-            // reset Row each test
-            r = {};
-            ec = {};
-            std::filesystem::remove_all(tmp, ec);
-        }
-    };
+TEST_F(StartupItemsTests, test_no_path) {
+  auto path = std::string{};
+  ASSERT_FALSE(parseStartupPath(path, r));
+  EXPECT_TRUE(r.empty());
+}
 
-    TEST_F(StartupItemsTests, test_no_path)
-    {
-        auto path = std::string{};
-        ASSERT_FALSE(parseStartupPath(path, r));
-        EXPECT_TRUE(r.empty());
-    }
+TEST_F(StartupItemsTests, test_path_no_spaces) {
+  auto path = std::string{"C:\\Windows\\System32\\cmd.exe"};
+  ASSERT_TRUE(parseStartupPath(path, r));
+  EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
+}
 
-    TEST_F(StartupItemsTests, test_path_no_spaces)
-    {
-        auto path = std::string{ "C:\\Windows\\System32\\cmd.exe" };
-        ASSERT_TRUE(parseStartupPath(path, r));
-        EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
-    }
+TEST_F(StartupItemsTests, test_path_no_spaces_with_argument) {
+  auto path = std::string{"C:\\Windows\\System32\\cmd.exe /r /c"};
+  ASSERT_TRUE(parseStartupPath(path, r));
+  EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
+  EXPECT_EQ(r["args"], "/r /c");
+}
 
-    TEST_F(StartupItemsTests, test_path_no_spaces_with_argument)
-    {
-        auto path = std::string{ "C:\\Windows\\System32\\cmd.exe /r /c" };
-        ASSERT_TRUE(parseStartupPath(path, r));
-        EXPECT_EQ(r["path"], "C:\\Windows\\System32\\cmd.exe");
-        EXPECT_EQ(r["args"], "/r /c");
-    }
+TEST_F(StartupItemsTests, test_path_with_spaces) {
+  auto file = tmp / "path with spaces";
+  file.make_preferred();
+  std::filesystem::create_directories(file);
 
-    TEST_F(StartupItemsTests, test_path_with_spaces)
-    {
-        auto file = tmp / "path with spaces";
-        file.make_preferred();
-        std::filesystem::create_directories(file);
+  file /= "startup_item.exe";
+  file.make_preferred();
+  {
+    std::ofstream out(file);
+    ASSERT_TRUE(out.is_open());
+    out << "";
+  }
+  ASSERT_TRUE(parseStartupPath(file.string(), r));
+  EXPECT_EQ(r["path"], file.string());
+  EXPECT_EQ(r["args"], "");
+}
 
-        file /= "startup_item.exe";
-        file.make_preferred();
-        {
-            std::ofstream out(file);
-            ASSERT_TRUE(out.is_open());
-            out << "";
-        }
-        ASSERT_TRUE(parseStartupPath(file.string(), r));
-        EXPECT_EQ(r["path"], file.string());
-        EXPECT_EQ(r["args"], "");
-    }
+TEST_F(StartupItemsTests, test_path_with_spaces_and_args) {
+  auto file = tmp / "spaces in path";
+  file.make_preferred();
+  std::filesystem::create_directories(file);
 
-    TEST_F(StartupItemsTests, test_path_with_spaces_and_args)
-    {
-        auto file = tmp / "spaces in path";
-        file.make_preferred();
-        std::filesystem::create_directories(file);
+  file /= "startup_item.exe";
+  file.make_preferred();
+  {
+    std::ofstream out(file);
+    ASSERT_TRUE(out.is_open());
+    out << "";
+  }
+  ASSERT_TRUE(parseStartupPath(file.string() + " /a /b", r));
+  EXPECT_EQ(r["path"], file.string());
+  EXPECT_EQ(r["args"], "/a /b");
+}
 
-        file /= "startup_item.exe";
-        file.make_preferred();
-        {
-            std::ofstream out(file);
-            ASSERT_TRUE(out.is_open());
-            out << "";
-        }
-        ASSERT_TRUE(parseStartupPath(file.string() + " /a /b", r));
-        EXPECT_EQ(r["path"], file.string());
-        EXPECT_EQ(r["args"], "/a /b");
-    }
+TEST_F(StartupItemsTests, test_quoted_path_with_spaces_and_args) {
+  auto file = tmp / "spaces in path";
+  file.make_preferred();
+  std::filesystem::create_directories(file);
 
-    TEST_F(StartupItemsTests, test_quoted_path_with_spaces_and_args)
-    {
-        auto file = tmp / "spaces in path";
-        file.make_preferred();
-        std::filesystem::create_directories(file);
+  file /= "startup_item.exe";
+  file.make_preferred();
+  {
+    std::ofstream out(file);
+    ASSERT_TRUE(out.is_open());
+    out << "";
+  }
+  ASSERT_TRUE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
+  EXPECT_EQ(r["path"], file.string());
+  EXPECT_EQ(r["args"], "/g /h");
+}
 
-        file /= "startup_item.exe";
-        file.make_preferred();
-        {
-            std::ofstream out(file);
-            ASSERT_TRUE(out.is_open());
-            out << "";
-        }
-        ASSERT_TRUE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
-        EXPECT_EQ(r["path"], file.string());
-        EXPECT_EQ(r["args"], "/g /h");
-    }
+TEST_F(StartupItemsTests, test_non_existing_path) {
+  auto file = tmp / "spaces in path" / "startup_item.exe";
+  file.make_preferred();
 
-    TEST_F(StartupItemsTests, test_non_existing_path)
-    {
-        auto file = tmp / "spaces in path" / "startup_item.exe";
-        file.make_preferred();
+  ASSERT_FALSE(parseStartupPath(file.string() + " /g /h", r));
+  EXPECT_TRUE(r.empty());
+}
 
-        ASSERT_FALSE(parseStartupPath(file.string() + " /g /h", r));
-        EXPECT_TRUE(r.empty());
-    }
+TEST_F(StartupItemsTests, test_quoted_non_existing_path) {
+  auto file = tmp / "spaces in path" / "startup_item.exe";
+  file.make_preferred();
 
-    TEST_F(StartupItemsTests, test_quoted_non_existing_path)
-    {
-        auto file = tmp / "spaces in path" / "startup_item.exe";
-        file.make_preferred();
-
-        ASSERT_FALSE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
-        EXPECT_TRUE(r.empty());
-    }
+  ASSERT_FALSE(parseStartupPath("\"" + file.string() + "\" /g /h", r));
+  EXPECT_TRUE(r.empty());
+}
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/windows/startup_items_tests.cpp
+++ b/osquery/tables/system/tests/windows/startup_items_tests.cpp
@@ -13,8 +13,6 @@
 
 #include <boost/filesystem.hpp>
 
-#include <osquery/tests/test_util.h>
-
 #include <osquery/tables/system/windows/startup_items.h>
 
 namespace osquery {

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -60,34 +60,60 @@ const std::set<std::string> kStartupStatusRegKeys = {
 // Starts with 0[0-9] but not followed by all 0s
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
-static inline void parseStartupPath(const std::string& path, Row& r) {
-  std::string expandedPath = path;
+bool parseStartupPath(const std::string& cmdline, Row& r) {
 
-  // NOTE(ww): This is a pretty dumb expansion test, but the query that feeds
-  // us these paths doesn't pass us REG_EXPAND_SZ or any other hint
-  // that we could use instead.
-  if (path.find('%') != std::string::npos) {
-    if (const auto expanded = expandEnvString(path)) {
-      expandedPath = *expanded;
+  const auto argsp = splitArgs(cmdline);
+
+  if (!argsp.has_value()) {
+    return false;
+  }
+
+  if (pathExists(cmdline)) {
+    r["path"] = cmdline;
+    return true;
+  }
+
+  auto args = argsp.value();
+
+  // In case the path is already quoted, splitArgs(...) extract correctly the path with/without spaces
+  // We already tested for emptyness
+  auto path = args[0];
+
+  /*
+   * Entries in HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\RunNotification are 
+   * just numbers. Should we keep them ?
+   */
+  if (args.size() == 1) {
+    r["path"] = path;
+    return true;
+  }
+
+  if (pathExists(path)) {
+    r["path"] = path;
+    r["args"] = boost::join(
+        std::vector<std::string>{std::begin(args) + 1, std::end(args)}, " ");
+    return true;
+  }
+
+  auto end = std::end(args);
+
+  std::vector<std::string> tmp_path(std::begin(args), end);
+
+  while (!pathExists(path)) {
+
+    path = boost::join(tmp_path, " ");
+    tmp_path = std::vector<std::string>{ std::begin(args), --end };
+
+    if (std::begin(args) == end) {
+      return false;
     }
   }
 
-  if (pathExists(fs::path(expandedPath)).ok()) {
-    r["path"] = expandedPath;
-  } else {
-    if (const auto argsp = splitArgs(expandedPath)) {
-      auto args = *argsp;
-
-      r["path"] = args[0];
-
-      if (args.size() > 1) {
-        args.erase(args.begin());
-        r["args"] = boost::join(args, " ");
-      }
-    } else {
-      r["path"] = expandedPath;
-    }
-  }
+  // We have a path and arguments
+  r["path"] = path;
+  r["args"] =
+      boost::join(std::vector<std::string>{end + 1, std::end(args)}, " ");
+  return true;
 }
 
 QueryData genStartupItems(QueryContext& context) {
@@ -136,7 +162,11 @@ QueryData genStartupItems(QueryContext& context) {
       }
     }
 
-    parseStartupPath(startup.at("data"), r);
+    const auto data = startup.at("data");
+    if (!parseStartupPath(data, r))
+    {
+        continue;
+    }
 
     r["status"] = regex_match(startup.at("status"), kStartupDisabledRegex)
                       ? "disabled"

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -61,8 +61,8 @@ const std::set<std::string> kStartupStatusRegKeys = {
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
 bool parseStartupPath(const std::string& entry, Row& r) {
-
-  // In case the path is already quoted, splitArgs(...) extract correctly the path with/without spaces
+  // In case the path is already quoted, splitArgs(...) extract correctly the
+  // path with/without spaces
   const auto argsp = splitArgs(entry);
 
   if (!argsp.has_value()) {

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <osquery/tables/system/windows/startup_items.h>
+
 #include <osquery/utils/system/system.h>
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -61,7 +61,6 @@ const std::set<std::string> kStartupStatusRegKeys = {
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
 bool parseStartupPath(const std::string& cmdline, Row& r) {
-
   const auto argsp = splitArgs(cmdline);
 
   if (!argsp.has_value()) {
@@ -75,13 +74,13 @@ bool parseStartupPath(const std::string& cmdline, Row& r) {
 
   auto args = argsp.value();
 
-  // In case the path is already quoted, splitArgs(...) extract correctly the path with/without spaces
   // We already tested for emptyness
   auto path = args[0];
 
   /*
-   * Entries in HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\RunNotification are 
-   * just numbers. Should we keep them ?
+   * Entries in
+   * HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\RunNotification
+   * are just numbers.
    */
   if (args.size() == 1) {
     r["path"] = path;
@@ -100,9 +99,8 @@ bool parseStartupPath(const std::string& cmdline, Row& r) {
   std::vector<std::string> tmp_path(std::begin(args), end);
 
   while (!pathExists(path)) {
-
     path = boost::join(tmp_path, " ");
-    tmp_path = std::vector<std::string>{ std::begin(args), --end };
+    tmp_path = std::vector<std::string>{std::begin(args), --end};
 
     if (std::begin(args) == end) {
       return false;
@@ -163,9 +161,8 @@ QueryData genStartupItems(QueryContext& context) {
     }
 
     const auto data = startup.at("data");
-    if (!parseStartupPath(data, r))
-    {
-        continue;
+    if (!parseStartupPath(data, r)) {
+      continue;
     }
 
     r["status"] = regex_match(startup.at("status"), kStartupDisabledRegex)

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -60,15 +60,17 @@ const std::set<std::string> kStartupStatusRegKeys = {
 // Starts with 0[0-9] but not followed by all 0s
 const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 
-bool parseStartupPath(const std::string& cmdline, Row& r) {
-  const auto argsp = splitArgs(cmdline);
+bool parseStartupPath(const std::string& entry, Row& r) {
+
+  // In case the path is already quoted, splitArgs(...) extract correctly the path with/without spaces
+  const auto argsp = splitArgs(entry);
 
   if (!argsp.has_value()) {
     return false;
   }
 
-  if (pathExists(cmdline)) {
-    r["path"] = cmdline;
+  if (pathExists(entry)) {
+    r["path"] = entry;
     return true;
   }
 
@@ -77,11 +79,6 @@ bool parseStartupPath(const std::string& cmdline, Row& r) {
   // We already tested for emptyness
   auto path = args[0];
 
-  /*
-   * Entries in
-   * HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\RunNotification
-   * are just numbers.
-   */
   if (args.size() == 1) {
     r["path"] = path;
     return true;

--- a/osquery/tables/system/windows/startup_items.h
+++ b/osquery/tables/system/windows/startup_items.h
@@ -14,15 +14,13 @@ namespace osquery {
 namespace tables {
 
 /**
- * @brief Extract path and arguments from a command line string in input
+ * @brief Extract path and arguments from a startup entry in input
  *
- * If no user is provided the current user is returned.
- *
- * @param cmdline The command line string in input
+ * @param path The startup path string
  * @param r  A row where to store `path` and `args`
- * @return true if extraction was succeeded, false otherwise
+ * @return true if the parsing succeeded, false otherwise
  */
-bool parseStartupPath(const std::string& cmdline, Row& r);
+bool parseStartupPath(const std::string& entry, Row& r);
 
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/windows/startup_items.h
+++ b/osquery/tables/system/windows/startup_items.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+#pragma once
+
+#include <osquery/core/tables.h>
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Extract path and arguments from a command line string in input
+ *
+ * If no user is provided the current user is returned.
+ *
+ * @param cmdline The command line string in input
+ * @param r  A row where to store `path` and `args`
+ * @return true if extraction was succeeded, false otherwise
+ */
+bool parseStartupPath(const std::string& cmdline, Row& r);
+
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION

Fixes [6402](https://github.com/osquery/osquery/issues/6402)

Made `parseStartupPath` as a free function rather than private in order to test it.
I am not expanding paths because according to my tests they were coming already expanded.
As per comments on the issue report, I left the entries that didn't make much sense in order to keep the same behaviour. 