### PR TITLE
Fix hardware UUID caching

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -158,18 +158,7 @@ std::string generateHostUUID() {
     // Construct a new string to remove trailing nulls.
     hardware_uuid = std::string(hardware_uuid.c_str());
   }
-
-  // Check whether the UUID is valid. If not generate an ephemeral UUID.
-  if (hardware_uuid.empty()) {
-    VLOG(1) << "Failed to read system uuid, returning ephemeral uuid";
-    return generateNewUUID();
-  } else if (isPlaceholderHardwareUUID(hardware_uuid)) {
-    VLOG(1) << "Hardware uuid '" << hardware_uuid
-            << "' is a placeholder, returning ephemeral uuid";
-    return generateNewUUID();
-  } else {
-    return hardware_uuid;
-  }
+  return hardware_uuid;
 }
 
 Status getInstanceUUID(std::string& ident) {
@@ -193,11 +182,22 @@ Status getEphemeralUUID(std::string& ident) {
 }
 
 Status getHostUUID(std::string& ident) {
+  static bool checked_hardware_uuid = false;
+  if (!checked_hardware_uuid) {
+    // Attempt to get the hardware UUID from the system.
+    std::string hardware_uuid = osquery::generateHostUUID();
+    // If it's valid, store it in the database.
+    if (!hardware_uuid.empty() && !isPlaceholderHardwareUUID(hardware_uuid)) {
+      setDatabaseValue(kPersistentSettings, "host_uuid_v3", hardware_uuid);
+    }
+    checked_hardware_uuid = true;
+  }
   // Lookup the host identifier (UUID) previously generated and stored.
   auto status = getDatabaseValue(kPersistentSettings, "host_uuid_v3", ident);
   if (ident.size() == 0) {
-    // There was no UUID stored in the database, generate one and store it.
-    ident = osquery::generateHostUUID();
+    // There was no UUID stored in the database, meaning that no valid
+    // hardware UUID was found. Generate a new one and store it.
+    ident = generateNewUUID();
     return setDatabaseValue(kPersistentSettings, "host_uuid_v3", ident);
   }
   return status;


### PR DESCRIPTION
For #7509
For https://github.com/fleetdm/fleet/issues/28535

## Details

This PR updates the logic for generating, storing and returning host identifiers when `--host-identifier=uuid` is used.  Previously, once a UUID was determined (either by getting a valid hardware UUID from the device, or failing that, creating a random UUID) it was stored in the local db and returned henceforth on every call to `getHostUUID()`.  With this update, the logic becomes:

1. Always check for a hardware UUID the first time `getHostUUID()` is called.
2. If one is found, store it in the db.
3. Check the db for a value.
4. If one is found, return it.
5. Otherwise generate a random UUID, store it in the db and return it.

This handles the most pertinent cases of 1) moving an osquery db between two hosts with different hardware UUIDs and 2) the hardware UUID of a host changing (e.g. due to a motherboard being swapped out).  It also maintains the behavior of randomly-generated UUIDs persisting across osquery restarts (provided that no hardware UUID is found) so that VMs using `--host-identifier=uuid` get a consistent UUID.  

The behavior when moving from a system with a hardware UUID to a system without one (or moving between two VMs) may still be considered sub-optimal, but those use-cases don't seem as problematic and I'm not sure what a good solve would be.

## Testing

I tested this manually with:

```
./osquery/osqueryi --verbose --database_path=./osquery.db --disable_database=false
```

and manipulating the db using [`ldb`](https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool).  I also simulated VM usage by temporarily adding my laptop's UUID to the "placeholders" list.  

I'd love to add a unit test for the new logic but the only way I can think to do that would be to change `getHostUUID` to use dependency-injection so I could mock `generateNewUUID()`, `getDatabaseValue()` and `setDatabaseValue()`.  I haven't seen that pattern elsewhere in osquery though.