### PR TITLE
feat: Java packages virtual table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -22,6 +22,7 @@ function(generateOsqueryTablesSystemSystemtable)
     ssh_configs.cpp
     system_utils.cpp
     uptime.cpp
+    java_packages.cpp
   )
 
   if(TARGET_PROCESSOR STREQUAL "x86_64")

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -1,0 +1,593 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+
+#include <stdlib.h>
+#include <string>
+
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/conversions/split.h>
+#include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/info/platform_type.h>
+#include <osquery/worker/ipc/platform_table_container_ipc.h>
+#include <osquery/worker/logging/glog/glog_logger.h>
+
+#ifdef WIN32
+#include "windows/registry.h"
+#endif
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+/// Number of fields when splitting metadata and info.
+const size_t kNumFields = 2;
+const std::set<std::string> kJavaPath = {
+    "/usr/local/lib/java%/dist-packages",
+    "/usr/local/lib/java%/site-packages",
+    "/usr/local/lib64/java%/site-packages",
+    "/opt/homebrew/lib/java%/dist-packages",
+    "/opt/homebrew/lib/java%/site-packages",
+    "/usr/lib/java%/dist-packages",
+    "/usr/lib/java%/site-packages",
+    "/Library/Java/%/site-packages"
+};
+
+const std::set<std::string> kUserDirectoryPaths = {
+    // Maven local repository
+    ".m2/repository",
+    // Gradle caches
+    ".gradle/caches/modules-2/files-2.1",
+};
+
+const std::set<std::string> kDarwinUserDirectoryPaths = {
+    // Maven local repository (macOS)
+    ".m2/repository",
+    // Gradle caches (macOS)
+    ".gradle/caches/modules-2/files-2.1",
+};
+
+const std::string kWinJavaInstallKey =
+    "SOFTWARE\\Java\\JavaCore\\%\\InstallPath";
+
+struct UserPath {
+  enum class Type { Int64, String };
+
+  Type type;
+  std::int64_t intValue;
+  std::string stringValue;
+
+  UserPath(std::int64_t value) : type(Type::Int64), intValue(value) {}
+  UserPath(std::string value)
+      : type(Type::String), stringValue(std::move(value)) {}
+};
+
+std::string extractAuthorFromPom(const std::string& content) {
+  // Find the <developers> block
+  size_t devsStart = content.find("<developers");
+  if (devsStart == std::string::npos) {
+    return "";
+  }
+
+  devsStart = content.find(">", devsStart);
+  if (devsStart == std::string::npos) {
+    return "";
+  }
+  ++devsStart;
+  
+  size_t devsEnd = content.find("</developers>", devsStart);
+  if (devsEnd == std::string::npos) {
+    return "";
+  }
+  
+  std::string devsBlock = content.substr(devsStart, devsEnd - devsStart);
+  std::string fallbackAuthor;
+  
+  // Find all <developer> blocks
+  size_t devPos = 0;
+  while ((devPos = devsBlock.find("<developer", devPos)) != std::string::npos) {
+    auto devTagEnd = devsBlock.find(">", devPos);
+    if (devTagEnd == std::string::npos) {
+      break;
+    }
+
+    size_t devEnd = devsBlock.find("</developer>", devTagEnd);
+    if (devEnd == std::string::npos) {
+      break;
+    }
+    
+    std::string devBlock = devsBlock.substr(devTagEnd + 1, devEnd - devTagEnd - 1);
+
+    auto getTagValue = [&devBlock](const std::string& tag_name) -> std::string {
+      auto tagStart = devBlock.find("<" + tag_name);
+      if (tagStart == std::string::npos) {
+        return "";
+      }
+
+      tagStart = devBlock.find(">", tagStart);
+      if (tagStart == std::string::npos) {
+        return "";
+      }
+      ++tagStart;
+
+      auto tagEnd = devBlock.find("</" + tag_name + ">", tagStart);
+      if (tagEnd == std::string::npos) {
+        return "";
+      }
+
+      return boost::algorithm::trim_copy(devBlock.substr(tagStart, tagEnd - tagStart));
+    };
+
+    if (fallbackAuthor.empty()) {
+      fallbackAuthor = getTagValue("name");
+    }
+    
+    // Check if this developer has the "owner" role
+    size_t rolesStart = devBlock.find("<roles");
+    if (rolesStart != std::string::npos) {
+      rolesStart = devBlock.find(">", rolesStart);
+      if (rolesStart == std::string::npos) {
+        devPos = devEnd + 12;
+        continue;
+      }
+      ++rolesStart;
+
+      size_t rolesEnd = devBlock.find("</roles>", rolesStart);
+      if (rolesEnd != std::string::npos) {
+        std::string rolesBlock = devBlock.substr(rolesStart, rolesEnd - rolesStart);
+
+        bool hasOwnerRole{false};
+        size_t rolePos = 0;
+        while ((rolePos = rolesBlock.find("<role", rolePos)) != std::string::npos) {
+          auto roleTagEnd = rolesBlock.find(">", rolePos);
+          if (roleTagEnd == std::string::npos) {
+            break;
+          }
+
+          auto roleEnd = rolesBlock.find("</role>", roleTagEnd);
+          if (roleEnd == std::string::npos) {
+            break;
+          }
+
+          auto roleValue = boost::algorithm::to_lower_copy(
+              boost::algorithm::trim_copy(
+                  rolesBlock.substr(roleTagEnd + 1, roleEnd - roleTagEnd - 1)));
+
+          if (roleValue == "owner") {
+            hasOwnerRole = true;
+            break;
+          }
+
+          rolePos = roleEnd + 7;
+        }
+
+        if (hasOwnerRole) {
+          auto ownerEmail = getTagValue("email");
+          if (!ownerEmail.empty()) {
+            return ownerEmail;
+          }
+
+          auto ownerName = getTagValue("name");
+          if (!ownerName.empty()) {
+            return ownerName;
+          }
+        }
+      }
+    }
+    
+    devPos = devEnd + 12;
+  }
+  
+  return fallbackAuthor;
+}
+
+void genMavenPackage(const std::string& groupPath,
+                     const std::string& artifactId,
+                     const std::string& version,
+                     Row& r,
+                     Logger& logger) {
+  // Maven repository structure: groupId/artifactId/version/
+  r["name"] = artifactId;
+  r["version"] = version;
+  r["type"] = "Maven";
+  
+  // Try to find and parse POM file for additional metadata
+  auto pomPath = groupPath + "/" + artifactId + "/" + version + "/" + 
+                 artifactId + "-" + version + ".pom";
+  
+  std::string content;
+  auto s = readFile(pomPath, content);
+  if (s.ok()) {
+    // Extract basic info from POM (simplified parsing)
+    // In a real implementation, you'd use an XML parser
+    size_t descStart = content.find("<description>");
+    size_t descEnd = content.find("</description>");
+    if (descStart != std::string::npos && descEnd != std::string::npos) {
+      descStart += 13; // length of "<description>"
+      r["summary"] = content.substr(descStart, descEnd - descStart);
+    }
+    
+    size_t licenseStart = content.find("<name>", content.find("<license>"));
+    size_t licenseEnd = content.find("</name>", licenseStart);
+    if (licenseStart != std::string::npos && licenseEnd != std::string::npos) {
+      licenseStart += 6; // length of "<name>"
+      r["license"] = content.substr(licenseStart, licenseEnd - licenseStart);
+    }
+    
+    // Extract author from developers block
+    std::string author = extractAuthorFromPom(content);
+    if (!author.empty()) {
+      r["author"] = author;
+    }
+    
+    logger.log(1, "Parsed POM file for Maven artifact: " + pomPath);
+  }
+}
+
+void genGradlePackage(const std::string& versionPath,
+                      const std::string& groupId,
+                      const std::string& artifactId,
+                      const std::string& version,
+                      Row& r,
+                      Logger& logger) {
+  // Gradle cache structure: groupId/artifactId/version/hash/
+  r["name"] = groupId + ":" + artifactId;
+  r["version"] = version;
+  r["type"] = "Gradle";
+  
+  // Look for POM file in hash subdirectories to extract metadata
+  std::vector<std::string> hashDirs;
+  if (listDirectoriesInDirectory(versionPath, hashDirs, false).ok()) {
+    for (const auto& hashDir : hashDirs) {
+      std::vector<std::string> files;
+      if (listFilesInDirectory(hashDir, files, false).ok()) {
+        for (const auto& file : files) {
+          if (boost::algorithm::ends_with(file, ".pom")) {
+            // Found POM file, parse it for metadata
+            std::string content;
+            auto s = readFile(file, content);
+            if (s.ok()) {
+              // Extract description
+              size_t descStart = content.find("<description>");
+              size_t descEnd = content.find("</description>");
+              if (descStart != std::string::npos && descEnd != std::string::npos) {
+                descStart += 13;
+                r["summary"] = content.substr(descStart, descEnd - descStart);
+              } else {
+                r["summary"] = groupId + ":" + artifactId;
+              }
+              
+              // Extract license
+              size_t licenseStart = content.find("<name>", content.find("<license>"));
+              size_t licenseEnd = content.find("</name>", licenseStart);
+              if (licenseStart != std::string::npos && licenseEnd != std::string::npos) {
+                licenseStart += 6;
+                r["license"] = content.substr(licenseStart, licenseEnd - licenseStart);
+              }
+              
+              // Extract author from developers block
+              std::string author = extractAuthorFromPom(content);
+              if (!author.empty()) {
+                r["author"] = author;
+              }
+            }
+            // Only parse the first POM found
+            return;
+          }
+        }
+      }
+    }
+  }
+  
+  // Fallback if no POM found
+  r["summary"] = groupId + ":" + artifactId;
+}
+
+void genJavaPackage(const std::string& path, Row& r, Logger& logger) {
+  std::string content;
+  auto s = readFile(path, content);
+  if (!s.ok()) {
+    logger.log(google::GLOG_WARNING, s.getMessage());
+    logger.log(1, "Cannot find info file: " + path);
+    return;
+  }
+
+  auto lines = split(content, "\n");
+
+  for (const auto& line : lines) {
+    auto fields = split(line, ":");
+
+    if (fields.size() != kNumFields) {
+      continue;
+    }
+
+    if (fields[0] == "Name") {
+      r["name"] = fields[1];
+    } else if (fields[0] == "Version") {
+      r["version"] = fields[1];
+    } else if (fields[0] == "Summary") {
+      r["summary"] = fields[1];
+    } else if (fields[0] == "Author") {
+      r["author"] = fields[1];
+    } else if (fields[0] == "License") {
+      r["license"] = fields[1];
+      break;
+    }
+  }
+}
+
+void genMavenArtifacts(const std::string& repoPath,
+                       QueryData& results,
+                       Logger& logger,
+                       const std::int64_t& user_id) {
+  // Maven repository structure: groupId/artifactId/version/
+  std::vector<std::string> groupDirs;
+  
+  if (!listDirectoriesInDirectory(repoPath, groupDirs, false).ok()) {
+    LOG(ERROR) << "Cannot list group directories in Maven repository: " + repoPath;
+    return;
+  }
+
+  for (const auto& groupDir : groupDirs) {
+    if (!isDirectory(groupDir).ok()) {
+      continue;
+    }
+
+    std::vector<std::string> artifactDirs;
+    if (!listDirectoriesInDirectory(groupDir, artifactDirs, false).ok()) {
+      continue;
+    }
+
+    for (const auto& artifactDir : artifactDirs) {
+      if (!isDirectory(artifactDir).ok()) {
+        continue;
+      }
+
+      std::vector<std::string> versionDirs;
+      if (!listDirectoriesInDirectory(artifactDir, versionDirs, false).ok()) {
+        continue;
+      }
+
+      for (const auto& versionDir : versionDirs) {
+        if (!isDirectory(versionDir).ok()) {
+          continue;
+        }
+
+        LOG(ERROR) << "Found Maven artifact: " + versionDir;
+
+        Row r;
+        auto artifactId = fs::path(artifactDir).filename().string();
+        auto version = fs::path(versionDir).filename().string();
+        
+        genMavenPackage(groupDir, artifactId, version, r, logger);
+        
+        r["directory"] = repoPath;
+        r["path"] = versionDir;
+        r["pid_with_namespace"] = "0";
+        r["uid"] = BIGINT(user_id);
+        results.push_back(r);
+      }
+    }
+  }
+}
+
+void genGradleArtifacts(const std::string& cachePath,
+                        QueryData& results,
+                        Logger& logger,
+                        const std::int64_t& user_id) {
+  // Gradle cache structure: groupId/artifactId/version/hash/
+  std::vector<std::string> groupDirs;
+  
+  if (!listDirectoriesInDirectory(cachePath, groupDirs, false).ok()) {
+    return;
+  }
+
+  for (const auto& groupDir : groupDirs) {
+    if (!isDirectory(groupDir).ok()) {
+      continue;
+    }
+
+    std::vector<std::string> artifactDirs;
+    if (!listDirectoriesInDirectory(groupDir, artifactDirs, false).ok()) {
+      continue;
+    }
+
+    for (const auto& artifactDir : artifactDirs) {
+      if (!isDirectory(artifactDir).ok()) {
+        continue;
+      }
+
+      std::vector<std::string> versionDirs;
+      if (!listDirectoriesInDirectory(artifactDir, versionDirs, false).ok()) {
+        continue;
+      }
+
+      for (const auto& versionDir : versionDirs) {
+        if (!isDirectory(versionDir).ok()) {
+          continue;
+        }
+
+        Row r;
+        auto groupId = fs::path(groupDir).filename().string();
+        auto artifactId = fs::path(artifactDir).filename().string();
+        auto version = fs::path(versionDir).filename().string();
+        
+        genGradlePackage(versionDir, groupId, artifactId, version, r, logger);
+        
+        r["directory"] = cachePath;
+        r["path"] = versionDir;
+        r["pid_with_namespace"] = "0";
+        r["uid"] = BIGINT(user_id);
+        results.push_back(r);
+      }
+    }
+  }
+}
+
+std::vector<std::string> listWinJavaPaths(const std::string& keyGlob) {
+#ifdef WIN32
+  std::vector<std::string> results;
+
+  std::set<std::string> installPathKeys;
+  auto status = expandRegistryGlobs(keyGlob, installPathKeys);
+  if (!status.ok()) {
+    return {};
+  }
+
+  QueryData javaInstallLocation;
+  for (const auto& installKey : installPathKeys) {
+    queryKey(installKey, javaInstallLocation);
+    for (const auto& p : javaInstallLocation) {
+      if (p.at("name") != "(Default)") {
+        continue;
+      }
+      results.push_back(p.at("data"));
+    }
+    javaInstallLocation.clear();
+  }
+  return results;
+#else
+  return {};
+#endif
+}
+
+std::vector<std::map<std::string, UserPath>> getJavaUserPathList(
+    const QueryContext& context) {
+  std::vector<std::map<std::string, UserPath>> paths_list;
+
+  // `all` is set to true for windows to not break existing behavior.
+  // Windows will always return all users' packages.
+  auto user_list =
+      usersFromContext(context, isPlatform(PlatformType::TYPE_WINDOWS));
+  for (const auto& user : user_list) {
+    if (user.count("uid") == 0 || user.count("directory") == 0) {
+      continue;
+    }
+
+    const auto& uid_as_string = user.at("uid");
+    auto uid_as_big_int = tryTo<int64_t>(uid_as_string, 10);
+    if (uid_as_big_int.isError()) {
+      LOG(ERROR) << "Invalid uid field returned: " << uid_as_string;
+      continue;
+    }
+    const auto& path = user.at("directory");
+
+    if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
+       LOG(ERROR) << "Generating Java packages for user path: " + path;
+      std::set<std::string> user_paths = kUserDirectoryPaths;
+
+      if (isPlatform(PlatformType::TYPE_OSX)) {
+        user_paths.insert(kDarwinUserDirectoryPaths.begin(),
+                          kDarwinUserDirectoryPaths.end());
+      }
+
+      for (const auto& path_postfix : user_paths) {
+        auto dir = path + "/" + path_postfix;
+        
+        // Check if directory exists
+        if (isDirectory(dir).ok()) {
+          std::map<std::string, UserPath> user_path;
+          user_path = {
+              {"user_id", uid_as_big_int.get()},
+              {"path", dir},
+              {"type", std::string(path_postfix)},
+          };
+          paths_list.push_back(user_path);
+        }
+      }
+    }
+
+    if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+      const auto& uuid_as_string = user.at("uuid");
+      auto installPathKey =
+          "HKEY_USERS\\" + uuid_as_string + "\\" + kWinJavaInstallKey;
+      auto win_paths = listWinJavaPaths(installPathKey);
+
+      for (const auto& win_path : win_paths) {
+        std::map<std::string, UserPath> user_path;
+        user_path = {
+            {"user_id", uid_as_big_int.get()},
+            {"path", win_path},
+            {"type", std::string("windows")},
+        };
+        paths_list.push_back(user_path);
+      }
+    }
+  }
+
+  return paths_list;
+}
+
+QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
+  QueryData results;
+  std::set<std::string> paths;
+  logger.log(1, "Generating Java packages for context");
+  bool directory_filter = context.constraints.count("directory") > 0 &&
+                          context.constraints.at("directory").exists(EQUALS);
+
+  if (directory_filter) {
+    paths = context.constraints["directory"].getAll(EQUALS);
+  } else {
+    for (const auto& path : kJavaPath) {
+        logger.log(1, "Resolving Java path pattern: " + path);
+      std::vector<std::string> sites;
+      resolveFilePattern(path, sites);
+      for (const auto& site : sites) {
+        paths.insert(site);
+      }
+    }
+  }
+
+  // If user has specified `where directory = "path"` then return results early.
+  if (directory_filter) {
+    return results;
+  }
+
+  // Enumerate user installed java packages from Maven and Gradle caches
+  auto user_paths = getJavaUserPathList(context);
+  for (const auto& user_path : user_paths) {
+    logger.log(1, "Generating Java packages for user path: " + user_path.at("path").stringValue);
+    const auto& path = user_path.at("path").stringValue;
+    const auto& type = user_path.at("type").stringValue;
+    
+    if (type.find(".m2/repository") != std::string::npos) {
+      // Maven repository
+      genMavenArtifacts(path,
+                       results,
+                       logger,
+                       user_path.at("user_id").intValue);
+    } else if (type.find(".gradle/caches") != std::string::npos) {
+      // Gradle cache
+      genGradleArtifacts(path,
+                        results,
+                        logger,
+                        user_path.at("user_id").intValue);
+    } 
+  }
+  return results;
+}
+
+QueryData genJavaPackages(QueryContext& context) {
+   GLOGLogger logger;
+  if (hasNamespaceConstraint(context)) {
+    logger.log(1, "Generating Java packages in namespace");
+    return generateInNamespace(
+        context, "java_packages", genJavaPackagesImpl);
+  } else {
+    return genJavaPackagesImpl(context, logger);
+  }
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -9,6 +9,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 #include <algorithm>
 #include <sstream>
@@ -24,8 +26,6 @@
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/worker/ipc/platform_table_container_ipc.h>
 #include <osquery/worker/logging/glog/glog_logger.h>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 
 #ifdef WIN32
 #include "windows/registry.h"
@@ -522,11 +522,13 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
     const auto& path = user_path.at("path").stringValue;
     const auto& type = user_path.at("type").stringValue;
 
-    if (type.find(".m2/repository") != std::string::npos or type.find(".m2\\repository") != std::string::npos) {
+    if (type.find(".m2/repository") != std::string::npos or
+        type.find(".m2\\repository") != std::string::npos) {
       // Maven repository
       genMavenArtifacts(
           path, results, logger, user_path.at("user_id").intValue);
-    } else if (type.find(".gradle/caches") != std::string::npos or type.find(".gradle\\caches") != std::string::npos) {
+    } else if (type.find(".gradle/caches") != std::string::npos or
+               type.find(".gradle\\caches") != std::string::npos) {
       // Gradle cache
       genGradleArtifacts(
           path, results, logger, user_path.at("user_id").intValue);

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -11,6 +11,7 @@
 #include <boost/filesystem.hpp>
 
 #include <algorithm>
+#include <sstream>
 #include <stdlib.h>
 #include <string>
 
@@ -23,6 +24,8 @@
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/worker/ipc/platform_table_container_ipc.h>
 #include <osquery/worker/logging/glog/glog_logger.h>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 #ifdef WIN32
 #include "windows/registry.h"
@@ -69,115 +72,60 @@ struct UserPath {
 };
 
 std::string extractAuthorFromPom(const std::string& content) {
-  // Find the <developers> block
-  size_t devsStart = content.find("<developers");
-  if (devsStart == std::string::npos) {
-    return "";
-  }
+  try {
+    // Parse the XML content into a property tree
+    boost::property_tree::ptree pt;
+    std::istringstream stream(content);
+    boost::property_tree::read_xml(stream, pt);
 
-  devsStart = content.find(">", devsStart);
-  if (devsStart == std::string::npos) {
-    return "";
-  }
-  ++devsStart;
+    std::string fallbackAuthor;
 
-  size_t devsEnd = content.find("</developers>", devsStart);
-  if (devsEnd == std::string::npos) {
-    return "";
-  }
-
-  std::string devsBlock = content.substr(devsStart, devsEnd - devsStart);
-  std::string fallbackAuthor;
-
-  // Find all <developer> blocks
-  size_t devPos = 0;
-  while ((devPos = devsBlock.find("<developer", devPos)) != std::string::npos) {
-    auto devTagEnd = devsBlock.find(">", devPos);
-    if (devTagEnd == std::string::npos) {
-      break;
+    // Navigate to the developers section
+    auto developers = pt.get_child_optional("project.developers");
+    if (!developers) {
+      return "";
     }
 
-    size_t devEnd = devsBlock.find("</developer>", devTagEnd);
-    if (devEnd == std::string::npos) {
-      break;
-    }
-
-    std::string devBlock =
-        devsBlock.substr(devTagEnd + 1, devEnd - devTagEnd - 1);
-
-    auto getTagValue = [&devBlock](const std::string& tag_name) -> std::string {
-      auto tagStart = devBlock.find("<" + tag_name);
-      if (tagStart == std::string::npos) {
-        return "";
-      }
-
-      tagStart = devBlock.find(">", tagStart);
-      if (tagStart == std::string::npos) {
-        return "";
-      }
-      ++tagStart;
-
-      auto tagEnd = devBlock.find("</" + tag_name + ">", tagStart);
-      if (tagEnd == std::string::npos) {
-        return "";
-      }
-
-      return boost::algorithm::trim_copy(
-          devBlock.substr(tagStart, tagEnd - tagStart));
-    };
-
-    if (fallbackAuthor.empty()) {
-      fallbackAuthor = getTagValue("name");
-    }
-
-    // Check if this developer has the "owner" role
-    size_t rolesStart = devBlock.find("<roles");
-    if (rolesStart != std::string::npos) {
-      rolesStart = devBlock.find(">", rolesStart);
-      if (rolesStart == std::string::npos) {
-        devPos = devEnd + 12;
+    // Iterate through all developer nodes
+    for (const auto& devPair : *developers) {
+      if (devPair.first != "developer") {
         continue;
       }
-      ++rolesStart;
 
-      size_t rolesEnd = devBlock.find("</roles>", rolesStart);
-      if (rolesEnd != std::string::npos) {
-        std::string rolesBlock =
-            devBlock.substr(rolesStart, rolesEnd - rolesStart);
+      const auto& developer = devPair.second;
 
-        bool hasOwnerRole{false};
-        size_t rolePos = 0;
-        while ((rolePos = rolesBlock.find("<role", rolePos)) !=
-               std::string::npos) {
-          auto roleTagEnd = rolesBlock.find(">", rolePos);
-          if (roleTagEnd == std::string::npos) {
-            break;
+      // Get the developer's name as fallback
+      if (fallbackAuthor.empty()) {
+        fallbackAuthor = developer.get<std::string>("name", "");
+      }
+
+      // Check if this developer has the "owner" role
+      auto roles = developer.get_child_optional("roles");
+      if (roles) {
+        bool hasOwnerRole = false;
+        for (const auto& rolePair : *roles) {
+          if (rolePair.first != "role") {
+            continue;
           }
 
-          auto roleEnd = rolesBlock.find("</role>", roleTagEnd);
-          if (roleEnd == std::string::npos) {
-            break;
-          }
-
-          auto roleValue =
-              boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(
-                  rolesBlock.substr(roleTagEnd + 1, roleEnd - roleTagEnd - 1)));
+          std::string roleValue = rolePair.second.get_value<std::string>("");
+          roleValue = boost::algorithm::to_lower_copy(
+              boost::algorithm::trim_copy(roleValue));
 
           if (roleValue == "owner") {
             hasOwnerRole = true;
             break;
           }
-
-          rolePos = roleEnd + 7;
         }
 
+        // If this developer is the owner, return their email or name
         if (hasOwnerRole) {
-          auto ownerEmail = getTagValue("email");
+          std::string ownerEmail = developer.get<std::string>("email", "");
           if (!ownerEmail.empty()) {
             return ownerEmail;
           }
 
-          auto ownerName = getTagValue("name");
+          std::string ownerName = developer.get<std::string>("name", "");
           if (!ownerName.empty()) {
             return ownerName;
           }
@@ -185,10 +133,14 @@ std::string extractAuthorFromPom(const std::string& content) {
       }
     }
 
-    devPos = devEnd + 12;
+    return fallbackAuthor;
+  } catch (const boost::property_tree::xml_parser_error& e) {
+    // Failed to parse XML, return empty string
+    return "";
+  } catch (const std::exception& e) {
+    // Other errors, return empty string
+    return "";
   }
-
-  return fallbackAuthor;
 }
 
 void genMavenPackage(const std::string& versionPath,
@@ -570,11 +522,11 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
     const auto& path = user_path.at("path").stringValue;
     const auto& type = user_path.at("type").stringValue;
 
-    if (type.find(".m2/repository") != std::string::npos) {
+    if (type.find(".m2/repository") != std::string::npos or type.find(".m2\\repository") != std::string::npos) {
       // Maven repository
       genMavenArtifacts(
           path, results, logger, user_path.at("user_id").intValue);
-    } else if (type.find(".gradle/caches") != std::string::npos) {
+    } else if (type.find(".gradle/caches") != std::string::npos or type.find(".gradle\\caches") != std::string::npos) {
       // Gradle cache
       genGradleArtifacts(
           path, results, logger, user_path.at("user_id").intValue);

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -79,15 +79,15 @@ std::string extractAuthorFromPom(const std::string& content) {
     return "";
   }
   ++devsStart;
-  
+
   size_t devsEnd = content.find("</developers>", devsStart);
   if (devsEnd == std::string::npos) {
     return "";
   }
-  
+
   std::string devsBlock = content.substr(devsStart, devsEnd - devsStart);
   std::string fallbackAuthor;
-  
+
   // Find all <developer> blocks
   size_t devPos = 0;
   while ((devPos = devsBlock.find("<developer", devPos)) != std::string::npos) {
@@ -100,8 +100,9 @@ std::string extractAuthorFromPom(const std::string& content) {
     if (devEnd == std::string::npos) {
       break;
     }
-    
-    std::string devBlock = devsBlock.substr(devTagEnd + 1, devEnd - devTagEnd - 1);
+
+    std::string devBlock =
+        devsBlock.substr(devTagEnd + 1, devEnd - devTagEnd - 1);
 
     auto getTagValue = [&devBlock](const std::string& tag_name) -> std::string {
       auto tagStart = devBlock.find("<" + tag_name);
@@ -120,13 +121,14 @@ std::string extractAuthorFromPom(const std::string& content) {
         return "";
       }
 
-      return boost::algorithm::trim_copy(devBlock.substr(tagStart, tagEnd - tagStart));
+      return boost::algorithm::trim_copy(
+          devBlock.substr(tagStart, tagEnd - tagStart));
     };
 
     if (fallbackAuthor.empty()) {
       fallbackAuthor = getTagValue("name");
     }
-    
+
     // Check if this developer has the "owner" role
     size_t rolesStart = devBlock.find("<roles");
     if (rolesStart != std::string::npos) {
@@ -139,11 +141,13 @@ std::string extractAuthorFromPom(const std::string& content) {
 
       size_t rolesEnd = devBlock.find("</roles>", rolesStart);
       if (rolesEnd != std::string::npos) {
-        std::string rolesBlock = devBlock.substr(rolesStart, rolesEnd - rolesStart);
+        std::string rolesBlock =
+            devBlock.substr(rolesStart, rolesEnd - rolesStart);
 
         bool hasOwnerRole{false};
         size_t rolePos = 0;
-        while ((rolePos = rolesBlock.find("<role", rolePos)) != std::string::npos) {
+        while ((rolePos = rolesBlock.find("<role", rolePos)) !=
+               std::string::npos) {
           auto roleTagEnd = rolesBlock.find(">", rolePos);
           if (roleTagEnd == std::string::npos) {
             break;
@@ -154,8 +158,8 @@ std::string extractAuthorFromPom(const std::string& content) {
             break;
           }
 
-          auto roleValue = boost::algorithm::to_lower_copy(
-              boost::algorithm::trim_copy(
+          auto roleValue =
+              boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(
                   rolesBlock.substr(roleTagEnd + 1, roleEnd - roleTagEnd - 1)));
 
           if (roleValue == "owner") {
@@ -179,10 +183,10 @@ std::string extractAuthorFromPom(const std::string& content) {
         }
       }
     }
-    
+
     devPos = devEnd + 12;
   }
-  
+
   return fallbackAuthor;
 }
 
@@ -195,11 +199,11 @@ void genMavenPackage(const std::string& groupPath,
   r["name"] = artifactId;
   r["version"] = version;
   r["type"] = "Maven";
-  
+
   // Try to find and parse POM file for additional metadata
-  auto pomPath = groupPath + "/" + artifactId + "/" + version + "/" + 
+  auto pomPath = groupPath + "/" + artifactId + "/" + version + "/" +
                  artifactId + "-" + version + ".pom";
-  
+
   std::string content;
   auto s = readFile(pomPath, content);
   if (s.ok()) {
@@ -211,19 +215,19 @@ void genMavenPackage(const std::string& groupPath,
       descStart += 13; // length of "<description>"
       r["summary"] = content.substr(descStart, descEnd - descStart);
     }
-    
+
     size_t licenseStart = content.find("<name>", content.find("<license>"));
     size_t licenseEnd = content.find("</name>", licenseStart);
     if (licenseStart != std::string::npos && licenseEnd != std::string::npos) {
       licenseStart += 6; // length of "<name>"
       r["license"] = content.substr(licenseStart, licenseEnd - licenseStart);
     }
-    
+
     // Extract author from developers block
     std::string author = extractAuthorFromPom(content);
     if (!author.empty()) {
       r["author"] = author;
-    }    
+    }
   }
 }
 
@@ -237,7 +241,7 @@ void genGradlePackage(const std::string& versionPath,
   r["name"] = groupId + ":" + artifactId;
   r["version"] = version;
   r["type"] = "Gradle";
-  
+
   // Look for POM file in hash subdirectories to extract metadata
   std::vector<std::string> hashDirs;
   if (listDirectoriesInDirectory(versionPath, hashDirs, false).ok()) {
@@ -253,21 +257,25 @@ void genGradlePackage(const std::string& versionPath,
               // Extract description
               size_t descStart = content.find("<description>");
               size_t descEnd = content.find("</description>");
-              if (descStart != std::string::npos && descEnd != std::string::npos) {
+              if (descStart != std::string::npos &&
+                  descEnd != std::string::npos) {
                 descStart += 13;
                 r["summary"] = content.substr(descStart, descEnd - descStart);
               } else {
                 r["summary"] = groupId + ":" + artifactId;
               }
-              
+
               // Extract license
-              size_t licenseStart = content.find("<name>", content.find("<license>"));
+              size_t licenseStart =
+                  content.find("<name>", content.find("<license>"));
               size_t licenseEnd = content.find("</name>", licenseStart);
-              if (licenseStart != std::string::npos && licenseEnd != std::string::npos) {
+              if (licenseStart != std::string::npos &&
+                  licenseEnd != std::string::npos) {
                 licenseStart += 6;
-                r["license"] = content.substr(licenseStart, licenseEnd - licenseStart);
+                r["license"] =
+                    content.substr(licenseStart, licenseEnd - licenseStart);
               }
-              
+
               // Extract author from developers block
               std::string author = extractAuthorFromPom(content);
               if (!author.empty()) {
@@ -281,7 +289,7 @@ void genGradlePackage(const std::string& versionPath,
       }
     }
   }
-  
+
   // Fallback if no POM found
   r["summary"] = groupId + ":" + artifactId;
 }
@@ -325,7 +333,7 @@ void genMavenArtifacts(const std::string& repoPath,
                        const std::int64_t& user_id) {
   // Maven repository structure: groupId/artifactId/version/
   std::vector<std::string> groupDirs;
-  
+
   if (!listDirectoriesInDirectory(repoPath, groupDirs, false).ok()) {
     return;
   }
@@ -358,9 +366,9 @@ void genMavenArtifacts(const std::string& repoPath,
         Row r;
         auto artifactId = fs::path(artifactDir).filename().string();
         auto version = fs::path(versionDir).filename().string();
-        
+
         genMavenPackage(groupDir, artifactId, version, r, logger);
-        
+
         r["directory"] = repoPath;
         r["path"] = versionDir;
         r["pid_with_namespace"] = "0";
@@ -377,7 +385,7 @@ void genGradleArtifacts(const std::string& cachePath,
                         const std::int64_t& user_id) {
   // Gradle cache structure: groupId/artifactId/version/hash/
   std::vector<std::string> groupDirs;
-  
+
   if (!listDirectoriesInDirectory(cachePath, groupDirs, false).ok()) {
     return;
   }
@@ -411,9 +419,9 @@ void genGradleArtifacts(const std::string& cachePath,
         auto groupId = fs::path(groupDir).filename().string();
         auto artifactId = fs::path(artifactDir).filename().string();
         auto version = fs::path(versionDir).filename().string();
-        
+
         genGradlePackage(versionDir, groupId, artifactId, version, r, logger);
-        
+
         r["directory"] = cachePath;
         r["path"] = versionDir;
         r["pid_with_namespace"] = "0";
@@ -482,7 +490,7 @@ std::vector<std::map<std::string, UserPath>> getJavaUserPathList(
 
       for (const auto& path_postfix : user_paths) {
         auto dir = path + "/" + path_postfix;
-        
+
         // Check if directory exists
         if (isDirectory(dir).ok()) {
           std::map<std::string, UserPath> user_path;
@@ -545,29 +553,24 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
   for (const auto& user_path : user_paths) {
     const auto& path = user_path.at("path").stringValue;
     const auto& type = user_path.at("type").stringValue;
-    
+
     if (type.find(".m2/repository") != std::string::npos) {
       // Maven repository
-      genMavenArtifacts(path,
-                       results,
-                       logger,
-                       user_path.at("user_id").intValue);
+      genMavenArtifacts(
+          path, results, logger, user_path.at("user_id").intValue);
     } else if (type.find(".gradle/caches") != std::string::npos) {
       // Gradle cache
-      genGradleArtifacts(path,
-                        results,
-                        logger,
-                        user_path.at("user_id").intValue);
-    } 
+      genGradleArtifacts(
+          path, results, logger, user_path.at("user_id").intValue);
+    }
   }
   return results;
 }
 
 QueryData genJavaPackages(QueryContext& context) {
-   GLOGLogger logger;
+  GLOGLogger logger;
   if (hasNamespaceConstraint(context)) {
-    return generateInNamespace(
-        context, "java_packages", genJavaPackagesImpl);
+    return generateInNamespace(context, "java_packages", genJavaPackagesImpl);
   } else {
     return genJavaPackagesImpl(context, logger);
   }

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -35,14 +35,7 @@ namespace tables {
 /// Number of fields when splitting metadata and info.
 const size_t kNumFields = 2;
 const std::set<std::string> kJavaPath = {
-    "/usr/local/lib/java%/dist-packages",
-    "/usr/local/lib/java%/site-packages",
-    "/usr/local/lib64/java%/site-packages",
-    "/opt/homebrew/lib/java%/dist-packages",
-    "/opt/homebrew/lib/java%/site-packages",
-    "/usr/lib/java%/dist-packages",
-    "/usr/lib/java%/site-packages",
-    "/Library/Java/%/site-packages"
+    "/Library/Java/Extensions",
 };
 
 const std::set<std::string> kUserDirectoryPaths = {
@@ -230,9 +223,7 @@ void genMavenPackage(const std::string& groupPath,
     std::string author = extractAuthorFromPom(content);
     if (!author.empty()) {
       r["author"] = author;
-    }
-    
-    logger.log(1, "Parsed POM file for Maven artifact: " + pomPath);
+    }    
   }
 }
 
@@ -336,7 +327,6 @@ void genMavenArtifacts(const std::string& repoPath,
   std::vector<std::string> groupDirs;
   
   if (!listDirectoriesInDirectory(repoPath, groupDirs, false).ok()) {
-    LOG(ERROR) << "Cannot list group directories in Maven repository: " + repoPath;
     return;
   }
 
@@ -364,8 +354,6 @@ void genMavenArtifacts(const std::string& repoPath,
         if (!isDirectory(versionDir).ok()) {
           continue;
         }
-
-        LOG(ERROR) << "Found Maven artifact: " + versionDir;
 
         Row r;
         auto artifactId = fs::path(artifactDir).filename().string();
@@ -485,7 +473,6 @@ std::vector<std::map<std::string, UserPath>> getJavaUserPathList(
     const auto& path = user.at("directory");
 
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
-       LOG(ERROR) << "Generating Java packages for user path: " + path;
       std::set<std::string> user_paths = kUserDirectoryPaths;
 
       if (isPlatform(PlatformType::TYPE_OSX)) {
@@ -533,7 +520,6 @@ std::vector<std::map<std::string, UserPath>> getJavaUserPathList(
 QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
   QueryData results;
   std::set<std::string> paths;
-  logger.log(1, "Generating Java packages for context");
   bool directory_filter = context.constraints.count("directory") > 0 &&
                           context.constraints.at("directory").exists(EQUALS);
 
@@ -541,7 +527,6 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
     paths = context.constraints["directory"].getAll(EQUALS);
   } else {
     for (const auto& path : kJavaPath) {
-        logger.log(1, "Resolving Java path pattern: " + path);
       std::vector<std::string> sites;
       resolveFilePattern(path, sites);
       for (const auto& site : sites) {
@@ -558,7 +543,6 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
   // Enumerate user installed java packages from Maven and Gradle caches
   auto user_paths = getJavaUserPathList(context);
   for (const auto& user_path : user_paths) {
-    logger.log(1, "Generating Java packages for user path: " + user_path.at("path").stringValue);
     const auto& path = user_path.at("path").stringValue;
     const auto& type = user_path.at("type").stringValue;
     
@@ -582,7 +566,6 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
 QueryData genJavaPackages(QueryContext& context) {
    GLOGLogger logger;
   if (hasNamespaceConstraint(context)) {
-    logger.log(1, "Generating Java packages in namespace");
     return generateInNamespace(
         context, "java_packages", genJavaPackagesImpl);
   } else {

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -10,6 +10,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
+#include <algorithm>
 #include <stdlib.h>
 #include <string>
 
@@ -190,19 +191,19 @@ std::string extractAuthorFromPom(const std::string& content) {
   return fallbackAuthor;
 }
 
-void genMavenPackage(const std::string& groupPath,
+void genMavenPackage(const std::string& versionPath,
+                     const std::string& groupId,
                      const std::string& artifactId,
                      const std::string& version,
                      Row& r,
                      Logger& logger) {
   // Maven repository structure: groupId/artifactId/version/
-  r["name"] = artifactId;
+  r["name"] = groupId + ":" + artifactId;
   r["version"] = version;
   r["type"] = "Maven";
 
   // Try to find and parse POM file for additional metadata
-  auto pomPath = groupPath + "/" + artifactId + "/" + version + "/" +
-                 artifactId + "-" + version + ".pom";
+  auto pomPath = versionPath + "/" + artifactId + "-" + version + ".pom";
 
   std::string content;
   auto s = readFile(pomPath, content);
@@ -228,6 +229,63 @@ void genMavenPackage(const std::string& groupPath,
     if (!author.empty()) {
       r["author"] = author;
     }
+  }
+}
+
+std::string getMavenGroupId(const std::string& repoPath,
+                            const std::string& groupPath) {
+  auto relativePath = groupPath;
+
+  if (groupPath.compare(0, repoPath.size(), repoPath) == 0) {
+    relativePath = groupPath.substr(repoPath.size());
+  }
+
+  boost::algorithm::trim_if(relativePath, boost::is_any_of("/\\"));
+  if (relativePath.empty()) {
+    return "";
+  }
+
+  std::replace(relativePath.begin(), relativePath.end(), '/', '.');
+  std::replace(relativePath.begin(), relativePath.end(), '\\', '.');
+  return relativePath;
+}
+
+void genMavenArtifactsRecursive(const std::string& repoPath,
+                                const std::string& currentPath,
+                                QueryData& results,
+                                Logger& logger,
+                                const std::int64_t& user_id) {
+  std::vector<std::string> childDirs;
+  if (!listDirectoriesInDirectory(currentPath, childDirs, false).ok()) {
+    return;
+  }
+
+  for (const auto& childDir : childDirs) {
+    if (!isDirectory(childDir).ok()) {
+      continue;
+    }
+
+    const auto artifactId = fs::path(currentPath).filename().string();
+    const auto version = fs::path(childDir).filename().string();
+    const auto pomPath = childDir + "/" + artifactId + "-" + version + ".pom";
+
+    // If a directory contains artifactId-version.pom, treat it as a version
+    // directory under groupId/artifactId/version.
+    if (pathExists(pomPath).ok()) {
+      Row r;
+      const auto groupPath = fs::path(currentPath).parent_path().string();
+      const auto groupId = getMavenGroupId(repoPath, groupPath);
+
+      genMavenPackage(childDir, groupId, artifactId, version, r, logger);
+
+      r["directory"] = repoPath;
+      r["path"] = childDir;
+      r["pid_with_namespace"] = "0";
+      r["uid"] = BIGINT(user_id);
+      results.push_back(r);
+    }
+
+    genMavenArtifactsRecursive(repoPath, childDir, results, logger, user_id);
   }
 }
 
@@ -331,52 +389,11 @@ void genMavenArtifacts(const std::string& repoPath,
                        QueryData& results,
                        Logger& logger,
                        const std::int64_t& user_id) {
-  // Maven repository structure: groupId/artifactId/version/
-  std::vector<std::string> groupDirs;
-
-  if (!listDirectoriesInDirectory(repoPath, groupDirs, false).ok()) {
+  if (!isDirectory(repoPath).ok()) {
     return;
   }
 
-  for (const auto& groupDir : groupDirs) {
-    if (!isDirectory(groupDir).ok()) {
-      continue;
-    }
-
-    std::vector<std::string> artifactDirs;
-    if (!listDirectoriesInDirectory(groupDir, artifactDirs, false).ok()) {
-      continue;
-    }
-
-    for (const auto& artifactDir : artifactDirs) {
-      if (!isDirectory(artifactDir).ok()) {
-        continue;
-      }
-
-      std::vector<std::string> versionDirs;
-      if (!listDirectoriesInDirectory(artifactDir, versionDirs, false).ok()) {
-        continue;
-      }
-
-      for (const auto& versionDir : versionDirs) {
-        if (!isDirectory(versionDir).ok()) {
-          continue;
-        }
-
-        Row r;
-        auto artifactId = fs::path(artifactDir).filename().string();
-        auto version = fs::path(versionDir).filename().string();
-
-        genMavenPackage(groupDir, artifactId, version, r, logger);
-
-        r["directory"] = repoPath;
-        r["path"] = versionDir;
-        r["pid_with_namespace"] = "0";
-        r["uid"] = BIGINT(user_id);
-        results.push_back(r);
-      }
-    }
-  }
+  genMavenArtifactsRecursive(repoPath, repoPath, results, logger, user_id);
 }
 
 void genGradleArtifacts(const std::string& cachePath,
@@ -475,7 +492,6 @@ std::vector<std::map<std::string, UserPath>> getJavaUserPathList(
     const auto& uid_as_string = user.at("uid");
     auto uid_as_big_int = tryTo<int64_t>(uid_as_string, 10);
     if (uid_as_big_int.isError()) {
-      LOG(ERROR) << "Invalid uid field returned: " << uid_as_string;
       continue;
     }
     const auto& path = user.at("directory");

--- a/osquery/tables/system/java_packages.cpp
+++ b/osquery/tables/system/java_packages.cpp
@@ -27,10 +27,6 @@
 #include <osquery/worker/ipc/platform_table_container_ipc.h>
 #include <osquery/worker/logging/glog/glog_logger.h>
 
-#ifdef WIN32
-#include "windows/registry.h"
-#endif
-
 namespace fs = boost::filesystem;
 
 namespace osquery {
@@ -71,13 +67,8 @@ struct UserPath {
       : type(Type::String), stringValue(std::move(value)) {}
 };
 
-std::string extractAuthorFromPom(const std::string& content) {
+std::string extractAuthorFromPom(const boost::property_tree::ptree& pt) {
   try {
-    // Parse the XML content into a property tree
-    boost::property_tree::ptree pt;
-    std::istringstream stream(content);
-    boost::property_tree::read_xml(stream, pt);
-
     std::string fallbackAuthor;
 
     // Navigate to the developers section
@@ -134,11 +125,8 @@ std::string extractAuthorFromPom(const std::string& content) {
     }
 
     return fallbackAuthor;
-  } catch (const boost::property_tree::xml_parser_error& e) {
-    // Failed to parse XML, return empty string
-    return "";
   } catch (const std::exception& e) {
-    // Other errors, return empty string
+    // Error accessing ptree, return empty string
     return "";
   }
 }
@@ -160,26 +148,34 @@ void genMavenPackage(const std::string& versionPath,
   std::string content;
   auto s = readFile(pomPath, content);
   if (s.ok()) {
-    // Extract basic info from POM (simplified parsing)
-    // In a real implementation, you'd use an XML parser
-    size_t descStart = content.find("<description>");
-    size_t descEnd = content.find("</description>");
-    if (descStart != std::string::npos && descEnd != std::string::npos) {
-      descStart += 13; // length of "<description>"
-      r["summary"] = content.substr(descStart, descEnd - descStart);
-    }
+    try {
+      // Parse the XML content using Boost::PropertyTree
+      boost::property_tree::ptree pt;
+      std::istringstream stream(content);
+      boost::property_tree::read_xml(stream, pt);
 
-    size_t licenseStart = content.find("<name>", content.find("<license>"));
-    size_t licenseEnd = content.find("</name>", licenseStart);
-    if (licenseStart != std::string::npos && licenseEnd != std::string::npos) {
-      licenseStart += 6; // length of "<name>"
-      r["license"] = content.substr(licenseStart, licenseEnd - licenseStart);
-    }
+      // Extract description
+      auto description = pt.get_optional<std::string>("project.description");
+      if (description) {
+        r["summary"] = *description;
+      }
 
-    // Extract author from developers block
-    std::string author = extractAuthorFromPom(content);
-    if (!author.empty()) {
-      r["author"] = author;
+      // Extract license name
+      auto license =
+          pt.get_optional<std::string>("project.licenses.license.name");
+      if (license) {
+        r["license"] = *license;
+      }
+
+      // Extract author from developers block
+      std::string author = extractAuthorFromPom(pt);
+      if (!author.empty()) {
+        r["author"] = author;
+      }
+    } catch (const boost::property_tree::xml_parser_error& e) {
+      // Failed to parse XML, skip metadata extraction
+    } catch (const std::exception& e) {
+      // Other errors, skip metadata extraction
     }
   }
 }
@@ -260,36 +256,43 @@ void genGradlePackage(const std::string& versionPath,
       if (listFilesInDirectory(hashDir, files, false).ok()) {
         for (const auto& file : files) {
           if (boost::algorithm::ends_with(file, ".pom")) {
-            // Found POM file, parse it for metadata
+            // Found POM file, parse it for metadata using Boost::PropertyTree
             std::string content;
             auto s = readFile(file, content);
             if (s.ok()) {
-              // Extract description
-              size_t descStart = content.find("<description>");
-              size_t descEnd = content.find("</description>");
-              if (descStart != std::string::npos &&
-                  descEnd != std::string::npos) {
-                descStart += 13;
-                r["summary"] = content.substr(descStart, descEnd - descStart);
-              } else {
+              try {
+                // Parse the XML content using Boost::PropertyTree
+                boost::property_tree::ptree pt;
+                std::istringstream stream(content);
+                boost::property_tree::read_xml(stream, pt);
+
+                // Extract description
+                auto description =
+                    pt.get_optional<std::string>("project.description");
+                if (description) {
+                  r["summary"] = *description;
+                } else {
+                  r["summary"] = groupId + ":" + artifactId;
+                }
+
+                // Extract license name
+                auto license = pt.get_optional<std::string>(
+                    "project.licenses.license.name");
+                if (license) {
+                  r["license"] = *license;
+                }
+
+                // Extract author from developers block
+                std::string author = extractAuthorFromPom(pt);
+                if (!author.empty()) {
+                  r["author"] = author;
+                }
+              } catch (const boost::property_tree::xml_parser_error& e) {
+                // Failed to parse XML, use fallback
                 r["summary"] = groupId + ":" + artifactId;
-              }
-
-              // Extract license
-              size_t licenseStart =
-                  content.find("<name>", content.find("<license>"));
-              size_t licenseEnd = content.find("</name>", licenseStart);
-              if (licenseStart != std::string::npos &&
-                  licenseEnd != std::string::npos) {
-                licenseStart += 6;
-                r["license"] =
-                    content.substr(licenseStart, licenseEnd - licenseStart);
-              }
-
-              // Extract author from developers block
-              std::string author = extractAuthorFromPom(content);
-              if (!author.empty()) {
-                r["author"] = author;
+              } catch (const std::exception& e) {
+                // Other errors, use fallback
+                r["summary"] = groupId + ":" + artifactId;
               }
             }
             // Only parse the first POM found
@@ -508,6 +511,20 @@ QueryData genJavaPackagesImpl(QueryContext& context, Logger& logger) {
       for (const auto& site : sites) {
         paths.insert(site);
       }
+    }
+  }
+
+  // Enumerate packages in the specified directories
+  for (const auto& path : paths) {
+    // Determine the type of repository based on the path
+    if (path.find(".m2/repository") != std::string::npos or
+        path.find(".m2\\repository") != std::string::npos) {
+      // Maven repository
+      genMavenArtifacts(path, results, logger, 0);
+    } else if (path.find(".gradle/caches") != std::string::npos or
+               path.find(".gradle\\caches") != std::string::npos) {
+      // Gradle cache
+      genGradleArtifacts(path, results, logger, 0);
     }
   }
 

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -49,6 +49,7 @@ function(generateNativeTables)
     hash.table
     interface_addresses.table
     interface_details.table
+    java_packages.table
     listening_ports.table
     logged_in_users.table
     memory_devices.table

--- a/specs/java_packages.table
+++ b/specs/java_packages.table
@@ -1,5 +1,5 @@
 table_name("java_packages")
-description("Java packages installed in a system. NOTE: when querying on windows, even without a users cross join, all user installed python packages will be returned. This special behavior is to not break original functionality.")
+description("Java artifacts found in local Maven (~/.m2/repository) and Gradle (~/.gradle/caches) caches.")
 schema([
     Column("name", TEXT, "Package display name"),
     Column("uid", BIGINT, "The local user that owns the python package", index=True),

--- a/specs/java_packages.table
+++ b/specs/java_packages.table
@@ -1,0 +1,23 @@
+table_name("java_packages")
+description("Java packages installed in a system. NOTE: when querying on windows, even without a users cross join, all user installed python packages will be returned. This special behavior is to not break original functionality.")
+schema([
+    Column("name", TEXT, "Package display name"),
+    Column("uid", BIGINT, "The local user that owns the python package", index=True),
+    Column("version", TEXT, "Package-supplied version", collate="version"),
+    Column("summary", TEXT, "Package-supplied summary"),
+    Column("author", TEXT, "Optional package author"),
+    Column("license", TEXT, "License under which package is launched"),
+    Column("path", TEXT, "Path at which this module resides"),
+    Column("type", TEXT, "Gradle or Maven"),
+    Column("directory", TEXT, "Directory where Python modules are located", index=True, optimized=True),
+    ForeignKey(column="uid", table="users"),
+])
+extended_schema(LINUX, [
+    Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
+])
+attributes(user_data=True)
+implementation("system/java_packages@genJavaPackages")
+examples([
+    "select * from java_packages where directory='/usr/'",
+    "select * from users cross join python_packages using (uid)"
+])

--- a/specs/java_packages.table
+++ b/specs/java_packages.table
@@ -2,14 +2,14 @@ table_name("java_packages")
 description("Java artifacts found in local Maven (~/.m2/repository) and Gradle (~/.gradle/caches) caches.")
 schema([
     Column("name", TEXT, "Package display name"),
-    Column("uid", BIGINT, "The local user that owns the python package", index=True),
+    Column("uid", BIGINT, "The local user that owns the Java library", index=True),
     Column("version", TEXT, "Package-supplied version", collate="version"),
     Column("summary", TEXT, "Package-supplied summary"),
     Column("author", TEXT, "Optional package author"),
     Column("license", TEXT, "License under which package is launched"),
     Column("path", TEXT, "Path at which this module resides"),
     Column("type", TEXT, "Gradle or Maven"),
-    Column("directory", TEXT, "Directory where Python modules are located", index=True, optimized=True),
+    Column("directory", TEXT, "Directory where Java librairies are located", index=True, optimized=True),
     ForeignKey(column="uid", table="users"),
 ])
 extended_schema(LINUX, [
@@ -19,5 +19,5 @@ attributes(user_data=True)
 implementation("system/java_packages@genJavaPackages")
 examples([
     "select * from java_packages where directory='/usr/'",
-    "select * from users cross join python_packages using (uid)"
+    "select * from users cross join java_packages using (uid)"
 ])

--- a/specs/java_packages.table
+++ b/specs/java_packages.table
@@ -6,10 +6,10 @@ schema([
     Column("version", TEXT, "Package-supplied version", collate="version"),
     Column("summary", TEXT, "Package-supplied summary"),
     Column("author", TEXT, "Optional package author"),
-    Column("license", TEXT, "License under which package is launched"),
+    Column("license", TEXT, "License under which package is licensed"),
     Column("path", TEXT, "Path at which this module resides"),
     Column("type", TEXT, "Gradle or Maven"),
-    Column("directory", TEXT, "Directory where Java librairies are located", index=True, optimized=True),
+    Column("directory", TEXT, "Directory where Java libraries are located", index=True, optimized=True),
     ForeignKey(column="uid", table="users"),
 ])
 extended_schema(LINUX, [
@@ -18,6 +18,5 @@ extended_schema(LINUX, [
 attributes(user_data=True)
 implementation("system/java_packages@genJavaPackages")
 examples([
-    "select * from java_packages where directory='/usr/'",
     "select * from users cross join java_packages using (uid)"
 ])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -48,6 +48,7 @@ function(generateTestsIntegrationTablesTestsTest)
     hash.cpp
     interface_addresses.cpp
     interface_details.cpp
+    java_packages.cpp
     jetbrains_plugins.cpp
     listening_ports.cpp
     logged_in_users.cpp

--- a/tests/integration/tables/java_packages.cpp
+++ b/tests/integration/tables/java_packages.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for java_packages
+// Spec file: specs/java_packages.table
+
+#include <osquery/dispatcher/dispatcher.h>
+#include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
+
+namespace osquery {
+namespace table_tests {
+
+class javaPackages : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
+};
+
+TEST_F(javaPackages, test_sanity) {
+  ValidationMap row_map = {
+      {"name", NormalType},
+      {"uid", IntType},
+      {"version", NormalType},
+      {"summary", NormalType},
+      {"author", NormalType},
+      {"license", NormalType},
+      {"path", NormalType},
+      {"directory", NormalType},
+      {"type", NormalType},
+  };
+
+  auto const data = execute_query("select * from java_packages");
+  ASSERT_FALSE(data.empty());
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/java_packages.cpp
+++ b/tests/integration/tables/java_packages.cpp
@@ -51,7 +51,6 @@ TEST_F(javaPackages, test_sanity) {
   };
 
   auto const data = execute_query("select * from java_packages");
-  ASSERT_FALSE(data.empty());
   validate_rows(data, row_map);
 }
 

--- a/tests/integration/tables/java_packages.cpp
+++ b/tests/integration/tables/java_packages.cpp
@@ -39,14 +39,14 @@ class javaPackages : public testing::Test {
 
 TEST_F(javaPackages, test_sanity) {
   ValidationMap row_map = {
-      {"name", NormalType},
+      {"name", NonEmptyString},
       {"uid", IntType},
       {"version", NormalType},
       {"summary", NormalType},
       {"author", NormalType},
       {"license", NormalType},
-      {"path", NormalType},
-      {"directory", NormalType},
+      {"path", FileOnDisk},
+      {"directory", DirectoryOnDisk},
       {"type", NormalType},
   };
 


### PR DESCRIPTION
New java_packages, in the same vein as python_packages and npm_packages. It will look at the JARs stored in USER_HOME/.m2/repository and USER_HOME/.gradle

I will try to get the author, license and other details from the .pom file of the artefacts. By default, the table won't return anything, since Maven and Gradle caches are usually stored in the user's home directory.

Tested on macOS 26.5.2. I don't have the developer tools required to build and test on Windows.

This is related to #9025