### PR TITLE
Fix flaky mdfind test in CI

### DIFF
--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -38,7 +38,7 @@ TEST_F(Mdfind, test_sanity) {
     GTEST_SKIP() << "mdfind is disabled on this system";
     return;
   }
-  if (strcmp(getenv("GITHUB_JOB"), "test_older_macos")) == 0 {
+  if (strcmp(getenv("GITHUB_JOB"), "test_older_macos") == 0) {
     LOG(INFO)
         << "Disabling mdfind test on the older macOS runner due to flakiness";
     GTEST_SKIP() << "mdfind test disabled on older macOS runner";

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -29,6 +29,14 @@ TEST_F(Mdfind, test_sanity) {
       "select * from mdfind where query = 'kMDItemFSName = \"*.app\"'"
       " LIMIT 10;");
 
+  // Skip the rest of the assertions if mdfind is disabled. We should still do
+  // the first query though just to be sure osquery doesn't crash in that case.
+  int mdfind_disabled = system("mdutil -s / | grep disabled");
+  if (mdfind_disabled == 0) {
+    GTEST_SKIP() << "mdfind is disabled on this system";
+    return;
+  }
+
   ASSERT_EQ(rows.size(), 10);
 
   ValidationMap row_map = {

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -15,7 +15,6 @@
 
 #include <boost/filesystem.hpp>
 
-
 namespace osquery {
 namespace table_tests {
 
@@ -39,7 +38,7 @@ TEST_F(Mdfind, test_sanity) {
     GTEST_SKIP() << "mdfind is disabled on this system";
     return;
   }
-  if (std::string(getenv("GITHUB_JOB")) == "test_older_macos") {
+  if (strcmp(getenv("GITHUB_JOB"), "test_older_macos")) == 0 {
     LOG(INFO)
         << "Disabling mdfind test on the older macOS runner due to flakiness";
     GTEST_SKIP() << "mdfind test disabled on older macOS runner";

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -33,7 +33,14 @@ TEST_F(Mdfind, test_sanity) {
   // the first query though just to be sure osquery doesn't crash in that case.
   int mdfind_disabled = system("mdutil -s / | grep disabled");
   if (mdfind_disabled == 0) {
+    LOG(INFO) << "Skipping mdfind test because mdfind is disabled";
     GTEST_SKIP() << "mdfind is disabled on this system";
+    return;
+  }
+  if (getenv("GITHUB_JOB") == "test_older_macos") {
+    LOG(INFO)
+        << "Disabling mdfind test on the older macOS runner due to flakiness";
+    GTEST_SKIP() << "mdfind test disabled on older macOS runner";
     return;
   }
 

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -38,7 +38,8 @@ TEST_F(Mdfind, test_sanity) {
     GTEST_SKIP() << "mdfind is disabled on this system";
     return;
   }
-  if (strcmp(getenv("GITHUB_JOB"), "test_older_macos") == 0) {
+  const char* github_job = getenv("GITHUB_JOB");
+  if (github_job != nullptr && strcmp(github_job, "test_older_macos") == 0) {
     LOG(INFO)
         << "Disabling mdfind test on the older macOS runner due to flakiness";
     GTEST_SKIP() << "mdfind test disabled on older macOS runner";

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -10,9 +10,11 @@
 // Sanity check integration test for mdfind
 // Spec file: specs/darwin/mdfind.table
 
+#include <osquery/logger/logger.h>
 #include <osquery/tests/integration/tables/helper.h>
 
 #include <boost/filesystem.hpp>
+
 
 namespace osquery {
 namespace table_tests {
@@ -37,7 +39,7 @@ TEST_F(Mdfind, test_sanity) {
     GTEST_SKIP() << "mdfind is disabled on this system";
     return;
   }
-  if (getenv("GITHUB_JOB") == "test_older_macos") {
+  if (std::string(getenv("GITHUB_JOB")) == "test_older_macos") {
     LOG(INFO)
         << "Disabling mdfind test on the older macOS runner due to flakiness";
     GTEST_SKIP() << "mdfind test disabled on older macOS runner";


### PR DESCRIPTION
- Skip most of the test when spotlight indexing is disabled
- Skip for the specific older macOS job because this fails even when indexing is enabled