### PR TITLE
Fix inconsistent counter resets due to `Config::purge()`

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -32,6 +32,7 @@
 #include <osquery/hashing/hashing.h>
 #include <osquery/logger/logger.h>
 #include <osquery/registry/registry.h>
+#include <osquery/utils/affixes.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/trim.h>
 #include <osquery/utils/conversions/tryto.h>
@@ -1018,7 +1019,7 @@ void Config::purge() {
                          const std::string& query_name) {
     for (const auto& pack : schedule->packs_) {
       for (const auto& query : pack->getSchedule()) {
-        if (query.name == query_name) {
+        if (getQueryName(pack->getName(), query.name) == query_name) {
           return true;
         }
       }
@@ -1029,7 +1030,9 @@ void Config::purge() {
   RecursiveLock lock(config_schedule_mutex_);
   // Iterate over each result set in the database.
   for (const auto& saved_query : saved_queries) {
-    if (queryExists(saved_query)) {
+    if (hasAnyPrefix(saved_query, kReservedDbPrefixes) ||
+        hasAnySuffix(saved_query, kReservedDbSuffixes) ||
+        queryExists(saved_query)) {
       continue;
     }
 

--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -372,6 +372,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ConfigTests, test_config_refresh);
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
   FRIEND_TEST(ConfigTests, test_nondenylist_query);
+  FRIEND_TEST(ConfigTests, test_queryname_validation);
   FRIEND_TEST(ConfigTests, test_config_cli_flags);
   FRIEND_TEST(ConfigTests, test_pack_stats);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -18,6 +18,8 @@
 #include <osquery/hashing/hashing.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
+#include <osquery/utils/affixes.h>
+#include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/info/version.h>
@@ -209,6 +211,20 @@ void Pack::initialize(const std::string& name,
     }
 
     auto query_name = q.name.GetString();
+
+    if (hasAnyPrefix(query_name, kReservedDbPrefixes)) {
+      LOG(WARNING) << "Invalid query name: " << query_name
+                   << " starts with one of the reserved prefixes: "
+                   << join(kReservedDbPrefixes, ", ");
+      continue;
+    }
+
+    if (hasAnySuffix(query_name, kReservedDbSuffixes)) {
+      LOG(WARNING) << "Invalid query name: " << query_name
+                   << " ends with one of the reserved suffixes: "
+                   << join(kReservedDbSuffixes, ", ");
+      continue;
+    }
 
     if (!q.value.HasMember("query") || !q.value["query"].IsString()) {
       VLOG(1) << "No query string defined for query " << query_name;

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -63,6 +63,11 @@ const std::vector<std::string> kDomains = {kPersistentSettings,
                                            kDistributedRunningQueries,
                                            kQueryPerformance};
 
+const std::vector<std::string> kReservedDbPrefixes = {
+    "query.", "cache.", "config_views."};
+const std::vector<std::string> kReservedDbSuffixes = {kDbEpochSuffix,
+                                                      kDbCounterSuffix};
+
 std::atomic<bool> kDBAllowOpen(false);
 std::atomic<bool> kDBInitialized(false);
 std::atomic<bool> kDBChecking(false);

--- a/osquery/database/database.h
+++ b/osquery/database/database.h
@@ -61,6 +61,12 @@ extern const std::string kDistributedRunningQueries;
 /// The "domain" where query performance stats are stored.
 extern const std::string kQueryPerformance;
 
+// Vector of reserved prefixes used for storing query metadata
+extern const std::vector<std::string> kReservedDbPrefixes;
+
+// Vector of reserved suffixes used for storing query metadata
+extern const std::vector<std::string> kReservedDbSuffixes;
+
 /// The running version of our database schema
 const int kDbCurrentVersion = 2;
 

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -122,6 +122,8 @@ TEST_F(SchedulerTests, test_config_results_purge) {
   setDatabaseValue(kPersistentSettings, "interval.test_query", "11");
   // Store meaningless query differential results.
   setDatabaseValue(kQueries, "test_query", "{}");
+  setDatabaseValue(kQueries, "test_querycounter", "1");
+  setDatabaseValue(kQueries, "query.test_query", "SELECT * FROM TIME");
 
   // We do not need "THE" config instance.
   // We only need to trigger a 'purge' event, this occurs when configuration
@@ -145,6 +147,21 @@ TEST_F(SchedulerTests, test_config_results_purge) {
     std::string content;
     getDatabaseValue(kQueries, "test_query", content);
     EXPECT_FALSE(content.empty());
+  }
+
+  // Reserved keys should not have a set timestamp
+  {
+    std::string content;
+    getDatabaseValue(
+        kPersistentSettings, "timestamp.test_querycounter", content);
+    EXPECT_TRUE(content.empty());
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(
+        kPersistentSettings, "timestamp.query.test_query", content);
+    EXPECT_TRUE(content.empty());
   }
 
   // Update the timestamp to have run a week and a day ago.

--- a/osquery/utils/CMakeLists.txt
+++ b/osquery/utils/CMakeLists.txt
@@ -44,6 +44,7 @@ endfunction()
 
 function(generateOsqueryUtils)
   set(source_files
+    affixes.cpp
     base64.cpp
     chars.cpp
     only_movable.cpp
@@ -76,6 +77,7 @@ function(generateOsqueryUtils)
   )
 
   set(public_header_files
+    affixes.h
     attribute.h
     base64.h
     chars.h
@@ -157,6 +159,7 @@ endfunction()
 
 function(generateOsqueryUtilsUtilstestsTest)
   set(source_files
+    tests/affixes.cpp
     tests/base64.cpp
     tests/chars.cpp
     tests/map_take.cpp

--- a/osquery/utils/affixes.cpp
+++ b/osquery/utils/affixes.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2025-present, Akamai Technologies Inc.
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include "affixes.h"
+
+#include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+namespace osquery {
+
+bool hasAnyPrefix(const std::string& s,
+                  const std::vector<std::string>& prefixes) {
+  return boost::algorithm::any_of(prefixes, [&s](const auto& prefix) {
+    return boost::algorithm::starts_with(s, prefix);
+  });
+}
+
+bool hasAnySuffix(const std::string& s,
+                  const std::vector<std::string>& suffixes) {
+  return boost::algorithm::any_of(suffixes, [&s](const auto& suffix) {
+    return boost::algorithm::ends_with(s, suffix);
+  });
+}
+
+} // namespace osquery

--- a/osquery/utils/affixes.cpp
+++ b/osquery/utils/affixes.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025-present, Akamai Technologies Inc.
+ * Copyright (c) 2014-present, The osquery authors
  *
  * This source code is licensed as defined by the LICENSE file found in the
  * root directory of this source tree.

--- a/osquery/utils/affixes.h
+++ b/osquery/utils/affixes.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2025-present, Akamai Technologies Inc.
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace osquery {
+
+/**
+ * @brief Check if a string starts with any prefix in a vector.
+ *
+ * @param s the string to be validated.
+ * @param prefixes vector of prefixes to be matched against.
+ *
+ * @return true if string contains any of the prefixes.
+ */
+bool hasAnyPrefix(const std::string& s,
+                  const std::vector<std::string>& prefixes);
+
+/**
+ * @brief Check if a string ends with any suffix in a vector.
+ *
+ * @param s the string to be validated.
+ * @param suffixes vector of suffixes to be matched against.
+ *
+ * @return true if string contains any of the suffixes.
+ */
+bool hasAnySuffix(const std::string& s,
+                  const std::vector<std::string>& suffixes);
+
+} // namespace osquery

--- a/osquery/utils/affixes.h
+++ b/osquery/utils/affixes.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025-present, Akamai Technologies Inc.
+ * Copyright (c) 2014-present, The osquery authors
  *
  * This source code is licensed as defined by the LICENSE file found in the
  * root directory of this source tree.

--- a/osquery/utils/tests/affixes.cpp
+++ b/osquery/utils/tests/affixes.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2025-present, Akamai Technologies Inc.
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+#include <osquery/utils/affixes.h>
+
+namespace osquery {
+
+class AffixesTests : public testing::Test {};
+
+TEST_F(AffixesTests, test_affixes) {
+  std::vector<std::string> prefixes = {"query.", "cache.", "prefix"};
+  std::vector<std::string> suffixes = {"epoch", "counter", "suffix"};
+
+  bool result = hasAnyPrefix("query.name", prefixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnyPrefix("query.", prefixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnyPrefix("cache.name", prefixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnyPrefix("othername", prefixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnyPrefix("cache", prefixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnyPrefix("pre", prefixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnySuffix("nameepoch", suffixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnySuffix("namecounter", suffixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnySuffix("counter", suffixes);
+  EXPECT_TRUE(result);
+
+  result = hasAnySuffix("nter", suffixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnySuffix("nameother", suffixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnySuffix("fix", suffixes);
+  EXPECT_FALSE(result);
+
+  result = hasAnySuffix("", suffixes);
+  EXPECT_FALSE(result);
+}
+
+} // namespace osquery

--- a/osquery/utils/tests/affixes.cpp
+++ b/osquery/utils/tests/affixes.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025-present, Akamai Technologies Inc.
+ * Copyright (c) 2014-present, The osquery authors
  *
  * This source code is licensed as defined by the LICENSE file found in the
  * root directory of this source tree.


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery/issues/8611

As described in the above issue, Osquery stores the state of the scheduled queries in the `kQueries` domain in RocksDB. The `Config::purge()` function is invoked on every config refresh. It is responsible for purging the stored state of queries that are no longer in the schedule and haven't been executed in the last 7 days. Whenever a query is scheduled, the timestamp for it is updated as `timestamp.<name>` in the `kPersistentSettings` domain. The `Config::purge()` function however, sets the timestamps for all metadata keys in the `kQueries` domain such as `<name>counter`, `<name>epoch`, `query.<name>` as well if not already present. The Osquery scheduler never updates the timestamp for these metadata keys. Every 7 days, `Config::purge()` checks the timestamps of these keys, and because they always have week old timestamps, they are purged from the store. This causes the counter metadata key of queries to reset but only differential results are reported leading to the issue above.
With this change,
	1.	Metadata keys are ignored from the purging logic.
	2.	Users will not be allowed to add queries with `query.`,`cache.` and `config_views.` as a prefix or `epoch` and `counter` as a suffix.

## Config module changes
* The `queryExists` function returns `false` for queries even if they are present in the schedule. Consider a query `query_name` in a pack `pack_name` with `/` as the pack delimiter. When `queryExists("pack/pack_name/query_name")` is called, it iterates over the schedule and compares if `"query_name" == "pack/pack_name/query_name"`. This always returns false even if the query is present in the schedule. This function is updated to use fully qualified query names to fix this behavior.
* The timestamp has the final say in determining if a key is purged from the store. The `Config::purge()` function ages and purges reserved keys such as `<name>counter`, `<name>epoch` and `query.<name>` as described above. This leads to the counter (and other query metadata) being purged inconsistently. With this change, such keys are not considered for purge. The unit test `test_config_results_purge` is updated to validate the same.
* Currently, there are no restrictions on the names that can be set for a query. Query names can contain metadata prefixes such as `query.` and `cache.` or suffixes such as `epoch` and `counter`. This leads to the following issues:
  * The updated purge function skips over keys which have metadata prefixes and suffixes. Queries having such names are not purged even if out of schedule.
  * When a query name conflicts with the metadata of another query, osquery crashes with an error. For example, in a pack `pack1`, if there are two queries with names `query1` and `query1counter`, osquery crashes with the following error: `E0624 15:50:45.187048 119689 shutdown.cpp:80] Error adding new results to database for query pack/pack1/query1counter: JSON object was not an array`.
  
* This change prevents queries from having such reserved prefixes and suffixes in their names to address the above issues and adds a new unit test `test_queryname_validation` for the same.

## Database module changes
* Vectors `kReservedPrefixes` and `kReservedSuffixes` are defined to store the reserved prefixes and suffixes that have a special meaning in the RocksDB store.

## Util Module Changes
* Helper functions `bool hasAnyPrefix(const std::string& s, const std::vector<std::string>& prefixes)`, `bool hasAnySuffix(const std::string& s, const std::vector<std::string>& suffixes)` and their corresponding unit test `test_affixes` are added. These functions are used in the config module to check if a string has any of the reserved database prefixes or suffixes.