### PR TITLE
Fix apt_sources silently dropping deb822 repos with Enabled: yes

### DIFF
--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -254,8 +254,16 @@ Status parseDeb822Block(const std::string& input_block,
       }
     }
 
-    if (key == "enabled" && value != "on") {
-      return Status::success();
+    if (key == "enabled") {
+      std::string lower_value = value;
+      std::transform(lower_value.begin(),
+                     lower_value.end(),
+                     lower_value.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      if (lower_value == "no" || lower_value == "false" ||
+          lower_value == "off") {
+        return Status::success();
+      }
     }
 
     if (key == "uris") {

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -260,8 +260,7 @@ Status parseDeb822Block(const std::string& input_block,
                      lower_value.end(),
                      lower_value.begin(),
                      [](unsigned char c) { return std::tolower(c); });
-      if (lower_value == "no" || lower_value == "false" ||
-          lower_value == "off") {
+      if (lower_value == "no" || lower_value == "off") {
         return Status::success();
       }
     }

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -8,7 +8,9 @@
  */
 
 #include <algorithm>
+#include <array>
 #include <boost/algorithm/string/compare.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/regex.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -211,6 +213,21 @@ static void genAptSource(const std::string& source,
   }
 }
 
+/**
+ * @brief Values that mark a deb822 stanza as disabled.
+ *
+ * This mirrors the negative set accepted by APT's StringToBool()
+ * (apt-pkg/contrib/strutl.cc), which is what
+ * pkgSourceList::Type::ParseStanza() uses to evaluate the Enabled field.
+ * Comparison there is case-insensitive (strcasecmp) and an absent Enabled
+ * field means the source is enabled. An unrecognized value also leaves the
+ * source enabled: ParseStanza() calls StringToBool(Enabled) with no Default,
+ * so the declared default of -1 (apt-pkg/contrib/strutl.h) is returned for
+ * unknown input, and the stanza is only skipped when the result is false (0).
+ */
+constexpr std::array<const char*, 6> kDeb822DisabledValues = {
+    {"no", "false", "without", "off", "disable", "0"}};
+
 Status parseDeb822Block(const std::string& input_block,
                         std::vector<AptSource>& apt_sources) {
   std::vector<std::string> uris;
@@ -254,8 +271,15 @@ Status parseDeb822Block(const std::string& input_block,
       }
     }
 
-    if (key == "enabled" && value != "on") {
-      return Status::success();
+    if (key == "enabled") {
+      auto is_disabled_value = [&value](const char* disabled_value) {
+        return boost::iequals(value, disabled_value);
+      };
+      if (std::any_of(kDeb822DisabledValues.begin(),
+                      kDeb822DisabledValues.end(),
+                      is_disabled_value)) {
+        return Status::success();
+      }
     }
 
     if (key == "uris") {

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -9,10 +9,9 @@
 
 #include <algorithm>
 #include <array>
-#include <boost/algorithm/string/compare.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/regex.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/regex/v5/regex_fwd.hpp>
 #include <filesystem>

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -249,8 +249,37 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
 
   s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: off",
                        apt_sourecs);
-  EXPECT_TRUE(s.ok()) << "disabled source";
+  EXPECT_TRUE(s.ok()) << "disabled source (off)";
   EXPECT_EQ(apt_sourecs.size(), 0);
+
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: no",
+                       apt_sourecs);
+  EXPECT_TRUE(s.ok()) << "disabled source (no)";
+  EXPECT_EQ(apt_sourecs.size(), 0);
+
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: false",
+                       apt_sourecs);
+  EXPECT_TRUE(s.ok()) << "disabled source (false)";
+  EXPECT_EQ(apt_sourecs.size(), 0);
+
+  // Case-insensitive: one example to verify tolower applies
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: No",
+                       apt_sourecs);
+  EXPECT_TRUE(s.ok()) << "disabled source (No, mixed case)";
+  EXPECT_EQ(apt_sourecs.size(), 0);
+
+  // Affirmative values that were previously broken (bug fix)
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: yes",
+                       apt_sourecs);
+  EXPECT_TRUE(s.ok()) << "enabled source (yes)";
+  EXPECT_EQ(apt_sourecs.size(), 1);
+  apt_sourecs.clear();
+
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: true",
+                       apt_sourecs);
+  EXPECT_TRUE(s.ok()) << "enabled source (true)";
+  EXPECT_EQ(apt_sourecs.size(), 1);
+  apt_sourecs.clear();
 }
 
 } // namespace tables

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -269,11 +269,6 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
   EXPECT_EQ(apt_sourecs.size(), 1);
   apt_sourecs.clear();
 
