### PR TITLE
Increase maximum config size from 1 MiB to 4MiB

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -48,7 +48,7 @@ const std::string kConfigPersistencePrefix{"config_persistence."};
 /// Max depth that the JSON document representing the configuration can have
 const int kMaxConfigDepth = 32;
 /// Max size that the configuration, stripped from its comments, can have
-const int kMaxConfigSize = 1024 * 1024;
+const int kMaxConfigSize = 1024 * 1024 * 4;
 
 using ConfigMap = std::map<std::string, std::string>;
 

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -300,7 +300,7 @@ TEST_F(ConfigTests, test_config_depth) {
 TEST_F(ConfigTests, test_config_too_big) {
   std::string big_config = "{ \"data\" : [ 1";
 
-  for (int i = 0; i < 1 * 1024 * 1024; ++i) {
+  for (int i = 0; i < 4 * 1024 * 1024; ++i) {
     big_config += ",1";
   }
 


### PR DESCRIPTION
Recently, we ran into an issue with a customer whose config size slightly exceeded osquery's limit of 1 MiB.

This PR increases the configured limit to 4 MiB, to give us more flexibility while still maintaining a reasonable limit.

Before, with a config of size `1210914` bytes, `osqueryd --config_check` returns: `Error reading config: Error parsing the config JSON: the config size exceeds the limit of 1048576 bytes`.

With the changes in this PR, running `osqueryd --config_check` against the same config passes.