### PR TITLE
Make profile.py performance thresholds configurable via CLI flags

### DIFF
--- a/docs/wiki/deployment/performance-safety.md
+++ b/docs/wiki/deployment/performance-safety.md
@@ -92,7 +92,7 @@ Duration is calculated by taking the subtracting `start_time` - 2 from the curre
 
 ### Understanding Profile.py Categories
 
-The numbers next to the stats in the script output (categories) are determined by the `RANGES` dictionary in `profile.py`
+The numbers next to the stats in the script output (categories) are determined by threshold triplets (warn, error, critical). The built-in defaults are:
 
 ```python
 KB = 1024 * 1024
@@ -106,7 +106,13 @@ RANGES = {
 }
 ```
 
-The script will take the value of the stat and compare it with the tuple at the corresponding stat's key in `RANGES`. If the value is less than the value in the tuple then the index for the value in the tuple is what appears in the script output. If the value for the stat is greater than all values of the tuple, then the length of the tuple is what appears in the script output. For example, if `cpu_time` for a query is 0.2, then you'll see `C: 0` in the script output. If `cpu_time` is 11, then you'll see `C:3` in the script output.
+These thresholds can be overridden at the command line using `--utilization`, `--cpu_time`, `--memory`, `--fds`, and `--duration`. Each flag accepts three values in increasing order (`WARN ERR CRIT`). For example:
+
+```sh
+./tools/analysis/profile.py --config /path/to/osquery.conf --duration 1.0 2.0 5.0 --memory 4194304 8388608 16777216
+```
+
+The script will take the value of the stat and compare it with the threshold triplet. If the value is less than the first threshold it scores `0` (green), less than the second scores `1` (yellow), less than the third scores `2` (orange), and above all three scores `3` (red). For example, if `cpu_time` for a query is 0.2, then you'll see `C: 0` in the script output. If `cpu_time` is 11, then you'll see `C:3` in the script output.
 
 Queries that fail to execute (for example, due to a non-existent table) will return the highest category result `3` and the value `-1` for all statistics.
 

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -311,7 +311,51 @@ if __name__ == "__main__":
         "--suppressions", metavar="SUPP", default="./tools/analysis/valgrind.supp",
         help="Add a suppressions files to memory leak checking (linux only)."
     )
+
+
+    group = parser.add_argument_group("Threshold Options:")
+    group.add_argument(
+        "--utilization", metavar=("WARN", "ERR", "CRIT"), nargs=3, type=int, default=RANGES["utilization"],
+        help="CPU utilization %% thresholds (default: %(default)s)"
+    )
+    group.add_argument(
+        "--cpu_time", metavar=("WARN", "ERR", "CRIT"), nargs=3, type=float, default=RANGES["cpu_time"],
+        help="CPU time (seconds) thresholds (default: %(default)s)"
+    )
+    group.add_argument(
+        "--memory", metavar=("WARN", "ERR", "CRIT"), nargs=3, type=int, default=RANGES["memory"],
+        help="Memory (bytes) thresholds (default: %(default)s)"
+    )
+    group.add_argument(
+        "--fds", metavar=("WARN", "ERR", "CRIT"), nargs=3, type=int, default=RANGES["fds"],
+        help="File descriptor count thresholds (default: %(default)s)"
+    )
+    group.add_argument(
+        "--duration", metavar=("WARN", "ERR", "CRIT"), nargs=3, type=float, default=RANGES["duration"],
+        help="Query duration (seconds) thresholds (default: %(default)s)"
+    )
+
     args = parser.parse_args()
+
+    # Validate threshold arguments: ensure v1 < v2 < v3
+    def validate_thresholds(name, values):
+        if not (values[0] < values[1] < values[2]):
+            parser.error(f"{name} thresholds must be in increasing order: v1 < v2 < v3 (got {values})")
+
+    validate_thresholds("Utilization", args.utilization)
+    validate_thresholds("CPU time", args.cpu_time)
+    validate_thresholds("Memory", args.memory)
+    validate_thresholds("File descriptors", args.fds)
+    validate_thresholds("Duration", args.duration)
+
+    # Update RANGES with argparse values
+    RANGES.update({
+        "utilization": args.utilization,
+        "cpu_time": args.cpu_time,
+        "memory": args.memory,
+        "fds": args.fds,
+        "duration": args.duration,
+    })
 
     if args.compare:
         with open(args.compare[0]) as fh:


### PR DESCRIPTION
Description:

It sems `profile.py` was written many years ago and the hardcoded thresholds no longer really make sense. For example, in my environment when I use it, even the most trivial of queries score highly for memory consumption.

Furthermore, to enhance the utility of the tooling, this PR updates performance thresholds used to categorize query stats (utilization, cpu_time, memory, fds, duration) were previously hardcoded in the RANGES dictionary. This change exposes them as CLI flags so users can tune them without modifying the script.

Changes:

- Added `--utilization`, `--cpu_time`, `--memory`, `--fds`, and `--duration` flags under a new "Threshold Options" argument group
- Each flag accepts 3 values (WARN ERR CRIT) and defaults to the existing hardcoded values (fully backward compatible)
- Added validation that rejects non-increasing threshold values with a clear error message
- Updated performance-safety.md to document the new flags


Testing:
Manually tested with `osqueryi` 5.22.1 on macOS:

- Default behavior unchanged when no threshold flags are passed
- Custom thresholds correctly affect category output
- Invalid (non-increasing) thresholds are rejected at startup


Example terminal session:

Example showing backward compatibility:
```
(venv) % python3 tools/analysis/profile.py \
  --query "select * from time" \
  --shell /usr/local/bin/osqueryi
1 query loaded from --query

Profiling query: select * from time
 U:0  C:0  M:2  F:0  D:0  manual (1/1): utilization: 2.5 cpu_time: 0.025066790999999998 memory: 21544960 fds: 4 duration: 0.524724006652832 
```

Demo showing tight thresholds:
```
(venv) % python3 tools/analysis/profile.py \
  --query "select * from time" \
  --shell /usr/local/bin/osqueryi \
  --duration 0.001 0.01 0.1
1 query loaded from --query

Profiling query: select * from time
 U:0  C:0  M:2  F:0  D:3  manual (1/1): utilization: 1.8 cpu_time: 0.018127790999999997 memory: 21512192 fds: 4 duration: 0.5138397216796875 
```

Demo showing out of order thresholds passed in as an argument
```
(venv) % python3 tools/analysis/profile.py \
  --query "select * from time" \
  --shell /usr/local/bin/osqueryi \
  --duration 5 1 3
usage: profile.py [-h] [-n] [--verbose] [--leaks] [--restrict LIST] [--tables PATH] [--config FILE] [--pack PACK]
                  [--query STRING] [--timeout N] [--count N] [--rounds N] [--shell PATH] [--force] [--output FILE]
                  [--check OLD_OUTPUT] [--compare FILE FILE] [--suppressions SUPP] [--utilization WARN ERR CRIT]
                  [--cpu_time WARN ERR CRIT] [--memory WARN ERR CRIT] [--fds WARN ERR CRIT]
                  [--duration WARN ERR CRIT]
profile.py: error: Duration thresholds must be in increasing order: v1 < v2 < v3 (got [5.0, 1.0, 3.0])
```
