### PR TITLE
Support `nvm` on `npm_packages` table

### DIFF
--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -31,13 +31,16 @@ namespace tables {
 
 const std::set<std::string> kNodeModulesPath = {
 #ifdef WIN32
-    "C:\\Users\\%\\AppData\\Roaming\\npm"
+    "C:\\Users\\%\\AppData\\Roaming\\npm",
+    "C:\\Users\\%\\AppData\\Local\\nvm\\%"
 #else
     "/usr/local/lib",
     "/opt/homebrew/lib",
     "/usr/lib",
     "/home/%/.npm-global/lib",
-    "/Users/%/.npm-global/lib"
+    "/home/%/.nvm/versions/node/%/lib",
+    "/Users/%/.npm-global/lib",
+    "/Users/%/.nvm/versions/node/%/lib"
 #endif
 };
 


### PR DESCRIPTION
Adds support for global node packages installed using a version of `node` managed by `nvm`.

A relatively simple change, just adds a couple of directories to search for `npm` packages. Should cover the default locations for `nvm` on macOS and Linux, as well as `nvm-windows` (a similar program for windows).

Related to https://github.com/fleetdm/fleet/issues/32268
