### PR TITLE
Escape service binary path in manage-osqueryd.ps1 

### DIFF
--- a/tools/deployment/windows_packaging/manage-osqueryd.ps1
+++ b/tools/deployment/windows_packaging/manage-osqueryd.ps1
@@ -66,7 +66,7 @@ function Do-Service {
       Write-Host "'$kServiceName' is already installed." -foregroundcolor Yellow
       Exit 1
     } else {
-      New-Service -BinaryPathName "$kServiceBinaryPath $startupArgs" `
+      New-Service -BinaryPathName "`"$kServiceBinaryPath`" $startupArgs" `
                   -Name $kServiceName `
                   -DisplayName $kServiceName `
                   -Description $kServiceDescription `


### PR DESCRIPTION
This pull request fixes a security vulnerability in the Windows service installation script (tools\deployment\osqueryd\manage-osqueryd.ps1). The issue is related to an unquoted service binary path, which could lead to privilege escalation if an attacker places a malicious executable in an unquoted directory path.

**Issue:**
When installing the osqueryd service, the script currently does not properly quote the service binary path:

```
New-Service -BinaryPathName "$kServiceBinaryPath $startupArgs" \
            -Name $kServiceName \
            -DisplayName $kServiceName \
            -Description $kServiceDescription \
            -StartupType Automatic
```

If $kServiceBinaryPath contains spaces (e.g., C:\Program Files\osquery\osqueryd.exe), Windows may attempt to execute a malicious executable placed in a higher-level directory (e.g., C:\Program.exe).

**Fix:**
This PR ensures the path is correctly quoted:

```
New-Service -BinaryPathName "`"$kServiceBinaryPath`" $startupArgs" \
            -Name $kServiceName \
            -DisplayName $kServiceName \
            -Description $kServiceDescription \
            -StartupType Automatic
```

**Security Impact:**
This change mitigates a potential privilege escalation vulnerability by ensuring that Windows correctly interprets the full path to osqueryd.exe as a single argument.

**Testing:**

- [ ] Verified that the script correctly installs the service with the quoted path.

- [ ] Ensured that osqueryd.exe starts without errors after installation.

- [ ] Confirmed that the fix prevents unintended execution of other executables in unquoted paths.

**References:**

[Microsoft Documentation on Unquoted Service Paths](https://learn.microsoft.com/en-us/windows/win32/services/configuring-a-service-for-startup)