### PR TITLE
Fix `NSInvalidArgumentException` when querying `connected_displays`

### DIFF
--- a/osquery/tables/system/darwin/connected_displays.mm
+++ b/osquery/tables/system/darwin/connected_displays.mm
@@ -133,14 +133,17 @@ QueryData genConnectedDisplays(QueryContext& context) {
         }
       }
 
-      if (NSString* rotation = [obj valueForKey:@"spdisplays_rotation"]) {
-        if ([rotation isEqualToString:@"spdisplays_supported"]) {
-          r["rotation"] = INTEGER(1);
-        } else {
-          r["rotation"] = INTEGER(0);
+      id rotation = [obj valueForKey:@"spdisplays_rotation"];
+      if (rotation) {
+        if ([rotation isKindOfClass:[NSString class]]) {
+          // rotation is supported and the display is not rotated
+          if ([rotation isEqualToString:@"spdisplays_supported"]) {
+            r["rotation"] = INTEGER(0);
+          }
+        } else if ([rotation isKindOfClass:[NSNumber class]]) {
+          // rotation is supported and the display is rotated (90/180/270 degrees)
+          r["rotation"] = INTEGER([rotation intValue]);
         }
-      } else {
-        r["rotation"] = INTEGER(0);
       }
 
       results.push_back(r);

--- a/osquery/tables/system/darwin/connected_displays.mm
+++ b/osquery/tables/system/darwin/connected_displays.mm
@@ -141,7 +141,7 @@ QueryData genConnectedDisplays(QueryContext& context) {
             r["rotation"] = INTEGER(0);
           }
         } else if ([rotation isKindOfClass:[NSNumber class]]) {
-          // rotation is supported and the display is rotated (90/180/270 degrees)
+          // the display is rotated (90/180/270 degrees)
           r["rotation"] = INTEGER([rotation intValue]);
         }
       }


### PR DESCRIPTION
This PR resolves an exception when querying `connected_displays` if one or more displays are rotated.

The content of `spdisplays_rotation` is `"spdisplays_supported"` when rotation is supported but the display is not rotated (i.e., 0 degree rotation) and either `90`, `180`, or `270` when the display is rotated. An example of both cases is available [here](https://github.com/osquery/osquery/issues/7486#issuecomment-1050680675).

## :bug: The bug
When querying `connected_displays` if any display is rotated a `uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber isEqualToString:]: unrecognized selector sent to instance` is raised because of the `isEqualToString` check [here](https://github.com/osquery/osquery/blob/2e1a79d65842f572732c526eedc7e998a75548b2/osquery/tables/system/darwin/connected_displays.mm#L137).

The [documentation for the `rotation` field](https://github.com/osquery/osquery/blob/2e1a79d65842f572732c526eedc7e998a75548b2/specs/darwin/connected_displays.table#L19) says it should be the rotation of the monitor but it's currently implemented as `1` when rotation is supported and `0` when it isn't supported.

The implementation proposed here changes that to be `0` for supported but not rotated, 90/180/270 if rotated, otherwise null. The table documentation should also be updated if this moves forward.

## :thought_balloon: Questions
- Should `rotation` be the degree rotation of the monitor, or should it indicate whether rotation is (or is not) supported?
- This is my first OSQuery PR, is there a good example of mocking both cases in the tests? [Currently only the type is being checked.](https://github.com/osquery/osquery/blob/2e1a79d65842f572732c526eedc7e998a75548b2/tests/integration/tables/connected_displays.cpp#L40) :crying_cat_face:

## :books: References
- cc https://github.com/osquery/osquery/pull/7946
- cc https://github.com/osquery/osquery/issues/7486#issuecomment-1050680675
- cc @cacab as the original implementer

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->