### PR TITLE
Fix the `python_paths` table to skip unnecessary code paths when filtering by `directory`

### DIFF
--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -259,8 +259,10 @@ std::vector<std::map<std::string, UserPath>> getUserPathList(
 QueryData genPythonPackagesImpl(QueryContext& context, Logger& logger) {
   QueryData results;
   std::set<std::string> paths;
-  if (context.constraints.count("directory") > 0 &&
-      context.constraints.at("directory").exists(EQUALS)) {
+  bool directory_filter = context.constraints.count("directory") > 0 &&
+                          context.constraints.at("directory").exists(EQUALS);
+
+  if (directory_filter) {
     paths = context.constraints["directory"].getAll(EQUALS);
   } else {
     for (const auto& path : kPythonPath) {
@@ -273,6 +275,10 @@ QueryData genPythonPackagesImpl(QueryContext& context, Logger& logger) {
   }
   for (const auto& key : paths) {
     genSiteDirectories(key, results, logger, 0);
+  }
+  // If user has specified `where directory = "path"` then return results early.
+  if (directory_filter) {
+    return results;
   }
 
   // Enumerate user installed python packages


### PR DESCRIPTION
`where directory = '....'` was added in https://github.com/osquery/osquery/pull/4407
When specifying a directory to filter by, the query still executes all the code paths unnecessarily.

```
osquery> select name, version, path from users cross join python_packages using(uid) where python_packages.directory = "/opt/homebrew/lib";
+-----------+---------+----------------------------------------------------------------------+
| name      | version | path                                                                 |
+-----------+---------+----------------------------------------------------------------------+
| packaging | 24.2    | /opt/homebrew/lib/python3.12/site-packages/packaging-24.2.dist-info  |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.12/site-packages/numpy-2.2.2.dist-info     |
| pip       | 24.3.1  | /opt/homebrew/lib/python3.13/site-packages/pip-24.3.1.dist-info      |
| packaging | 24.2    | /opt/homebrew/lib/python3.13/site-packages/packaging-24.2.dist-info  |
| wheel     | 0.45.1  | /opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info    |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.13/site-packages/numpy-2.2.2.dist-info     |
| mercurial | 6.8.2   | /opt/homebrew/lib/python3.13/site-packages/mercurial-6.8.2.dist-info |
+-----------+---------+----------------------------------------------------------------------+
Run Time: real 18.694 user 4.362583 sys 14.125906
osquery> select name, version, path from python_packages where python_packages.directory = "/opt/homebrew/lib";
W0121 18:26:17.506508 -245185984 virtual_table.cpp:1005] The python_packages table returns data based on the current user by default, consider JOINing against the users table
W0121 18:26:17.506549 -245185984 virtual_table.cpp:1022] Please see the table documentation: https://osquery.io/schema/#python_packages
+-----------+---------+----------------------------------------------------------------------+
| name      | version | path                                                                 |
+-----------+---------+----------------------------------------------------------------------+
| packaging | 24.2    | /opt/homebrew/lib/python3.12/site-packages/packaging-24.2.dist-info  |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.12/site-packages/numpy-2.2.2.dist-info     |
| pip       | 24.3.1  | /opt/homebrew/lib/python3.13/site-packages/pip-24.3.1.dist-info      |
| packaging | 24.2    | /opt/homebrew/lib/python3.13/site-packages/packaging-24.2.dist-info  |
| wheel     | 0.45.1  | /opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info    |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.13/site-packages/numpy-2.2.2.dist-info     |
| mercurial | 6.8.2   | /opt/homebrew/lib/python3.13/site-packages/mercurial-6.8.2.dist-info |
+-----------+---------+----------------------------------------------------------------------+
Run Time: real 0.175 user 0.037518 sys 0.134921
```

Exiting early yields a slightly more performant result.

```
osquery> select name, version, path from users cross join python_packages using(uid) where python_packages.directory = "/opt/homebrew/lib";
+-----------+---------+----------------------------------------------------------------------+
| name      | version | path                                                                 |
+-----------+---------+----------------------------------------------------------------------+
| packaging | 24.2    | /opt/homebrew/lib/python3.12/site-packages/packaging-24.2.dist-info  |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.12/site-packages/numpy-2.2.2.dist-info     |
| pip       | 24.3.1  | /opt/homebrew/lib/python3.13/site-packages/pip-24.3.1.dist-info      |
| packaging | 24.2    | /opt/homebrew/lib/python3.13/site-packages/packaging-24.2.dist-info  |
| wheel     | 0.45.1  | /opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info    |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.13/site-packages/numpy-2.2.2.dist-info     |
| mercurial | 6.8.2   | /opt/homebrew/lib/python3.13/site-packages/mercurial-6.8.2.dist-info |
+-----------+---------+----------------------------------------------------------------------+
Run Time: real 16.561 user 4.024763 sys 12.490508
osquery> select name, version, path from python_packages where python_packages.directory = "/opt/homebrew/lib";
W0121 18:47:53.716681 -245185984 virtual_table.cpp:1005] The python_packages table returns data based on the current user by default, consider JOINing against the users table
W0121 18:47:53.716734 -245185984 virtual_table.cpp:1022] Please see the table documentation: https://osquery.io/schema/#python_packages
+-----------+---------+----------------------------------------------------------------------+
| name      | version | path                                                                 |
+-----------+---------+----------------------------------------------------------------------+
| packaging | 24.2    | /opt/homebrew/lib/python3.12/site-packages/packaging-24.2.dist-info  |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.12/site-packages/numpy-2.2.2.dist-info     |
| pip       | 24.3.1  | /opt/homebrew/lib/python3.13/site-packages/pip-24.3.1.dist-info      |
| packaging | 24.2    | /opt/homebrew/lib/python3.13/site-packages/packaging-24.2.dist-info  |
| wheel     | 0.45.1  | /opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info    |
| numpy     | 2.2.2   | /opt/homebrew/lib/python3.13/site-packages/numpy-2.2.2.dist-info     |
| mercurial | 6.8.2   | /opt/homebrew/lib/python3.13/site-packages/mercurial-6.8.2.dist-info |
+-----------+---------+----------------------------------------------------------------------+
Run Time: real 0.161 user 0.037412 sys 0.123799
```