### PR TITLE
Fix dicker container table disk/write metrics, compares "op" values with ignore case

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 #include <iostream>
 #include <regex>
-#include <string>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iostream>
 #include <regex>
+#include <string>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -830,7 +831,7 @@ std::string getIOBytes(const pt::ptree& tree, const std::string& op) {
   uint64_t value = 0;
   for (const auto& entry : tree) {
     const pt::ptree& node = entry.second;
-    if (node.get<std::string>("op", "") == op) {
+    if (boost::iequals(node.get<std::string>("op", ""), op)) {
       value += node.get<uint64_t>("value", 0);
     }
   }


### PR DESCRIPTION
At the 27.4.0 docker engine version, there was a change with the "blkio_stats. io_service_bytes_recursive.op" in the container stats API response. The value of the "op" became lowercase, and it caused a mismatch in the getIOBytes function which is called with Capitalised op. 
Example:
getIOBytes(container.get_child("blkio_stats.io_service_bytes_recursive"),"Write");