### PR TITLE
[Performance Analysis] print stderr if exists

### DIFF
--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -213,6 +213,14 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
 
     if len(stats.keys()) == 0:
         raise Exception("No stats recorded, perhaps binary returns -1?")
+    
+    # print out stderr if it exists
+    exit_code = p.wait()
+    if exit_code != 0:
+        err = proc.stderr.read()
+        if len(err) > 0:
+            print("Error: %s" % err.decode("utf-8"))
+
     rval = {
         "utilization": avg_utilization,
         "duration": duration,


### PR DESCRIPTION
This pull request adds a print of `stderr` if it exists during performance analysis. This improves the readability of the performance analysis output. 

For example, without printing `stderr`, the output will look like this:
```bash
$ sudo -E python ./tools/analysis/profile.py --query 'SELECT * FROM system_info;'
Profiling query: SELECT * FROM system_info;
U:3  C:3  M:3  F:3  D:3  manual (1/1): utilization: -1 cpu_time: -1 memory: -1 fds: -1 duration: -1 
```

With `stderr` printing:

```bash
Profiling query: SELECT * FROM system_info;
Error: E0417 14:42:06.650187 3823731 virtual_table.cpp:1052] Exception while executing table system_info: Cannot get database value: host_uuid_v3
Query failed (1): Cannot get database value: host_uuid_v3
U:3  C:3  M:3  F:3  D:3  manual (1/1): utilization: -1 cpu_time: -1 memory: -1 fds: -1 duration: -1 
```

Osquery doc reference: https://osquery.readthedocs.io/en/stable/deployment/performance-safety/#understanding-the-output-from-profilepy
Related issue: https://github.com/osquery/osquery/issues/8538