### PR TITLE
Docs: change macOS build steps to recommend Python venv

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -74,7 +74,7 @@ cd osquery
 
 # Optional: install Python test prerequisites
 # Homebrew Python uses an externally managed environment, so install these in a virtualenv
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -80,7 +80,7 @@ pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0
 
 # Configure
 mkdir build; cd build
-cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) ..
+cmake ..
 
 # Build
 cmake --build . -j $(sysctl -n hw.ncpu)

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -63,9 +63,6 @@ Then do the following.
 # Install prerequisites
 xcode-select --install
 brew install ccache git git-lfs cmake python clang-format flex bison
-
-# Optional: install python tests prerequisites
-pip3 install --user setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
 ```
 
 ### Step 2: Download and build source on macOS
@@ -75,9 +72,16 @@ pip3 install --user setuptools pexpect==3.3 psutil timeout_decorator six thrift=
 git clone https://github.com/osquery/osquery
 cd osquery
 
+# Optional: install python tests prerequisites
+# Creating a Python virtual env is needed, 
+# because Python installed by Homebrew don't allow package installations without a venv
+python -m venv .venv
+source .venv/bin/activate
+pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
+
 # Configure
 mkdir build; cd build
-cmake ..
+cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) ..
 
 # Build
 cmake --build . -j $(sysctl -n hw.ncpu)

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -72,9 +72,8 @@ brew install ccache git git-lfs cmake python clang-format flex bison
 git clone https://github.com/osquery/osquery
 cd osquery
 
-# Optional: install python tests prerequisites
-# Creating a Python virtual env is needed, 
-# because Python installed by Homebrew don't allow package installations without a venv
+# Optional: install Python test prerequisites
+# Homebrew Python uses an externally managed environment, so install these in a virtualenv
 python -m venv .venv
 source .venv/bin/activate
 pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery


### PR DESCRIPTION
Python installed by Homebrew don't allow modules installation by a global pip3 exec anymore. It will results with:

```
➜  pip3 install setuptools pexpect==3.3 psutil timeout_decorator six thrift==0.11.0 osquery
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
```

Simpliest and cleanest solution is to create a Python virtual env.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [X] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [X] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [X] Ensure your PR contains a single logical change.
- [X] Ensure your PR contains tests for the changes you're submitting.
- [X] Describe your changes with as much detail as you can.
- [X] Link any issues this PR is related to.
- [X] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
