### PR TITLE
Add a pacman_packages table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -72,6 +72,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/model_specific_register.cpp
       linux/mounts.cpp
       linux/os_version.cpp
+      linux/pacman_packages.cpp
       linux/pci_devices.cpp
       linux/portage.cpp
       linux/process_open_files.cpp

--- a/osquery/tables/system/linux/pacman_packages.cpp
+++ b/osquery/tables/system/linux/pacman_packages.cpp
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/filesystem/path.hpp>
+
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/join.h>
+#include <osquery/utils/conversions/split.h>
+
+namespace osquery {
+namespace tables {
+
+/// Default pacman database path, matching pacman's own default DBPath.
+const std::string kPacmanDbPath{"/var/lib/pacman"};
+
+/// Installed packages are recorded in this subdirectory of the database path.
+const std::string kPacmanLocalDir{"local"};
+
+/// Metadata for an installed package is stored in this file.
+const std::string kPacmanDescFile{"desc"};
+
+/// Separator used to flatten fields that may hold more than one value.
+const std::string kPacmanValueSeparator{","};
+
+/// Maps a key in a local database 'desc' file to the column it populates.
+const std::unordered_map<std::string, std::string> kPacmanDescColumns = {
+    {"%NAME%", "name"},
+    {"%VERSION%", "version"},
+    {"%BASE%", "source"},
+    {"%DESC%", "description"},
+    {"%URL%", "url"},
+    {"%LICENSE%", "licenses"},
+    {"%GROUPS%", "groups"},
+    {"%ARCH%", "arch"},
+    {"%SIZE%", "size"},
+    {"%PACKAGER%", "packager"},
+    {"%BUILDDATE%", "build_time"},
+    {"%INSTALLDATE%", "install_time"},
+    {"%VALIDATION%", "validation"},
+};
+
+/// Fields libalpm reads as a list. Every other field holds a single value.
+const std::unordered_set<std::string> kPacmanDescListFields = {
+    "%LICENSE%",
+    "%GROUPS%",
+    "%VALIDATION%",
+};
+
+/**
+ * @brief Determine whether a 'desc' file line introduces a new field.
+ *
+ * Keys are written as the field name wrapped in '%', for example '%NAME%'.
+ * Any line of that shape starts a new field, including keys this table does
+ * not map to a column, so that a database written by a newer pacman is still
+ * parsed correctly rather than having unrecognized values folded into the
+ * preceding field.
+ */
+static inline bool isPacmanDescKey(const std::string& line) {
+  return line.size() > 2 && line.front() == '%' && line.back() == '%';
+}
+
+/**
+ * @brief Translate a '%REASON%' value into the install_reason column.
+ *
+ * libalpm records '0' for a package the user asked for and '1' for one pulled
+ * in to satisfy a dependency. The field is omitted for explicitly installed
+ * packages in practice, and libalpm treats a missing value as explicit, so
+ * that is the default applied by the caller.
+ */
+static std::string pacmanInstallReason(const std::string& reason) {
+  if (reason == "0") {
+    return "explicit";
+  } else if (reason == "1") {
+    return "dependency";
+  }
+
+  return "";
+}
+
+/**
+ * @brief Parse the contents of a local database 'desc' file into a Row.
+ *
+ * The file is a sequence of keys, each followed by its value lines. A field
+ * runs until the next key, which tolerates an entry written without the blank
+ * line that libalpm uses to end a list. Fields libalpm reads as a list are
+ * flattened into a comma separated value; every other field takes only its
+ * first line, so a column never holds a joined value where one was not
+ * intended.
+ *
+ * A Row without a 'name' is returned when the file does not describe a usable
+ * package, which happens for a database entry left incomplete by an
+ * interrupted transaction.
+ */
+Row parsePacmanDesc(const std::string& content) {
+  std::unordered_map<std::string, std::vector<std::string>> fields;
+  std::string key;
+
+  // Each line arrives trimmed, so a key is matched exactly and values have no
+  // surrounding whitespace. A line holding only whitespace, which is what a
+  // blank line written with CRLF endings becomes, trims away to nothing and
+  // carries no value.
+  for (const auto& line : osquery::split(content, "\n")) {
+    if (line.empty()) {
+      continue;
+    } else if (isPacmanDescKey(line)) {
+      key = line;
+    } else if (!key.empty()) {
+      fields[key].push_back(line);
+    }
+  }
+
+  Row r;
+  if (fields.count("%NAME%") == 0) {
+    return r;
+  }
+
+  for (const auto& field : fields) {
+    const auto& column = kPacmanDescColumns.find(field.first);
+    if (column == kPacmanDescColumns.end() || field.second.empty()) {
+      continue;
+    }
+
+    if (kPacmanDescListFields.count(field.first) > 0) {
+      r[column->second] = osquery::join(field.second, kPacmanValueSeparator);
+    } else {
+      r[column->second] = field.second.front();
+    }
+  }
+
+  // A package the user requested has no recorded reason, so report the value
+  // libalpm would infer. An unrecognized reason is left empty rather than
+  // guessed at.
+  auto reason = fields.find("%REASON%");
+  if (reason == fields.end()) {
+    r["install_reason"] = "explicit";
+  } else if (!reason->second.empty()) {
+    r["install_reason"] = pacmanInstallReason(reason->second.front());
+  }
+
+  // Packages that install no files of their own, such as the 'base' group
+  // metapackage, record no size. libalpm reports these as zero.
+  if (r.count("size") == 0) {
+    r["size"] = "0";
+  }
+
+  return r;
+}
+
+QueryData genPacmanPackages(QueryContext& context) {
+  QueryData results;
+
+  std::vector<std::string> dbpaths;
+  if (context.hasConstraint("dbpath", EQUALS)) {
+    for (const auto& dbpath : context.constraints["dbpath"].getAll(EQUALS)) {
+      dbpaths.push_back(dbpath);
+    }
+  } else {
+    dbpaths.push_back(kPacmanDbPath);
+  }
+
+  for (const auto& dbpath : dbpaths) {
+    const auto local_dir = boost::filesystem::path(dbpath) / kPacmanLocalDir;
+    if (!isDirectory(local_dir.string()).ok()) {
+      // Not a pacman based system, or a database path that does not exist.
+      continue;
+    }
+
+    // Every installed package is a directory here. The database also holds a
+    // version file alongside them, which resolving only folders skips.
+    std::vector<std::string> package_dirs;
+    if (!resolveFilePattern((local_dir / kSQLGlobWildcard).string(),
+                            package_dirs,
+                            GLOB_FOLDERS)
+             .ok()) {
+      VLOG(1) << "Could not list the pacman local database: "
+              << local_dir.string();
+      continue;
+    }
+
+    for (const auto& package_dir : package_dirs) {
+      std::string content;
+      const auto desc_path =
+          boost::filesystem::path(package_dir) / kPacmanDescFile;
+      if (!readFile(desc_path.string(), content).ok()) {
+        // An entry without metadata cannot describe an installed package.
+        continue;
+      }
+
+      auto r = parsePacmanDesc(content);
+      if (r.count("name") == 0) {
+        VLOG(1) << "Skipping malformed pacman database entry: " << package_dir;
+        continue;
+      }
+
+      r["dbpath"] = dbpath;
+      results.push_back(std::move(r));
+    }
+  }
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ function(generateOsqueryTablesSystemLinuxTests)
     linux/apt_sources_tests.cpp
     linux/extended_attributes_tests.cpp
     linux/md_tables_tests.cpp
+    linux/pacman_packages_tests.cpp
     linux/pci_devices_tests.cpp
     linux/pcidb_tests.cpp
     linux/portage_tests.cpp

--- a/osquery/tables/system/tests/linux/pacman_packages_tests.cpp
+++ b/osquery/tables/system/tests/linux/pacman_packages_tests.cpp
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/core/tables.h>
+
+namespace osquery {
+namespace tables {
+
+Row parsePacmanDesc(const std::string& content);
+
+class PacmanPackagesTests : public testing::Test {};
+
+TEST_F(PacmanPackagesTests, parses_a_complete_entry) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "gvfs\n"
+      "\n"
+      "%VERSION%\n"
+      "1.60.1-1\n"
+      "\n"
+      "%BASE%\n"
+      "gvfs\n"
+      "\n"
+      "%DESC%\n"
+      "Virtual filesystem implementation for GIO\n"
+      "\n"
+      "%URL%\n"
+      "https://gitlab.gnome.org/GNOME/gvfs\n"
+      "\n"
+      "%ARCH%\n"
+      "x86_64\n"
+      "\n"
+      "%BUILDDATE%\n"
+      "1782428050\n"
+      "\n"
+      "%INSTALLDATE%\n"
+      "1784305014\n"
+      "\n"
+      "%PACKAGER%\n"
+      "Jan Alexander Steffens (heftig) <heftig@archlinux.org>\n"
+      "\n"
+      "%SIZE%\n"
+      "5504179\n"
+      "\n"
+      "%REASON%\n"
+      "1\n"
+      "\n"
+      "%GROUPS%\n"
+      "gnome\n"
+      "\n"
+      "%LICENSE%\n"
+      "LGPL-2.0-only\n"
+      "\n"
+      "%VALIDATION%\n"
+      "pgp\n");
+
+  EXPECT_EQ(r["name"], "gvfs");
+  EXPECT_EQ(r["version"], "1.60.1-1");
+  EXPECT_EQ(r["source"], "gvfs");
+  EXPECT_EQ(r["description"], "Virtual filesystem implementation for GIO");
+  EXPECT_EQ(r["url"], "https://gitlab.gnome.org/GNOME/gvfs");
+  EXPECT_EQ(r["arch"], "x86_64");
+  EXPECT_EQ(r["build_time"], "1782428050");
+  EXPECT_EQ(r["install_time"], "1784305014");
+  EXPECT_EQ(r["packager"],
+            "Jan Alexander Steffens (heftig) <heftig@archlinux.org>");
+  EXPECT_EQ(r["size"], "5504179");
+  EXPECT_EQ(r["install_reason"], "dependency");
+  EXPECT_EQ(r["groups"], "gnome");
+  EXPECT_EQ(r["licenses"], "LGPL-2.0-only");
+  EXPECT_EQ(r["validation"], "pgp");
+}
+
+TEST_F(PacmanPackagesTests, joins_fields_holding_several_values) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%LICENSE%\n"
+      "GPL2\n"
+      "custom\n"
+      "\n"
+      "%VALIDATION%\n"
+      "sha256\n"
+      "pgp\n"
+      "\n"
+      "%GROUPS%\n"
+      "base-devel\n"
+      "gnome\n");
+
+  EXPECT_EQ(r["licenses"], "GPL2,custom");
+  EXPECT_EQ(r["validation"], "sha256,pgp");
+  EXPECT_EQ(r["groups"], "base-devel,gnome");
+}
+
+TEST_F(PacmanPackagesTests, takes_only_the_first_line_of_a_single_value_field) {
+  // libalpm reads one line for these fields. Joining extra lines would put a
+  // list into a column that is meant to hold a single, and here numeric, value.
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%SIZE%\n"
+      "123\n"
+      "456\n"
+      "\n"
+      "%DESC%\n"
+      "first line\n"
+      "second line\n");
+
+  EXPECT_EQ(r["size"], "123");
+  EXPECT_EQ(r["description"], "first line");
+}
+
+TEST_F(PacmanPackagesTests, a_missing_reason_means_explicitly_installed) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%VERSION%\n"
+      "1.0-1\n");
+
+  EXPECT_EQ(r["install_reason"], "explicit");
+}
+
+TEST_F(PacmanPackagesTests, a_recorded_reason_of_zero_is_explicit) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%REASON%\n"
+      "0\n");
+
+  EXPECT_EQ(r["install_reason"], "explicit");
+}
+
+TEST_F(PacmanPackagesTests, an_unrecognized_reason_is_left_empty) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%REASON%\n"
+      "7\n");
+
+  EXPECT_EQ(r["name"], "example");
+  EXPECT_EQ(r["install_reason"], "");
+}
+
+TEST_F(PacmanPackagesTests, keeps_an_epoch_in_the_version) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%VERSION%\n"
+      "2:2.4.19-1\n");
+
+  EXPECT_EQ(r["version"], "2:2.4.19-1");
+}
+
+TEST_F(PacmanPackagesTests, reports_a_missing_size_as_zero) {
+  // Metapackages such as 'base' install no files and record no size, which
+  // libalpm reports as zero.
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "base\n"
+      "\n"
+      "%VERSION%\n"
+      "3-3\n");
+
+  EXPECT_EQ(r["name"], "base");
+  EXPECT_EQ(r["size"], "0");
+}
+
+TEST_F(PacmanPackagesTests, skips_keys_that_are_not_mapped_to_a_column) {
+  // A field this table does not expose must not have its values folded into
+  // whichever field happens to follow it.
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%DEPENDS%\n"
+      "glibc\n"
+      "libgcc\n"
+      "\n"
+      "%XDATA%\n"
+      "pkgtype=pkg\n"
+      "\n"
+      "%ARCH%\n"
+      "x86_64\n");
+
+  EXPECT_EQ(r["name"], "example");
+  EXPECT_EQ(r["arch"], "x86_64");
+  EXPECT_EQ(r.count("depends"), 0U);
+  EXPECT_EQ(r.count("xdata"), 0U);
+}
+
+TEST_F(PacmanPackagesTests, skips_an_unknown_key_from_a_newer_database) {
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "\n"
+      "%SOMETHINGNEW%\n"
+      "surprising\n"
+      "\n"
+      "%VERSION%\n"
+      "1.0-1\n");
+
+  EXPECT_EQ(r["name"], "example");
+  EXPECT_EQ(r["version"], "1.0-1");
+}
+
+TEST_F(PacmanPackagesTests, parses_an_entry_without_blank_separators) {
+  // libalpm ends a list at a blank line. Reading a field up to the next key
+  // instead gives the same result for the entries pacman writes, and still
+  // parses one that was written without the usual blank line between fields.
+  auto r = parsePacmanDesc(
+      "%NAME%\n"
+      "example\n"
+      "%VERSION%\n"
+      "1.0-1\n"
+      "%ARCH%\n"
+      "any\n");
+
+  EXPECT_EQ(r["name"], "example");
+  EXPECT_EQ(r["version"], "1.0-1");
+  EXPECT_EQ(r["arch"], "any");
+}
+
+TEST_F(PacmanPackagesTests, ignores_lines_holding_only_whitespace) {
+  // A blank line written with CRLF endings reaches the parser as whitespace
+  // and must not be recorded as an additional value for the current field.
+  auto r = parsePacmanDesc(
+      "%NAME%\r\n"
+      "example\r\n"
+      "\r\n"
+      "%VERSION%\r\n"
+      "1.0-1\r\n");
+
+  EXPECT_EQ(r["name"], "example");
+  EXPECT_EQ(r["version"], "1.0-1");
+}
+
+TEST_F(PacmanPackagesTests,
+       returns_nothing_useful_for_an_entry_without_a_name) {
+  // An interrupted transaction can leave a database entry behind that does not
+  // describe an installed package.
+  auto r = parsePacmanDesc(
+      "%VERSION%\n"
+      "1.0-1\n");
+
+  EXPECT_EQ(r.count("name"), 0U);
+}
+
+TEST_F(PacmanPackagesTests, returns_nothing_useful_for_empty_content) {
+  auto r = parsePacmanDesc("");
+
+  EXPECT_EQ(r.count("name"), 0U);
+}
+
+TEST_F(PacmanPackagesTests, ignores_values_before_any_key) {
+  auto r = parsePacmanDesc(
+      "stray\n"
+      "%NAME%\n"
+      "example\n");
+
+  EXPECT_EQ(r["name"], "example");
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -181,6 +181,7 @@ function(generateNativeTables)
     "linux/md_drives.table:linux"
     "linux/md_personalities.table:linux"
     "linux/msr.table:linux"
+    "linux/pacman_packages.table:linux"
     "linux/portage_keywords.table:linux"
     "linux/portage_packages.table:linux"
     "linux/portage_use.table:linux"

--- a/specs/linux/pacman_packages.table
+++ b/specs/linux/pacman_packages.table
@@ -1,0 +1,24 @@
+table_name("pacman_packages")
+description("Packages installed by the pacman package manager.")
+schema([
+    Column("name", TEXT, "Package name", index=True, optimized=True),
+    Column("version", TEXT, "Package version, including epoch and release", collate="version"),
+    Column("source", TEXT, "Name of the base package this package was built from"),
+    Column("description", TEXT, "Package description"),
+    Column("url", TEXT, "Upstream project URL"),
+    Column("licenses", TEXT, "Comma separated list of licenses"),
+    Column("groups", TEXT, "Comma separated list of groups the package belongs to"),
+    Column("arch", TEXT, "Package architecture"),
+    Column("size", BIGINT, "Installed size of the package in bytes"),
+    Column("packager", TEXT, "Person or process that built the package"),
+    Column("build_time", BIGINT, "Unix time when the package was built"),
+    Column("install_time", BIGINT, "Unix time when the package was installed"),
+    Column("install_reason", TEXT, "Either 'explicit' if the package was installed directly, or 'dependency' if it was installed to satisfy another package"),
+    Column("validation", TEXT, "Comma separated list of methods used to validate the package, for example 'sha256' or 'pgp'"),
+    Column("dbpath", TEXT, "pacman database path. The installed packages are read from the 'local' subdirectory. Defaults to /var/lib/pacman", additional=True, optimized=True),
+])
+attributes(cacheable=True)
+implementation("system/pacman_packages@genPacmanPackages")
+fuzz_paths([
+    "/var/lib/pacman",
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -172,6 +172,7 @@ function(generateTestsIntegrationTablesTestsTest)
       memory_info.cpp
       memory_map.cpp
       msr.cpp
+      pacman_packages.cpp
       portage_keywords.cpp
       portage_packages.cpp
       portage_use.cpp

--- a/tests/integration/tables/pacman_packages.cpp
+++ b/tests/integration/tables/pacman_packages.cpp
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for pacman_packages
+// Spec file: specs/linux/pacman_packages.table
+
+#include <unordered_set>
+
+#include <osquery/logger/logger.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class PacmanPackages : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(PacmanPackages, test_sanity) {
+  QueryData rows = execute_query("select * from pacman_packages");
+  if (rows.size() > 0) {
+    ValidationMap row_map = {
+        {"name", NonEmptyString},
+        {"version", NonEmptyString},
+        {"source", NormalType},
+        {"description", NormalType},
+        {"url", NormalType},
+        {"licenses", NormalType},
+        {"groups", NormalType},
+        {"arch", NonEmptyString},
+        {"size", NonNegativeInt},
+        {"packager", NormalType},
+        {"build_time", NonNegativeInt},
+        {"install_time", NonNegativeInt},
+        {"install_reason", NormalType},
+        {"validation", NormalType},
+        {"dbpath", NonEmptyString},
+    };
+
+    validate_rows(rows, row_map);
+
+    // pacman manages its own package, so a database that reports anything at
+    // all reports this.
+    auto all_packages = std::unordered_set<std::string>{};
+    for (const auto& row : rows) {
+      all_packages.insert(row.at("name"));
+    }
+
+    ASSERT_EQ(all_packages.count("pacman"), 1u);
+  } else {
+    LOG(WARNING) << "Empty results of query from 'pacman_packages', assume "
+                    "there is no pacman in the system";
+  }
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
Adds a `pacman_packages` table so Arch and its derivatives get a software inventory like `deb_packages` and `rpm_packages`. Closes #6477.

**One thing I'd like a call on before anyone reviews the details:** this parses the `desc` files under the pacman database path rather than using libalpm. But osquery vendors libdpkg and librpm for the deb/rpm equivalents, so file parsing may be the wrong instinct. Would you rather this match that pattern?

Vendoring libalpm looks feasible without new third-party deps — libarchive and openssl are already available, and curl/gpgme are only needed for downloading, not reading a local DB. It'd add a submodule and a CMake wrapper. In exchange it gets vercmp (so a real `version_pacman` collation instead of the generic one), reverse dependencies, and the ability to distinguish AUR-built packages from official repo ones — which parsing the local DB can't do, since the repo isn't recorded there. Swapping it in would mostly just replace the parser, so I'm happy either way.

FWIW the last attempt failed on the dependency route rather than the feature: @anatol's patch shipped in Arch's package through 4.6.0 but linked *system* libalpm inside a devendorizing patch, so it was dropped at 5.0.1 when the package moved to the vendored static build (#6286). A properly vendored libalpm wouldn't have that problem.

### As it stands

Columns are in the spec. Choices worth calling out:

- `source` for `%BASE%`, matching what deb/rpm call the same thing.
- Integer `install_time`/`build_time`, so date functions work.
- `install_reason` as `explicit`/`dependency`. pacman omits `%REASON%` for explicit installs and libalpm treats absent as explicit.
- `dbpath` as a constraint, since it's configurable in `pacman.conf`. Also makes chroots and container images queryable.
- Gated on the database directory existing rather than the os-release ID, so derivatives work without listing them.

### Testing

Built on Arch with the 1.2.0 toolchain, `OSQUERY_BUILD_TESTS=ON`. 15 unit tests on the parser, plus an integration test that no-ops where there's no pacman database. Diffed all 1133 rows on my machine against `expac`: they match libalpm's own output on every field both expose, and `install_reason` totals match `pacman -Qd`/`-Qe`.

Also: should this carry `pid_with_namespace`/`mount_namespace_id` like deb/rpm, or is following `portage_packages` without them fine to start?