### PR TITLE
Add version collate to os_version table's version column

### DIFF
--- a/specs/os_version.table
+++ b/specs/os_version.table
@@ -2,7 +2,7 @@ table_name("os_version")
 description("A single row containing the operating system name and version.")
 schema([
     Column("name", TEXT, "Distribution or product name"),
-    Column("version", TEXT, "Pretty, suitable for presentation, OS version"),
+    Column("version", TEXT, "Pretty, suitable for presentation, OS version", collate="version"),
     Column("major", INTEGER, "Major release version"),
     Column("minor", INTEGER, "Minor release version"),
     Column("patch", INTEGER, "Optional patch release"),


### PR DESCRIPTION
This is a small PR to add the version collation to the os_version's `version` column. This will allow easier comparison for queries checking if the os version is below or above a certain release.