### PR TITLE
Filter the Win32_Processor query to only required fields

### DIFF
--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -39,8 +39,11 @@ QueryData genSystemInfo(QueryContext& context) {
   const auto wmiSystemReq =
       WmiRequest::CreateWmiRequest("select * from Win32_ComputerSystem");
   auto wmiExecutedSuccessful = wmiSystemReq.isValue();
+  // Why not select * here?  Because we only use NumberOfCores out of this
+  // structure, however getting the full structure takes a 1s per CPU core
+  // penalty, which really hurts on large CPU systems
   const auto wmiSystemReqProc =
-      WmiRequest::CreateWmiRequest("select * from Win32_Processor");
+      WmiRequest::CreateWmiRequest("select NumberOfCores from Win32_Processor");
   wmiExecutedSuccessful &= wmiSystemReqProc.isValue();
   if (wmiExecutedSuccessful && !wmiSystemReq->results().empty() &&
       !wmiSystemReqProc->results().empty()) {


### PR DESCRIPTION
Querying Win32_Processor for all fields has a performance penalty of 1.1s per CPU core - this is mostly unnoticable on small boxes, but on larger boxes can actualloy have a significant impact on startup performance.  Even on an 8 core system, this takes the startup time for osqueryi from 8.5s to 0.2s