-  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: true",
-                       apt_sourecs);
-  EXPECT_TRUE(s.ok()) << "enabled source (true)";
-  EXPECT_EQ(apt_sourecs.size(), 1);
-  apt_sourecs.clear();
 }
 
 } // namespace tables

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -268,7 +268,6 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
   EXPECT_TRUE(s.ok()) << "enabled source (yes)";
   EXPECT_EQ(apt_sourecs.size(), 1);
   apt_sourecs.clear();
-
 }
 
 } // namespace tables

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -257,12 +257,6 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
   EXPECT_TRUE(s.ok()) << "disabled source (no)";
   EXPECT_EQ(apt_sourecs.size(), 0);
 
-  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: false",
-                       apt_sourecs);
-  EXPECT_TRUE(s.ok()) << "disabled source (false)";
-  EXPECT_EQ(apt_sourecs.size(), 0);
-
-  // Case-insensitive: one example to verify tolower applies
   s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: No",
                        apt_sourecs);
   EXPECT_TRUE(s.ok()) << "disabled source (No, mixed case)";

--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -246,11 +246,76 @@ TEST_F(AptSourcesImplTests, test_deb822_failures) {
   EXPECT_TRUE(s.ok()) << "missing URL protocol skips that URL";
   EXPECT_EQ(apt_sourecs.size(), 1);
   apt_sourecs.clear();
+}
 
-  s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled: off",
-                       apt_sourecs);
-  EXPECT_TRUE(s.ok()) << "disabled source";
-  EXPECT_EQ(apt_sourecs.size(), 0);
+TEST_F(AptSourcesImplTests, test_deb822_enabled_field) {
+  // The Enabled field follows APT's StringToBool() (apt-pkg/contrib/strutl.cc):
+  // matching is case-insensitive, only an explicit negative disables a stanza,
+  // and an absent or unrecognized value leaves the source enabled.
+  struct EnabledTestCase {
+    std::string value;
+    bool expect_enabled;
+    std::string description;
+  };
+
+  const std::vector<EnabledTestCase> test_cases = {
+      // Negative values recognized by StringToBool()
+      {"no", false, "no"},
+      {"false", false, "false"},
+      {"without", false, "without"},
+      {"off", false, "off"},
+      {"disable", false, "disable"},
+      {"0", false, "0"},
+
+      // Matching is case-insensitive
+      {"No", false, "No (mixed case)"},
+      {"OFF", false, "OFF (upper case)"},
+      {"FaLsE", false, "FaLsE (mixed case)"},
+
+      // Affirmative values recognized by StringToBool(). "yes" and "true" were
+      // previously dropped because the parser only accepted "on".
+      {"yes", true, "yes"},
+      {"true", true, "true"},
+      {"with", true, "with"},
+      {"on", true, "on"},
+      {"enable", true, "enable"},
+      {"1", true, "1"},
+      {"YES", true, "YES (upper case)"},
+
+      // Unrecognized values leave the source enabled: APT's ParseStanza()
+      // calls StringToBool(Enabled) with no Default, so the declared default
+      // of -1 (apt-pkg/contrib/strutl.h) is returned for unknown input, and
+      // the stanza is only skipped when the result is false (0).
+      {"banana", true, "unrecognized value"},
+  };
+
+  for (const auto& test_case : test_cases) {
+    std::vector<AptSource> apt_sources;
+
+    auto block =
+        "URIs: http://example.com\nSuites: main\nEnabled: " + test_case.value;
+    auto s = parseDeb822Block(block, apt_sources);
+
+    // A disabled stanza is skipped, not an error.
+    ASSERT_TRUE(s.ok()) << "Enabled: " << test_case.description
+                        << " failed with " << s.getMessage();
+    EXPECT_EQ(apt_sources.size(), test_case.expect_enabled ? 1U : 0U)
+        << "Enabled: " << test_case.description;
+  }
+
+  // An Enabled field with no value is treated as absent, so the source stays
+  // enabled.
+  std::vector<AptSource> apt_sources;
+  auto s = parseDeb822Block("URIs: http://example.com\nSuites: main\nEnabled:",
+                            apt_sources);
+  EXPECT_TRUE(s.ok()) << "empty Enabled value";
+  EXPECT_EQ(apt_sources.size(), 1U) << "empty Enabled value stays enabled";
+  apt_sources.clear();
+
+  // An absent Enabled field means enabled.
+  s = parseDeb822Block("URIs: http://example.com\nSuites: main", apt_sources);
+  EXPECT_TRUE(s.ok()) << "absent Enabled field";
+  EXPECT_EQ(apt_sources.size(), 1U) << "absent Enabled field stays enabled";
 }
 
 } // namespace tables


