### PR TITLE
libs: openssl: 3.2.1 -> 3.4.1

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(thirdparty_openssl)
 
-set(OPENSSL_VERSION "3.2.1")
-set(OPENSSL_ARCHIVE_SHA256 "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39")
+set(OPENSSL_VERSION "3.4.1")
+set(OPENSSL_ARCHIVE_SHA256 "002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3")
 
 set(OSQUERY_OPENSSL_ARCHIVE_PATH "" CACHE FILEPATH "Optional path to an openssl archive to use instead of downloading it")
 

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -2,7 +2,7 @@
   "openssl": {
     "product": "openssl",
     "vendor": "openssl",
-    "version": "3.2.1",
+    "version": "3.4.1",
     "ignored-cves": []
   },
   "augeas": {


### PR DESCRIPTION
Fixes CVE-2024-4741, CVE-2024-4603, CVE-2024-2511, CVE-2024-5535 and CVE-2024-6119.
