### PR TITLE
Add chrome_search_engines table exposing the default search engine

### DIFF
--- a/osquery/tables/applications/CMakeLists.txt
+++ b/osquery/tables/applications/CMakeLists.txt
@@ -19,6 +19,7 @@ function(generateOsqueryTablesApplications)
   set(source_files
     chrome/chrome_extensions.cpp
     chrome/chrome_extension_content_scripts.cpp
+    chrome/chrome_search_engines.cpp
     chrome/utils.cpp
     browser_firefox.cpp
     jetbrains_plugins.cpp

--- a/osquery/tables/applications/chrome/chrome_search_engines.cpp
+++ b/osquery/tables/applications/chrome/chrome_search_engines.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/tables/applications/chrome/utils.h>
+
+namespace osquery {
+
+namespace tables {
+
+QueryData genChromeSearchEngines(QueryContext& context) {
+  auto profile_list = getChromeProfiles(context);
+
+  QueryData results;
+
+  for (const auto& profile : profile_list) {
+    // Skip profiles that have no default search provider data at all;
+    // there is nothing meaningful to report for them
+    if (!profile.search_engine_name.has_value() &&
+        !profile.search_engine_keyword.has_value() &&
+        !profile.search_engine_url.has_value()) {
+      continue;
+    }
+
+    Row row = {};
+    row["browser_type"] = SQL_TEXT(getChromeBrowserName(profile.type));
+
+    row["uid"] = BIGINT(profile.uid);
+    row["profile"] = SQL_TEXT(profile.name);
+    row["profile_path"] = SQL_TEXT(profile.path);
+
+    row["name"] = SQL_TEXT(profile.search_engine_name.value_or(""));
+    row["keyword"] = SQL_TEXT(profile.search_engine_keyword.value_or(""));
+    row["url"] = SQL_TEXT(profile.search_engine_url.value_or(""));
+
+    results.push_back(std::move(row));
+  }
+
+  return results;
+}
+
+} // namespace tables
+
+} // namespace osquery

--- a/osquery/tables/applications/chrome/tests/utils.cpp
+++ b/osquery/tables/applications/chrome/tests/utils.cpp
@@ -122,6 +122,19 @@ constexpr auto kTestLocalizationFile = R"LOCALIZATION(
 }
 )LOCALIZATION";
 