### PR DESCRIPTION
## Problem

`parseDeb822Block()` gated the deb822 `Enabled` field on an exact match:

```cpp
if (key == "enabled" && value != "on") {
  return Status::success();   // skip the stanza
}
```

Anything but the literal lowercase `on` was treated as disabled, so valid stanzas using `Enabled: yes` or `Enabled: true` were silently dropped. In our environment this left `apt_sources` empty on hosts with valid repos configured.

## Fix

This PR moves osquery to match APT's own semantics. `pkgSourceList::Type::ParseStanza()` ([apt-pkg/sourcelist.cc](https://salsa.debian.org/apt-team/apt/-/blob/main/apt-pkg/sourcelist.cc)) evaluates the field with `StringToBool()` ([apt-pkg/contrib/strutl.cc](https://salsa.debian.org/apt-team/apt/-/blob/main/apt-pkg/contrib/strutl.cc)):

| `Enabled` value | Result |
|---|---|
| absent or empty | enabled |
| `yes` `true` `with` `on` `enable` `1` | enabled |
| `no` `false` `without` `off` `disable` `0` | disabled |
| unrecognized (e.g. `banana`) | enabled |

All case-insensitive. The check becomes a denylist of explicit negatives instead of an allowlist of one affirmative, using `boost::iequals` to mirror APT's `strcasecmp` chain without allocating a lowercased copy. A disabled stanza still returns `Status::success()` with no rows — a skip, not a parse error, as in APT.


## Testing

Unit tests cover the full table above in mixed case, plus absent/empty values.

Functional, Ubuntu 24.04 (noble), `/etc/apt/sources.list.d/zz-osquery-test.sources` alongside the host's real repos:

```
Types: deb
URIs: http://us-central1.gce.archive.ubuntu.com/ubuntu/
Suites: noble
Components: main
Enabled: yes

Types: deb
URIs: http://us-central1.gce.archive.ubuntu.com/ubuntu/
Suites: noble-updates
Components: main
Enabled: true

Types: deb
URIs: http://us-central1.gce.archive.ubuntu.com/ubuntu/
Suites: noble-backports
Components: main
Enabled: no

Types: deb
URIs: http://security.ubuntu.com/ubuntu/
Suites: noble-security
Components: main
Enabled: false
```

| Build | `select count(*) from apt_sources` |
|---|---|
| baseline, test file absent | 5 |
| `master`, test file present | 5 — all four stanzas dropped |
| this branch, test file present | 7 |

```
osquery> select name, source from apt_sources;
+--------------------------------------------------------------+----------------------------------------------------------+
| name                                                         | source                                                   |
+--------------------------------------------------------------+----------------------------------------------------------+
| packages.cloud.google.com/apt google-cloud-ops-agent-noble-2 | /etc/apt/sources.list.d/osconfig_managed_9487794be1.list |
| us-central1.gce.archive.ubuntu.com/ubuntu noble              | /etc/apt/sources.list.d/ubuntu.sources                   |
| us-central1.gce.archive.ubuntu.com/ubuntu noble-updates      | /etc/apt/sources.list.d/ubuntu.sources                   |
| us-central1.gce.archive.ubuntu.com/ubuntu noble-backports    | /etc/apt/sources.list.d/ubuntu.sources                   |
| security.ubuntu.com/ubuntu noble-security                    | /etc/apt/sources.list.d/ubuntu.sources                   |
| us-central1.gce.archive.ubuntu.com/ubuntu noble              | /etc/apt/sources.list.d/zz-osquery-test.sources          |
| us-central1.gce.archive.ubuntu.com/ubuntu noble-updates      | /etc/apt/sources.list.d/zz-osquery-test.sources          |
+--------------------------------------------------------------+----------------------------------------------------------+
```

The two extra rows are exactly the `yes` and `true` stanzas; `no` and `false` are correctly absent.