### PR TITLE
Add support for DEB822-style apt sources

### DIFF
--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include "osquery/utils/status/status.h"
+#include <osquery/utils/status/status.h>
 #include <algorithm>
 #include <boost/algorithm/string/compare.hpp>
 #include <boost/algorithm/string/regex.hpp>

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -214,7 +214,6 @@ Status parseDeb822Block(const std::string& input_block,
                         std::vector<AptSource>& apt_sources) {
   std::vector<std::string> uris;
   std::vector<std::string> suites;
-  std::vector<std::string> components;
 
   for (const auto& input_line : osquery::split(input_block, "\n")) {
     // Skip empty lines
@@ -271,12 +270,6 @@ Status parseDeb822Block(const std::string& input_block,
     if (key == "Suites") {
       for (const auto& suite : osquery::split(value)) {
         suites.push_back(suite);
-      }
-    }
-
-    if (key == "Components") {
-      for (const auto& component : osquery::split(value)) {
-        components.push_back(component);
       }
     }
   }

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -237,10 +237,9 @@ Status parseDeb822Block(const std::string& input_block,
     }
 
     auto key = line.substr(0, colon_pos);
-    std::transform(
-        key.begin(), key.end(), key.begin(), [](unsigned char c) {
-          return std::tolower(c);
-        });
+    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
     auto value = line.substr(colon_pos + 1, std::string::npos);
     boost::trim(value);
 

--- a/osquery/tables/system/linux/apt_sources.h
+++ b/osquery/tables/system/linux/apt_sources.h
@@ -25,6 +25,8 @@ struct AptSource {
 };
 
 Status parseAptSourceLine(const std::string& input_line, AptSource& apt_source);
+Status parseDeb822Block(const std::string& input_block,
+                        std::vector<AptSource>& apt_sources);
 
 std::string getCacheFilename(const std::vector<std::string>& cache_file);
 

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -188,9 +188,9 @@ Signed-By: /usr/share/keyrings/osquery-archive-keyring.gpg",
        "pkg.osquery.io_dists_noble"},
       // trailing comments are ok
       {"Types: deb # commented line \n\
-URIs: https://pkg.osquery.io \n\
+uris: https://pkg.osquery.io \n\
 # Entire commented line \n\
-Suites: noble \n\
+suites: noble \n\
 Components: main # trailing comment \n\
 Signed-By: /usr/share/keyrings/osquery-archive-keyring.gpg",
        "https://pkg.osquery.io",

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -241,7 +241,7 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
 
   s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: off",
                        apt_sourecs);
-  EXPECT_FALSE(s.ok()) << "disabled source";
+  EXPECT_TRUE(s.ok()) << "disabled source";
   EXPECT_EQ(apt_sourecs.size(), 0);
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

Adds support for the new [DEB822 source format](https://repolib.readthedocs.io/en/latest/deb822-format.html) on the `apt_sources` table. DEB822 is a new format used by Debian-based distributions to describe the sources apt will use when fetching packages.
