### PR TITLE
Exclude config views from db migration

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -562,7 +562,7 @@ static Status migrateV0V1(void) {
     if (boost::algorithm::ends_with(key, kDbEpochSuffix) ||
         boost::algorithm::ends_with(key, kDbCounterSuffix) ||
         boost::algorithm::starts_with(key, "query.") ||
-        boost::algorithm::states_with(key, "config_views.")) {
+        boost::algorithm::starts_with(key, "config_views.")) {
       continue;
     }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -562,7 +562,7 @@ static Status migrateV0V1(void) {
     if (boost::algorithm::ends_with(key, kDbEpochSuffix) ||
         boost::algorithm::ends_with(key, kDbCounterSuffix) ||
         boost::algorithm::starts_with(key, "query.") ||
-        boost::algorithn::states_with(key, "config_views.")) {
+        boost::algorithm::states_with(key, "config_views.")) {
       continue;
     }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -561,7 +561,8 @@ static Status migrateV0V1(void) {
     // Skip over epoch and counter entries, as 0 is parsed by ptree
     if (boost::algorithm::ends_with(key, kDbEpochSuffix) ||
         boost::algorithm::ends_with(key, kDbCounterSuffix) ||
-        boost::algorithm::starts_with(key, "query.")) {
+        boost::algorithm::starts_with(key, "query.") ||
+        boost::algorithn::states_with(key, "config_views.")) {
       continue;
     }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -652,8 +652,8 @@ Status upgradeDatabase(int to_version) {
       db_version = ret.get();
     }
   } else {
-    LOG(ERROR) << "Failed to obtain database version. Assume version '"
-               << std::to_string(db_version) << "' and migrate.";
+    LOG(WARNING) << "Failed to obtain database version. Assume version '"
+                 << std::to_string(db_version) << "' and migrate.";
   }
 
   while (db_version != to_version) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -652,8 +652,8 @@ Status upgradeDatabase(int to_version) {
       db_version = ret.get();
     }
   } else {
-    LOG(WARNING) << "Failed to obtain database version. Assume version '"
-                 << std::to_string(db_version) << "' and migrate.";
+    LOG(INFO) << "Failed to obtain database version. Assume version '"
+              << std::to_string(db_version) << "' and migrate.";
   }
 
   while (db_version != to_version) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -653,7 +653,7 @@ Status upgradeDatabase(int to_version) {
     }
   } else {
     LOG(ERROR) << "Failed to obtain database version. Assume version '"
-               << std::to_string(db_version) << "' and migrate."
+               << std::to_string(db_version) << "' and migrate.";
   }
 
   while (db_version != to_version) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -651,6 +651,9 @@ Status upgradeDatabase(int to_version) {
     } else {
       db_version = ret.get();
     }
+  } else {
+    LOG(ERROR) << "Failed to obtain database version. Assume version '"
+               << std::to_string(db_version) << "' and migrate."
   }
 
   while (db_version != to_version) {


### PR DESCRIPTION
This PR makes it so views from osquery configuration files will be skipped in the database migration. This is because the `Conversion from ptree to RapidJSON` fails for config views. Our company has started to use the views within the osquery config, but quickly noticed that a lot of instances of osquery were not creating the views.

After diagnosing, it appears to be when osquery is unable to obtain the current `db_version`, and has to assume version `0`. This then causes osquery to migrate, but the config views are not proper JSON, so it fails to convert them every time. Similar to queries, I added a check to skip keys that start with `config_views.`.

I also added error logging for when the database version value is not obtained as I believe this is useful to know.