### PR TITLE
Add support for scheduled queries to run at startup

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -319,6 +319,7 @@ The basic scheduled query specification includes:
 - `version`: only run on osquery versions greater than or equal-to this version string
 - `shard`: restrict this query to a percentage (1-100) of target hosts
 - `denylist`: a boolean to determine if this query may be denylisted (when stopped by the Watchdog for excessive resource consumption), default true
+- `startup_priority`: an unsigned integer to set the order of executing scheduled queries on startup, default is UINT64_MAX
 
 The `platform` key can be:
 
@@ -338,6 +339,8 @@ Snapshot queries, those with `snapshot: true` will not store differentials and w
 the next section on [logging](../deployment/logging.md) for examples of each log output.
 
 Queries may be "denylisted" if they cause osquery to use excessive system resources. A denylisted query returns to the schedule after a cool-down period of 1 day. Some queries may be very important and you may request that they continue to run even if they are latent. Set the `denylist: false` to prevent a query from being denylisted.
+
+Note that queries which leave `startup_priority` as the default value will not execute at startup.
 
 ### Packs
 
@@ -646,7 +649,7 @@ Here is an example configuration:
 You can inspect the list of subscribers using the query `SELECT * FROM osquery_events where type = 'subscriber';`.
 This table will show `1` for the `active` column if a subscriber is enabled.
 Note that publishers are more complex and cannot be disabled and enabled this way, please look for a specific CLI flag to control specific publishers.
-Also note that different platforms such as Windows and Linux have different sets of subscriber tables. 
+Also note that different platforms such as Windows and Linux have different sets of subscriber tables.
 
 ## Chef Configuration
 

--- a/osquery/config/packs.h
+++ b/osquery/config/packs.h
@@ -79,10 +79,10 @@ class Pack : private boost::noncopyable {
   }
 
   /// Returns the schedule dictated by the pack
-  const std::map<std::string, ScheduledQuery>& getSchedule() const;
+  const std::vector<ScheduledQuery>& getSchedule() const;
 
   /// Returns the schedule dictated by the pack
-  std::map<std::string, ScheduledQuery>& getSchedule();
+  std::vector<ScheduledQuery>& getSchedule();
 
   /// Verify that the platform is compatible
   bool checkPlatform() const;
