### PR TITLE
Implement dns_lookup_events table on Windows

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -68,6 +68,7 @@ function(generateOsqueryEvents)
       list(APPEND source_files
         windows/etw/etw_user_session.cpp
         windows/etw/etw_publisher_processes.cpp
+        windows/etw/etw_publisher_dns.cpp
         windows/etw/etw_provider_config.cpp
         windows/etw/etw_post_processing_pipeline.cpp
         windows/etw/etw_kernel_session.cpp
@@ -183,6 +184,7 @@ function(generateOsqueryEvents)
     if(OSQUERY_BUILD_ETW)
       list(APPEND platform_public_header_files
         windows/etw/etw_user_session.h
+        windows/etw/etw_publisher_dns.h
         windows/etw/etw_publisher_processes.h
         windows/etw/etw_publisher.h
         windows/etw/etw_provider_config.h

--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -272,7 +272,6 @@ EventSubscriberRef EventFactory::getEventSubscriber(
 }
 
 bool EventFactory::exists(const std::string& name_id) {
-
   return (getInstance().event_subs_.count(name_id) > 0);
 }
 

--- a/osquery/events/eventfactory.cpp
+++ b/osquery/events/eventfactory.cpp
@@ -272,6 +272,7 @@ EventSubscriberRef EventFactory::getEventSubscriber(
 }
 
 bool EventFactory::exists(const std::string& name_id) {
+
   return (getInstance().event_subs_.count(name_id) > 0);
 }
 

--- a/osquery/events/windows/etw/etw_data_event.h
+++ b/osquery/events/windows/etw/etw_data_event.h
@@ -108,17 +108,53 @@ struct EtwProcessStopData final {
 using EtwProcStopDataRef = std::shared_ptr<EtwProcessStopData>;
 
 /**
+ * @brief DNS request event payload
+ */
+struct EtwDnsRequestData final {
+  /// Process ID
+  std::uint32_t ProcessId{0};
+
+  // Process image path
+  std::string ProcessImagePath;
+
+  /// Query Name
+  std::string QueryName;
+
+  /// Query Type
+  std::uint32_t QueryType{0};
+
+  // Query Type as a string
+  std::string QueryTypeString;
+
+  /// Query Status Code
+  std::uint32_t QueryStatus{0};
+
+  /// Query Results
+  std::string QueryResults;
+
+  /// User SID
+  std::string UserSid;
+
+  /// User Name
+  std::string UserName;
+};
+
+using EtwDnsRequestDataRef = std::shared_ptr<EtwDnsRequestData>;
+
+/**
  * @brief ETW Event Payload
  */
-using EtwPayloadVariant =
-    std::variant<std::monostate, EtwProcStartDataRef, EtwProcStopDataRef>;
+using EtwPayloadVariant = std::variant<std::monostate,
+                                       EtwProcStartDataRef,
+                                       EtwProcStopDataRef,
+                                       EtwDnsRequestDataRef>;
 
 /**
  * @brief Event types
  * The event type is used to tag an ETW event to an specific data type that will
  * be used to dispatch events to different provider post processors
  */
-enum class EtwEventType { Invalid, ProcessStart, ProcessStop };
+enum class EtwEventType { Invalid, ProcessStart, ProcessStop, DnsRequest };
 
 /**
  * @brief Event Type string representation
@@ -126,7 +162,8 @@ enum class EtwEventType { Invalid, ProcessStart, ProcessStop };
 const auto kEtwEventTypeStrings = std::unordered_map<EtwEventType, std::string>{
     {EtwEventType::Invalid, "Invalid"},
     {EtwEventType::ProcessStart, "ProcessStart"},
-    {EtwEventType::ProcessStop, "ProcessStop"}};
+    {EtwEventType::ProcessStop, "ProcessStop"},
+    {EtwEventType::DnsRequest, "DnsRequests"}};
 
 /**
  * @brief ETW Event Header

--- a/osquery/events/windows/etw/etw_publisher.cpp
+++ b/osquery/events/windows/etw/etw_publisher.cpp
@@ -34,4 +34,55 @@ EtwPublisherBase::getPostProcessorCallback() {
   };
 }
 
+void EtwPublisherBase::updateUserInfo(const std::string& userSid,
+  std::string& username) {
+// Updating user information using gathered user SIDs as input
+auto usernameIt = usernamesBySIDs_.find(userSid);
+if (usernameIt != usernamesBySIDs_.end()) {
+auto cachedUsername = usernameIt->second;
+username.assign(cachedUsername);
+} else {
+PSID pSid = nullptr;
+
+if (!ConvertStringSidToSidA(userSid.c_str(), &pSid) || pSid == nullptr) {
+// Inserting empty username to avoid the lookup logic to be called again
+usernamesBySIDs_.insert({userSid, ""});
+return;
+}
+
+std::vector<char> domainNameStr(MAX_PATH - 1, 0x0);
+std::vector<char> userNameStr(MAX_PATH - 1, 0x0);
+DWORD domainNameSize = MAX_PATH;
+DWORD userNameSize = MAX_PATH;
+SID_NAME_USE sidType = SID_NAME_USE::SidTypeInvalid;
+
+if (!LookupAccountSidA(NULL,
+pSid,
+userNameStr.data(),
+&userNameSize,
+domainNameStr.data(),
+&domainNameSize,
+&sidType) ||
+strlen(domainNameStr.data()) == 0 ||
+strlen(domainNameStr.data()) >= MAX_PATH ||
+strlen(userNameStr.data()) == 0 ||
+strlen(userNameStr.data()) >= MAX_PATH ||
+sidType == SID_NAME_USE::SidTypeInvalid) {
+// Inserting empty username to avoid the lookup logic to be called again
+usernamesBySIDs_.insert({userSid, ""});
+LocalFree(pSid);
+return;
+}
+
+LocalFree(pSid);
+
+username.append(domainNameStr.data());
+username.append("\\");
+username.append(userNameStr.data());
+
+usernamesBySIDs_.insert({userSid, username});
+}
+}
+
+
 } // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher.cpp
+++ b/osquery/events/windows/etw/etw_publisher.cpp
@@ -15,6 +15,7 @@ namespace osquery {
 
 EtwPublisherBase::EtwPublisherBase(const std::string& name) {
   name_ = name;
+  initializeHardVolumeConversions();
 }
 
 EtwController& EtwPublisherBase::EtwEngine() {
@@ -35,54 +36,79 @@ EtwPublisherBase::getPostProcessorCallback() {
 }
 
 void EtwPublisherBase::updateUserInfo(const std::string& userSid,
-  std::string& username) {
-// Updating user information using gathered user SIDs as input
-auto usernameIt = usernamesBySIDs_.find(userSid);
-if (usernameIt != usernamesBySIDs_.end()) {
-auto cachedUsername = usernameIt->second;
-username.assign(cachedUsername);
-} else {
-PSID pSid = nullptr;
+                                      std::string& username) {
+  // Updating user information using gathered user SIDs as input
+  auto usernameIt = usernamesBySIDs_.find(userSid);
+  if (usernameIt != usernamesBySIDs_.end()) {
+    auto cachedUsername = usernameIt->second;
+    username.assign(cachedUsername);
+  } else {
+    PSID pSid = nullptr;
 
-if (!ConvertStringSidToSidA(userSid.c_str(), &pSid) || pSid == nullptr) {
-// Inserting empty username to avoid the lookup logic to be called again
-usernamesBySIDs_.insert({userSid, ""});
-return;
+    if (!ConvertStringSidToSidA(userSid.c_str(), &pSid) || pSid == nullptr) {
+      // Inserting empty username to avoid the lookup logic to be called again
+      usernamesBySIDs_.insert({userSid, ""});
+      return;
+    }
+
+    std::vector<char> domainNameStr(MAX_PATH - 1, 0x0);
+    std::vector<char> userNameStr(MAX_PATH - 1, 0x0);
+    DWORD domainNameSize = MAX_PATH;
+    DWORD userNameSize = MAX_PATH;
+    SID_NAME_USE sidType = SID_NAME_USE::SidTypeInvalid;
+
+    if (!LookupAccountSidA(NULL,
+                           pSid,
+                           userNameStr.data(),
+                           &userNameSize,
+                           domainNameStr.data(),
+                           &domainNameSize,
+                           &sidType) ||
+        strlen(domainNameStr.data()) == 0 ||
+        strlen(domainNameStr.data()) >= MAX_PATH ||
+        strlen(userNameStr.data()) == 0 ||
+        strlen(userNameStr.data()) >= MAX_PATH ||
+        sidType == SID_NAME_USE::SidTypeInvalid) {
+      // Inserting empty username to avoid the lookup logic to be called again
+      usernamesBySIDs_.insert({userSid, ""});
+      LocalFree(pSid);
+      return;
+    }
+
+    LocalFree(pSid);
+
+    username.append(domainNameStr.data());
+    username.append("\\");
+    username.append(userNameStr.data());
+
+    usernamesBySIDs_.insert({userSid, username});
+  }
 }
 
-std::vector<char> domainNameStr(MAX_PATH - 1, 0x0);
-std::vector<char> userNameStr(MAX_PATH - 1, 0x0);
-DWORD domainNameSize = MAX_PATH;
-DWORD userNameSize = MAX_PATH;
-SID_NAME_USE sidType = SID_NAME_USE::SidTypeInvalid;
+void EtwPublisherBase::initializeHardVolumeConversions() {
+  const auto& validDriveLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-if (!LookupAccountSidA(NULL,
-pSid,
-userNameStr.data(),
-&userNameSize,
-domainNameStr.data(),
-&domainNameSize,
-&sidType) ||
-strlen(domainNameStr.data()) == 0 ||
-strlen(domainNameStr.data()) >= MAX_PATH ||
-strlen(userNameStr.data()) == 0 ||
-strlen(userNameStr.data()) >= MAX_PATH ||
-sidType == SID_NAME_USE::SidTypeInvalid) {
-// Inserting empty username to avoid the lookup logic to be called again
-usernamesBySIDs_.insert({userSid, ""});
-LocalFree(pSid);
-return;
+  for (const auto& driveLetter : validDriveLetters) {
+    std::string queryPath;
+    queryPath.push_back(driveLetter);
+    queryPath.push_back(':');
+
+    char hardVolume[MAX_PATH + 1] = {0};
+    if (QueryDosDeviceA(queryPath.c_str(), hardVolume, MAX_PATH)) {
+      hardVolumeDrives_.insert({hardVolume, queryPath});
+    }
+  }
 }
 
-LocalFree(pSid);
-
-username.append(domainNameStr.data());
-username.append("\\");
-username.append(userNameStr.data());
-
-usernamesBySIDs_.insert({userSid, username});
+void EtwPublisherBase::updateHardVolumeWithLogicalDrive(std::string& path) {
+  // Updating the hardvolume entries with logical volume data
+  for (const auto& [hardVolume, logicalDrive] : hardVolumeDrives_) {
+    size_t pos = 0;
+    if ((pos = path.find(hardVolume, pos)) != std::string::npos) {
+      path.replace(pos, hardVolume.length(), logicalDrive);
+      break;
+    }
+  }
 }
-}
-
 
 } // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher.h
+++ b/osquery/events/windows/etw/etw_publisher.h
@@ -64,6 +64,13 @@ class EtwPublisherBase {
    */
   std::function<void(const EtwEventDataRef&)> getPostProcessorCallback();
 
+ protected:
+  /**
+   * @brief Given the userSid, update the username using a cached value or
+   * looking up the value if no cached value exists.
+   */
+  void updateUserInfo(const std::string& userSid, std::string& username);
+
  private:
   /**
    * @brief Abstract method that has to be implemented in the ETW publisher
@@ -79,6 +86,10 @@ class EtwPublisherBase {
    * @brief Provider name
    */
   std::string name_;
+
+  // Cache for updateUserInfo
+  using UsernameBySIDCollection = std::unordered_map<std::string, std::string>;
+  UsernameBySIDCollection usernamesBySIDs_;
 };
 
 } // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher.h
+++ b/osquery/events/windows/etw/etw_publisher.h
@@ -71,6 +71,12 @@ class EtwPublisherBase {
    */
   void updateUserInfo(const std::string& userSid, std::string& username);
 
+  /**
+   * @brief Given an image file (device) path, update to use the logical (eg.
+   * C:) drive
+   */
+  void updateHardVolumeWithLogicalDrive(std::string& path);
+
  private:
   /**
    * @brief Abstract method that has to be implemented in the ETW publisher
@@ -86,6 +92,12 @@ class EtwPublisherBase {
    * @brief Provider name
    */
   std::string name_;
+
+  // Cache for hard volume conversions
+  void initializeHardVolumeConversions();
+  using HardVolumeDriveCollection =
+      std::unordered_map<std::string, std::string>;
+  HardVolumeDriveCollection hardVolumeDrives_;
 
   // Cache for updateUserInfo
   using UsernameBySIDCollection = std::unordered_map<std::string, std::string>;

--- a/osquery/events/windows/etw/etw_publisher_dns.cpp
+++ b/osquery/events/windows/etw/etw_publisher_dns.cpp
@@ -245,12 +245,12 @@ void EtwPublisherDNS::providerPostProcessor(const EtwEventDataRef& eventData) {
     return;
   }
 
-  updateUserInfo(dnsRequestData->UserSid, dnsRequestData->UserName);
-  dnsRequestData->QueryTypeString =
-      dnsQueryTypeToString(dnsRequestData->QueryType);
   dnsRequestData->ProcessImagePath =
       processImagePathFromProcessId(dnsRequestData->ProcessId);
   updateHardVolumeWithLogicalDrive(dnsRequestData->ProcessImagePath);
+  updateUserInfo(dnsRequestData->UserSid, dnsRequestData->UserName);
+  dnsRequestData->QueryTypeString =
+      dnsQueryTypeToString(dnsRequestData->QueryType);
   
   // Event dispatch
   event_context->data = std::move(eventData);

--- a/osquery/events/windows/etw/etw_publisher_dns.cpp
+++ b/osquery/events/windows/etw/etw_publisher_dns.cpp
@@ -250,6 +250,7 @@ void EtwPublisherDNS::providerPostProcessor(const EtwEventDataRef& eventData) {
       dnsQueryTypeToString(dnsRequestData->QueryType);
   dnsRequestData->ProcessImagePath =
       processImagePathFromProcessId(dnsRequestData->ProcessId);
+  updateHardVolumeWithLogicalDrive(dnsRequestData->ProcessImagePath);
   
   LOG(INFO) << "QueryName: " << dnsRequestData->QueryName
             << " QueryType: " << dnsRequestData->QueryType

--- a/osquery/events/windows/etw/etw_publisher_dns.cpp
+++ b/osquery/events/windows/etw/etw_publisher_dns.cpp
@@ -21,9 +21,9 @@
 namespace osquery {
 
 FLAG(bool,
-     enable_dns_etw_events,
+     enable_dns_lookup_events,
      false,
-     "Enables the dns_etw_events publisher");
+     "Enables the dns_lookup_events publisher");
 
 // ETW Event publisher registration into the Osquery pub-sub framework
 REGISTER_ETW_PUBLISHER(EtwPublisherDNS, kEtwDNSPublisherName.c_str());
@@ -252,16 +252,6 @@ void EtwPublisherDNS::providerPostProcessor(const EtwEventDataRef& eventData) {
       processImagePathFromProcessId(dnsRequestData->ProcessId);
   updateHardVolumeWithLogicalDrive(dnsRequestData->ProcessImagePath);
   
-  LOG(INFO) << "QueryName: " << dnsRequestData->QueryName
-            << " QueryType: " << dnsRequestData->QueryType
-            << " QueryTypeString: " << dnsRequestData->QueryTypeString
-            << " QueryStatus: " << dnsRequestData->QueryStatus
-            << " QueryResults: " << dnsRequestData->QueryResults
-            << " UserSid: " << dnsRequestData->UserSid
-            << " UserName: " << dnsRequestData->UserName
-            << " ProcessID: " << dnsRequestData->ProcessId
-            << " ProcessImagePath: " << dnsRequestData->ProcessImagePath;
-
   // Event dispatch
   event_context->data = std::move(eventData);
   fire(event_context);

--- a/osquery/events/windows/etw/etw_publisher_dns.cpp
+++ b/osquery/events/windows/etw/etw_publisher_dns.cpp
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <ctime>
+
+#include <osquery/events/windows/etw/etw_publisher_dns.h>
+
+#include <osquery/core/flags.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/system/errno.h>
+#include <osquery/utils/system/windows/etw_helpers.h>
+
+#include <windns.h>
+
+namespace osquery {
+
+FLAG(bool,
+     enable_dns_etw_events,
+     false,
+     "Enables the dns_etw_events publisher");
+
+// ETW Event publisher registration into the Osquery pub-sub framework
+REGISTER_ETW_PUBLISHER(EtwPublisherDNS, kEtwDNSPublisherName.c_str());
+
+// Publisher constructor
+EtwPublisherDNS::EtwPublisherDNS() : EtwPublisherBase(kEtwDNSPublisherName) {};
+
+Status EtwPublisherDNS::setUp() {
+  // Userspace ETW Provider configuration
+  EtwProviderConfig dnsETWconfig;
+  dnsETWconfig.setName("Microsoft-Windows-DNS-Client");
+  dnsETWconfig.setPreProcessor(getPreProcessorCallback());
+  dnsETWconfig.setPostProcessor(getPostProcessorCallback());
+  dnsETWconfig.addEventTypeToHandle(EtwEventType::DnsRequest);
+  dnsETWconfig.setTraceFlags(
+      EVENT_ENABLE_PROPERTY_SID); // Required to get user SID in extended data
+
+  // Adding the provider to the ETW Engine
+  Status userProviderAddStatus = EtwEngine().addProvider(dnsETWconfig);
+  if (!userProviderAddStatus.ok()) {
+    return userProviderAddStatus;
+  }
+
+  return Status::success();
+}
+
+// Callback to perform pre-processing logic
+void EtwPublisherDNS::providerPreProcessor(
+    const EVENT_RECORD& rawEvent, const krabs::trace_context& traceCtx) {
+  // Helper accessors for userspace events
+  const EVENT_HEADER& eventHeader = rawEvent.EventHeader;
+
+  // ETW Event ID 3008 contains the DNS Request status
+  if (eventHeader.EventDescriptor.Id != 3008) {
+    return;
+  }
+
+  // ETW event schema parsing
+  krabs::schema schema(rawEvent, traceCtx.schema_locator);
+  krabs::parser parser(schema);
+
+  // Internal ETW Event allocation
+  std::shared_ptr<EtwEventData> newEvent = std::make_shared<EtwEventData>();
+  if (newEvent == nullptr) {
+    return;
+  }
+
+  // Allocating DNS monitoring specific payload
+  EtwDnsRequestDataRef dnsRequestData = std::make_shared<EtwDnsRequestData>();
+  if (!dnsRequestData) {
+    return;
+  }
+
+  // Populating DNS monitoring fields
+  newEvent->Header.Type = EtwEventType::DnsRequest;
+  newEvent->Payload = dnsRequestData;
+  dnsRequestData->ProcessId = rawEvent.EventHeader.ProcessId;
+  dnsRequestData->QueryName =
+      wstringToString(parser.parse<std::wstring>(L"QueryName"));
+  dnsRequestData->QueryType = parser.parse<uint32_t>(L"QueryType");
+  dnsRequestData->QueryStatus = parser.parse<uint32_t>(L"QueryStatus");
+  dnsRequestData->QueryResults =
+      wstringToString(parser.parse<std::wstring>(L"QueryResults"));
+  dnsRequestData->UserSid = sidStringFromEtwRecord(rawEvent);
+
+  // Raw Header update
+  newEvent->Header.RawHeader = rawEvent.EventHeader;
+
+  // Dispatch the event
+  EtwController::instance().dispatchETWEvents(std::move(newEvent));
+}
+
+std::string dnsQueryTypeToString(WORD queryType) {
+  switch (queryType) {
+  case DNS_TYPE_ZERO:
+    return "ZERO";
+  case DNS_TYPE_A:
+    return "A";
+  case DNS_TYPE_NS:
+    return "NS";
+  case DNS_TYPE_MD:
+    return "MD";
+  case DNS_TYPE_MF:
+    return "MF";
+  case DNS_TYPE_CNAME:
+    return "CNAME";
+  case DNS_TYPE_SOA:
+    return "SOA";
+  case DNS_TYPE_MB:
+    return "MB";
+  case DNS_TYPE_MG:
+    return "MG";
+  case DNS_TYPE_MR:
+    return "MR";
+  case DNS_TYPE_NULL:
+    return "NULL";
+  case DNS_TYPE_WKS:
+    return "WKS";
+  case DNS_TYPE_PTR:
+    return "PTR";
+  case DNS_TYPE_HINFO:
+    return "HINFO";
+  case DNS_TYPE_MINFO:
+    return "MINFO";
+  case DNS_TYPE_MX:
+    return "MX";
+  case DNS_TYPE_TEXT:
+    return "TEXT";
+  case DNS_TYPE_RP:
+    return "RP";
+  case DNS_TYPE_AFSDB:
+    return "AFSDB";
+  case DNS_TYPE_X25:
+    return "X25";
+  case DNS_TYPE_ISDN:
+    return "ISDN";
+  case DNS_TYPE_RT:
+    return "RT";
+  case DNS_TYPE_NSAP:
+    return "NSAP";
+  case DNS_TYPE_NSAPPTR:
+    return "NSAPPTR";
+  case DNS_TYPE_SIG:
+    return "SIG";
+  case DNS_TYPE_KEY:
+    return "KEY";
+  case DNS_TYPE_PX:
+    return "PX";
+  case DNS_TYPE_GPOS:
+    return "GPOS";
+  case DNS_TYPE_AAAA:
+    return "AAAA";
+  case DNS_TYPE_LOC:
+    return "LOC";
+  case DNS_TYPE_NXT:
+    return "NXT";
+  case DNS_TYPE_EID:
+    return "EID";
+  case DNS_TYPE_NIMLOC:
+    return "NIMLOC";
+  case DNS_TYPE_SRV:
+    return "SRV";
+  case DNS_TYPE_ATMA:
+    return "ATMA";
+  case DNS_TYPE_NAPTR:
+    return "NAPTR";
+  case DNS_TYPE_KX:
+    return "KX";
+  case DNS_TYPE_CERT:
+    return "CERT";
+  case DNS_TYPE_A6:
+    return "A6";
+  case DNS_TYPE_DNAME:
+    return "DNAME";
+  case DNS_TYPE_SINK:
+    return "SINK";
+  case DNS_TYPE_OPT:
+    return "OPT";
+  case DNS_TYPE_DS:
+    return "DS";
+  case DNS_TYPE_RRSIG:
+    return "RRSIG";
+  case DNS_TYPE_NSEC:
+    return "NSEC";
+  case DNS_TYPE_DNSKEY:
+    return "DNSKEY";
+  case DNS_TYPE_DHCID:
+    return "DHCID";
+  case DNS_TYPE_NSEC3:
+    return "NSEC3";
+  case DNS_TYPE_NSEC3PARAM:
+    return "NSEC3PARAM";
+  case DNS_TYPE_TLSA:
+    return "TLSA";
+  case DNS_TYPE_UINFO:
+    return "UINFO";
+  case DNS_TYPE_UID:
+    return "UID";
+  case DNS_TYPE_GID:
+    return "GID";
+  case DNS_TYPE_UNSPEC:
+    return "UNSPEC";
+  case DNS_TYPE_ADDRS:
+    return "ADDRS";
+  case DNS_TYPE_TKEY:
+    return "TKEY";
+  case DNS_TYPE_TSIG:
+    return "TSIG";
+  case DNS_TYPE_IXFR:
+    return "IXFR";
+  case DNS_TYPE_AXFR:
+    return "AXFR";
+  case DNS_TYPE_MAILB:
+    return "MAILB";
+  case DNS_TYPE_MAILA:
+    return "MAILA";
+  case DNS_TYPE_ALL:
+    return "ALL";
+  case DNS_TYPE_WINS:
+    return "WINS";
+  case DNS_TYPE_WINSR:
+    return "WINSR";
+  default:
+    return "Unknown";
+  }
+}
+
+// Callback to perform post-processing logic
+void EtwPublisherDNS::providerPostProcessor(const EtwEventDataRef& eventData) {
+  auto event_context = createEventContext();
+
+  // Sanity check on event types that this callback will handle
+  if (eventData->Header.Type != EtwEventType::DnsRequest) {
+    return;
+  }
+
+  auto dnsRequestData = std::get<EtwDnsRequestDataRef>(eventData->Payload);
+  if (dnsRequestData == nullptr) {
+    return;
+  }
+
+  updateUserInfo(dnsRequestData->UserSid, dnsRequestData->UserName);
+  dnsRequestData->QueryTypeString =
+      dnsQueryTypeToString(dnsRequestData->QueryType);
+  dnsRequestData->ProcessImagePath =
+      processImagePathFromProcessId(dnsRequestData->ProcessId);
+  
+  LOG(INFO) << "QueryName: " << dnsRequestData->QueryName
+            << " QueryType: " << dnsRequestData->QueryType
+            << " QueryTypeString: " << dnsRequestData->QueryTypeString
+            << " QueryStatus: " << dnsRequestData->QueryStatus
+            << " QueryResults: " << dnsRequestData->QueryResults
+            << " UserSid: " << dnsRequestData->UserSid
+            << " UserName: " << dnsRequestData->UserName
+            << " ProcessID: " << dnsRequestData->ProcessId
+            << " ProcessImagePath: " << dnsRequestData->ProcessImagePath;
+
+  // Event dispatch
+  event_context->data = std::move(eventData);
+  fire(event_context);
+}
+
+} // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher_dns.h
+++ b/osquery/events/windows/etw/etw_publisher_dns.h
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <osquery/events/windows/etw/etw_publisher.h>
+
+namespace osquery {
+
+/**
+ * @brief Subscription details for EtwPublisherDNS events.
+ */
+struct EtwDNSEventSubContext : public SubscriptionContext {
+ private:
+  friend class EtwPublisherDNS;
+};
+
+/**
+ * @brief Event details for EtwPublisherDNS events.
+ */
+struct EtwDNSEventContext : public EventContext {
+  EtwEventDataRef data;
+};
+
+using EtwDNSEventContextRef = std::shared_ptr<EtwDNSEventContext>;
+using EtwDNSEventSubContextRef = std::shared_ptr<EtwDNSEventSubContext>;
+
+/**
+ * @brief Publisher Name
+ */
+const std::string kEtwDNSPublisherName = "etw_dns_publisher";
+
+/**
+ * @brief Implements an EtwPublisher that collects and
+ * dispatches ETW events with process-start and process-stop OS information.
+ */
+class EtwPublisherDNS
+    : public EtwPublisherBase,
+      public EventPublisher<EtwDNSEventSubContext, EtwDNSEventContext> {
+  /**
+   * @brief Publisher constants
+   */
+  static const USHORT etwDefaultKernelID = 0;
+  static const USHORT etwDNSStartID = 1;
+  static const USHORT etwDNSStopID = 2;
+
+  /**
+   * @brief Supported User Start DNS Events versions
+   */
+  const enum class etwUserDNSStartVersion {
+    Version0 = 0,
+    Version1,
+    Version2,
+    Version3
+  };
+
+  /**
+   * @brief Supported User Stop DNS Events versions
+   */
+  enum class etwUserDNSStopVersion { Version0 = 0, Version1, Version2 };
+
+  /**
+   * @brief Supported Kernel DNS Events versions
+   */
+  enum class etwKernelDNSVersion { Version3 = 3, Version4 };
+
+  /**
+   * @brief Publisher type declaration
+   */
+  DECLARE_PUBLISHER(kEtwDNSPublisherName);
+
+ public:
+  EtwPublisherDNS();
+
+  /**
+   * @brief Used to configure the ETW providers to listen, along with
+   * its configuration parameters and processing callbacks.
+   *
+   * @return Status of the provider setup process.
+   */
+  Status setUp() override;
+
+ private:
+  /**
+   * @brief Provides the c-function callback in charge of performing the pre
+   * processing logic. This is the entry point for the event arriving from the
+   * ETW OS interface. This callback gets called from the OS for every new ETW
+   * event. There should be lightweight logic here, with no significant
+   * performance implications.
+   *
+   * @param rawEvent is the RAW ETW event obtained from OS ETW provider. It
+   * comprises an EVENT_HEADER common to all ETW providers and a UserData field
+   * with provider-specific content.
+   * https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_record
+   *
+   * @param traceCtx This is a helper class that it is used to parse the ETW
+   * event manifest when needed.
+   */
+  static void providerPreProcessor(const EVENT_RECORD& rawEvent,
+                                   const krabs::trace_context& traceCtx);
+
+  /**
+   * @brief Provides the std::function callback in charge of performing the
+   * post processing logic. This logic is used to enrich, aggregate and modify
+   * the event data before dispatching it to the event subscribers.
+   */
+  void providerPostProcessor(const EtwEventDataRef& data) override;
+
+ private:
+  using HardVolumeDriveCollection =
+      std::unordered_map<std::string, std::string>;
+  using UsernameBySIDCollection = std::unordered_map<std::string, std::string>;
+
+  HardVolumeDriveCollection hardVolumeDrives_;
+  UsernameBySIDCollection usernamesBySIDs_;
+};
+
+} // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher_processes.cpp
+++ b/osquery/events/windows/etw/etw_publisher_processes.cpp
@@ -27,9 +27,7 @@ REGISTER_ETW_PUBLISHER(EtwPublisherProcesses, kEtwProcessPublisherName.c_str());
 
 // Publisher constructor
 EtwPublisherProcesses::EtwPublisherProcesses()
-    : EtwPublisherBase(kEtwProcessPublisherName) {
-  initializeHardVolumeConversions();
-};
+    : EtwPublisherBase(kEtwProcessPublisherName) {};
 
 // There are multiple ETW providers being setup here. Events arriving from
 // these providers will be aggregated in the post-processing phase.
@@ -361,21 +359,6 @@ void EtwPublisherProcesses::providerPostProcessor(
   }
 }
 
-void EtwPublisherProcesses::initializeHardVolumeConversions() {
-  const auto& validDriveLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-  for (const auto& driveLetter : validDriveLetters) {
-    std::string queryPath;
-    queryPath.push_back(driveLetter);
-    queryPath.push_back(':');
-
-    char hardVolume[MAX_PATH + 1] = {0};
-    if (QueryDosDeviceA(queryPath.c_str(), hardVolume, MAX_PATH)) {
-      hardVolumeDrives_.insert({hardVolume, queryPath});
-    }
-  }
-}
-
 void EtwPublisherProcesses::cleanOldAggregationCacheEntries() {
   // Time stamp value is expressed in 100 nanosecond units, this is about
   // 10000000 nanoseconds per second
@@ -406,18 +389,6 @@ void EtwPublisherProcesses::cleanOldAggregationCacheEntries() {
     }
 
     ++it;
-  }
-}
-
-void EtwPublisherProcesses::updateHardVolumeWithLogicalDrive(
-    std::string& path) {
-  // Updating the hardvolume entries with logical volume data
-  for (const auto& [hardVolume, logicalDrive] : hardVolumeDrives_) {
-    size_t pos = 0;
-    if ((pos = path.find(hardVolume, pos)) != std::string::npos) {
-      path.replace(pos, hardVolume.length(), logicalDrive);
-      break;
-    }
   }
 }
 

--- a/osquery/events/windows/etw/etw_publisher_processes.h
+++ b/osquery/events/windows/etw/etw_publisher_processes.h
@@ -117,7 +117,6 @@ class EtwPublisherProcesses
   void cleanOldAggregationCacheEntries();
   void updateHardVolumeWithLogicalDrive(std::string& path);
   void updateTokenInfo(const std::uint32_t& tokenType, std::string& tokenInfo);
-  void updateUserInfo(const std::string& userSid, std::string& username);
   void updateImagePath(const std::uint64_t& key1,
                        const std::uint64_t& key2,
                        std::string& imagePath);
@@ -138,12 +137,10 @@ class EtwPublisherProcesses
       std::unordered_map<std::uint64_t, std::string>;
   using HardVolumeDriveCollection =
       std::unordered_map<std::string, std::string>;
-  using UsernameBySIDCollection = std::unordered_map<std::string, std::string>;
 
   ProcessStartCacheCollection processStartAggregationCache_;
   ProcessImageCacheCollection processImageCache_;
   HardVolumeDriveCollection hardVolumeDrives_;
-  UsernameBySIDCollection usernamesBySIDs_;
 };
 
 } // namespace osquery

