### PR TITLE
Fix: Do not read FIFOs when hashing files in file_events

### DIFF
--- a/osquery/tables/events/event_utils.cpp
+++ b/osquery/tables/events/event_utils.cpp
@@ -7,9 +7,10 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <osquery/sql/sql.h>
+#include <boost/filesystem.hpp>
 
 #include <osquery/hashing/hashing.h>
+#include <osquery/sql/sql.h>
 #include <osquery/tables/events/event_utils.h>
 
 namespace osquery {
@@ -29,7 +30,8 @@ void decorateFileEvent(const std::string& path, bool hash, Row& r) {
     }
   }
 
-  if (hash) {
+  boost::system::error_code ec;
+  if (hash && boost::filesystem::is_regular_file(path, ec)) {
     auto hashes = hashMultiFromFile(
         HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256, path);
     r["md5"] = std::move(hashes.md5);

--- a/osquery/tables/events/event_utils.cpp
+++ b/osquery/tables/events/event_utils.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <osquery/hashing/hashing.h>
 #include <osquery/sql/sql.h>
@@ -30,8 +30,8 @@ void decorateFileEvent(const std::string& path, bool hash, Row& r) {
     }
   }
 
-  boost::system::error_code ec;
-  if (hash && boost::filesystem::is_regular_file(path, ec)) {
+  std::error_code ec;
+  if (hash && std::filesystem::is_regular_file(path, ec)) {
     auto hashes = hashMultiFromFile(
         HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256, path);
     r["md5"] = std::move(hashes.md5);

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -9,6 +9,13 @@
 
 #include <gtest/gtest.h>
 
+#ifndef WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <fstream>
+
 #include <osquery/config/config.h>
 #include <osquery/config/tests/test_utils.h>
 #include <osquery/core/flags.h>
@@ -57,6 +64,46 @@ class FileEventsTableTests : public testing::Test {
 };
 
 #ifndef WIN32
+TEST_F(FileEventsTableTests, test_decorate_file_event_skips_hash_for_fifo) {
+  // Regression test: decorateFileEvent must not hash non-regular files.
+  // Before the fix, FIFOs (e.g. GNU make's jobserver pipe) would be opened
+  // and drained by readFile() via hashMultiFromFile().
+  const std::string fifo_path =
+      "/tmp/osquery_fim_fifo_test_" + std::to_string(::getpid());
+  ::unlink(fifo_path.c_str());
+  ASSERT_EQ(0, ::mkfifo(fifo_path.c_str(), 0600))
+      << "mkfifo failed: " << strerror(errno);
+
+  Row r;
+  decorateFileEvent(fifo_path, /* hash */ true, r);
+
+  EXPECT_EQ(r.at("hashed"), "0");
+  EXPECT_EQ(r.count("md5"), 0u);
+  EXPECT_EQ(r.count("sha1"), 0u);
+  EXPECT_EQ(r.count("sha256"), 0u);
+
+  ::unlink(fifo_path.c_str());
+}
+
+TEST_F(FileEventsTableTests, test_decorate_file_event_hashes_regular_file) {
+  const std::string file_path =
+      "/tmp/osquery_fim_file_test_" + std::to_string(::getpid());
+  {
+    std::ofstream f(file_path);
+    f << "osquery test content";
+  }
+
+  Row r;
+  decorateFileEvent(file_path, /* hash */ true, r);
+
+  EXPECT_NE(r.at("hashed"), "0");
+  EXPECT_FALSE(r.at("md5").empty());
+  EXPECT_FALSE(r.at("sha1").empty());
+  EXPECT_FALSE(r.at("sha256").empty());
+
+  ::unlink(file_path.c_str());
+}
+
 TEST_F(FileEventsTableTests, test_subscriber_exists) {
   ASSERT_TRUE(Registry::get().exists("event_subscriber", "file_events"));
 

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -10,11 +10,11 @@
 #include <gtest/gtest.h>
 
 #ifndef WIN32
+#include <cstring>
+#include <fstream>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
-
-#include <fstream>
 
 #include <osquery/config/config.h>
 #include <osquery/config/tests/test_utils.h>
@@ -72,7 +72,7 @@ TEST_F(FileEventsTableTests, test_decorate_file_event_skips_hash_for_fifo) {
       "/tmp/osquery_fim_fifo_test_" + std::to_string(::getpid());
   ::unlink(fifo_path.c_str());
   ASSERT_EQ(0, ::mkfifo(fifo_path.c_str(), 0600))
-      << "mkfifo failed: " << strerror(errno);
+      << "mkfifo failed: " << std::strerror(errno);
 
   Row r;
   decorateFileEvent(fifo_path, /* hash */ true, r);


### PR DESCRIPTION
Reading these can consume data that is intended to be read by other programs. Instead, skip the hashing step.

Fixes #8939