+constexpr auto kTestProfilePreferencesWithSearchEngine = R"PREFERENCES(
+{
+  "default_search_provider_data": {
+    "template_url_data": {
+      "short_name": "Test Search",
+      "keyword": "test",
+      "url": "https://search.example.com/?q={searchTerms}"
+    }
+  },
+  "profile": { "name": "test" }
+}
+)PREFERENCES";
+
 const std::vector<std::pair<std::string, std::string>>
     kExpectedContentScriptsMatches = {
         {"/js/1.js", "http://*/1*"},
@@ -452,6 +465,49 @@ TEST_F(ChromeUtilsTests, getChromeProfilesFromSnapshotList) {
   const auto& referenced_extension = profile.extension_list.at(1U);
   ASSERT_TRUE(referenced_extension.referenced);
   ASSERT_FALSE(referenced_extension.profile_settings.empty());
+}
+
+TEST_F(ChromeUtilsTests,
+       getChromeProfilesFromSnapshotList_defaultSearchEngine) {
+  ChromeProfileSnapshot snapshot;
+  snapshot.type = ChromeBrowserType::GoogleChrome;
+  snapshot.path = kTestProfilePath;
+  snapshot.preferences = kTestProfilePreferencesWithSearchEngine;
+  snapshot.uid = 1000;
+
+  auto chrome_profile_list = getChromeProfilesFromSnapshotList({snapshot});
+  ASSERT_EQ(chrome_profile_list.size(), 1U);
+
+  const auto& profile = chrome_profile_list.at(0);
+
+  ASSERT_TRUE(profile.search_engine_name.has_value());
+  EXPECT_EQ(*profile.search_engine_name, "Test Search");
+
+  ASSERT_TRUE(profile.search_engine_keyword.has_value());
+  EXPECT_EQ(*profile.search_engine_keyword, "test");
+
+  ASSERT_TRUE(profile.search_engine_url.has_value());
+  EXPECT_EQ(*profile.search_engine_url,
+            "https://search.example.com/?q={searchTerms}");
+}
+
+TEST_F(ChromeUtilsTests, getChromeProfilesFromSnapshotList_noSearchEngine) {
+  // kTestProfilePreferences (used throughout the rest of this file) has no
+  // default_search_provider_data node; make sure the new fields are left
+  // unset in that case rather than defaulting to empty strings.
+  ChromeProfileSnapshot snapshot;
+  snapshot.type = ChromeBrowserType::GoogleChrome;
+  snapshot.path = kTestProfilePath;
+  snapshot.preferences = kTestProfilePreferences;
+  snapshot.uid = 1000;
+
+  auto chrome_profile_list = getChromeProfilesFromSnapshotList({snapshot});
+  ASSERT_EQ(chrome_profile_list.size(), 1U);
+
+  const auto& profile = chrome_profile_list.at(0);
+  EXPECT_FALSE(profile.search_engine_name.has_value());
+  EXPECT_FALSE(profile.search_engine_keyword.has_value());
+  EXPECT_FALSE(profile.search_engine_url.has_value());
 }
 
 TEST_F(ChromeUtilsTests, webkitTimeToUnixTimestamp) {

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -809,6 +809,23 @@ ChromeProfileList getChromeProfilesFromSnapshotList(
       continue;
     }
 
+    // Extract the default search engine settings, if any have been
+    // configured for this profile
+    const auto& opt_search_engine_node =
+        parsed_preferences.get_child_optional(
+            "default_search_provider_data.template_url_data");
+
+    if (opt_search_engine_node) {
+      const auto& search_engine_node = opt_search_engine_node.get();
+
+      profile.search_engine_name =
+          search_engine_node.get_optional<std::string>("short_name");
+      profile.search_engine_keyword =
+          search_engine_node.get_optional<std::string>("keyword");
+      profile.search_engine_url =
+          search_engine_node.get_optional<std::string>("url");
+    }
+
     // Parse all the extensions that are inside the profile folder but are
     // not referenced by the Preferences file
     for (const auto& ext_p : snapshot.unreferenced_extensions) {

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -811,9 +811,8 @@ ChromeProfileList getChromeProfilesFromSnapshotList(
 
     // Extract the default search engine settings, if any have been
     // configured for this profile
-    const auto& opt_search_engine_node =
-        parsed_preferences.get_child_optional(
-            "default_search_provider_data.template_url_data");
+    const auto& opt_search_engine_node = parsed_preferences.get_child_optional(
+        "default_search_provider_data.template_url_data");
 
     if (opt_search_engine_node) {
       const auto& search_engine_node = opt_search_engine_node.get();

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -152,6 +152,16 @@ struct ChromeProfile final {
 
   /// A list of extensions associated with this profile
   ExtensionList extension_list;
+
+  /// The display name of the default search engine, if set
+  boost::optional<std::string> search_engine_name;
+
+  /// The keyword used to trigger the default search engine from the
+  /// address bar, if set
+  boost::optional<std::string> search_engine_keyword;
+
+  /// The URL template used by the default search engine, if set
+  boost::optional<std::string> search_engine_url;
 };
 
 /// A list of Chrome profiles

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -37,6 +37,7 @@ function(generateNativeTables)
     carves.table
     certificates.table
     chrome_extensions.table
+    chrome_search_engines.table
     chrome_extension_content_scripts.table
     curl.table
     curl_certificate.table

--- a/specs/chrome_search_engines.table
+++ b/specs/chrome_search_engines.table
@@ -1,0 +1,21 @@
+table_name("chrome_search_engines")
+description("The configured default search engine for Chrome-based browser profiles.")
+schema([
+    Column("browser_type", TEXT, "The browser type (Valid values: chrome, chrome_beta, chrome_dev, chrome_canary, chromium, opera, yandex, brave, brave_beta, brave_nightly, edge, edge_beta, edge_dev, edge_canary, vivaldi, arc, dia, comet)"),
+    Column("uid", BIGINT, "The local user that owns the profile", index=True, optimized=True),
+    Column("profile", TEXT, "The name of the Chrome profile"),
+    Column("profile_path", TEXT, "The profile path"),
+    Column("name", TEXT, "The display name of the default search engine"),
+    Column("keyword", TEXT, "The keyword used to trigger this search engine from the address bar"),
+    Column("url", TEXT, "The URL template used by this search engine"),
+    ForeignKey(column="uid", table="users"),
+])
+attributes(user_data=True)
+implementation("applications/browser_chrome@genChromeSearchEngines")
+examples([
+    "select * from users join chrome_search_engines using (uid)",
+])
+fuzz_paths([
+    "/Library/Application Support/Google/Chrome/",
+    "/Users",
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -36,6 +36,7 @@ function(generateTestsIntegrationTablesTestsTest)
     carves.cpp
     certificates.cpp
     chrome_extensions.cpp
+    chrome_search_engines.cpp
     curl.cpp
     curl_certificate.cpp
     etc_hosts.cpp

--- a/tests/integration/tables/chrome_search_engines.cpp
+++ b/tests/integration/tables/chrome_search_engines.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for chrome_search_engines
+// Spec file: specs/chrome_search_engines.table
+
+#include <osquery/dispatcher/dispatcher.h>
+#include <osquery/tests/integration/tables/helper.h>
+#include <osquery/tests/test_util.h>
+
+namespace osquery {
+namespace table_tests {
+
+class chromeSearchEngines : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+
+#ifdef OSQUERY_WINDOWS
+  static void SetUpTestSuite() {
+    initUsersAndGroupsServices(true, false);
+  }
+
+  static void TearDownTestSuite() {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+    deinitUsersAndGroupsServices(true, false);
+    Dispatcher::instance().resetStopping();
+  }
+#endif
+};
+
+TEST_F(chromeSearchEngines, test_sanity) {
+  auto const data = execute_query("select * from chrome_search_engines");
+
+  ASSERT_GE(data.size(), 0ul);
+  ValidationMap row_map = {{"browser_type", NormalType},
+                           {"uid", IntType},
+                           {"profile", NormalType},
+                           {"profile_path", NormalType},
+                           {"name", NormalType},
+                           {"keyword", NormalType},
+                           {"url", NormalType}};
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery

--- a/tests/integration/tables/chrome_search_engines.cpp
+++ b/tests/integration/tables/chrome_search_engines.cpp
@@ -41,13 +41,13 @@ TEST_F(chromeSearchEngines, test_sanity) {
   auto const data = execute_query("select * from chrome_search_engines");
 
   ASSERT_GE(data.size(), 0ul);
-  ValidationMap row_map = {{"browser_type", NormalType},
+  ValidationMap row_map = {{"browser_type", NonEmptyString},
                            {"uid", IntType},
-                           {"profile", NormalType},
-                           {"profile_path", NormalType},
-                           {"name", NormalType},
-                           {"keyword", NormalType},
-                           {"url", NormalType}};
+                           {"profile", NonEmptyString},
+                           {"profile_path", FileOnDisk},
+                           {"name", NonEmptyString},
+                           {"keyword", NonEmptyString},
+                           {"url", NonEmptyString}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
Adds a new virtual table, chrome_search_engines, that surfaces the configured default search engine (name, keyword, URL template) for each profile of Chrome-family browsers (Chrome, Brave, Chromium, Opera, Yandex, Edge, Vivaldi, etc).

The default search provider is stored in each profile's Preferences JSON file under default_search_provider_data.template_url_data, alongside the extension data chrome_extensions already parses. This reuses that existing profile-discovery and Preferences-parsing infrastructure in utils.cpp/utils.h rather than duplicating it.

Firefox and Safari are intentionally out of scope for this PR: Firefox stores this in a differently-formatted, LZ4-compressed file, and Safari uses a plist-based subsystem entirely. Both would need separate follow-up work.

Fixes #8750

- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.