### PR TITLE
Agent skills

### DIFF
--- a/osquery/tables/applications/CMakeLists.txt
+++ b/osquery/tables/applications/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction()
 
 function(generateOsqueryTablesApplications)
   set(source_files
+    agent_skills.cpp
     chrome/chrome_extensions.cpp
     chrome/chrome_extension_content_scripts.cpp
     chrome/utils.cpp

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -276,9 +276,13 @@ bool statSkillFile(const std::string& path, int64_t& size, int64_t& mtime) {
   return true;
 }
 
-// Symlink-loop-safe directory traversal, modeled on npm_packages.cpp's
-// dirs_to_search queue + inode-tracking pattern (there is no existing
-// depth-limited counting utility in osquery/filesystem/filesystem.h).
+// Inode-tracking loop guard, modeled on npm_packages.cpp's dirs_to_search
+// queue + inode-tracking pattern (there is no existing depth-limited
+// counting utility in osquery/filesystem/filesystem.h). platformLstat() is
+// a stub that always fails on Windows (osquery/filesystem/windows/fileops.cpp),
+// so this check is inert there -- a genuine symlink cycle would do
+// redundant re-visiting rather than being caught here, bounded only by
+// max_depth/max_dirs in the callers below, same as npm_packages.cpp today.
 bool isDirVisited(std::unordered_set<int>& visited_inos,
                   const std::string& path) {
   if (path.empty()) {
@@ -318,11 +322,11 @@ struct WalkedDir {
   std::vector<std::string> files;
 };
 
-// Bounded, symlink-loop-safe, and containment-checked directory walk shared
-// by the per-skill resource/script counter and the plugin-cache SKILL.md
-// finder below (each previously carried its own copy of this traversal). A
-// subdirectory whose canonical path resolves outside `root` -- e.g. a
-// symlink pointing elsewhere on disk -- is skipped rather than followed, so
+// Bounded and containment-checked directory walk shared by the per-skill
+// resource/script counter and the plugin-cache SKILL.md finder below (each
+// previously carried its own copy of this traversal). A subdirectory whose
+// canonical path resolves outside `root` -- e.g. a symlink pointing
+// elsewhere on disk -- is skipped rather than followed, so
 // a skill directory can't use a symlink to pull unrelated parts of the
 // filesystem into the scan. `skip_dir_names` subdirectory names are pruned
 // entirely (e.g. ".git").

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -1,0 +1,520 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <sys/stat.h>
+
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/hashing/hashing.h>
+#include <osquery/tables/system/system_utils.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+namespace {
+
+// A skill discovery root: a path relative to some base (a home directory,
+// or an operator-supplied project directory) and the agent runtime it's
+// associated with, per that runtime's own documented discovery convention.
+struct SkillRoot {
+  std::string relative_path;
+  std::string agent;
+};
+
+const std::vector<SkillRoot> kUserSkillRoots = {
+    {".claude/skills", "claude"},
+    {".cursor/skills", "cursor"},
+    // Observed in practice (not in Cursor's own docs, which say
+    // .cursor/skills/): some Cursor installs sync another tool's skills
+    // into .cursor/skills-<source>/ (a .sync-manifest.json marks it as a
+    // sync target). Kept alongside the documented path since it holds real,
+    // loadable skill content.
+    {".cursor/skills-cursor", "cursor"},
+    {".copilot/skills", "copilot"},
+    {".agents/skills", "agents"},
+};
+
+const std::vector<SkillRoot> kProjectSkillRoots = {
+    {".claude/skills", "claude"},
+    {".cursor/skills", "cursor"},
+    {".github/skills", "copilot"},
+    {".agents/skills", "agents"},
+};
+
+// Relative to "/"; POSIX-only (there is no documented Windows equivalent).
+const std::string kSystemSkillRootRelative = "etc/codex/skills";
+const std::string kSystemSkillAgent = "codex";
+
+// SKILL.md files are recommended to stay under 500 lines / ~5000 tokens.
+// Anything far larger than that is capped rather than parsed, to bound
+// per-row cost; such rows still get path/hash/size/mtime/counts.
+const size_t kMaxFrontmatterFileSize = 256 * 1024;
+
+// Skill directories are inherently shallow (SKILL.md plus scripts/,
+// references/, assets/); these bound resource/script counting cost without
+// exposing a query-configurable knob like npm_packages' max_depth.
+const int kMaxResourceScanDepth = 8;
+const size_t kMaxResourceScanFiles = 5000;
+
+// Claude Code plugin installs put skills several directories deep under
+// ~/.claude/plugins/ (marketplace source checkouts under marketplaces/, an
+// active copy under cache/), and how deep depends on how each marketplace
+// repo organizes its own plugins -- there is no single fixed glob shape
+// across marketplaces the way there is for kUserSkillRoots, so this root is
+// walked (bounded, pruning .git/node_modules) instead of glob-matched.
+const std::string kClaudePluginsRootRelative = ".claude/plugins";
+const int kMaxPluginScanDepth = 12;
+const size_t kMaxPluginScanEntries = 20000;
+
+struct ParsedSkill {
+  std::string name;
+  std::string description;
+  std::string license;
+  std::string compatibility;
+  std::string allowed_tools;
+  std::string version;
+  std::string content;
+};
+
+std::string trim(const std::string& value) {
+  auto start = value.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos) {
+    return "";
+  }
+  auto end = value.find_last_not_of(" \t\r\n");
+  return value.substr(start, end - start + 1);
+}
+
+std::string stripQuotes(const std::string& value) {
+  auto trimmed = trim(value);
+  if (trimmed.size() >= 2 &&
+      ((trimmed.front() == '"' && trimmed.back() == '"') ||
+       (trimmed.front() == '\'' && trimmed.back() == '\''))) {
+    trimmed = trimmed.substr(1, trimmed.size() - 2);
+  }
+  return trimmed;
+}
+
+// Consumes a YAML block scalar (`>`/`>-`/`>+` folded, `|`/`|-`/`|+`
+// literal) starting at lines[start], whose continuation lines are indented
+// further than `key_indent`. Returns the assembled value and advances
+// `next_index` past the consumed lines. Folded lines join with spaces;
+// literal lines keep their newlines; blank lines become a paragraph break
+// either way. Chomping indicators (-/+) are not distinguished: trailing
+// whitespace is trimmed regardless, which is a fine approximation for the
+// short description-style values this table cares about.
+std::string consumeBlockScalar(const std::vector<std::string>& lines,
+                               size_t start,
+                               size_t key_indent,
+                               bool folded,
+                               size_t& next_index) {
+  std::string value;
+  size_t i = start;
+  for (; i < lines.size(); ++i) {
+    const std::string& line = lines[i];
+    if (trim(line).empty()) {
+      value += "\n";
+      continue;
+    }
+
+    size_t indent = line.find_first_not_of(" \t");
+    if (indent == std::string::npos || indent <= key_indent) {
+      break;
+    }
+
+    if (!value.empty() && value.back() != '\n') {
+      value += folded ? " " : "\n";
+    }
+    value += trim(line);
+  }
+  next_index = i;
+  return trim(value);
+}
+
+// A minimal frontmatter reader, not a general YAML parser: osquery does not
+// vendor a YAML library. Handles the flat scalar keys the Agent Skills open
+// standard (agentskills.io/specification) defines at the top level (name,
+// description, license, compatibility, allowed-tools), plus one level of
+// nesting to pull `version` out of a `metadata:` block, per that spec's own
+// documented convention for where version numbers live, plus YAML block
+// scalars (`>`/`|`) since real-world descriptions commonly use them.
+// Unrecognized keys are dropped rather than surfaced as a partial blob.
+void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
+  if (file_content.compare(0, 4, "---\n") != 0) {
+    skill.content = file_content;
+    return;
+  }
+
+  auto close = file_content.find("\n---", 3);
+  if (close == std::string::npos) {
+    skill.content = file_content;
+    return;
+  }
+
+  auto body_start = file_content.find('\n', close + 1);
+  skill.content = (body_start == std::string::npos)
+                      ? ""
+                      : trim(file_content.substr(body_start + 1));
+
+  std::string frontmatter = file_content.substr(4, close - 4);
+  std::vector<std::string> lines;
+  {
+    std::istringstream stream(frontmatter);
+    std::string line;
+    while (std::getline(stream, line)) {
+      lines.push_back(line);
+    }
+  }
+
+  bool in_metadata = false;
+  for (size_t i = 0; i < lines.size(); ++i) {
+    const std::string& line = lines[i];
+    if (trim(line).empty()) {
+      continue;
+    }
+
+    bool indented = line[0] == ' ' || line[0] == '\t';
+    if (!indented) {
+      in_metadata = false;
+    }
+
+    auto colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+
+    std::string key = trim(line.substr(0, colon));
+    std::string raw_value = trim(line.substr(colon + 1));
+
+    std::string value;
+    if (!raw_value.empty() && (raw_value[0] == '>' || raw_value[0] == '|') &&
+        (raw_value.size() == 1 || raw_value[1] == '-' || raw_value[1] == '+')) {
+      size_t key_indent = line.find_first_not_of(" \t");
+      size_t next_index = i + 1;
+      value = consumeBlockScalar(
+          lines, i + 1, key_indent, raw_value[0] == '>', next_index);
+      i = next_index - 1;
+    } else {
+      value = stripQuotes(raw_value);
+    }
+
+    if (!indented) {
+      if (key == "name") {
+        skill.name = value;
+      } else if (key == "description") {
+        skill.description = value;
+      } else if (key == "license") {
+        skill.license = value;
+      } else if (key == "compatibility") {
+        skill.compatibility = value;
+      } else if (key == "allowed-tools" || key == "allowed_tools") {
+        skill.allowed_tools = value;
+      } else if (key == "metadata") {
+        in_metadata = true;
+      }
+    } else if (in_metadata && key == "version") {
+      skill.version = value;
+    }
+  }
+}
+
+bool statSkillFile(const std::string& path, int64_t& size, int64_t& mtime) {
+#ifdef WIN32
+  WINDOWS_STAT file_stat;
+  if (!platformStat(path, &file_stat).ok()) {
+    return false;
+  }
+  size = static_cast<int64_t>(file_stat.size);
+  mtime = static_cast<int64_t>(file_stat.mtime);
+#else
+  struct stat file_stat;
+  if (stat(path.c_str(), &file_stat) != 0) {
+    return false;
+  }
+  size = static_cast<int64_t>(file_stat.st_size);
+  mtime = static_cast<int64_t>(file_stat.st_mtime);
+#endif
+  return true;
+}
+
+// Symlink-loop-safe directory traversal, modeled on npm_packages.cpp's
+// dirs_to_search queue + inode-tracking pattern (there is no existing
+// depth-limited counting utility in osquery/filesystem/filesystem.h).
+bool isDirVisited(std::unordered_set<int>& visited_inos,
+                  const std::string& path) {
+  if (path.empty()) {
+    return true;
+  }
+
+  struct stat d_stat;
+  if (!platformLstat(path, d_stat).ok()) {
+    return false;
+  }
+
+  auto [_, inserted] = visited_inos.emplace(d_stat.st_ino);
+  return !inserted;
+}
+
+// Counts files under `root` (or under `root/scripts` when scripts_only),
+// depth-limited and symlink-loop-safe.
+int countFiles(const fs::path& root, bool scripts_only) {
+  fs::path start = scripts_only ? root / "scripts" : root;
+  if (!isDirectory(start).ok()) {
+    return 0;
+  }
+
+  size_t count = 0;
+  std::unordered_set<int> visited_inos;
+  std::vector<std::pair<std::string, int>> dirs_to_search;
+  dirs_to_search.emplace_back(start.string(), 0);
+
+  while (!dirs_to_search.empty() && count < kMaxResourceScanFiles) {
+    auto [current_dir, depth] = dirs_to_search.back();
+    dirs_to_search.pop_back();
+
+    if (isDirVisited(visited_inos, current_dir)) {
+      continue;
+    }
+
+    std::vector<std::string> files;
+    if (listFilesInDirectory(current_dir, files, false).ok()) {
+      count += files.size();
+    }
+
+    if (depth < kMaxResourceScanDepth) {
+      std::vector<std::string> subdirs;
+      if (listDirectoriesInDirectory(current_dir, subdirs, false).ok()) {
+        for (const auto& subdir : subdirs) {
+          dirs_to_search.emplace_back(subdir, depth + 1);
+        }
+      }
+    }
+  }
+
+  return static_cast<int>(count);
+}
+
+// Bounded, symlink-loop-safe recursive search for SKILL.md files under
+// `root`, pruning `.git`/`node_modules` subtrees. Used for plugin-cache
+// discovery, where skill depth varies per marketplace repo layout and a
+// single glob pattern (as used for kUserSkillRoots) can't cover it.
+std::vector<std::string> findSkillMdFiles(const fs::path& root,
+                                          int max_depth,
+                                          size_t max_entries) {
+  std::vector<std::string> found;
+  if (!isDirectory(root).ok()) {
+    return found;
+  }
+
+  size_t visited_entries = 0;
+  std::unordered_set<int> visited_inos;
+  std::vector<std::pair<std::string, int>> dirs_to_search;
+  dirs_to_search.emplace_back(root.string(), 0);
+
+  while (!dirs_to_search.empty() && visited_entries < max_entries) {
+    auto [current_dir, depth] = dirs_to_search.back();
+    dirs_to_search.pop_back();
+
+    if (isDirVisited(visited_inos, current_dir)) {
+      continue;
+    }
+    visited_entries++;
+
+    std::vector<std::string> files;
+    if (listFilesInDirectory(current_dir, files, false).ok()) {
+      for (const auto& file : files) {
+        if (fs::path(file).filename() == "SKILL.md") {
+          found.push_back(file);
+        }
+      }
+    }
+
+    if (depth < max_depth) {
+      std::vector<std::string> subdirs;
+      if (listDirectoriesInDirectory(current_dir, subdirs, false).ok()) {
+        for (const auto& subdir : subdirs) {
+          auto name = fs::path(subdir).filename().string();
+          if (name == ".git" || name == "node_modules") {
+            continue;
+          }
+          dirs_to_search.emplace_back(subdir, depth + 1);
+        }
+      }
+    }
+  }
+
+  return found;
+}
+
+// `directory_override`, when non-empty, is used as the row's `directory`
+// column instead of the skill's own folder. This matters because SQLite
+// residually re-checks EQUALS constraints against the values a table
+// returns (osquery's xBestIndex never sets the `omit` flag - see
+// osquery/sql/virtual_table.cpp) - so for project-scope rows, `directory`
+// must echo back exactly the constraint value that triggered the scan
+// (mirroring npm_packages' `directory` column), or `WHERE directory = 'X'`
+// would silently return zero rows despite the scan finding real matches.
+// User/system-scope rows aren't driven by that constraint, so they use the
+// more informative per-skill folder instead.
+void addSkillRow(const std::string& skill_md_path,
+                 const std::string& agent,
+                 std::string scope,
+                 const std::string& uid,
+                 const std::string& username,
+                 const std::string& directory_override,
+                 QueryData& results) {
+  fs::path path(skill_md_path);
+  fs::path skill_dir = path.parent_path();
+
+  Row r;
+  r["path"] = skill_md_path;
+  r["directory"] =
+      directory_override.empty() ? skill_dir.string() : directory_override;
+  r["agent"] = agent;
+
+  // A skill folder that also carries a `.claude-plugin/plugin.json`
+  // manifest loads as a plugin, per Claude Code's "skills-directory
+  // plugins" behavior; reclassify scope accordingly rather than hardcoding
+  // an unstable plugin-cache root.
+  if (pathExists(skill_dir / ".claude-plugin" / "plugin.json").ok()) {
+    scope = "plugin";
+  }
+  r["scope"] = scope;
+
+  r["sha256"] = hashFromFile(HASH_TYPE_SHA256, skill_md_path);
+
+  int64_t size = 0;
+  int64_t mtime = 0;
+  bool stat_ok = statSkillFile(skill_md_path, size, mtime);
+  r["size"] = BIGINT(size);
+  r["mtime"] = BIGINT(mtime);
+
+  ParsedSkill parsed;
+  if (stat_ok && size > 0 &&
+      static_cast<size_t>(size) <= kMaxFrontmatterFileSize) {
+    std::string content;
+    if (readFile(path, content, false).ok()) {
+      parseFrontmatter(content, parsed);
+    }
+  }
+  r["name"] = parsed.name;
+  r["description"] = parsed.description;
+  r["content"] = parsed.content;
+  r["version"] = parsed.version;
+  r["license"] = parsed.license;
+  r["compatibility"] = parsed.compatibility;
+  r["allowed_tools"] = parsed.allowed_tools;
+
+  auto resources = countFiles(skill_dir, false);
+  r["resource_count"] = INTEGER(resources > 0 ? resources - 1 : 0);
+  r["script_count"] = INTEGER(countFiles(skill_dir, true));
+
+  r["uid"] = uid;
+  r["username"] = username;
+
+  results.push_back(std::move(r));
+}
+
+void scanRoots(const fs::path& base,
+              const std::vector<SkillRoot>& roots,
+              const std::string& scope,
+              const std::string& uid,
+              const std::string& username,
+              const std::string& directory_override,
+              QueryData& results) {
+  for (const auto& root : roots) {
+    std::vector<std::string> matches;
+    resolveFilePattern(base / root.relative_path / "%" / "SKILL.md", matches);
+    for (const auto& match : matches) {
+      addSkillRow(
+          match, root.agent, scope, uid, username, directory_override, results);
+    }
+  }
+}
+
+} // namespace
+
+QueryData genAgentSkills(QueryContext& context) {
+  QueryData results;
+
+  // User scope: personal skill directories under every home directory the
+  // caller is allowed to see (usersFromContext honors a uid constraint, and
+  // is restricted to the running user when unprivileged and unconstrained).
+  auto users = usersFromContext(context);
+  for (const auto& user : users) {
+    auto uid = user.find("uid");
+    auto username = user.find("username");
+    auto directory = user.find("directory");
+    if (uid == user.end() || username == user.end() ||
+        directory == user.end() || directory->second.empty()) {
+      continue;
+    }
+
+    scanRoots(fs::path(directory->second),
+             kUserSkillRoots,
+             "user",
+             uid->second,
+             username->second,
+             "",
+             results);
+
+    auto plugin_skills =
+        findSkillMdFiles(fs::path(directory->second) / kClaudePluginsRootRelative,
+                        kMaxPluginScanDepth,
+                        kMaxPluginScanEntries);
+    for (const auto& skill_md : plugin_skills) {
+      addSkillRow(
+          skill_md, "claude", "plugin", uid->second, username->second, "", results);
+    }
+  }
+
+  // System scope: the one admin-installed system location documented by a
+  // vendor (OpenAI Codex's own docs). POSIX-only; there is no equivalent
+  // documented Windows system root.
+#if !defined(WIN32)
+  scanRoots(fs::path("/"),
+           {{kSystemSkillRootRelative, kSystemSkillAgent}},
+           "system",
+           "",
+           "",
+           "",
+           results);
+#endif
+
+  // Project scope: never walked implicitly. Only scanned when the caller
+  // supplies a directory constraint, matching npm_packages' `directory`
+  // pattern, so this table never recurses through arbitrary checkouts.
+  if (context.hasConstraint("directory", EQUALS)) {
+    auto directories = context.constraints["directory"].getAll(EQUALS);
+    for (const auto& directory : directories) {
+      scanRoots(fs::path(directory),
+               kProjectSkillRoots,
+               "project",
+               "",
+               "",
+               directory,
+               results);
+    }
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -400,8 +400,9 @@ std::vector<WalkedDir> walkBounded(
     // named SKILL.md pointing outside root), and callers like
     // findSkillMdFiles() read/hash whatever path is returned here.
     std::vector<std::string> files;
-    listFilesInDirectory(current_dir, files, false);
-
+    if (!listFilesInDirectory(current_dir, files, false).ok()) {
+      continue;
+    }
     std::vector<std::string> contained_files;
     contained_files.reserve(files.size());
     for (const auto& file : files) {

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -356,9 +356,25 @@ std::vector<WalkedDir> walkBounded(
     }
     visited_dirs++;
 
+    // Individual files are canonicalized and containment-checked too, not
+    // just subdirectories: a file entry can itself be a symlink (e.g. one
+    // named SKILL.md pointing outside root), and callers like
+    // findSkillMdFiles() read/hash whatever path is returned here.
     std::vector<std::string> files;
     listFilesInDirectory(current_dir, files, false);
-    result.push_back(WalkedDir{current_dir, depth, std::move(files)});
+
+    std::vector<std::string> contained_files;
+    contained_files.reserve(files.size());
+    for (const auto& file : files) {
+      fs::path file_canonical = fs::canonical(file, ec);
+      if (ec || !isUnderRoot(root_canonical, file_canonical)) {
+        continue;
+      }
+      contained_files.push_back(file_canonical.string());
+    }
+
+    result.push_back(
+        WalkedDir{current_dir, depth, std::move(contained_files)});
 
     if (depth >= max_depth) {
       continue;

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -184,17 +184,42 @@ void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
     return;
   }
 
-  auto close = file_content.find("\n---", fence_len);
+  size_t close = std::string::npos;
+  size_t fence_eol = std::string::npos;
+
+  for (size_t search_pos = fence_len;;) {
+    auto pos = file_content.find("\n---", search_pos);
+    if (pos == std::string::npos) {
+      break;
+    }
+
+    const auto after = pos + 4; // just after "\n---"
+    if (after == file_content.size()) {
+      close = pos;
+      fence_eol = after;
+      break;
+    } else if (file_content[after] == '\n') {
+      close = pos;
+      fence_eol = after + 1;
+      break;
+    } else if (file_content[after] == '\r' && after + 1 < file_content.size() &&
+               file_content[after + 1] == '\n') {
+      close = pos;
+      fence_eol = after + 2;
+      break;
+    }
+
+    search_pos = after;
+  }
+
   if (close == std::string::npos) {
     skill.content = file_content;
     return;
   }
 
-  auto body_start = file_content.find('\n', close + 1);
-  skill.content = (body_start == std::string::npos)
+  skill.content = (fence_eol >= file_content.size())
                       ? ""
-                      : trim(file_content.substr(body_start + 1));
-
+                      : trim(file_content.substr(fence_eol));
   std::string frontmatter = file_content.substr(fence_len, close - fence_len);
   std::vector<std::string> lines;
   {

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -217,9 +217,8 @@ void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
     return;
   }
 
-  skill.content = (fence_eol >= file_content.size())
-                      ? ""
-                      : trim(file_content.substr(fence_eol));
+  skill.content =
+      (fence_eol >= file_content.size()) ? "" : file_content.substr(fence_eol);
   std::string frontmatter = file_content.substr(fence_len, close - fence_len);
   std::vector<std::string> lines;
   {

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -9,6 +9,7 @@
 
 #include <sys/stat.h>
 
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -61,16 +62,20 @@ const std::vector<SkillRoot> kProjectSkillRoots = {
 const std::string kSystemSkillRootRelative = "etc/codex/skills";
 const std::string kSystemSkillAgent = "codex";
 
-// SKILL.md files are recommended to stay under 500 lines / ~5000 tokens.
-// Anything far larger than that is capped rather than parsed, to bound
-// per-row cost; such rows still get path/hash/size/mtime/counts.
+// SKILL.md files are recommended to stay under 500 lines / ~5000 tokens, so
+// frontmatter is always near the start of the file. Rather than skipping
+// parsing entirely for oversized files (which would silently blank out
+// name/description/etc. for an otherwise-valid, just-large SKILL.md), only
+// this many leading bytes are ever read: enough for any real frontmatter
+// block, bounding per-row cost regardless of total file size. `content`
+// may end up truncated for files whose body exceeds this.
 const size_t kMaxFrontmatterFileSize = 256 * 1024;
 
 // Skill directories are inherently shallow (SKILL.md plus scripts/,
 // references/, assets/); these bound resource/script counting cost without
 // exposing a query-configurable knob like npm_packages' max_depth.
 const int kMaxResourceScanDepth = 8;
-const size_t kMaxResourceScanFiles = 5000;
+const size_t kMaxResourceScanDirs = 5000;
 
 // Claude Code plugin installs put skills several directories deep under
 // ~/.claude/plugins/ (marketplace source checkouts under marketplaces/, an
@@ -80,7 +85,7 @@ const size_t kMaxResourceScanFiles = 5000;
 // walked (bounded, pruning .git/node_modules) instead of glob-matched.
 const std::string kClaudePluginsRootRelative = ".claude/plugins";
 const int kMaxPluginScanDepth = 12;
-const size_t kMaxPluginScanEntries = 20000;
+const size_t kMaxPluginScanDirs = 20000;
 
 struct ParsedSkill {
   std::string name;
@@ -154,14 +159,22 @@ std::string consumeBlockScalar(const std::vector<std::string>& lines,
 // nesting to pull `version` out of a `metadata:` block, per that spec's own
 // documented convention for where version numbers live, plus YAML block
 // scalars (`>`/`|`) since real-world descriptions commonly use them.
+// Accepts both LF and CRLF line endings for the frontmatter fence itself;
+// embedded CRLFs within the frontmatter body are handled by the per-line
+// trim() calls below, which strip trailing '\r' along with other whitespace.
 // Unrecognized keys are dropped rather than surfaced as a partial blob.
 void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
-  if (file_content.compare(0, 4, "---\n") != 0) {
+  size_t fence_len = 0;
+  if (file_content.compare(0, 4, "---\n") == 0) {
+    fence_len = 4;
+  } else if (file_content.compare(0, 5, "---\r\n") == 0) {
+    fence_len = 5;
+  } else {
     skill.content = file_content;
     return;
   }
 
-  auto close = file_content.find("\n---", 3);
+  auto close = file_content.find("\n---", fence_len);
   if (close == std::string::npos) {
     skill.content = file_content;
     return;
@@ -172,7 +185,7 @@ void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
                       ? ""
                       : trim(file_content.substr(body_start + 1));
 
-  std::string frontmatter = file_content.substr(4, close - 4);
+  std::string frontmatter = file_content.substr(fence_len, close - fence_len);
   std::vector<std::string> lines;
   {
     std::istringstream stream(frontmatter);
@@ -271,95 +284,158 @@ bool isDirVisited(std::unordered_set<int>& visited_inos,
   return !inserted;
 }
 
-// Counts files under `root` (or under `root/scripts` when scripts_only),
-// depth-limited and symlink-loop-safe.
-int countFiles(const fs::path& root, bool scripts_only) {
-  fs::path start = scripts_only ? root / "scripts" : root;
-  if (!isDirectory(start).ok()) {
-    return 0;
+// True if `candidate` is `root` itself or a path-segment-aligned descendant
+// of it. A plain string-prefix check would wrongly accept "/a/bc" as being
+// under "/a/b"; this requires the next character after the shared prefix
+// to be a path separator.
+bool isUnderRoot(const fs::path& root, const fs::path& candidate) {
+  const auto& root_str = root.string();
+  const auto& candidate_str = candidate.string();
+  if (candidate_str == root_str) {
+    return true;
   }
-
-  size_t count = 0;
-  std::unordered_set<int> visited_inos;
-  std::vector<std::pair<std::string, int>> dirs_to_search;
-  dirs_to_search.emplace_back(start.string(), 0);
-
-  while (!dirs_to_search.empty() && count < kMaxResourceScanFiles) {
-    auto [current_dir, depth] = dirs_to_search.back();
-    dirs_to_search.pop_back();
-
-    if (isDirVisited(visited_inos, current_dir)) {
-      continue;
-    }
-
-    std::vector<std::string> files;
-    if (listFilesInDirectory(current_dir, files, false).ok()) {
-      count += files.size();
-    }
-
-    if (depth < kMaxResourceScanDepth) {
-      std::vector<std::string> subdirs;
-      if (listDirectoriesInDirectory(current_dir, subdirs, false).ok()) {
-        for (const auto& subdir : subdirs) {
-          dirs_to_search.emplace_back(subdir, depth + 1);
-        }
-      }
-    }
+  if (candidate_str.size() <= root_str.size() ||
+      candidate_str.compare(0, root_str.size(), root_str) != 0) {
+    return false;
   }
-
-  return static_cast<int>(count);
+  char next = candidate_str[root_str.size()];
+  return next == '/' || next == '\\';
 }
 
-// Bounded, symlink-loop-safe recursive search for SKILL.md files under
-// `root`, pruning `.git`/`node_modules` subtrees. Used for plugin-cache
-// discovery, where skill depth varies per marketplace repo layout and a
-// single glob pattern (as used for kUserSkillRoots) can't cover it.
-std::vector<std::string> findSkillMdFiles(const fs::path& root,
-                                          int max_depth,
-                                          size_t max_entries) {
-  std::vector<std::string> found;
+struct WalkedDir {
+  std::string path;
+  int depth;
+  std::vector<std::string> files;
+};
+
+// Bounded, symlink-loop-safe, and containment-checked directory walk shared
+// by the per-skill resource/script counter and the plugin-cache SKILL.md
+// finder below (each previously carried its own copy of this traversal). A
+// subdirectory whose canonical path resolves outside `root` -- e.g. a
+// symlink pointing elsewhere on disk -- is skipped rather than followed, so
+// a skill directory can't use a symlink to pull unrelated parts of the
+// filesystem into the scan. `skip_dir_names` subdirectory names are pruned
+// entirely (e.g. ".git").
+std::vector<WalkedDir> walkBounded(
+    const fs::path& root,
+    int max_depth,
+    size_t max_dirs,
+    const std::unordered_set<std::string>& skip_dir_names) {
+  std::vector<WalkedDir> result;
   if (!isDirectory(root).ok()) {
-    return found;
+    return result;
   }
 
-  size_t visited_entries = 0;
+  boost::system::error_code ec;
+  fs::path root_canonical = fs::canonical(root, ec);
+  if (ec) {
+    return result;
+  }
+
+  size_t visited_dirs = 0;
   std::unordered_set<int> visited_inos;
   std::vector<std::pair<std::string, int>> dirs_to_search;
   dirs_to_search.emplace_back(root.string(), 0);
 
-  while (!dirs_to_search.empty() && visited_entries < max_entries) {
+  while (!dirs_to_search.empty() && visited_dirs < max_dirs) {
     auto [current_dir, depth] = dirs_to_search.back();
     dirs_to_search.pop_back();
 
     if (isDirVisited(visited_inos, current_dir)) {
       continue;
     }
-    visited_entries++;
+    visited_dirs++;
 
     std::vector<std::string> files;
-    if (listFilesInDirectory(current_dir, files, false).ok()) {
-      for (const auto& file : files) {
-        if (fs::path(file).filename() == "SKILL.md") {
-          found.push_back(file);
-        }
-      }
+    listFilesInDirectory(current_dir, files, false);
+    result.push_back(WalkedDir{current_dir, depth, std::move(files)});
+
+    if (depth >= max_depth) {
+      continue;
     }
 
-    if (depth < max_depth) {
-      std::vector<std::string> subdirs;
-      if (listDirectoriesInDirectory(current_dir, subdirs, false).ok()) {
-        for (const auto& subdir : subdirs) {
-          auto name = fs::path(subdir).filename().string();
-          if (name == ".git" || name == "node_modules") {
-            continue;
-          }
-          dirs_to_search.emplace_back(subdir, depth + 1);
-        }
+    std::vector<std::string> subdirs;
+    if (!listDirectoriesInDirectory(current_dir, subdirs, false).ok()) {
+      continue;
+    }
+
+    for (const auto& subdir : subdirs) {
+      if (skip_dir_names.count(fs::path(subdir).filename().string())) {
+        continue;
       }
+
+      fs::path subdir_canonical = fs::canonical(subdir, ec);
+      if (ec || !isUnderRoot(root_canonical, subdir_canonical)) {
+        continue;
+      }
+
+      dirs_to_search.emplace_back(subdir, depth + 1);
     }
   }
 
+  return result;
+}
+
+struct SkillCounts {
+  int resource_count = 0;
+  int script_count = 0;
+};
+
+// Counts bundled resources (every file under the skill directory, excluding
+// SKILL.md itself) and files under scripts/ in a single traversal, rather
+// than two full passes over the same directory tree.
+SkillCounts countSkillFiles(const fs::path& skill_dir) {
+  SkillCounts counts;
+  fs::path scripts_dir = skill_dir / "scripts";
+
+  size_t total = 0;
+  for (const auto& dir : walkBounded(
+           skill_dir, kMaxResourceScanDepth, kMaxResourceScanDirs, {})) {
+    total += dir.files.size();
+    if (isUnderRoot(scripts_dir, fs::path(dir.path))) {
+      counts.script_count += static_cast<int>(dir.files.size());
+    }
+  }
+
+  counts.resource_count = total > 0 ? static_cast<int>(total) - 1 : 0;
+  return counts;
+}
+
+// Bounded recursive search for SKILL.md files under `root`, pruning
+// `.git`/`node_modules` subtrees. Used for plugin-cache discovery, where
+// skill depth varies per marketplace repo layout and a single glob pattern
+// (as used for kUserSkillRoots) can't cover it.
+std::vector<std::string> findSkillMdFiles(const fs::path& root,
+                                          int max_depth,
+                                          size_t max_dirs) {
+  std::vector<std::string> found;
+  for (const auto& dir :
+       walkBounded(root, max_depth, max_dirs, {".git", "node_modules"})) {
+    for (const auto& file : dir.files) {
+      if (fs::path(file).filename() == "SKILL.md") {
+        found.push_back(file);
+      }
+    }
+  }
   return found;
+}
+
+// Reads up to `max_bytes` of `path`'s content. Used to bound the cost of
+// frontmatter parsing independent of total file size: a large SKILL.md
+// still gets its (small, leading) frontmatter parsed correctly, rather than
+// an all-or-nothing size gate blanking out every field.
+bool readFilePrefix(const std::string& path,
+                    size_t max_bytes,
+                    std::string& content) {
+  std::ifstream stream(path, std::ios::in | std::ios::binary);
+  if (!stream.is_open()) {
+    return false;
+  }
+
+  content.resize(max_bytes);
+  stream.read(&content[0], static_cast<std::streamsize>(max_bytes));
+  content.resize(static_cast<size_t>(stream.gcount()));
+  return true;
 }
 
 // `directory_override`, when non-empty, is used as the row's `directory`
@@ -406,10 +482,9 @@ void addSkillRow(const std::string& skill_md_path,
   r["mtime"] = BIGINT(mtime);
 
   ParsedSkill parsed;
-  if (stat_ok && size > 0 &&
-      static_cast<size_t>(size) <= kMaxFrontmatterFileSize) {
+  if (stat_ok && size > 0) {
     std::string content;
-    if (readFile(path, content, false).ok()) {
+    if (readFilePrefix(skill_md_path, kMaxFrontmatterFileSize, content)) {
       parseFrontmatter(content, parsed);
     }
   }
@@ -421,9 +496,9 @@ void addSkillRow(const std::string& skill_md_path,
   r["compatibility"] = parsed.compatibility;
   r["allowed_tools"] = parsed.allowed_tools;
 
-  auto resources = countFiles(skill_dir, false);
-  r["resource_count"] = INTEGER(resources > 0 ? resources - 1 : 0);
-  r["script_count"] = INTEGER(countFiles(skill_dir, true));
+  auto counts = countSkillFiles(skill_dir);
+  r["resource_count"] = INTEGER(counts.resource_count);
+  r["script_count"] = INTEGER(counts.script_count);
 
   r["uid"] = uid;
   r["username"] = username;
@@ -477,7 +552,7 @@ QueryData genAgentSkills(QueryContext& context) {
     auto plugin_skills =
         findSkillMdFiles(fs::path(directory->second) / kClaudePluginsRootRelative,
                         kMaxPluginScanDepth,
-                        kMaxPluginScanEntries);
+                        kMaxPluginScanDirs);
     for (const auto& skill_md : plugin_skills) {
       addSkillRow(
           skill_md, "claude", "plugin", uid->second, username->second, "", results);

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -382,22 +382,31 @@ struct SkillCounts {
 };
 
 // Counts bundled resources (every file under the skill directory, excluding
-// SKILL.md itself) and files under scripts/ in a single traversal, rather
-// than two full passes over the same directory tree.
+// any SKILL.md file -- there may legitimately be more than one, e.g. an
+// example or reference SKILL.md bundled by a skill-authoring plugin) and
+// files under scripts/, in a single traversal rather than two full passes
+// over the same directory tree.
 SkillCounts countSkillFiles(const fs::path& skill_dir) {
   SkillCounts counts;
   fs::path scripts_dir = skill_dir / "scripts";
 
   size_t total = 0;
+  size_t skill_md_count = 0;
   for (const auto& dir : walkBounded(
            skill_dir, kMaxResourceScanDepth, kMaxResourceScanDirs, {})) {
     total += dir.files.size();
     if (isUnderRoot(scripts_dir, fs::path(dir.path))) {
       counts.script_count += static_cast<int>(dir.files.size());
     }
+    for (const auto& file : dir.files) {
+      if (fs::path(file).filename() == "SKILL.md") {
+        skill_md_count++;
+      }
+    }
   }
 
-  counts.resource_count = total > 0 ? static_cast<int>(total) - 1 : 0;
+  counts.resource_count =
+      total > skill_md_count ? static_cast<int>(total - skill_md_count) : 0;
   return counts;
 }
 
@@ -514,11 +523,33 @@ void scanRoots(const fs::path& base,
               const std::string& directory_override,
               QueryData& results) {
   for (const auto& root : roots) {
+    fs::path expected_root = base / root.relative_path;
+
+    // Canonicalize the expected root once; a symlink at this level (e.g. a
+    // dotfile-managed ~/.claude) is a legitimate, common setup. What isn't
+    // legitimate is a *matched* SKILL.md resolving somewhere else entirely,
+    // which is checked below per match.
+    boost::system::error_code ec;
+    fs::path expected_root_canonical = fs::canonical(expected_root, ec);
+    if (ec) {
+      continue;
+    }
+
     std::vector<std::string> matches;
-    resolveFilePattern(base / root.relative_path / "%" / "SKILL.md", matches);
+    resolveFilePattern(expected_root / "%" / "SKILL.md", matches);
     for (const auto& match : matches) {
-      addSkillRow(
-          match, root.agent, scope, uid, username, directory_override, results);
+      fs::path match_canonical = fs::canonical(match, ec);
+      if (ec || !isUnderRoot(expected_root_canonical, match_canonical)) {
+        continue;
+      }
+
+      addSkillRow(match_canonical.string(),
+                 root.agent,
+                 scope,
+                 uid,
+                 username,
+                 directory_override,
+                 results);
     }
   }
 }

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -328,16 +328,26 @@ bool isDirVisited(std::unordered_set<int>& visited_inos,
 // under "/a/b"; this requires the next character after the shared prefix
 // to be a path separator.
 bool isUnderRoot(const fs::path& root, const fs::path& candidate) {
-  const auto& root_str = root.string();
-  const auto& candidate_str = candidate.string();
+  const auto root_str = root.string();
+  const auto candidate_str = candidate.string();
+
   if (candidate_str == root_str) {
     return true;
   }
-  if (candidate_str.size() <= root_str.size() ||
+
+  if (root_str.empty() || candidate_str.size() <= root_str.size() ||
       candidate_str.compare(0, root_str.size(), root_str) != 0) {
     return false;
   }
-  char next = candidate_str[root_str.size()];
+
+  // If the root already ends with a separator (e.g. "/"), a prefix match is
+  // sufficient.
+  const char last = root_str.back();
+  if (last == '/' || last == '\\') {
+    return true;
+  }
+
+  const char next = candidate_str[root_str.size()];
   return next == '/' || next == '\\';
 }
 

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -62,6 +62,16 @@ const std::vector<SkillRoot> kProjectSkillRoots = {
 const std::string kSystemSkillRootRelative = "etc/codex/skills";
 const std::string kSystemSkillAgent = "codex";
 
+// Subdirectory names pruned entirely from any bounded walk below: a skill
+// installed from (or bundling) a git checkout or vendored JS dependencies
+// can otherwise make resource/script counting expensive and inflate counts
+// with unrelated files, potentially exhausting the scan budget before
+// reaching the skill's own content.
+const std::unordered_set<std::string> kPrunedDirNames = {
+    ".git",
+    "node_modules",
+};
+
 // SKILL.md files are recommended to stay under 500 lines / ~5000 tokens, so
 // frontmatter is always near the start of the file. Rather than skipping
 // parsing entirely for oversized files (which would silently blank out
@@ -393,8 +403,10 @@ SkillCounts countSkillFiles(const fs::path& skill_dir) {
 
   size_t total = 0;
   size_t skill_md_count = 0;
-  for (const auto& dir : walkBounded(
-           skill_dir, kMaxResourceScanDepth, kMaxResourceScanDirs, {})) {
+  for (const auto& dir : walkBounded(skill_dir,
+                                     kMaxResourceScanDepth,
+                                     kMaxResourceScanDirs,
+                                     kPrunedDirNames)) {
     total += dir.files.size();
     if (isUnderRoot(scripts_dir, fs::path(dir.path))) {
       counts.script_count += static_cast<int>(dir.files.size());
@@ -420,7 +432,7 @@ std::vector<std::string> findSkillMdFiles(const fs::path& root,
                                           size_t max_dirs) {
   std::vector<std::string> found;
   for (const auto& dir :
-       walkBounded(root, max_depth, max_dirs, {".git", "node_modules"})) {
+       walkBounded(root, max_depth, max_dirs, kPrunedDirNames)) {
     for (const auto& file : dir.files) {
       if (fs::path(file).filename() == "SKILL.md") {
         found.push_back(file);

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -382,10 +382,11 @@ struct SkillCounts {
 };
 
 // Counts bundled resources (every file under the skill directory, excluding
-// any SKILL.md file -- there may legitimately be more than one, e.g. an
-// example or reference SKILL.md bundled by a skill-authoring plugin) and
-// files under scripts/, in a single traversal rather than two full passes
-// over the same directory tree.
+// any SKILL.md file) and files under scripts/, in a single traversal rather
+// than two full passes over the same directory tree. A skill directory can
+// legitimately contain more than one SKILL.md -- e.g. an example or
+// reference file bundled by a skill-authoring plugin -- so all of them are
+// excluded from resource_count, not just the first one found.
 SkillCounts countSkillFiles(const fs::path& skill_dir) {
   SkillCounts counts;
   fs::path scripts_dir = skill_dir / "scripts";

--- a/osquery/tables/applications/agent_skills.cpp
+++ b/osquery/tables/applications/agent_skills.cpp
@@ -187,7 +187,11 @@ void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
   size_t close = std::string::npos;
   size_t fence_eol = std::string::npos;
 
-  for (size_t search_pos = fence_len;;) {
+  // Start the search one character before fence_len: for an empty
+  // frontmatter block ("---\n---\n..."), the closing fence's leading '\n'
+  // is the very same '\n' that ends the opening fence line, at index
+  // fence_len - 1. Starting at fence_len would skip past it entirely.
+  for (size_t search_pos = fence_len - 1;;) {
     auto pos = file_content.find("\n---", search_pos);
     if (pos == std::string::npos) {
       break;
@@ -217,9 +221,16 @@ void parseFrontmatter(const std::string& file_content, ParsedSkill& skill) {
     return;
   }
 
-  skill.content =
-      (fence_eol >= file_content.size()) ? "" : file_content.substr(fence_eol);
-  std::string frontmatter = file_content.substr(fence_len, close - fence_len);
+  skill.content = (fence_eol >= file_content.size())
+                      ? ""
+                      : trim(file_content.substr(fence_eol));
+  // close can be less than fence_len for an empty frontmatter block
+  // ("---\n---\n..."), where the closing fence is found at fence_len - 1;
+  // close - fence_len would underflow (both are size_t) and substr's clamped
+  // count would silently turn the rest of the file into `frontmatter`.
+  std::string frontmatter =
+      close > fence_len ? file_content.substr(fence_len, close - fence_len)
+                        : "";
   std::vector<std::string> lines;
   {
     std::istringstream stream(frontmatter);

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -31,6 +31,7 @@ endfunction()
 
 function(generateNativeTables)
   set(platform_independent_spec_files
+    agent_skills.table
     azure_instance_metadata.table
     azure_instance_tags.table
     carbon_black_info.table

--- a/specs/agent_skills.table
+++ b/specs/agent_skills.table
@@ -1,5 +1,5 @@
 table_name("agent_skills")
-description("AI agent skills (SKILL.md packages) found on the system, including project-scope matches when queried with a directory constraint.")
+description("AI agent skills (SKILL.md packages) found on the system, including project-scope matches when queried with an exact directory = <value> constraint.")
 schema([
     Column("name", TEXT, "Skill name from SKILL.md frontmatter"),
     Column("description", TEXT, "Skill description from SKILL.md frontmatter"),
@@ -10,7 +10,7 @@ schema([
     Column("allowed_tools", TEXT, "Declared pre-approved tool permissions, if present"),
     Column("agent", TEXT, "Agent runtime the skill was discovered for (claude, cursor, copilot, codex, agents)"),
     Column("scope", TEXT, "Installation scope: user, project, system or plugin"),
-    Column("directory", TEXT, "Skill root directory; for project-scope rows, echoes the queried directory constraint", index=True, optimized=True),
+    Column("directory", TEXT, "Skill root directory; for project-scope rows, echoes the exact directory = <value> constraint that triggered the scan (LIKE and other predicates are not supported and return no project-scope rows)", index=True, optimized=True),
     Column("path", TEXT, "Absolute path to SKILL.md", index=True),
     Column("sha256", TEXT, "SHA256 hash of SKILL.md"),
     Column("size", BIGINT, "Size of SKILL.md in bytes"),

--- a/specs/agent_skills.table
+++ b/specs/agent_skills.table
@@ -1,9 +1,9 @@
 table_name("agent_skills")
-description("Installed AI agent skills (SKILL.md packages) discovered on the system.")
+description("AI agent skills (SKILL.md packages) found on the system, including project-scope matches when queried with a directory constraint.")
 schema([
     Column("name", TEXT, "Skill name from SKILL.md frontmatter"),
     Column("description", TEXT, "Skill description from SKILL.md frontmatter"),
-    Column("content", TEXT, "Markdown instructions body of SKILL.md, excluding frontmatter", hidden=True),
+    Column("content", TEXT, "Markdown instructions body of SKILL.md, excluding frontmatter; truncated for files whose body exceeds the frontmatter read cap", hidden=True),
     Column("version", TEXT, "Skill version, from the conventional metadata.version frontmatter key, if present"),
     Column("license", TEXT, "Declared license, if present"),
     Column("compatibility", TEXT, "Declared environment requirements (target product, required packages, network access), if present"),
@@ -18,7 +18,7 @@ schema([
     Column("resource_count", INTEGER, "Number of bundled files under the skill directory, excluding SKILL.md"),
     Column("script_count", INTEGER, "Number of files under scripts/"),
     Column("uid", BIGINT, "Owning user id (user-scope rows only)", index=True, optimized=True),
-    Column("username", TEXT, "Owning username (user-scope rows only; join users on uid for project/system rows)"),
+    Column("username", TEXT, "Owning username; only populated for user-scope rows. Blank for project/system-scope rows, which have no owning user and are not joinable to the users table on uid"),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/specs/agent_skills.table
+++ b/specs/agent_skills.table
@@ -1,0 +1,32 @@
+table_name("agent_skills")
+description("Installed AI agent skills (SKILL.md packages) discovered on the system.")
+schema([
+    Column("name", TEXT, "Skill name from SKILL.md frontmatter"),
+    Column("description", TEXT, "Skill description from SKILL.md frontmatter"),
+    Column("content", TEXT, "Markdown instructions body of SKILL.md, excluding frontmatter", hidden=True),
+    Column("version", TEXT, "Skill version, from the conventional metadata.version frontmatter key, if present"),
+    Column("license", TEXT, "Declared license, if present"),
+    Column("compatibility", TEXT, "Declared environment requirements (target product, required packages, network access), if present"),
+    Column("allowed_tools", TEXT, "Declared pre-approved tool permissions, if present"),
+    Column("agent", TEXT, "Agent runtime the skill was discovered for (claude, cursor, copilot, codex, agents)"),
+    Column("scope", TEXT, "Installation scope: user, project, system or plugin"),
+    Column("directory", TEXT, "Skill root directory; for project-scope rows, echoes the queried directory constraint", index=True, optimized=True),
+    Column("path", TEXT, "Absolute path to SKILL.md", index=True),
+    Column("sha256", TEXT, "SHA256 hash of SKILL.md"),
+    Column("size", BIGINT, "Size of SKILL.md in bytes"),
+    Column("mtime", BIGINT, "Last modification time of SKILL.md"),
+    Column("resource_count", INTEGER, "Number of bundled files under the skill directory, excluding SKILL.md"),
+    Column("script_count", INTEGER, "Number of files under scripts/"),
+    Column("uid", BIGINT, "Owning user id (user-scope rows only)", index=True, optimized=True),
+    Column("username", TEXT, "Owning username (user-scope rows only; join users on uid for project/system rows)"),
+    ForeignKey(column="uid", table="users"),
+])
+attributes(user_data=True)
+implementation("applications/agent_skills@genAgentSkills")
+examples([
+    "select * from agent_skills",
+    "select * from users join agent_skills using (uid)",
+    "select * from agent_skills where directory = '/path/to/repo'",
+    "select username, name, sha256 from agent_skills where script_count > 0",
+    "select name, content from agent_skills where content like '%curl%'",
+])

--- a/specs/agent_skills.table
+++ b/specs/agent_skills.table
@@ -17,8 +17,8 @@ schema([
     Column("mtime", BIGINT, "Last modification time of SKILL.md"),
     Column("resource_count", INTEGER, "Number of bundled files under the skill directory, excluding SKILL.md"),
     Column("script_count", INTEGER, "Number of files under scripts/"),
-    Column("uid", BIGINT, "Owning user id (user-scope rows only)", index=True, optimized=True),
-    Column("username", TEXT, "Owning username; only populated for user-scope rows. Blank for project/system-scope rows, which have no owning user and are not joinable to the users table on uid"),
+    Column("uid", BIGINT, "Owning user id; populated for user-scope rows and for plugin-scope rows discovered under a user's home directory. Blank for project/system-scope rows", index=True, optimized=True),
+    Column("username", TEXT, "Owning username; populated for user-scope rows and for plugin-scope rows discovered under a user's home directory. Blank for project/system-scope rows, which have no owning user and are not joinable to the users table on uid"),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -32,6 +32,7 @@ endfunction()
 
 function(generateTestsIntegrationTablesTestsTest)
   set(source_files
+    agent_skills.cpp
     carbon_black_info.cpp
     carves.cpp
     certificates.cpp

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for agent_skills
+// Spec file: specs/agent_skills.table
+
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+namespace fs = boost::filesystem;
+
+class AgentSkills : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+
+    // resolveFilePattern canonicalizes the path up to the first wildcard
+    // (e.g. /var/... -> /private/var/... on macOS, since /var is a symlink);
+    // canonicalize here too so the `directory` constraint this test queries
+    // with matches what the table's own discovery will produce.
+    project_dir = fs::canonical(fs::temp_directory_path()) /
+                  fs::unique_path("osquery.tests.agent_skills.%%%%-%%%%");
+    skill_dir = project_dir / ".claude" / "skills" / "test-skill";
+    block_scalar_skill_dir =
+        project_dir / ".cursor" / "skills" / "block-scalar-skill";
+
+    ASSERT_TRUE(createDirectory(skill_dir / "scripts", true).ok());
+    ASSERT_TRUE(writeTextFile(skill_dir / "SKILL.md", kSkillMarkdown).ok());
+    ASSERT_TRUE(
+        writeTextFile(skill_dir / "scripts" / "helper.sh", "#!/bin/sh\n")
+            .ok());
+
+    ASSERT_TRUE(createDirectory(block_scalar_skill_dir, true).ok());
+    ASSERT_TRUE(writeTextFile(block_scalar_skill_dir / "SKILL.md",
+                              kBlockScalarSkillMarkdown)
+                    .ok());
+  }
+
+  void TearDown() override {
+    fs::remove_all(project_dir);
+  }
+
+  fs::path project_dir;
+  fs::path skill_dir;
+  fs::path block_scalar_skill_dir;
+
+  static const std::string kSkillMarkdown;
+  static const std::string kBlockScalarSkillMarkdown;
+};
+
+const std::string AgentSkills::kSkillMarkdown = R"(---
+name: test-skill
+description: A skill used only for osquery's own integration test.
+license: MIT
+allowed-tools: Read Bash(git:*)
+metadata:
+  version: "1.2.3"
+---
+
+Do the thing under test.
+)";
+
+// Real-world SKILL.md files commonly use YAML block-scalar descriptions
+// (folded `>-`), observed while validating this table's discovery logic
+// against actual installed skills; this fixture pins that parsing.
+const std::string AgentSkills::kBlockScalarSkillMarkdown = R"(---
+name: block-scalar-skill
+description: >-
+  This description spans
+  multiple folded lines. Use when testing
+  the frontmatter parser.
+---
+
+Body content.
+)";
+
+namespace {
+const Row& findRowByPath(const QueryData& data, const std::string& path) {
+  for (const auto& row : data) {
+    if (row.at("path") == path) {
+      return row;
+    }
+  }
+  ADD_FAILURE() << "No row found with path " << path;
+  return data.front();
+}
+} // namespace
+
+TEST_F(AgentSkills, test_sanity) {
+  auto const data = execute_query(
+      "select *, content from agent_skills where directory = '" +
+      project_dir.string() + "'");
+
+  ASSERT_EQ(data.size(), 2ul);
+
+  ValidationMap row_map = {
+      {"name", NormalType},
+      {"description", NormalType},
+      {"content", NormalType},
+      {"version", NormalType},
+      {"license", NormalType},
+      {"compatibility", NormalType},
+      {"allowed_tools", NormalType},
+      {"agent", NonEmptyString},
+      {"scope", NonEmptyString},
+      {"directory", NonEmptyString},
+      {"path", NonEmptyString},
+      {"sha256", NonEmptyString},
+      {"size", NonNegativeInt},
+      {"mtime", NonNegativeInt},
+      {"resource_count", NonNegativeInt},
+      {"script_count", NonNegativeInt},
+      {"uid", NormalType},
+      {"username", NormalType},
+  };
+  validate_rows(data, row_map);
+
+  const auto& row = findRowByPath(data, (skill_dir / "SKILL.md").string());
+  EXPECT_EQ(row.at("name"), "test-skill");
+  EXPECT_EQ(row.at("description"),
+            "A skill used only for osquery's own integration test.");
+  EXPECT_EQ(row.at("license"), "MIT");
+  EXPECT_EQ(row.at("version"), "1.2.3");
+  EXPECT_EQ(row.at("agent"), "claude");
+  EXPECT_EQ(row.at("scope"), "project");
+  EXPECT_EQ(row.at("directory"), project_dir.string());
+  EXPECT_EQ(row.at("content"), "Do the thing under test.");
+  EXPECT_EQ(row.at("script_count"), "1");
+  EXPECT_EQ(row.at("resource_count"), "1");
+}
+
+TEST_F(AgentSkills, test_block_scalar_description) {
+  auto const data = execute_query(
+      "select * from agent_skills where directory = '" +
+      project_dir.string() + "'");
+
+  const auto& row =
+      findRowByPath(data, (block_scalar_skill_dir / "SKILL.md").string());
+  EXPECT_EQ(row.at("name"), "block-scalar-skill");
+  EXPECT_EQ(row.at("agent"), "cursor");
+  EXPECT_EQ(row.at("description"),
+            "This description spans multiple folded lines. Use when "
+            "testing the frontmatter parser.");
+}
+
+TEST_F(AgentSkills, test_unconstrained_query_excludes_project_scope) {
+  auto const data = execute_query("select * from agent_skills");
+
+  for (const auto& row : data) {
+    EXPECT_NE(row.at("directory"), project_dir.string());
+  }
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -26,9 +26,15 @@ class AgentSkills : public testing::Test {
     // resolveFilePattern canonicalizes the path up to the first wildcard
     // (e.g. /var/... -> /private/var/... on macOS, since /var is a symlink);
     // canonicalize here too so the `directory` constraint this test queries
-    // with matches what the table's own discovery will produce.
-    project_dir = fs::canonical(fs::temp_directory_path()) /
-                  fs::unique_path("osquery.tests.agent_skills.%%%%-%%%%");
+    // with matches what the table's own discovery will produce. Uses the
+    // non-throwing overload since the throwing one would abort the test
+    // runner on failure instead of reporting a clean assertion failure.
+    boost::system::error_code ec;
+    fs::path canonical_tmp = fs::canonical(fs::temp_directory_path(), ec);
+    ASSERT_FALSE(ec) << "Failed to canonicalize temp directory: "
+                     << ec.message();
+    project_dir =
+        canonical_tmp / fs::unique_path("osquery.tests.agent_skills.%%%%-%%%%");
     skill_dir = project_dir / ".claude" / "skills" / "test-skill";
     block_scalar_skill_dir =
         project_dir / ".cursor" / "skills" / "block-scalar-skill";
@@ -46,7 +52,10 @@ class AgentSkills : public testing::Test {
   }
 
   void TearDown() override {
-    fs::remove_all(project_dir);
+    boost::system::error_code ec;
+    fs::remove_all(project_dir, ec);
+    EXPECT_FALSE(ec) << "Failed to remove " << project_dir.string() << ": "
+                     << ec.message();
   }
 
   fs::path project_dir;

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -51,16 +51,16 @@ class AgentSkills : public testing::Test {
                     .ok());
   }
 
-void TearDown() override {
-  if (project_dir.empty()) {
-    return;
-  }
+  void TearDown() override {
+    if (project_dir.empty()) {
+      return;
+    }
 
-  boost::system::error_code ec;
-  fs::remove_all(project_dir, ec);
-  EXPECT_FALSE(ec) << "Failed to remove " << project_dir.string() << ": "
-                   << ec.message();
-}
+    boost::system::error_code ec;
+    fs::remove_all(project_dir, ec);
+    EXPECT_FALSE(ec) << "Failed to remove " << project_dir.string() << ": "
+                     << ec.message();
+  }
 
   fs::path project_dir;
   fs::path skill_dir;

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -85,13 +85,17 @@ Body content.
 
 namespace {
 const Row& findRowByPath(const QueryData& data, const std::string& path) {
+  static const Row kEmptyRow;
   for (const auto& row : data) {
     if (row.at("path") == path) {
       return row;
     }
   }
   ADD_FAILURE() << "No row found with path " << path;
-  return data.front();
+  // data.front() would be undefined behavior if data is empty; fall back to
+  // an empty row so callers still fail loudly (via Row::at() throwing)
+  // instead of crashing the test runner.
+  return data.empty() ? kEmptyRow : data.front();
 }
 } // namespace
 

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -51,12 +51,16 @@ class AgentSkills : public testing::Test {
                     .ok());
   }
 
-  void TearDown() override {
-    boost::system::error_code ec;
-    fs::remove_all(project_dir, ec);
-    EXPECT_FALSE(ec) << "Failed to remove " << project_dir.string() << ": "
-                     << ec.message();
+void TearDown() override {
+  if (project_dir.empty()) {
+    return;
   }
+
+  boost::system::error_code ec;
+  fs::remove_all(project_dir, ec);
+  EXPECT_FALSE(ec) << "Failed to remove " << project_dir.string() << ": "
+                   << ec.message();
+}
 
   fs::path project_dir;
   fs::path skill_dir;
@@ -151,6 +155,7 @@ TEST_F(AgentSkills, test_sanity) {
   EXPECT_EQ(row.at("resource_count"), "1");
   EXPECT_TRUE(row.at("uid").empty());
   EXPECT_TRUE(row.at("username").empty());
+}
 
 TEST_F(AgentSkills, test_block_scalar_description) {
   auto const data = execute_query(

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -149,7 +149,8 @@ TEST_F(AgentSkills, test_sanity) {
   EXPECT_EQ(row.at("content"), "Do the thing under test.");
   EXPECT_EQ(row.at("script_count"), "1");
   EXPECT_EQ(row.at("resource_count"), "1");
-}
+  EXPECT_TRUE(row.at("uid").empty());
+  EXPECT_TRUE(row.at("username").empty());
 
 TEST_F(AgentSkills, test_block_scalar_description) {
   auto const data = execute_query(

--- a/tests/integration/tables/agent_skills.cpp
+++ b/tests/integration/tables/agent_skills.cpp
@@ -38,6 +38,8 @@ class AgentSkills : public testing::Test {
     skill_dir = project_dir / ".claude" / "skills" / "test-skill";
     block_scalar_skill_dir =
         project_dir / ".cursor" / "skills" / "block-scalar-skill";
+    empty_frontmatter_skill_dir =
+        project_dir / ".agents" / "skills" / "empty-frontmatter-skill";
 
     ASSERT_TRUE(createDirectory(skill_dir / "scripts", true).ok());
     ASSERT_TRUE(writeTextFile(skill_dir / "SKILL.md", kSkillMarkdown).ok());
@@ -48,6 +50,11 @@ class AgentSkills : public testing::Test {
     ASSERT_TRUE(createDirectory(block_scalar_skill_dir, true).ok());
     ASSERT_TRUE(writeTextFile(block_scalar_skill_dir / "SKILL.md",
                               kBlockScalarSkillMarkdown)
+                    .ok());
+
+    ASSERT_TRUE(createDirectory(empty_frontmatter_skill_dir, true).ok());
+    ASSERT_TRUE(writeTextFile(empty_frontmatter_skill_dir / "SKILL.md",
+                              kEmptyFrontmatterSkillMarkdown)
                     .ok());
   }
 
@@ -65,9 +72,11 @@ class AgentSkills : public testing::Test {
   fs::path project_dir;
   fs::path skill_dir;
   fs::path block_scalar_skill_dir;
+  fs::path empty_frontmatter_skill_dir;
 
   static const std::string kSkillMarkdown;
   static const std::string kBlockScalarSkillMarkdown;
+  static const std::string kEmptyFrontmatterSkillMarkdown;
 };
 
 const std::string AgentSkills::kSkillMarkdown = R"(---
@@ -96,6 +105,23 @@ description: >-
 Body content.
 )";
 
+// An empty frontmatter block: the closing fence's "\n" coincides with the
+// opening fence's own trailing "\n" (no lines in between), so `close` ends
+// up less than `fence_len`. This pins two things: the closing fence is
+// still detected (a regression would make the parser treat the whole file,
+// delimiters included, as `content`), and the frontmatter substring is
+// computed as empty rather than underflowing to "the rest of the file"
+// (a regression there would parse the body's "license: MIT" line as if it
+// were real frontmatter, since the body deliberately starts with a line
+// that matches a recognized key -- the earlier version of this fixture had
+// no colon in its body at all, so it couldn't have caught that bug).
+const std::string AgentSkills::kEmptyFrontmatterSkillMarkdown = R"(---
+---
+
+license: MIT
+Body after an empty frontmatter block.
+)";
+
 namespace {
 const Row& findRowByPath(const QueryData& data, const std::string& path) {
   static const Row kEmptyRow;
@@ -117,7 +143,7 @@ TEST_F(AgentSkills, test_sanity) {
       "select *, content from agent_skills where directory = '" +
       project_dir.string() + "'");
 
-  ASSERT_EQ(data.size(), 2ul);
+  ASSERT_EQ(data.size(), 3ul);
 
   ValidationMap row_map = {
       {"name", NormalType},
@@ -169,6 +195,27 @@ TEST_F(AgentSkills, test_block_scalar_description) {
   EXPECT_EQ(row.at("description"),
             "This description spans multiple folded lines. Use when "
             "testing the frontmatter parser.");
+}
+
+TEST_F(AgentSkills, test_empty_frontmatter_block) {
+  auto const data = execute_query(
+      "select *, content from agent_skills where directory = '" +
+      project_dir.string() + "'");
+
+  const auto& row = findRowByPath(
+      data, (empty_frontmatter_skill_dir / "SKILL.md").string());
+  // No metadata to parse from an empty frontmatter block, but the closing
+  // fence must still be detected: content should be just the body, not the
+  // whole raw file with both "---" delimiter lines still attached (which is
+  // what a regression in the closing-fence search would produce).
+  EXPECT_TRUE(row.at("name").empty());
+  EXPECT_TRUE(row.at("description").empty());
+  // The body's "license: MIT" line must NOT be parsed as frontmatter: it
+  // would be if the (empty) frontmatter substring computation underflowed
+  // and silently became "the rest of the file" instead of "".
+  EXPECT_TRUE(row.at("license").empty());
+  EXPECT_EQ(row.at("content"),
+            "license: MIT\nBody after an empty frontmatter block.");
 }
 
 TEST_F(AgentSkills, test_unconstrained_query_excludes_project_scope) {


### PR DESCRIPTION

Implement: https://github.com/osquery/osquery/issues/9007 
Skills (SKILL.md packages) are a fast-growing class of user-installed, unsigned content whose instructions load straight into an agent's context, the same class of thing chrome_extensions/vscode_extensions/npm_packages already inventory for other ecosystems. This table discovers SKILL.md files under known personal/system roots, plus project roots when queried with a directory constraint, parses their frontmatter (including YAML block scalars), and reports hash/size/mtime/resource and script counts for drift and compliance queries.

Verified against a real build and real installed skills on a live machine, not just unit tests.




