### PR TITLE
Add `entitlements` column to macOS `signature` table

### DIFF
--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -207,17 +207,24 @@ Status genSignatureForFileAndArch(const std::string& path,
   // Get entitlements dictionary
   r["entitlements"] = "";
   CFDictionaryRef entitlements = nullptr;
-  if (CFDictionaryGetValueIfPresent(code_info, kSecCodeInfoEntitlementsDict, (const void**)&entitlements)) {
+  if (CFDictionaryGetValueIfPresent(code_info,
+                                    kSecCodeInfoEntitlementsDict,
+                                    (const void**)&entitlements)) {
     if (entitlements != nullptr) {
       @autoreleasepool {
-        NSDictionary *nsDict = (__bridge NSDictionary *)entitlements;
-        NSError *error = nil;
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:nsDict options:0 error:&error];
+        NSDictionary* nsDict = (__bridge NSDictionary*)entitlements;
+        NSError* error = nil;
+        NSData* jsonData = [NSJSONSerialization dataWithJSONObject:nsDict
+                                                           options:0
+                                                             error:&error];
         if (error == nil) {
-          NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+          NSString* jsonString =
+              [[NSString alloc] initWithData:jsonData
+                                    encoding:NSUTF8StringEncoding];
           r["entitlements"] = [jsonString UTF8String];
         } else {
-          LOG(ERROR) << "Failed to serialize entitlements to JSON for " << path << ": " << [[error localizedDescription] UTF8String];
+          LOG(ERROR) << "Failed to serialize entitlements to JSON for " << path
+                     << ": " << [[error localizedDescription] UTF8String];
         }
       }
     }

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -204,6 +204,25 @@ Status genSignatureForFileAndArch(const std::string& path,
     }
   }
 
+  // Get entitlements dictionary
+  r["entitlements"] = "";
+  CFDictionaryRef entitlements = nullptr;
+  if (CFDictionaryGetValueIfPresent(code_info, kSecCodeInfoEntitlementsDict, (const void**)&entitlements)) {
+    if (entitlements != nullptr) {
+      @autoreleasepool {
+        NSDictionary *nsDict = (__bridge NSDictionary *)entitlements;
+        NSError *error = nil;
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:nsDict options:0 error:&error];
+        if (error == nil) {
+          NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+          r["entitlements"] = [jsonString UTF8String];
+        } else {
+          LOG(ERROR) << "Failed to serialize entitlements to JSON for " << path << ": " << [[error localizedDescription] UTF8String];
+        }
+      }
+    }
+  }
+
   results.push_back(r);
   CFRelease(static_code);
   CFRelease(code_info);

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -14,6 +14,7 @@ schema([
     Column("cdhash", TEXT, "Hash of the application Code Directory"),
     Column("team_identifier", TEXT, "The team signing identifier sealed into the signature"),
     Column("authority", TEXT, "Certificate Common Name"),
+    Column("entitlements", TEXT, "JSON representation of the code signing entitlements"),
 ])
 implementation("signature@genSignature")
 examples([

--- a/tests/integration/tables/signature.cpp
+++ b/tests/integration/tables/signature.cpp
@@ -15,35 +15,290 @@
 namespace osquery {
 namespace table_tests {
 
-class signature : public testing::Test {
+class SignatureTests : public testing::Test {
  protected:
   void SetUp() override {
     setUpEnvironment();
   }
 };
 
-TEST_F(signature, test_sanity) {
-  // 1. Query data
-  auto const data = execute_query("select * from signature where path = ''");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for available flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"path", NormalType}
-  //      {"hash_resources", IntType}
-  //      {"arch", NormalType}
-  //      {"signed", IntType}
-  //      {"identifier", NormalType}
-  //      {"cdhash", NormalType}
-  //      {"team_identifier", NormalType}
-  //      {"authority", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+TEST_F(SignatureTests, test_sanity) {
+  // Test with a known system file that should be signed
+  auto data = execute_query("SELECT * FROM signature WHERE path = '/bin/ls'");
+
+  // Should return at least one row (one per architecture)
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  // Check that the path is correct
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("path"), "/bin/ls");
+    ASSERT_EQ(row.at("identifier"), "com.apple.ls");
+    ASSERT_TRUE(row.at("signed") == "1");
+  }
+}
+
+TEST_F(SignatureTests, test_hash_resources_constraint) {
+  // Test with hash_resources = 0
+  auto data = execute_query(
+      "SELECT * FROM signature WHERE path = '/bin/ls' AND hash_resources = 0");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("hash_resources"), "0");
+  }
+
+  // Test with hash_resources = 1
+  data = execute_query(
+      "SELECT * FROM signature WHERE path = '/bin/ls' AND hash_resources = 1");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("hash_resources"), "1");
+  }
+}
+
+TEST_F(SignatureTests, test_hash_executable_constraint) {
+  // Test with hash_executable = 0
+  auto data = execute_query(
+      "SELECT * FROM signature WHERE path = '/bin/ls' AND hash_executable = 0");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("hash_executable"), "0");
+  }
+
+  // Test with hash_executable = 1
+  data = execute_query(
+      "SELECT * FROM signature WHERE path = '/bin/ls' AND hash_executable = 1");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("hash_executable"), "1");
+  }
+}
+
+TEST_F(SignatureTests, test_multiple_architectures) {
+  // Test that we get results for multiple architectures
+  auto data = execute_query("SELECT * FROM signature WHERE path = '/bin/ls'");
+
+  // Should return multiple rows for different architectures
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  std::set<std::string> architectures;
+  for (const auto& row : data) {
+    architectures.insert(row.at("arch"));
+  }
+
+  // Should have at least one architecture
+  ASSERT_GE(architectures.size(), 1ul);
+}
+
+TEST_F(SignatureTests, test_unsigned_file) {
+  // Test with a file that should be unsigned (use a text file)
+  auto data =
+      execute_query("SELECT * FROM signature WHERE path = '/etc/hosts'");
+
+  // Should return at least one row
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NormalType}, // Allow empty for unsigned files
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("path"), "/etc/hosts");
+    // Text files should be unsigned
+    ASSERT_EQ(row.at("signed"), "0");
+    // Unsigned file should have empty identifier
+    ASSERT_TRUE(row.at("identifier").empty());
+  }
+}
+
+TEST_F(SignatureTests, test_app_signature) {
+  // Test with a macOS app that should be signed
+  auto data = execute_query(
+      "SELECT * FROM signature WHERE path = '/System/Applications/System "
+      "Settings.app'");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    ASSERT_EQ(row.at("path"), "/System/Applications/System Settings.app");
+    // App should be signed
+    ASSERT_EQ(row.at("signed"), "1");
+    // Should have an identifier
+    ASSERT_FALSE(row.at("identifier").empty());
+    // Should have entitlements (apps typically have entitlements)
+    ASSERT_FALSE(row.at("entitlements").empty());
+  }
+}
+
+TEST_F(SignatureTests, test_nonexistent_file) {
+  // Test with a file that doesn't exist
+  auto data =
+      execute_query("SELECT * FROM signature WHERE path = '/nonexistent/file'");
+
+  // Should return no rows
+  ASSERT_EQ(data.size(), 0ul);
+}
+
+TEST_F(SignatureTests, test_entitlements_json) {
+  // Test that entitlements field contains valid JSON when present
+  auto data = execute_query(
+      "SELECT * FROM signature WHERE path = '/System/Applications/System "
+      "Settings.app' AND entitlements != ''");
+
+  // This test should have results since System Settings.app has entitlements
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    const auto& entitlements = row.at("entitlements");
+    if (!entitlements.empty()) {
+      // Basic JSON validation - should start with { and end with }
+      ASSERT_TRUE(entitlements.front() == '{');
+      ASSERT_TRUE(entitlements.back() == '}');
+    }
+  }
+}
+
+TEST_F(SignatureTests, test_cdhash_format) {
+  // Test that cdhash is in hex format when present
+  auto data = execute_query(
+      "SELECT * FROM signature WHERE path = '/bin/ls' AND cdhash != ''");
+
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"hash_resources", IntType},
+      {"hash_executable", IntType},
+      {"arch", NormalType},
+      {"signed", IntType},
+      {"identifier", NormalType},
+      {"cdhash", NonEmptyString},
+      {"team_identifier", NormalType},
+      {"authority", NormalType},
+      {"entitlements", NormalType},
+  };
+
+  validate_rows(data, row_map);
+
+  for (const auto& row : data) {
+    const auto& cdhash = row.at("cdhash");
+    if (!cdhash.empty()) {
+      // CDHash should be a hex string
+      ASSERT_TRUE(is_valid_hex(cdhash));
+    }
+  }
 }
 
 } // namespace table_tests


### PR DESCRIPTION
Entitlements are returned as JSON, or an empty string if no entitlements are set.

Also added some integration testing to the table.

https://github.com/fleetdm/fleet/issues/25679