### PR TITLE
Fix ATC for open Firefox databases

### DIFF
--- a/plugins/config/parsers/auto_constructed_tables.cpp
+++ b/plugins/config/parsers/auto_constructed_tables.cpp
@@ -56,7 +56,7 @@ TableRows ATCPlugin::generate(QueryContext& context) {
     if (!s.ok()) {
       LOG(WARNING) << "ATC Table: Error Code: " << s.getCode()
                    << " Could not generate data: " << s.getMessage()
-                   << " for path " << path_;
+                   << " for path " << path;
     }
   }
   return result;


### PR DESCRIPTION
Fixes #8630 

When the ATC query fails, attempt to reopen with `immutable=1` option. This works in the case of Firefox databases.
