### PR TITLE
Split the sudoers header on the first unescaped whitespace

### DIFF
--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -35,6 +35,25 @@ const std::string kSudoWhitespaceChars = "\t\v ";
 // sudoers(5): No more than 128 files are allowed to be nested.
 static const unsigned int kMaxNest = 128;
 
+// sudoers(5): an unquoted user or group name escapes spaces and other special
+// characters with a backslash, so the first whitespace character on a line is
+// not necessarily the end of the header.
+static std::string::size_type findHeaderEnd(const std::string& line) {
+  for (std::string::size_type i = 0; i < line.size(); ++i) {
+    if (line[i] == '\\') {
+      // Skip whatever the backslash escapes, including another backslash.
+      ++i;
+      continue;
+    }
+
+    if (kSudoWhitespaceChars.find(line[i]) != std::string::npos) {
+      return i;
+    }
+  }
+
+  return std::string::npos;
+}
+
 void genSudoersFile(const std::string& filename,
                     unsigned int level,
                     QueryData& results) {
@@ -78,7 +97,7 @@ void genSudoersFile(const std::string& filename,
     }
 
     // Find the rule header
-    auto header_len = line.find_first_of(kSudoWhitespaceChars);
+    auto header_len = findHeaderEnd(line);
     auto header = line.substr(0, header_len);
     boost::trim_if(header, boost::is_any_of(kSudoWhitespaceChars));
 

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -220,5 +220,47 @@ TEST_F(SudoersTests, long_line) {
   EXPECT_EQ(results[4].at("rule_details"), "ALL=(ALL)CMDS_1");
 }
 
+TEST_F(SudoersTests, escaped_space_in_header) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_file = directory / fs::path("sudoers");
+
+  {
+    auto fout = std::ofstream(sudoers_file.native());
+    // sudoers(5): unquoted user and group names escape spaces with a backslash
+    fout << "%Domain\\ Users ALL=(ALL:ALL) ALL\n"
+         << "user\\ one ALL=(ALL) NOPASSWD: /usr/bin/id\n"
+         << "%two\\ escaped\\ spaces ALL=(ALL) ALL\n"
+         << "%ends\\ with\\ a\\ backslash\\\\ ALL=(ALL) ALL\n";
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_file.string(), 1, results);
+
+  ASSERT_EQ(results.size(), 4);
+
+  EXPECT_EQ(results[0].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[0].at("header"), "%Domain\\ Users");
+  EXPECT_EQ(results[0].at("rule_details"), "ALL=(ALL:ALL) ALL");
+
+  EXPECT_EQ(results[1].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[1].at("header"), "user\\ one");
+  EXPECT_EQ(results[1].at("rule_details"), "ALL=(ALL) NOPASSWD: /usr/bin/id");
+
+  EXPECT_EQ(results[2].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[2].at("header"), "%two\\ escaped\\ spaces");
+  EXPECT_EQ(results[2].at("rule_details"), "ALL=(ALL) ALL");
+
+  EXPECT_EQ(results[3].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[3].at("header"), "%ends\\ with\\ a\\ backslash\\\\");
+  EXPECT_EQ(results[3].at("rule_details"), "ALL=(ALL) ALL");
+}
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -262,5 +262,80 @@ TEST_F(SudoersTests, escaped_space_in_header) {
   EXPECT_EQ(results[3].at("rule_details"), "ALL=(ALL) ALL");
 }
 
+TEST_F(SudoersTests, header_split_edge_cases) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_file = directory / fs::path("sudoers");
+
+  {
+    auto fout = std::ofstream(sudoers_file.native());
+    // a tab separates the header just like a space
+    fout << "dave\tALL=(ALL) ALL\n"
+         // an escaped backslash ends the escape, so the space still splits
+         << "a\\\\b c\n"
+         // a leading escaped space is part of the name
+         << "\\ leading ALL=(ALL) ALL\n"
+         // no whitespace at all: the whole line is the header
+         << "onlyaheader\n"
+         // every space escaped: also header only
+         << "one\\ single\\ token\n";
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_file.string(), 1, results);
+
+  ASSERT_EQ(results.size(), 5);
+
+  EXPECT_EQ(results[0].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[0].at("header"), "dave");
+  EXPECT_EQ(results[0].at("rule_details"), "ALL=(ALL) ALL");
+
+  EXPECT_EQ(results[1].at("header"), "a\\\\b");
+  EXPECT_EQ(results[1].at("rule_details"), "c");
+
+  EXPECT_EQ(results[2].at("header"), "\\ leading");
+  EXPECT_EQ(results[2].at("rule_details"), "ALL=(ALL) ALL");
+
+  EXPECT_EQ(results[3].at("header"), "onlyaheader");
+  EXPECT_EQ(results[3].at("rule_details"), "");
+
+  EXPECT_EQ(results[4].at("header"), "one\\ single\\ token");
+  EXPECT_EQ(results[4].at("rule_details"), "");
+}
+
+TEST_F(SudoersTests, escaped_header_with_continuation) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_file = directory / fs::path("sudoers");
+
+  {
+    auto fout = std::ofstream(sudoers_file.native());
+    // an escaped name and a line continuation on the same rule
+    fout << "%Domain\\ Admins ALL=(ALL) \\\n"
+         << "NOPASSWD: ALL\n";
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_file.string(), 1, results);
+
+  ASSERT_EQ(results.size(), 1);
+
+  EXPECT_EQ(results[0].at("source"), sudoers_file.string());
+  EXPECT_EQ(results[0].at("header"), "%Domain\\ Admins");
+  EXPECT_EQ(results[0].at("rule_details"), "ALL=(ALL) NOPASSWD: ALL");
+}
+
 } // namespace tables
 } // namespace osquery


