### PR TITLE
Don't overwrite hardware_version if it has a value

### DIFF
--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -172,7 +172,9 @@ QueryData genSystemInfo(QueryContext& context) {
   }
 
   r["cpu_subtype"] = "-1";
-  r["hardware_version"] = "-1";
+  if (r["hardware_version"] == "") {
+    r["hardware_version"] = "-1";
+  }
   return {r};
 }
 }


### PR DESCRIPTION
When the previous changes to lenovo systems were made, hardware_version was used to store the old value. The problem is  we overwrote that everytime so hardware_version, regardless of value would be reset to "-1".

Only set hardware_version when its not previously set.
