### PR TITLE
Make `vscode_extensions` more consistently report UUID

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -86,11 +86,6 @@ void genReadJSONAndAddExtensionRows(const std::string& uid,
       r["name"] = it->value.GetString();
     }
 
-    it = identifier.FindMember("uuid");
-    if (it != identifier.MemberEnd() && it->value.IsString()) {
-      r["uuid"] = it->value.GetString();
-    }
-
     it = extension.FindMember("version");
     if (it != extension.MemberEnd() && it->value.IsString()) {
       r["version"] = it->value.GetString();
@@ -99,6 +94,14 @@ void genReadJSONAndAddExtensionRows(const std::string& uid,
     it = location.FindMember("path");
     if (it != location.MemberEnd() && it->value.IsString()) {
       r["path"] = it->value.GetString();
+    }
+
+    // Note that we used to look for identifier.uuid but it is not always
+    // present and in every example checked, metadata.id is present and has the
+    // same value (on Windows, macOS, and Linux and multiple VSCode forks)
+    it = metadata.FindMember("id");
+    if (it != identifier.MemberEnd() && it->value.IsString()) {
+      r["uuid"] = it->value.GetString();
     }
 
     it = metadata.FindMember("publisherDisplayName");

--- a/tests/integration/tables/vscode_extensions.cpp
+++ b/tests/integration/tables/vscode_extensions.cpp
@@ -48,16 +48,16 @@ TEST_F(vscodeExtensions, test_sanity) {
   }
 
   ValidationMap row_map = {
-      {"name", NormalType},
-      {"uuid", NormalType},
-      {"version", NormalType},
-      {"path", NormalType},
-      {"publisher", NormalType},
-      {"publisher_id", NormalType},
+      {"name", NonEmptyString},
+      {"uuid", NonEmptyString},
+      {"version", NonEmptyString},
+      {"path", NonEmptyString},
+      {"publisher", NonEmptyString},
+      {"publisher_id", NonEmptyString},
       {"installed_at", NonNegativeInt},
       {"prerelease", Bool | EmptyOk},
       {"uid", NonNegativeInt},
-      {"vscode_edition", NormalType},
+      {"vscode_edition", NonEmptyString},
   };
   validate_rows(data, row_map);
 }


### PR DESCRIPTION
Observations indicated that the identifier.uuid field was not always populated, while the metadata.id field was always populated with the same data (if it existed in the former).

