### PR TITLE
Added UpgradeCode to programs table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -354,6 +354,7 @@ function(generateOsqueryTablesSystemSystemtable)
 
   elseif(DEFINED PLATFORM_WINDOWS)
     list(APPEND platform_public_header_files
+      windows/programs.h
       windows/registry.h
       windows/certificates.h
       windows/windows_eventlog.h

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ endfunction()
 function(generateOsqueryTablesSystemWindowsTests)
   add_osquery_executable(osquery_tables_system_windows_tests-test
     windows/certificates_tests.cpp
+    windows/programs_tests.cpp
     windows/registry_tests.cpp
     windows/windows_eventlog_tests.cpp
     windows/windows_optional_features_tests.cpp

--- a/osquery/tables/system/tests/windows/programs_tests.cpp
+++ b/osquery/tables/system/tests/windows/programs_tests.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+#include <osquery/core/system.h>
+#include <osquery/database/database.h>
+#include <osquery/registry/registry.h>
+#include <osquery/tables/system/windows/programs.h>
+#include <osquery/tests/test_util.h>
+
+namespace osquery {
+namespace tables {
+
+class ProgramsTablesTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    platformSetup();
+    registryAndPluginInit();
+    initDatabasePluginForTesting();
+  }
+};
+
+TEST_F(ProgramsTablesTest, test_decode_msi_registry_guid) {
+  // Empty guid
+  std::string emptyGUID = "";
+  ASSERT_EQ(decodeMsiRegistryGuid(emptyGUID), "");
+
+  // Invalid length
+  std::string invalidCompactGUID = "{0D8797326E7E4114DAECB3B66B9CD045}";
+  ASSERT_EQ(decodeMsiRegistryGuid(invalidCompactGUID), "");
+
+  // Valid conversion
+  std::string validCompactGUID = "0D8797326E7E4114DAECB3B66B9CD045";
+  ASSERT_EQ(decodeMsiRegistryGuid(validCompactGUID),
+            "{237978D0-E7E6-4114-ADCE-3B6BB6C90D54}");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -124,8 +124,105 @@ std::string packageFamilyNameFromPackageFullName(
   return packageName + "_" + publisherHash;
 }
 
+// Function to reverse a string
+std::string reverseString(const std::string& input) {
+  std::string reversed = input;
+  std::reverse(reversed.begin(), reversed.end());
+  return reversed;
+}
+
+// Function to convert a registry-encoded GUID into a standard GUID
+std::string decodeMsiRegistryGuid(const std::string& encoded) {
+  // Ensure the encoded string is exactly 32 characters long
+  if (encoded.length() != 32) {
+    VLOG(1) << "Invalid registry GUID '" << encoded << "'";
+    return "";
+  }
+
+  // Microsoft uses a custom encoding for GUIDs in the registry
+  // It reverses the order of the bytes in the string
+  // This 2CCAB6107DB47314AB175756630CCD04
+  // 1.  Reverse last 2 characters 04
+  // 2.  Reverse next 2 characters CD
+  // 3.  Reverse next 2 characters 0C
+  // 4.  Reverse next 2 characters 63
+  // 5.  Reverse next 2 characters 56
+  // 6.  Reverse next 2 characters 57
+  // 7.  Reverse next 2 characters 17
+  // 8.  Reverse next 2 characters AB
+  // 9.  Reverse next 4 characters 7314
+  // 10. Reverse next 4 characters 7DB4
+  // 11. Reverse first 8 characters 2CCAB610
+  // becomes 016BACC2-4BD7-4137-BA71-756536C0DC40
+
+  std::string str = reverseString(encoded.substr(0, 8)) + "-" +
+                    reverseString(encoded.substr(8, 4)) + "-" +
+                    reverseString(encoded.substr(12, 4)) + "-" +
+                    reverseString(encoded.substr(16, 2)) +
+                    reverseString(encoded.substr(18, 2)) + "-" +
+                    reverseString(encoded.substr(20, 2)) +
+                    reverseString(encoded.substr(22, 2)) +
+                    reverseString(encoded.substr(24, 2)) +
+                    reverseString(encoded.substr(26, 2)) +
+                    reverseString(encoded.substr(28, 2)) +
+                    reverseString(encoded.substr(30, 2));
+
+  return "{" + str + "}";
+}
+
+// Function to return a map of product code -> upgrade code
+// Note that this is not a 1:1 mapping, a single upgrade code can have many
+// product codes However, a product code can only have one upgrade code
+std::map<std::string, std::string> generateProductCodeUpgradeCodeMap() {
+  std::map<std::string, std::string> productCodeUpgradeCodeMap;
+  std::set<std::string> upgradeCodeKeys = {
+      "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\Installer\\UpgradeCodes",
+      "HKEY_LOCAL_"
+      "MACHINE\\SOFTWARE\\WOW6432Node\\Classes\\Installer\\UpgradeCodes",
+  };
+
+  for (const auto& key : upgradeCodeKeys) {
+    QueryData regResults;
+    queryKey(key, regResults);
+    for (const auto& rKey : regResults) {
+      // Each subkey represents an upgrade code
+      if (rKey.at("type") != "subkey") {
+        continue;
+      }
+
+      auto upgradeCode = decodeMsiRegistryGuid(rKey.at("name"));
+      if (upgradeCode.empty()) {
+        continue;
+      }
+
+      // Each upgrade code can have 1 or more product codes
+      QueryData upgradeCodeResults;
+      queryKey(rKey.at("path"), upgradeCodeResults);
+      for (const auto& pKey : upgradeCodeResults) {
+        // name contains the data for the product code
+        const auto& encryptedProductCode = pKey.find("name");
+        if (encryptedProductCode != pKey.end()) {
+          auto productCode =
+              decodeMsiRegistryGuid(encryptedProductCode->second);
+          if (productCode.empty()) {
+            continue;
+          }
+          std::transform(productCode.begin(),
+                         productCode.end(),
+                         productCode.begin(),
+                         ::toupper);
+          productCodeUpgradeCodeMap[productCode] = upgradeCode;
+        }
+      }
+    }
+  }
+
+  return productCodeUpgradeCodeMap;
+}
+
 void keyEnumPrograms(const std::string& key,
                      std::set<std::string>& processed,
+                     std::map<std::string, std::string> upgradeCodeMap,
                      QueryData& results) {
   QueryData regResults;
   queryKey(key, regResults);
@@ -156,6 +253,19 @@ void keyEnumPrograms(const std::string& key,
     if (std::regex_search(fullProgramName, matches, expression)) {
       identifyingNumber = matches[0];
       r["identifying_number"] = identifyingNumber;
+    }
+
+    if (!identifyingNumber.empty()) {
+      std::string identifyingNumberUpper = identifyingNumber;
+      std::transform(identifyingNumberUpper.begin(),
+                     identifyingNumberUpper.end(),
+                     identifyingNumberUpper.begin(),
+                     ::toupper);
+
+      const auto& upgradeCode = upgradeCodeMap[identifyingNumberUpper];
+      if (!upgradeCode.empty()) {
+        r["upgrade_code"] = upgradeCode;
+      }
     }
 
     for (const auto& aKey : appResults) {
@@ -325,9 +435,10 @@ QueryData genPrograms(QueryContext& context) {
       userProgramKeys);
   programKeys.insert(userProgramKeys.begin(), userProgramKeys.end());
 
+  const auto& upgradeCodeMap = generateProductCodeUpgradeCodeMap();
   std::set<std::string> processedPrograms;
   for (const auto& k : programKeys) {
-    keyEnumPrograms(k, processedPrograms, results);
+    keyEnumPrograms(k, processedPrograms, upgradeCodeMap, results);
   }
 
   std::set<std::string> userMsixKeys;

--- a/osquery/tables/system/windows/programs.h
+++ b/osquery/tables/system/windows/programs.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+namespace osquery {
+namespace tables {
+
+/*
+ * @brief Helper Function to convert a registry-encoded GUID into a standard
+ * GUID
+ *
+ * @param a string that contains the encoded guid, e.g.
+ * "0D8797326E7E4114DAECB3B66B9CD045"
+ * @return a string that contains the decoded guid, e.g.
+ * "{237978D0-E7E6-4114-ADCE-3B6BB6C90D54}" or an empty string if the input is
+ * invalid (input must be 32 characters long)
+ */
+std::string decodeMsiRegistryGuid(const std::string& encoded);
+
+} // namespace tables
+} // namespace osquery

--- a/specs/windows/programs.table
+++ b/specs/windows/programs.table
@@ -11,6 +11,7 @@ schema([
     Column("install_date", TEXT, "Date that this product was installed on the system. "),
     Column("identifying_number", TEXT, "Product identification such as a serial number on software, or a die number on a hardware chip."),
     Column("package_family_name", TEXT, "A combination of PackageName and PublisherHash that is used to uniquely identify applications across versions and architectures."),
+    Column("upgrade_code", TEXT, "Specific to MSI applications, a GUID used to identify a product suite across multiple versions.")
 ])
 implementation("programs@genPrograms")
 examples([

--- a/tests/integration/tables/programs.cpp
+++ b/tests/integration/tables/programs.cpp
@@ -34,7 +34,8 @@ TEST_F(ProgramsTest, test_sanity) {
                            {"uninstall_string", NormalType},
                            {"install_date", NormalType},
                            {"identifying_number", NormalType},
-                           {"package_family_name", NormalType}};
+                           {"package_family_name", NormalType},
+                           {"upgrade_code", NormalType}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
For issue https://github.com/fleetdm/fleet/issues/27759
Related to PR https://github.com/osquery/osquery/pull/8585

There are a few identifiers for windows programs. `UpgradeCode` is the unique identifier for MSI applications that is stable between version upgrades. It is different than the `identifying_number` column (which is typically `ProductCode`), as this changes between versions.

https://learn.microsoft.com/en-us/windows/win32/msi/productcode
https://learn.microsoft.com/en-us/windows/win32/msi/upgradecode