### PR TITLE
Reduce log noise for `hash` table

### DIFF
--- a/osquery/hashing/hashing.cpp
+++ b/osquery/hashing/hashing.cpp
@@ -121,16 +121,18 @@ MultiHashes hashMultiFromFile(int mask, const std::string& path) {
   hashes.emplace(HASH_TYPE_SHA1, Hash{HASH_TYPE_SHA1});
   hashes.emplace(HASH_TYPE_SHA256, Hash{HASH_TYPE_SHA256});
 
-  auto status = readFile(path, ([&hashes, &mask](std::string_view buffer) {
+  auto status = readFile(path,
+                         ([&hashes, &mask](std::string_view buffer) {
                            for (auto& hash : hashes) {
                              if (mask & hash.first) {
                                hash.second.update(buffer.data(), buffer.size());
                              }
                            }
-                         }));
+                         }),
+                         false);
 
   if (!status.ok()) {
-    LOG(WARNING) << "Failed to hash " << path;
+    VLOG(1) << "Failed to hash " << path << ": " << status.getMessage();
     return {};
   }
 


### PR DESCRIPTION
Fixes https://github.com/fleetdm/fleet/issues/28577.

TL;DR: When `hash` table is used as scheduled query, the generated `WARNING` logs fill up the disk space.

Sample:
Without `--verbose`:
```
sudo ./osquery/osqueryi

osquery> SELECT * FROM hash WHERE path = '/Users/lucas/Downloads/Win11_24H2_English_Arm64.iso';
+-----------------------------------------------------+------------------------+-----+------+--------+
| path                                                | directory              | md5 | sha1 | sha256 |
+-----------------------------------------------------+------------------------+-----+------+--------+
| /Users/lucas/Downloads/Win11_24H2_English_Arm64.iso | /Users/lucas/Downloads |     |      |        |
+-----------------------------------------------------+------------------------+-----+------+--------+
```

With `--verbose`:
```
sudo ./osquery/osqueryi --verbose

osquery> SELECT * FROM hash WHERE path = '/Users/lucas/Downloads/Win11_24H2_English_Arm64.iso';
I0611 10:23:41.937412 -289448192 hashing.cpp:133] Failed to hash /Users/lucas/Downloads/Win11_24H2_English_Arm64.iso: Cannot read /Users/lucas/Downloads/Win11_24H2_English_Arm64.iso size exceeds limit: 5460387840 > 52428800
+-----------------------------------------------------+------------------------+-----+------+--------+
| path                                                | directory              | md5 | sha1 | sha256 |
+-----------------------------------------------------+------------------------+-----+------+--------+
| /Users/lucas/Downloads/Win11_24H2_English_Arm64.iso | /Users/lucas/Downloads |     |      |        |
+-----------------------------------------------------+------------------------+-----+------+--------+
```