### PR TITLE
libs: libarchive: 3.6.2 -> 3.7.9

### DIFF
--- a/libraries/cmake/source/libarchive/config/linux/aarch64/config.h
+++ b/libraries/cmake/source/libarchive/config/linux/aarch64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/linux/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/linux/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/macos/aarch64/config.h
+++ b/libraries/cmake/source/libarchive/config/macos/aarch64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/macos/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/macos/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/windows/aarch64/config.h
+++ b/libraries/cmake/source/libarchive/config/windows/aarch64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/cmake/source/libarchive/config/windows/x86_64/config.h
+++ b/libraries/cmake/source/libarchive/config/windows/x86_64/config.h
@@ -316,13 +316,13 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.6.2"
+#define BSDCPIO_VERSION_STRING "3.7.9"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.6.2"
+#define BSDTAR_VERSION_STRING "3.7.9"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.6.2"
+#define BSDCAT_VERSION_STRING "3.7.9"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1234,10 +1234,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST 
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3006002"
+#define LIBARCHIVE_VERSION_NUMBER "3007009"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.6.2"
+#define LIBARCHIVE_VERSION_STRING "3.7.9"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1291,7 +1291,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.6.2"
+#define VERSION "3.7.9"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -129,15 +129,9 @@
   "libarchive": {
     "product": "libarchive",
     "vendor": "libarchive",
-    "version": "3.6.2",
-    "commit": "ba80276ccc3c941c4918ec6e2460059f0c525c43",
-    "ignored-cves": [
-      "CVE-2023-30571",
-      "CVE-2024-37407",
-      "CVE-2024-48957",
-      "CVE-2024-48958",
-      "CVE-2024-26256"
-    ]
+    "version": "3.7.9",
+    "commit": "8a7a9cc527fd1d6d8664315d3bed47c4259479cc",
+    "ignored-cves": []
   },
   "libaudit": {
     "product": "audit-userspace",


### PR DESCRIPTION
Fixes:
* CVE-2023-30571
* CVE-2024-37407
* CVE-2024-48957
* CVE-2024-48958
* CVE-2024-57970
* CVE-2025-1632
* CVE-2025-25724
* CVE-2024-20696
* CVE-2024-26256
* CVE-2024-26256

Fixes #8581
Fixes #8597

Changes:
https://github.com/libarchive/libarchive/releases/tag/v3.7.0 https://github.com/libarchive/libarchive/releases/tag/v3.7.1 https://github.com/libarchive/libarchive/releases/tag/v3.7.2 https://github.com/libarchive/libarchive/releases/tag/v3.7.3 https://github.com/libarchive/libarchive/releases/tag/v3.7.4 https://github.com/libarchive/libarchive/releases/tag/v3.7.5 https://github.com/libarchive/libarchive/releases/tag/v3.7.6 https://github.com/libarchive/libarchive/releases/tag/v3.7.7 https://github.com/libarchive/libarchive/releases/tag/v3.7.8 https://github.com/libarchive/libarchive/releases/tag/v3.7.9
