### PR TITLE
Add support for msix packages

### DIFF
--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -12,11 +12,117 @@
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
 
 #include "osquery/tables/system/windows/registry.h"
 
 namespace osquery {
 namespace tables {
+
+// Function to extract attributes from a tag
+std::map<std::string, std::string> parseAttributes(
+    const std::string& tagContent) {
+  std::regex attributeRegex("((\\w+)=\"([^\"]*)\")");
+  std::smatch match;
+  std::map<std::string, std::string> attributes;
+
+  std::string::const_iterator searchStart(tagContent.cbegin());
+  while (std::regex_search(
+      searchStart, tagContent.cend(), match, attributeRegex)) {
+    // match[1] is the entire attribute="value" string
+    // match[2] is the attribute name
+    // match[3] is the attribute value
+    attributes[match[2]] = match[3];
+    searchStart = match.suffix().first;
+  }
+
+  return attributes;
+}
+
+// Function to extract the contents of a specific tag
+std::string getTagContent(const std::string& xml, const std::string& tagName) {
+  std::regex tagRegex("<" + tagName + "[\\s\\S]*?>([\\s\\S]*?)<\\/" + tagName +
+                      ">");
+  std::smatch match;
+
+  if (std::regex_search(xml, match, tagRegex)) {
+    // match[0] is the entire tag with contents <TagName>contents</TagName>
+    // match[1] is the contents of the tag
+    return match[1];
+  }
+  return "";
+}
+
+// Function to find self closing tag in xml
+std::string findSelfClosingTag(const std::string& xml,
+                               const std::string& tagName) {
+  std::regex tagRegex("<" + tagName + "[\\s\\S]*?/>");
+  std::smatch match;
+
+  if (std::regex_search(xml, match, tagRegex)) {
+    // match[0] is the entire self-closing tag
+    return match[0];
+  }
+  return "";
+}
+
+// Convert a Unix timestamp to a date in YYYYMMDD format
+std::string formatTimestampToDate(time_t timestamp) {
+  try {
+    // Convert the timestamp to a tm structure
+    std::tm* timeInfo = std::gmtime(&timestamp);
+
+    // Format the date as YYYYMMDD
+    std::ostringstream oss;
+    oss << std::put_time(timeInfo, "%Y%m%d");
+    return oss.str();
+  } catch (...) {
+    return "";
+  }
+}
+
+std::string packageFamilyNameFromPackageFullName(
+    const std::string& packageFullName) {
+  // The package full name format
+  // <PackageName>_<Version>_<Architecture>__<PublisherHash>
+  // Example:
+  // MSTeams_25060.205.3499.6849_arm64__8wekyb3d8bbwe
+  // The package family name
+  // [PackageName + "_" + PublisherHash]
+  // shall become the identifying number/"bundle identifier"
+
+  auto pos = packageFullName.find('_');
+  std::string packageName;
+  if (pos != std::string::npos) {
+    packageName = packageFullName.substr(0, pos);
+  }
+
+  pos = packageFullName.find("__");
+  std::string publisherHash;
+  if (pos != std::string::npos) {
+    publisherHash = packageFullName.substr(pos + 2);
+  }
+
+  if (publisherHash.empty()) {
+    // This package is an inbox or framework package, often times a part of core
+    // windows PRI-based naming format:
+    // <PackageName>_<Version>_<Architecture>_<ResourceQualifer>_<PublisherHash>
+    // Example: Windows.PrintDialog_6.2.3.0_neutral_neutral_cw5n1h2txyewy
+    pos = packageFullName.find_last_of('_');
+    if (pos != std::string::npos) {
+      publisherHash = packageFullName.substr(pos + 1);
+    }
+  }
+
+  if (packageName.empty() || publisherHash.empty()) {
+    // Some kind of unknown package
+    LOG(INFO) << "Non MSIX or PRI/resource package detected:'" +
+                     packageFullName + "'";
+    return "";
+  }
+
+  return packageName + "_" + publisherHash;
+}
 
 void keyEnumPrograms(const std::string& key,
                      std::set<std::string>& processed,
@@ -88,6 +194,120 @@ void keyEnumPrograms(const std::string& key,
   }
 }
 
+void genMsixPrograms(const std::string& key,
+                     std::set<std::string>& packageFamilyNameProcessed,
+                     QueryData& results) {
+  QueryData regResults;
+  queryKey(key, regResults);
+  for (const auto& rKey : regResults) {
+    // Each subkey represents a package, skip if not a subkey
+    if (rKey.at("type") != "subkey") {
+      continue;
+    }
+    const auto& regPath = rKey.at("path");
+    const auto& regPackageFullName = rKey.at("name");
+
+    // Get all registry entries for the package
+    QueryData appResults;
+    queryKey(regPath, appResults);
+    Row result;
+
+    result["identifying_name"] = regPackageFullName;
+    result["package_family_name"] =
+        packageFamilyNameFromPackageFullName(regPackageFullName);
+
+    for (const auto& aKey : appResults) {
+      auto name = aKey.find("name");
+
+      if (name->second == "PackageRootFolder") {
+        result["install_location"] = aKey.at("data");
+        std::string filePath =
+            result["install_location"] + "\\AppxManifest.xml";
+
+        // btime "Birth Time"
+        // When a file is first created, btime is set and does not change
+        // ::Warning:: not all filesystems support btime
+        // Older file systems such as ext3 or FAT32 will have this missing
+        WINDOWS_STAT file_stat;
+        auto rtn = platformStat(filePath.c_str(), &file_stat);
+        if (rtn.ok()) {
+          result["install_date"] = formatTimestampToDate(file_stat.btime);
+        }
+
+        auto s = osquery::pathExists(filePath);
+        if (!s.ok()) {
+          // Skip this package, as we cannot find the manifest file
+          // We can extract some information from the registry key
+          // <PackageName>_<Version>_<Architecture>__<PublisherHash>
+          // Example:
+          // MSTeams_25060.205.3499.6849_arm64__8wekyb3d8bbwe
+          // But all proper MSIX packages have an AppxManifest.xml file
+          VLOG(1) << "Cannot find manifest file:'" + filePath + "'";
+          result.clear();
+          continue;
+        }
+
+        std::string xmlContent;
+        s = osquery::readFile(filePath, xmlContent);
+        if (!s.ok()) {
+          // Skip this package, as we cannot read the manifest file
+          VLOG(1) << "Cannot read manifest file:'" + filePath + "'";
+          result.clear();
+          continue;
+        }
+
+        // Find the Identity tag, extract attributes
+        std::string identityTag = findSelfClosingTag(xmlContent, "Identity");
+        if (!identityTag.empty()) {
+          auto attributes = parseAttributes(identityTag);
+          result["name"] = attributes["Name"];
+          result["publisher"] = attributes["Publisher"];
+          result["version"] = attributes["Version"];
+        }
+
+        // Find the Properties tag, extract child tags
+        std::string propertiesTag = getTagContent(xmlContent, "Properties");
+        if (!propertiesTag.empty()) {
+          auto displayName = getTagContent(propertiesTag, "DisplayName");
+          auto publisherDisplayName =
+              getTagContent(propertiesTag, "PublisherDisplayName");
+
+          // "ms-resource:" prefix means that the string is dynamically
+          // generated from a .pri file .pri file is a binary index of all
+          // localized and scaled resources compiled from .resw files or
+          // .resources at build time
+          if (!displayName.empty() &&
+              displayName.find("ms-resource") == std::string::npos) {
+            result["name"] = displayName;
+          }
+          if (!publisherDisplayName.empty() &&
+              publisherDisplayName.find("ms-resource") == std::string::npos) {
+            result["publisher"] = publisherDisplayName;
+          }
+        }
+
+        // Done processing this package registry entries
+        // No need to read anymore keys
+        continue;
+      }
+    } // end processing package registry entry
+
+    if (!result.empty()) {
+      auto packageKey = result["package_family_name"];
+      if (packageKey.empty()) {
+        // This should never happen
+        packageKey = result["name"];
+      }
+
+      if (packageFamilyNameProcessed.find(packageKey) ==
+          packageFamilyNameProcessed.end()) {
+        packageFamilyNameProcessed.insert(packageKey);
+        results.push_back(result);
+      }
+    }
+  }
+}
+
 QueryData genPrograms(QueryContext& context) {
   QueryData results;
 
@@ -108,6 +328,18 @@ QueryData genPrograms(QueryContext& context) {
   std::set<std::string> processedPrograms;
   for (const auto& k : programKeys) {
     keyEnumPrograms(k, processedPrograms, results);
+  }
+
+  std::set<std::string> userMsixKeys;
+  expandRegistryGlobs(
+      "HKEY_USERS\\%\\Software\\Classes\\Local "
+      "Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\Reposi"
+      "tory\\Packages",
+      userMsixKeys);
+
+  std::set<std::string> packageFamilyNameProcessed;
+  for (const auto& k : userMsixKeys) {
+    genMsixPrograms(k, packageFamilyNameProcessed, results);
   }
 
   return results;

--- a/specs/windows/programs.table
+++ b/specs/windows/programs.table
@@ -10,6 +10,7 @@ schema([
     Column("uninstall_string", TEXT, "Path and filename of the uninstaller."),
     Column("install_date", TEXT, "Date that this product was installed on the system. "),
     Column("identifying_number", TEXT, "Product identification such as a serial number on software, or a die number on a hardware chip."),
+    Column("package_family_name", TEXT, "A combination of PackageName and PublisherHash that is used to uniquely identify applications across versions and architectures."),
 ])
 implementation("programs@genPrograms")
 examples([

--- a/tests/integration/tables/programs.cpp
+++ b/tests/integration/tables/programs.cpp
@@ -33,7 +33,8 @@ TEST_F(ProgramsTest, test_sanity) {
                            {"publisher", NormalType},
                            {"uninstall_string", NormalType},
                            {"install_date", NormalType},
-                           {"identifying_number", NormalType}};
+                           {"identifying_number", NormalType},
+                           {"package_family_name", NormalType}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/27199

This code scans the new registry location for MSIX packages and adds them to the `programs` osquery table. MSIX is the new an improved format designed to replace older formats like MSI, AppX, EXE installers. The Windows App Store uses it.  To learn more about it https://learn.microsoft.com/en-us/windows/msix/overview

The important bits to know about them is that they are scoped by user (see comment below). And a lot of the meta data around the application is contained in a file called `appxmanifest.xml`.

This code walks through the registry and grabs the installed applications. It also parses bits of the appxmanifest.xml file to get relevant data out.

