### PR TITLE
Add support for VSCode forks in vscode_extensions

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -23,6 +23,25 @@ namespace fs = boost::filesystem;
 namespace osquery {
 namespace tables {
 
+// Constants for VSCode configuration paths
+const std::vector<std::pair<std::string, std::string>> KPathList = {
+    {".vscode-server", "vscode"},
+    {".vscode", "vscode"},
+    {".vscode-server-insiders", "vscode_insiders"},
+    {".vscode-insiders", "vscode_insiders"},
+    // Note vscodium regular does not follow the pattern
+    {".vscode-oss", "vscodium"},
+    {".vscodium-server", "vscodium"},
+    {".vscodium-insiders", "vscodium_insiders"},
+    {".vscodium-server-insiders", "vscodium_insiders"},
+    {".cursor", "cursor"},
+    {".cursor-server", "cursor"},
+    {".windsurf", "windsurf"},
+    {".windsurf-server", "windsurf"},
+    {".trae", "trae"},
+    {".trae-server", "trae"},
+};
+
 void genReadJSONAndAddExtensionRows(const std::string& uid,
                                     const std::string& path,
                                     const std::string& vscode_edition,
@@ -130,19 +149,11 @@ QueryData genVSCodeExtensions(QueryContext& context) {
       continue;
     }
 
-    // Determine the version type and add paths for both VSCode and VSCode
-    // Insiders
-    conf_dirs.insert(ConfDir{
-        uid->second, fs::path(directory->second) / ".vscode-server", "vscode"});
-    conf_dirs.insert(ConfDir{
-        uid->second, fs::path(directory->second) / ".vscode", "vscode"});
-    conf_dirs.insert(
-        ConfDir{uid->second,
-                fs::path(directory->second) / ".vscode-server-insiders",
-                "vscode_insiders"});
-    conf_dirs.insert(ConfDir{uid->second,
-                             fs::path(directory->second) / ".vscode-insiders",
-                             "vscode_insiders"});
+    // Add paths for each of the supported VSCode editions
+    for (const auto& path_info : KPathList) {
+      conf_dirs.insert(ConfDir{
+          uid->second, fs::path(directory->second) / path_info.first, path_info.second});
+    }
   }
 
   for (const auto& conf_dir : conf_dirs) {

--- a/specs/vscode_extensions.table
+++ b/specs/vscode_extensions.table
@@ -10,7 +10,7 @@ schema([
     Column("installed_at", BIGINT, "Installed Timestamp"),
     Column("prerelease", INTEGER, "Pre release version"),
     Column("uid", BIGINT, "The local user that owns the plugin", additional=True, optimized=True),
-    Column("vscode_edition", TEXT, "VSCode or VSCode Insiders")
+    Column("vscode_edition", TEXT, "The VSCode edition (vscode, vscode_insiders, vscodium, vscodium_insiders, cursor, windsurf, trae)")
 ])
 attributes(user_data=True)
 implementation("applications/vscode_extensions@genVSCodeExtensions")


### PR DESCRIPTION
Suport for VSCodium, VSCodium Insiders, Cursor, Windsurf, and Trae editors, along with their server variants (when using remote SSH editing).

Tested across all of these editors on macOS, some of the server variants on Ubuntu, and some of the editors on Windows.