@@ -113,8 +113,8 @@ class Pack : private boost::noncopyable {
   /// List of query strings.
   std::vector<std::string> discovery_queries_;
 
-  /// Map of query names to the scheduled query details.
-  std::map<std::string, ScheduledQuery> schedule_;
+  /// Array of scheduled query details.
+  std::vector<ScheduledQuery> schedule_;
 
   /// Platform requirement for pack.
   std::string platform_;

--- a/osquery/core/sql/scheduled_query.h
+++ b/osquery/core/sql/scheduled_query.h
@@ -42,6 +42,10 @@ struct ScheduledQuery : private only_movable {
   /// A temporary splayed internal.
   uint64_t splayed_interval{0};
 
+  /// The priority of running at startup. Only runs at startup if the priority
+  /// is not the default value.
+  uint64_t startup_priority{UINT64_MAX};
+
   /**
    * @brief Queries are denylisted based on logic in the configuration.
    *

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -213,7 +213,7 @@ static double timeDiff(struct timeval* pStart, struct timeval* pEnd) {
 static void endTimer() {
   if (enableTimer != 0) {
     sqlite3_int64 iEnd = timeOfDay();
-    struct rusage sEnd {};
+    struct rusage sEnd{};
 
 #ifdef WIN32
     FILETIME ftCreation, ftExit;
@@ -1398,7 +1398,7 @@ static int do_meta_command(char* zLine, struct callback_data* p) {
   n = strlen30(azArg[0]);
   c = azArg[0][0];
   if (c == 'a' && strncmp(azArg[0], "all", n) == 0 && nArg == 2) {
-    struct callback_data data {};
+    struct callback_data data{};
     memcpy(&data, p, sizeof(data));
     auto query = std::string("SELECT * FROM ") + azArg[1];
     rc = shell_exec(query.c_str(), shell_callback, &data, nullptr);
@@ -1818,12 +1818,12 @@ int runPack(struct callback_data* data) {
     }
 
     for (const auto& query : pack.getSchedule()) {
-      rc = runQuery(data, query.second.query.c_str());
+      rc = runQuery(data, query.query.c_str());
       if (rc != 0) {
         fprintf(stderr,
                 "Could not execute query %s: %s\n",
-                query.first.c_str(),
-                query.second.query.c_str());
+                query.name.c_str(),
+                query.query.c_str());
         return;
       }
     }
@@ -1832,7 +1832,7 @@ int runPack(struct callback_data* data) {
 }
 
 int launchIntoShell(int argc, char** argv) {
-  struct callback_data data {};
+  struct callback_data data{};
   main_init(&data);
 
 #if defined(SQLITE_ENABLE_WHERETRACE)

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -277,11 +277,21 @@ void SchedulerRunner::start() {
   // Timeout is the number of seconds from starting.
   auto end = (timeout_ == 0) ? 0 : timeout_ + i;
 
+  // A set of query names which have run for the first time.
+  std::unordered_set<std::string> first_query_runs;
+
   for (; (end == 0) || (i <= end); ++i) {
     auto start_time_point = std::chrono::steady_clock::now();
-    Config::get().scheduledQueries(([&i](const std::string& name,
-                                         const ScheduledQuery& query) {
-      if (query.splayed_interval > 0 && i % query.splayed_interval == 0) {
+    Config::get().scheduledQueries(([&i, &first_query_runs](
+                                        const std::string& name,
+                                        const ScheduledQuery& query) {
+      bool query_has_not_run =
+          first_query_runs.find(name) == first_query_runs.end();
+      if ((query.splayed_interval > 0 && i % query.splayed_interval == 0) ||
+          (query.startup_priority != UINT64_MAX && query_has_not_run)) {
+        if (query_has_not_run) {
+          first_query_runs.insert(name);
+        }
         TablePlugin::kCacheInterval = query.splayed_interval;
         TablePlugin::kCacheStep = i;
         const auto status = launchQuery(name, query);
@@ -325,8 +335,8 @@ void SchedulerRunner::start() {
   }
 }
 
-std::chrono::milliseconds SchedulerRunner::getCurrentTimeDrift() const
-    noexcept {
+std::chrono::milliseconds SchedulerRunner::getCurrentTimeDrift()
+    const noexcept {
   return time_drift_;
 }
 


### PR DESCRIPTION
This PR adds a new field for scheduled queries `startup_priority` which if set to a non-default value will run queries in ascending order once osqueryd starts the `SchedulerRunner`. 

I've tested this a fair amount on MacOS, and I've attached time table of my tests showing when osqueryd initialized and when it executed the defined scheduled queries.
[Time Table.csv](https://github.com/user-attachments/files/18914662/Time.Table.csv)


Here are some logs also showing the example change:
```
I0219 17:35:35.824323 107137088 dispatcher.cpp:78] Adding new service: SchedulerRunner (0x60000121c558) to thread: 0x17039f000 (0x6000029293c0) in process 25893
I0219 17:35:35.824326 1881698304 eventfactory.cpp:410] Event publisher fsevents run loop terminated for reason: Publisher disabled via configuration
I0219 17:35:35.824347 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_0_int_400: select * from processes
I0219 17:35:35.890591 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_0_int_400
I0219 17:35:35.890978 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_1_int_120: select * from processes
I0219 17:35:35.942234 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_1_int_120
I0219 17:35:35.942560 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_1_int_300_1: select * from processes
I0219 17:35:35.990871 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_1_int_300_1
I0219 17:35:35.991300 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_1_int_300_2: select * from processes
I0219 17:35:36.050416 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_1_int_300_2
I0219 17:35:36.050863 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_2_int_30_1: select * from processes
I0219 17:35:36.099247 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_2_int_30_1
...
I0219 17:36:05.949177 1882845184 scheduler.cpp:120] Executing scheduled query test_startup_priority_max_int_60: select * from processes
I0219 17:36:06.005627 1882845184 scheduler.cpp:201] Found results for query: test_startup_priority_max_int_60
```