### PR TITLE
Optimize `rpm_packages` and `rpm_package_files` use of query context

### DIFF
--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -151,8 +151,10 @@ QueryData genRpmPackagesImpl(QueryContext& context, Logger& logger) {
     auto names = context.constraints["name"].getAll(EQUALS);
     for (const auto& name : names) {
       // Limit RPM iterator to constraint values
-      if (rpmdbSetIteratorRE(matches, RPMTAG_NAME, RPMMIRE_STRCMP, name.c_str()) != 0) {
-        logger.vlog(1, "Cannot add pattern: (" + name + ") to RPM iterator selector");
+      if (rpmdbSetIteratorRE(
+              matches, RPMTAG_NAME, RPMMIRE_STRCMP, name.c_str()) != 0) {
+        logger.vlog(
+            1, "Cannot add pattern: (" + name + ") to RPM iterator selector");
       }
     }
   }
@@ -220,8 +222,11 @@ void genRpmPackageFiles(RowYield& yield, QueryContext& context) {
     auto packages = context.constraints["package"].getAll(EQUALS);
     for (const auto& package : packages) {
       // Limit RPM iterator to constraint values
-      if (rpmdbSetIteratorRE(matches, RPMTAG_NAME, RPMMIRE_STRCMP, package.c_str()) != 0) {
-        logger.vlog(1, "Cannot add pattern: (" + package + ") to RPM iterator selector");
+      if (rpmdbSetIteratorRE(
+              matches, RPMTAG_NAME, RPMMIRE_STRCMP, package.c_str()) != 0) {
+        logger.vlog(
+            1,
+            "Cannot add pattern: (" + package + ") to RPM iterator selector");
       }
     }
   }

--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -145,12 +145,16 @@ QueryData genRpmPackagesImpl(QueryContext& context, Logger& logger) {
   }
 
   rpmts ts = rpmtsCreate();
-  rpmdbMatchIterator matches;
+  rpmdbMatchIterator matches = rpmtsInitIterator(ts, RPMTAG_NAME, nullptr, 0);
+
   if (context.constraints["name"].exists(EQUALS)) {
-    auto name = (*context.constraints["name"].getAll(EQUALS).begin());
-    matches = rpmtsInitIterator(ts, RPMTAG_NAME, name.c_str(), name.size());
-  } else {
-    matches = rpmtsInitIterator(ts, RPMTAG_NAME, nullptr, 0);
+    auto names = context.constraints["name"].getAll(EQUALS);
+    for (const auto& name : names) {
+      // Limit RPM iterator to constraint values
+      if (rpmdbSetIteratorRE(matches, RPMTAG_NAME, RPMMIRE_STRCMP, name.c_str()) != 0) {
+        logger.vlog(1, "Cannot add pattern: (" + name + ") to RPM iterator selector");
+      }
+    }
   }
 
   Header header;
@@ -210,12 +214,16 @@ void genRpmPackageFiles(RowYield& yield, QueryContext& context) {
   }
 
   rpmts ts = rpmtsCreate();
-  rpmdbMatchIterator matches;
+  rpmdbMatchIterator matches = rpmtsInitIterator(ts, RPMTAG_NAME, nullptr, 0);
+
   if (context.constraints["package"].exists(EQUALS)) {
-    auto name = (*context.constraints["package"].getAll(EQUALS).begin());
-    matches = rpmtsInitIterator(ts, RPMTAG_NAME, name.c_str(), name.size());
-  } else {
-    matches = rpmtsInitIterator(ts, RPMTAG_NAME, nullptr, 0);
+    auto packages = context.constraints["package"].getAll(EQUALS);
+    for (const auto& package : packages) {
+      // Limit RPM iterator to constraint values
+      if (rpmdbSetIteratorRE(matches, RPMTAG_NAME, RPMMIRE_STRCMP, package.c_str()) != 0) {
+        logger.vlog(1, "Cannot add pattern: (" + package + ") to RPM iterator selector");
+      }
+    }
   }
 
   Header header;

--- a/specs/linux/rpm_package_files.table
+++ b/specs/linux/rpm_package_files.table
@@ -1,7 +1,7 @@
 table_name("rpm_package_files")
 description("RPM packages that are currently installed on the host system.")
 schema([
-    Column("package", TEXT, "RPM package name", index=True),
+    Column("package", TEXT, "RPM package name", index=True, optimized=True),
     Column("path", TEXT, "File path within the package", index=True),
     Column("username", TEXT, "File default username from info DB"),
     Column("groupname", TEXT, "File default groupname from info DB"),

--- a/specs/linux/rpm_packages.table
+++ b/specs/linux/rpm_packages.table
@@ -1,7 +1,7 @@
 table_name("rpm_packages")
 description("RPM packages that are currently installed on the host system.")
 schema([
-    Column("name", TEXT, "RPM package name", index=True),
+    Column("name", TEXT, "RPM package name", index=True, optimized=True),
     Column("version", TEXT, "Package version" ,index=True, collate="version_rhel"),
     Column("release", TEXT, "Package release", index=True),
     Column("source", TEXT, "Source RPM package name (optional)"),


### PR DESCRIPTION
Currently the RPM table is being generated by initializing the RPM db with all packages, or a single package by name with query context. I've changed this table to start using `rpmdbSetIteratorRE` with string compare, by iterating through all values given in query context, and adding those regex patterns to the RPM iterator selector.

RPM API `rpmdbSetIteratorRE`: https://ftp.osuosl.org/pub/rpm/api/4.4.2.2/group__rpmdb.html#g9f84dbc47d1d432f4ffe83b713fb47c9

This allows the table to generate results with all values from query context at once.

I've confirmed that the columns can support these changes by querying the tables with an IN constraint on the optimized columns. I validated the expected results by comparing returned values from osquery 5.13.1 (before IN optimization existed), 5.14.1, and 5.14.1 containing these spec file changes.

With each query I included a NULL, '' (empty string), and some non-existent values in my IN constraint.

Tests were ran on CentOS Linux release 7.9.2009 (Core)