--- a/osquery/events/windows/etw/etw_publisher_processes.h
+++ b/osquery/events/windows/etw/etw_publisher_processes.h
@@ -113,9 +113,7 @@ class EtwPublisherProcesses
   void providerPostProcessor(const EtwEventDataRef& data) override;
 
   /// Event post-processing helpers
-  void initializeHardVolumeConversions();
   void cleanOldAggregationCacheEntries();
-  void updateHardVolumeWithLogicalDrive(std::string& path);
   void updateTokenInfo(const std::uint32_t& tokenType, std::string& tokenInfo);
   void updateImagePath(const std::uint64_t& key1,
                        const std::uint64_t& key2,
@@ -135,12 +133,9 @@ class EtwPublisherProcesses
       std::unordered_map<std::uint64_t, EtwProcStartDataRef>;
   using ProcessImageCacheCollection =
       std::unordered_map<std::uint64_t, std::string>;
-  using HardVolumeDriveCollection =
-      std::unordered_map<std::string, std::string>;
 
   ProcessStartCacheCollection processStartAggregationCache_;
   ProcessImageCacheCollection processImageCache_;
-  HardVolumeDriveCollection hardVolumeDrives_;
 };
 
 } // namespace osquery

--- a/osquery/tables/events/CMakeLists.txt
+++ b/osquery/tables/events/CMakeLists.txt
@@ -61,7 +61,8 @@ function(generateOsqueryTablesEventsEventstable)
 	
     if(OSQUERY_BUILD_ETW)
       list(APPEND source_files
-        windows/etw_process_events.cpp
+      windows/etw_process_events.cpp
+      windows/dns_lookup_events.cpp
       )
     endif()	
   endif()