### PR DESCRIPTION
Fixes #8157.

`genSudoersFile()` splits every line at `line.find_first_of(kSudoWhitespaceChars)` and calls whatever comes before that the header. sudoers(5) says an unquoted user or group name has to escape spaces with a backslash, so a rule for a group named `Domain Users` is written `%Domain\ Users`, and that split lands in the middle of the name. The header comes back as `%Domain\` and the rest of the group name gets glued onto the front of `rule_details`.

sudo itself is fine with the escaped form:

```
$ printf '%%Domain\\ Users ALL=(ALL:ALL) ALL\n' > s1
$ cat -A s1
%Domain\ Users ALL=(ALL:ALL) ALL$
$ visudo -c -f s1
s1: parsed OK
```

Here is the table reading a three line sudoers file, before the change. I bind mounted the file over `/etc/sudoers` inside a user namespace so nothing on the host was touched:

```
$ cat demo
Defaults env_reset
%Domain\ Users ALL=(ALL:ALL) ALL
%Domain\ Admins ALL=(ALL:ALL) NOPASSWD:ALL

$ unshare -Urm --propagation private bash -c '
    mount --bind ./demo /etc/sudoers
    ./osqueryd -S --json "select header, rule_details from sudoers"'
[
  {"header":"Defaults","rule_details":"env_reset"},
  {"header":"%Domain\\","rule_details":"Users ALL=(ALL:ALL) ALL"},
  {"header":"%Domain\\","rule_details":"Admins ALL=(ALL:ALL) NOPASSWD:ALL"}
]
```

And after:

```
[
  {"header":"Defaults","rule_details":"env_reset"},
  {"header":"%Domain\\ Users","rule_details":"ALL=(ALL:ALL) ALL"},
  {"header":"%Domain\\ Admins","rule_details":"ALL=(ALL:ALL) NOPASSWD:ALL"}
]
```

The fix walks the line and skips the character following a backslash, so the split lands on the first whitespace that is not escaped. Skipping the escaped character rather than just the space also covers `\\`, where the second backslash is data and a space after it really does end the header.

There is a second spelling I deliberately left alone. sudoers(5) also lets you quote the name instead of escaping it, with the `%` inside the quotes, and visudo here accepts both `"%Domain Users" ALL=(ALL:ALL) ALL` and `"Some User" ALL=(ALL) ALL`. Those two still come back cut at the space with this change applied, headers `"%Domain` and `"Some`. Skipping a quoted span is a different piece of parsing and I would rather not fold it into the escape fix, so it stays broken for now.

New test in `sudoers_tests.cpp` covering one escaped space, two escaped spaces, and a name ending in an escaped backslash. All four lines it writes are accepted by `visudo -c`, together and one at a time. With only the test file applied on top of master, every expectation in it fails:

```
$ ./osquery_tables_system_posix_tests-test --gtest_filter=SudoersTests.escaped_space_in_header 2>&1 | grep -c ': Failure'
8
```

The first two, with the build path trimmed off the front so the lines fit:

```
$ ./osquery_tables_system_posix_tests-test --gtest_filter=SudoersTests.escaped_space_in_header 2>&1 | sed 's#/[^ ]*/osquery/##g' | head -17
Running main() from libraries/cmake/source/googletest/src/googletest/src/gtest_main.cc
Note: Google Test filter = SudoersTests.escaped_space_in_header
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SudoersTests
[ RUN      ] SudoersTests.escaped_space_in_header
tables/system/tests/posix/sudoers_tests.cpp:249: Failure
Expected equality of these values:
  results[0].at("header")
    Which is: "%Domain\\"
  "%Domain\\ Users"

tables/system/tests/posix/sudoers_tests.cpp:250: Failure
Expected equality of these values:
  results[0].at("rule_details")
    Which is: "Users ALL=(ALL:ALL) ALL"
  "ALL=(ALL:ALL) ALL"
```

With the fix in, the whole target is green, including the existing `long_line` test that exercises trailing backslash continuations:

```
$ ./osquery_tables_system_posix_tests-test | tail -1
[  PASSED  ] 19 tests.
```

Built and run on Linux x86_64 with the osquery toolchain, RelWithDebInfo. `clang-format --style=file` reports no changes on either file.
