### PR TITLE
Add curl additional headers option

### DIFF
--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -35,6 +35,20 @@ Status processRequest(Row& r) {
 
     // Change the user-agent for the request to be osquery
     request << osquery::http::Request::Header("User-Agent", r["user_agent"]);
+    
+    // Process additional headers
+    if (!r["additional_headers"].empty()) {
+      std::stringstream ss(r["additional_headers"]);
+      std::string line;
+      while (std::getline(ss, line,'\n')) {
+        size_t separator = line.find(':');
+        if (separator != std::string::npos) {
+          std::string k = line.substr(0, separator);
+          std::string v = line.substr(separator + 1);
+          request << osquery::http::Request::Header(k, v);
+        }
+      }
+    }
 
     // Measure the rtt using the system clock
     auto time_start = std::chrono::system_clock::now();

--- a/specs/curl.table
+++ b/specs/curl.table
@@ -5,6 +5,7 @@ schema([
     Column("method", TEXT, "The HTTP method for the request"),
     Column("user_agent", TEXT, "The user-agent string to use for the request",
        additional=True),
+    Column("additional_headers", TEXT, "A newline separated list of additional headers to use for the request", additional=True),
     Column("response_code", INTEGER, "The HTTP status code for the response"),
     Column("round_trip_time", BIGINT, "Time taken to complete the request"),
     Column("bytes", BIGINT, "Number of bytes in the response"),


### PR DESCRIPTION
Add the option to pass additional headers to the curl function. Useful for auth headers and other arbitrary http headers.