### PR TITLE
Windows pipes: set SQOS on named-pipe CreateFile (defense-in-depth)

### DIFF
--- a/osquery/tables/system/windows/pipes.cpp
+++ b/osquery/tables/system/windows/pipes.cpp
@@ -37,13 +37,18 @@ QueryData genPipes(QueryContext& context) {
 
     unsigned long pid = 0;
     auto pipePath = L"\\\\.\\pipe\\" + std::wstring(findFileData.cFileName);
+    // Open the pipe with an explicit Security Quality of Service level as
+    // defense-in-depth: SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION lets
+    // the pipe server identify this client but prevents it from impersonating
+    // the (potentially privileged) osquery process. Without an explicit SQOS
+    // the server could request impersonation-level access.
     auto pipeHandle =
         CreateFileW(pipePath.c_str(),
                     GENERIC_READ,
                     (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE),
                     nullptr,
                     OPEN_EXISTING,
-                    0,
+                    SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
                     nullptr);
     if (pipeHandle == INVALID_HANDLE_VALUE) {
       results.push_back(r);


### PR DESCRIPTION
When enumerating named pipes on Windows, `genPipes` opens each pipe with `CreateFileW` but passes `0` for `dwFlagsAndAttributes`, leaving the client's "Security Quality of Service" unspecified. A malicious pipe server could request impersonation-level access against the (potentially privileged) osquery process.

osquery only reads pipe metadata and never writes to the pipe, so this **is not exploitable in practice**, but we should still specify `SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION` so the server can identify but not impersonate the client. This is a defense-in-depth hardening change.