### PR TITLE
Pare down openssl build

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -15,6 +15,9 @@ function(opensslMain)
     no-shared
     no-weak-ssl-ciphers
     no-comp
+    no-tests
+    no-apps
+    no-docs
     enable-cms
   )
 


### PR DESCRIPTION
Don't build docs, apps (CLI tools), or tests, as they are all unused.

Results in ~40% speedup in the openssl build on my dev machine.

```
cmake --build . --target openssl
```