@@ -127,7 +128,8 @@ function(generateOsqueryTablesEventsEventstable)
 	
     if(OSQUERY_BUILD_ETW)
       list(APPEND platform_public_header_files
-        windows/etw_process_events.h
+      windows/etw_process_events.h
+      windows/dns_lookup_events.h
       )
     endif()
 

--- a/osquery/tables/events/windows/dns_lookup_events.cpp
+++ b/osquery/tables/events/windows/dns_lookup_events.cpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <variant>
+
+#include <osquery/core/flags.h>
+#include <osquery/events/events.h>
+#include <osquery/registry/registry_factory.h>
+#include <osquery/sql/sql.h>
+#include <osquery/tables/events/windows/dns_lookup_events.h>
+
+namespace osquery {
+
+REGISTER_ETW_SUBSCRIBER(EtwDNSEventSubscriber, "dns_lookup_events");
+DECLARE_bool(enable_dns_lookup_events);
+
+Status EtwDNSEventSubscriber::init() {
+  if (!FLAGS_enable_dns_lookup_events) {
+    return Status::failure("subscriber disabled via configuration.");
+  }
+  auto subscription_context = createSubscriptionContext();
+  subscribe(&EtwDNSEventSubscriber::eventCallback, subscription_context);
+
+  return Status::success();
+}
+
+Status EtwDNSEventSubscriber::eventCallback(const ECRef& event_context,
+                                            const SCRef& event_subscription) {
+  if ((!event_context) || (!event_context->data)) {
+    return Status::failure("Invalid event context");
+  }
+
+  // New event row to capture the incoming ETW event data
+  Row newRow;
+
+  // Sugar syntax to facilitate the access to the event header
+  const auto& eventHeader = event_context->data->Header;
+
+  // Common fields
+  newRow["datetime"] = BIGINT(eventHeader.UnixTimestamp);
+  newRow["time_windows"] = BIGINT(eventHeader.WinTimestamp);
+
+  if (!std::holds_alternative<EtwDnsRequestDataRef>(
+          event_context->data->Payload)) {
+    return Status::failure("Invalid event payload");
+  }
+
+  // Sugar syntax to facilitate the access to the event payload
+  const auto& eventPayload =
+      std::get<EtwDnsRequestDataRef>(event_context->data->Payload);
+
+  if (!eventPayload) {
+    return Status::failure("Event payload was null");
+  }
+
+  newRow["pid"] = BIGINT(eventPayload->ProcessId);
+  newRow["path"] = SQL_TEXT(eventPayload->ProcessImagePath);
+  newRow["username"] = SQL_TEXT(eventPayload->UserName);
+  newRow["name"] = SQL_TEXT(eventPayload->QueryName);
+  newRow["type"] = SQL_TEXT(eventPayload->QueryTypeString);
+  newRow["type_id"] = INTEGER(eventPayload->QueryType);
+  newRow["status"] = INTEGER(eventPayload->QueryStatus);
+  newRow["response"] = SQL_TEXT(eventPayload->QueryResults);
+
+  std::vector<Row> rowList;
+  rowList.push_back(std::move(newRow));
+  addBatch(rowList, eventHeader.UnixTimestamp);
+
+  return Status::success();
+}
+
+} // namespace osquery

