### PR TITLE
Pin macos python versions in CI to fix mismatch between builder and test runner

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -641,7 +641,8 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13.x'
+        # Pin an exact python version to avoid mismatches between this builder and the test_older_macos runner
+        python-version: '3.13.1'
         architecture: arm64
 
     - name: Install tests dependencies
@@ -822,7 +823,8 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13.x'
+          # Pin an exact python version to avoid mismatches between the builder and this test_older_macos runner
+          python-version: '3.13.1'
           architecture: ${{ matrix.python_architecture }}
 
       - name: Install tests dependencies


### PR DESCRIPTION
Changes:
- Pin a specific Python version (3.13.1) when installing python on the macos builder and the test_older_macos runner

Motivation:
- Fix the test_older_macos CI tests
  - Failures are of the form "Could not start process at /Users/runner/hostedtoolcache/Python/3.13.1/x64/bin/python3" (e.g. [this run](https://github.com/osquery/osquery/actions/runs/13625228685/job/38083016971))
  - The macos-13 runner image was [recently updated to have Python 3.13.2](https://github.com/actions/runner-images/commit/1366aad0aa64d0c3c50ec054feba9b8eceb69ccd#diff-49d5008075920b3466eff9e2bb3f4a933cca7733524c0153fd761cf9b6fc4fd4R30) but the other macos runners are still on Python 3.13.1
  - Notably, the "Setup python" step in the test_older_macos run shows "Successfully set up CPython (3.13.2)", which mismatches the version (3.13.1) that gets set up in the "Setup python" step of the build_macos (macos-14, x86_64) build that builds the macos_tests_Debug/Release artifacts uses in test_older_macos

Test plan:
- CI
- (I've validated that this change fixes the test_older_macos failures on a local fork with similar CI setup)