--- a/osquery/tables/events/windows/dns_lookup_events.h
+++ b/osquery/tables/events/windows/dns_lookup_events.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+ #include <osquery/events/eventsubscriber.h>
+ #include <osquery/events/windows/etw/etw_publisher_dns.h>
+ 
+ namespace osquery {
+ 
+ class EtwDNSEventSubscriber final
+     : public EventSubscriber<EtwPublisherDNS> {
+  public:
+   virtual ~EtwDNSEventSubscriber() override = default;
+   virtual Status init() override;
+ 
+   Status eventCallback(const ECRef& event_context,
+                        const SCRef& subscription_context);
+ };
+ 
+ } // namespace osquery 

--- a/osquery/utils/system/CMakeLists.txt
+++ b/osquery/utils/system/CMakeLists.txt
@@ -279,6 +279,7 @@ endfunction()
 function(generateOsqueryUtilsSystemUsersGroups)
   add_osquery_library(osquery_utils_system_usersgroupshelpers EXCLUDE_FROM_ALL
     windows/users_groups_helpers.cpp
+    windows/etw_helpers.cpp
   )
 
   target_link_libraries(osquery_utils_system_usersgroupshelpers PUBLIC
@@ -288,6 +289,7 @@ function(generateOsqueryUtilsSystemUsersGroups)
 
   set(public_header_files
     windows/users_groups_helpers.h
+    windows/etw_helpers.h
   )
 
   generateIncludeNamespace(osquery_utils_system_usersgroupshelpers "osquery/utils/system" "FULL_PATH" ${public_header_files})

--- a/osquery/utils/system/windows/etw_helpers.cpp
+++ b/osquery/utils/system/windows/etw_helpers.cpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include "etw_helpers.h"
+
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/scope_guard.h>
+#include <osquery/utils/system/windows/users_groups_helpers.h>
+
+#include <psapi.h>
+
+#pragma comment(lib, "psapi.lib")
+
+namespace osquery {
+
+std::string sidStringFromEtwRecord(const EVENT_RECORD& record) {
+  if (record.ExtendedDataCount == 0 || record.ExtendedData == nullptr) {
+    return "";
+  }
+
+  // Iterate through extended data to find EVENT_HEADER_EXT_TYPE_SID
+  for (USHORT i = 0; i < record.ExtendedDataCount; ++i) {
+    const EVENT_HEADER_EXTENDED_DATA_ITEM& data = record.ExtendedData[i];
+
+    if (data.ExtType == EVENT_HEADER_EXT_TYPE_SID) {
+      PSID userSid = reinterpret_cast<PSID>(data.DataPtr);
+      if (userSid && IsValidSid(userSid)) {
+        return psidToString(userSid);
+      }
+    }
+  }
+  return "";
+}
+
+std::string processImagePathFromProcessId(uint32_t processId) {
+  // Open the process
+  HANDLE hProcess = OpenProcess(
+      PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId);
+  if (hProcess == NULL) {
+    return "";
+  }
+  auto guard = scope_guard::create([&] { CloseHandle(hProcess); });
+
+  // Get the path of the executable
+  wchar_t processPath[MAX_PATH];
+  DWORD length = GetProcessImageFileNameW(
+      hProcess, processPath, sizeof(processPath) / sizeof(wchar_t));
+
+  if (length == 0) {
+    return "";
+  }
+
+  return wstringToString(processPath);
+}
+
+} // namespace osquery

--- a/osquery/utils/system/windows/etw_helpers.h
+++ b/osquery/utils/system/windows/etw_helpers.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <string>
+
+#include <osquery/utils/system/system.h>
+
+#include <evntcons.h>
+
+namespace osquery {
+
+/**
+ * @brief Windows helper function that gets the user SID string from the
+ * extended header information in an ETW event record.
+ *
+ * @returns string representation of the user SID.
+ */
+std::string sidStringFromEtwRecord(const EVENT_RECORD& record);
+
+/**
+ * @brief Windows helper function that gets the process image file path from the process ID.
+ * 
+ * @returns string representation of the process image file path.
+ */
+std::string processImagePathFromProcessId(uint32_t processId);
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -319,7 +319,8 @@ function(generateNativeTables)
 
   if(OSQUERY_BUILD_ETW)
     list(APPEND platform_dependent_spec_files
-      "windows/process_etw_events.table:windows"
+    "windows/process_etw_events.table:windows"
+    "windows/dns_lookup_events.table:windows"
     )
   endif()
 

--- a/specs/windows/dns_lookup_events.table
+++ b/specs/windows/dns_lookup_events.table
@@ -1,0 +1,21 @@
+table_name("dns_lookup_events")
+description("DNS lookups performed through the Windows DNS stack.")
+schema([
+    Column("eid", INTEGER, "Event ID", hidden=True),
+    Column("time", BIGINT, "Event timestamp in Unix format", hidden=True, additional=True),
+    Column("time_windows", BIGINT, "Event timestamp in Windows format", hidden=True),
+    Column("datetime", DATETIME, "Event timestamp in DATETIME format"),
+    Column("pid", BIGINT, "Process ID of process making the lookup"),
+    Column("path", TEXT, "Path to binary of process making the lookup"),
+    Column("username", TEXT, "User rights - primary token username"),
+    Column("name", TEXT, "Name being queried in lookup"),
+    Column("type", TEXT, "DNS record type of lookup as string"),
+    Column("type_id", INTEGER, "Integer type ID for record type"),
+    Column("status", INTEGER, "Response status code"),
+    Column("response", TEXT, "Results returned by lookup"),
+])
+attributes(event_subscriber=True)
+implementation("dns_lookup_events@dns_lookup_events::genTable")
+examples([
+	"select * from dns_lookup_events;",
+])

--- a/specs/windows/dns_lookup_events.table
+++ b/specs/windows/dns_lookup_events.table
@@ -6,7 +6,7 @@ schema([
     Column("time_windows", BIGINT, "Event timestamp in Windows format", hidden=True),
     Column("datetime", DATETIME, "Event timestamp in DATETIME format"),
     Column("pid", BIGINT, "Process ID of process making the lookup"),
-    Column("path", TEXT, "Path to binary of process making the lookup"),
+    Column("path", TEXT, "Path to binary of process making the lookup (sometimes unavailable for very short-lived processes)"),
     Column("username", TEXT, "User rights - primary token username"),
     Column("name", TEXT, "Name being queried in lookup"),
     Column("type", TEXT, "DNS record type of lookup as string"),

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -341,7 +341,8 @@ function(generateTestsIntegrationTablesTestsTest)
 
     if(OSQUERY_BUILD_ETW)
       list(APPEND platform_source_files
-        etw_process_events.cpp
+      etw_process_events.cpp
+      dns_lookup_events.cpp
       )
     endif()
 

--- a/tests/integration/tables/dns_lookup_events.cpp
+++ b/tests/integration/tables/dns_lookup_events.cpp
@@ -27,9 +27,9 @@ class etwdnsEvents : public testing::Test {
   void SetUp() override {
     setUpEnvironment();
 
-    // Enable ETW dns events
+    // Enable ETW DNS events
     RegistryFactory::get().registry("config_parser")->setUp();
-    FLAGS_enable_dns_etw_events = true;
+    FLAGS_enable_dns_lookup_events = true;
 
     // Start eventing framework
     attachEvents();
@@ -42,18 +42,14 @@ class etwdnsEvents : public testing::Test {
   }
 };
 
-TEST_F(etwdnsEvents, test_sanity) {
-  // 1. Launching process to generate ProcessStart and ProcessStop events
+TEST_F(dnsLookupEvents, test_sanity) {
+  // 1. Ping to generate a DNS request
   system("ping -n 1 hostname.invalid");
   Sleep(4000);
 
   // 2. Query data
   auto const data = execute_query(
-      "select type, pid, ppid, session_id, flags, exit_code, path, cmdline, "
-      "username, token_elevation_type, token_elevation_status, "
-      "mandatory_label, datetime, time_windows, time, eid, header_pid, "
-      "process_sequence_number, parent_process_sequence_number from "
-      "process_etw_events");
+      "select * from dns_lookup_events");
 
   // 3. Check size before validation
   ASSERT_GE(data.size(), 0ul);

--- a/tests/integration/tables/dns_lookup_events.cpp
+++ b/tests/integration/tables/dns_lookup_events.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for dns_lookup_events
+// Spec file: specs/posix/dns_lookup_events.table
+
+#include <osquery/config/config.h>
+#include <osquery/dispatcher/dispatcher.h>
+#include <osquery/events/events.h>
+#include <osquery/registry/registry.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+
+DECLARE_bool(enable_dns_lookup_events);
+
+namespace table_tests {
+
+class etwdnsEvents : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+
+    // Enable ETW dns events
+    RegistryFactory::get().registry("config_parser")->setUp();
+    FLAGS_enable_dns_etw_events = true;
+
+    // Start eventing framework
+    attachEvents();
+  }
+
+  void TearDown() override {
+    Dispatcher::instance().stopServices();
+    Dispatcher::instance().joinServices();
+    Dispatcher::instance().resetStopping();
+  }
+};
+
+TEST_F(etwdnsEvents, test_sanity) {
+  // 1. Launching process to generate ProcessStart and ProcessStop events
+  system("ping -n 1 hostname.invalid");
+  Sleep(4000);
+
+  // 2. Query data
+  auto const data = execute_query(
+      "select type, pid, ppid, session_id, flags, exit_code, path, cmdline, "
+      "username, token_elevation_type, token_elevation_status, "
+      "mandatory_label, datetime, time_windows, time, eid, header_pid, "
+      "process_sequence_number, parent_process_sequence_number from "
+      "process_etw_events");
+
+  // 3. Check size before validation
+  ASSERT_GE(data.size(), 0ul);
+
+  // 4. Build validation map
+  ValidationMap row_map = {
+      {"type", NonEmptyString},
+      {"pid", NonNegativeInt},
+      {"ppid", NonNegativeInt},
+      {"session_id", NonNegativeInt},
+      {"flags", NonNegativeInt},
+      {"exit_code", EmptyOk | NullOk},
+      {"path", NonEmptyString},
+      {"cmdline", EmptyOk | NullOk},
+      {"username", NonEmptyString},
+      {"token_elevation_type", EmptyOk | NullOk},
+      {"token_elevation_status", EmptyOk | NullOk},
+      {"mandatory_label", EmptyOk | NullOk},
+      {"datetime", NonNegativeInt},
+      {"time_windows", NonNegativeInt},
+      {"time", NonNegativeInt},
+      {"eid", NonNegativeInt},
+      {"header_pid", NonNegativeInt},
+      {"process_sequence_number", NonNegativeInt},
+      {"parent_process_sequence_number", EmptyOk | NullOk}};
+
+  // 5. Perform validation
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
Uses ETW events to get DNS lookups.

Includes some refactors to move shared functionality into the parent class for ETW publishers.

Tested manually and includes integration test.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
