### PR TITLE
Add snap_packages table and yaml-cpp dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,3 +145,6 @@
 [submodule "libraries/cmake/source/lz4/src"]
 	path = libraries/cmake/source/lz4/src
 	url = https://github.com/lz4/lz4.git
+[submodule "libraries/cmake/source/yaml-cpp/src"]
+	path = libraries/cmake/source/yaml-cpp/src
+	url = https://github.com/jbeder/yaml-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ function(importLibraries)
     "Linux,Darwin,Windows:zstd"
     "Linux:dbus"
     "Linux:libcap"
+    "Linux:yaml-cpp"
   )
 
 

--- a/libraries/cmake/source/modules/Findyaml-cpp.cmake
+++ b/libraries/cmake/source/modules/Findyaml-cpp.cmake
@@ -12,6 +12,6 @@ importSourceSubmodule(
 
   NO_RECURSIVE
 
-  SUBMODULES
+  SHALLOW_SUBMODULES
     "src"
 )

--- a/libraries/cmake/source/modules/Findyaml-cpp.cmake
+++ b/libraries/cmake/source/modules/Findyaml-cpp.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
+
+importSourceSubmodule(
+  NAME "yaml-cpp"
+
+  NO_RECURSIVE
+
+  SUBMODULES
+    "src"
+)

--- a/libraries/cmake/source/yaml-cpp/CMakeLists.txt
+++ b/libraries/cmake/source/yaml-cpp/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+function(yamlcppMain)
+  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+  add_library(thirdparty_yaml-cpp
+    "${library_root}/src/binary.cpp"
+    "${library_root}/src/convert.cpp"
+    "${library_root}/src/depthguard.cpp"
+    "${library_root}/src/directives.cpp"
+    "${library_root}/src/emit.cpp"
+    "${library_root}/src/emitfromevents.cpp"
+    "${library_root}/src/emitter.cpp"
+    "${library_root}/src/emitterstate.cpp"
+    "${library_root}/src/emitterutils.cpp"
+    "${library_root}/src/exceptions.cpp"
+    "${library_root}/src/exp.cpp"
+    "${library_root}/src/fptostring.cpp"
+    "${library_root}/src/memory.cpp"
+    "${library_root}/src/node.cpp"
+    "${library_root}/src/node_data.cpp"
+    "${library_root}/src/nodebuilder.cpp"
+    "${library_root}/src/nodeevents.cpp"
+    "${library_root}/src/null.cpp"
+    "${library_root}/src/ostream_wrapper.cpp"
+    "${library_root}/src/parse.cpp"
+    "${library_root}/src/parser.cpp"
+    "${library_root}/src/regex_yaml.cpp"
+    "${library_root}/src/scanner.cpp"
+    "${library_root}/src/scanscalar.cpp"
+    "${library_root}/src/scantag.cpp"
+    "${library_root}/src/scantoken.cpp"
+    "${library_root}/src/simplekey.cpp"
+    "${library_root}/src/singledocparser.cpp"
+    "${library_root}/src/stream.cpp"
+    "${library_root}/src/tag.cpp"
+  )
+
+  target_compile_definitions(thirdparty_yaml-cpp PRIVATE
+    YAML_CPP_NO_CONTRIB
+  )
+
+  target_link_libraries(thirdparty_yaml-cpp PRIVATE
+    thirdparty_cxx_settings
+  )
+
+  set_target_properties(thirdparty_yaml-cpp PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  target_include_directories(thirdparty_yaml-cpp PRIVATE
+    "${library_root}/include"
+  )
+
+  target_include_directories(thirdparty_yaml-cpp SYSTEM INTERFACE
+    "${library_root}/include"
+  )
+endfunction()
+
+yamlcppMain()

--- a/libraries/third_party_libraries_manifest.json
+++ b/libraries/third_party_libraries_manifest.json
@@ -284,6 +284,13 @@
       "CVE-2024-28085"
     ]
   },
+  "yaml-cpp": {
+    "product": "yaml-cpp",
+    "vendor": "jbeder",
+    "version": "0.9.0",
+    "commit": "c3f81127320662deb3e28f4da0a511f1faecd860",
+    "ignored-cves": []
+  },
   "yara": {
     "product": "yara",
     "vendor": "virustotal",

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -270,7 +270,6 @@ function(generateOsqueryTablesSystemSystemtable)
     osquery_worker_ipc_platformtablecontaineripc
     osquery_utils_json
     thirdparty_boost
-    thirdparty_yaml-cpp
     osquery_rows_processes_header
   )
 
@@ -294,6 +293,7 @@ function(generateOsqueryTablesSystemSystemtable)
       thirdparty_librpm
       thirdparty_dbus
       thirdparty_libcap
+      thirdparty_yaml-cpp
     )
 
     if(OSQUERY_BUILD_DPKG)

--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -79,6 +79,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/process_open_pipes.cpp
       linux/processes.cpp
       linux/rpm_packages.cpp
+      linux/snap_packages.cpp
       linux/secureboot.cpp
       linux/secureboot_certificates.cpp
       linux/shadow.cpp
@@ -267,7 +268,9 @@ function(generateOsqueryTablesSystemSystemtable)
     osquery_utils_system_time
     osquery_utils_system_uptime
     osquery_worker_ipc_platformtablecontaineripc
+    osquery_utils_json
     thirdparty_boost
+    thirdparty_yaml-cpp
     osquery_rows_processes_header
   )
 

--- a/osquery/tables/system/linux/snap_packages.cpp
+++ b/osquery/tables/system/linux/snap_packages.cpp
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/join.h>
+#include <osquery/utils/json/json.h>
+
+namespace osquery {
+namespace tables {
+
+const std::string kSnapdStatePath{"/var/lib/snapd/state.json"};
+const std::string kSnapMountRoot{"/snap"};
+
+struct SnapStateInfo {
+  std::string revision;
+  std::string channel;
+  std::string snap_id;
+};
+
+/**
+ * @brief Parse a snap.yaml string into a Row using yaml-cpp.
+ */
+Row parseSnapYaml(const std::string& content) {
+  Row r;
+
+  YAML::Node doc;
+  try {
+    doc = YAML::Load(content);
+  } catch (const YAML::Exception& e) {
+    VLOG(1) << "snap_packages: failed to parse snap.yaml: " << e.what();
+    return r;
+  }
+
+  if (!doc.IsMap()) {
+    return r;
+  }
+
+  static const std::unordered_map<std::string, std::string> kScalarColumns = {
+      {"name", "name"},
+      {"version", "version"},
+      {"summary", "summary"},
+      {"description", "description"},
+      {"type", "type"},
+      {"confinement", "confinement"},
+      {"base", "base"},
+      {"license", "license"},
+      {"grade", "grade"},
+  };
+
+  for (const auto& [yaml_key, col_name] : kScalarColumns) {
+    const auto& node = doc[yaml_key];
+    if (node && node.IsScalar()) {
+      r[col_name] = node.as<std::string>();
+    }
+  }
+
+  // architectures may be a simple list or a list of build-on/run-on maps.
+  const auto& archs_node = doc["architectures"];
+  if (archs_node && archs_node.IsSequence()) {
+    std::vector<std::string> archs;
+    for (const auto& item : archs_node) {
+      if (item.IsScalar()) {
+        archs.push_back(item.as<std::string>());
+      } else if (item.IsMap()) {
+        const auto& run_on = item["run-on"];
+        if (run_on && run_on.IsScalar()) {
+          archs.push_back(run_on.as<std::string>());
+        } else if (run_on && run_on.IsSequence()) {
+          for (const auto& a : run_on) {
+            archs.push_back(a.as<std::string>());
+          }
+        }
+      }
+    }
+    r["architectures"] = join(archs, ",");
+  }
+
+  return r;
+}
+
+/**
+ * @brief Parse /var/lib/snapd/state.json for per-snap state.
+ *
+ * Returns a map from snap name to SnapStateInfo containing the current
+ * revision, tracking channel, snap-id, and confinement flags.
+ */
+static std::unordered_map<std::string, SnapStateInfo> parseSnapdState(
+    const std::string& json_content) {
+  std::unordered_map<std::string, SnapStateInfo> result;
+
+  auto doc = JSON::newObject();
+  if (!doc.fromString(json_content).ok() || !doc.doc().IsObject()) {
+    return result;
+  }
+
+  if (!doc.doc().HasMember("data") || !doc.doc()["data"].IsObject()) {
+    return result;
+  }
+
+  const auto& data = doc.doc()["data"];
+  if (!data.HasMember("snaps") || !data["snaps"].IsObject()) {
+    return result;
+  }
+
+  const auto& snaps = data["snaps"];
+  for (auto it = snaps.MemberBegin(); it != snaps.MemberEnd(); ++it) {
+    if (!it->value.IsObject()) {
+      continue;
+    }
+
+    SnapStateInfo info;
+    const auto& snap = it->value;
+
+    if (snap.HasMember("current") && snap["current"].IsString()) {
+      info.revision = snap["current"].GetString();
+    }
+
+    if (snap.HasMember("channel") && snap["channel"].IsString()) {
+      info.channel = snap["channel"].GetString();
+    }
+
+    // snap-id lives inside each sequence element; find the current revision.
+    if (snap.HasMember("sequence") && snap["sequence"].IsArray()) {
+      for (const auto& seq_elem : snap["sequence"].GetArray()) {
+        if (!seq_elem.IsObject()) {
+          continue;
+        }
+        const bool revision_matches =
+            seq_elem.HasMember("revision") && seq_elem["revision"].IsString() &&
+            seq_elem["revision"].GetString() == info.revision;
+        if (revision_matches && seq_elem.HasMember("snap-id") &&
+            seq_elem["snap-id"].IsString()) {
+          info.snap_id = seq_elem["snap-id"].GetString();
+          break;
+        }
+      }
+    }
+
+    // Fallback: snap-id may also appear at the snap-state level.
+    if (info.snap_id.empty() && snap.HasMember("snap-id") &&
+        snap["snap-id"].IsString()) {
+      info.snap_id = snap["snap-id"].GetString();
+    }
+
+    result[it->name.GetString()] = std::move(info);
+  }
+
+  return result;
+}
+
+QueryData genSnapPackages(QueryContext& context) {
+  QueryData results;
+
+  if (!isDirectory(kSnapMountRoot).ok()) {
+    return results;
+  }
+
+  // Parse state.json for channel, snap-id, and confinement flags.
+  // This file is root-readable only; missing state is handled gracefully.
+  std::unordered_map<std::string, SnapStateInfo> snap_states;
+  {
+    std::string state_json;
+    if (readFile(kSnapdStatePath, state_json, false).ok()) {
+      snap_states = parseSnapdState(state_json);
+    }
+  }
+
+  // Enumerate installed snaps from /snap/<name>/ directories.
+  std::vector<std::string> snap_dirs;
+  if (!resolveFilePattern(
+           boost::filesystem::path(kSnapMountRoot) / kSQLGlobWildcard,
+           snap_dirs,
+           GLOB_FOLDERS)
+           .ok()) {
+    VLOG(1) << "snap_packages: could not list " << kSnapMountRoot;
+    return results;
+  }
+
+  for (const auto& snap_dir_str : snap_dirs) {
+    const boost::filesystem::path snap_dir(snap_dir_str);
+    // boost path::filename() returns "." for paths with a trailing separator.
+    const std::string snap_name =
+        snap_dir.filename() == "." ? snap_dir.parent_path().filename().string()
+                                   : snap_dir.filename().string();
+
+    // /snap/bin holds command symlinks, not a snap package.
+    if (snap_name == "bin" || snap_name.empty()) {
+      continue;
+    }
+
+    // Determine the current revision from state.json or the 'current' symlink.
+    std::string revision;
+    const auto state_it = snap_states.find(snap_name);
+    if (state_it != snap_states.end() && !state_it->second.revision.empty()) {
+      revision = state_it->second.revision;
+    } else {
+      boost::system::error_code ec;
+      const auto target =
+          boost::filesystem::read_symlink(snap_dir / "current", ec);
+      if (ec) {
+        VLOG(1) << "snap_packages: no revision for " << snap_name;
+        continue;
+      }
+      revision = target.filename().string();
+    }
+
+    if (revision.empty()) {
+      continue;
+    }
+
+    // Read the snap metadata from the mounted squashfs.
+    const auto yaml_path = snap_dir / revision / "meta" / "snap.yaml";
+    std::string yaml_content;
+    if (!readFile(yaml_path.string(), yaml_content, false).ok()) {
+      VLOG(1) << "snap_packages: could not read snap.yaml for " << snap_name;
+      continue;
+    }
+
+    Row r = parseSnapYaml(yaml_content);
+
+    if (!r.count("name") || r["name"].empty()) {
+      r["name"] = snap_name;
+    }
+
+    r["revision"] = revision;
+
+    if (state_it != snap_states.end()) {
+      r["channel"] = state_it->second.channel;
+      r["snap_id"] = state_it->second.snap_id;
+    } else {
+      r["channel"] = "";
+      r["snap_id"] = "";
+    }
+
+    // Guarantee every schema column is present.
+    for (const auto* col : {"version",
+                            "summary",
+                            "description",
+                            "type",
+                            "confinement",
+                            "base",
+                            "license",
+                            "title",
+                            "grade",
+                            "architectures"}) {
+      if (r.count(col) == 0) {
+        r[col] = "";
+      }
+    }
+
+    results.push_back(std::move(r));
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/snap_packages.cpp
+++ b/osquery/tables/system/linux/snap_packages.cpp
@@ -98,7 +98,7 @@ Row parseSnapYaml(const std::string& content) {
  * @brief Parse /var/lib/snapd/state.json for per-snap state.
  *
  * Returns a map from snap name to SnapStateInfo containing the current
- * revision, tracking channel, snap-id, and confinement flags.
+ * revision, tracking channel, and snap-id flags.
  */
 static std::unordered_map<std::string, SnapStateInfo> parseSnapdState(
     const std::string& json_content) {
@@ -171,7 +171,7 @@ QueryData genSnapPackages(QueryContext& context) {
     return results;
   }
 
-  // Parse state.json for channel, snap-id, and confinement flags.
+  // Parse state.json for channel, revision, and snap-id flags.
   // This file is root-readable only; missing state is handled gracefully.
   std::unordered_map<std::string, SnapStateInfo> snap_states;
   {
@@ -246,22 +246,6 @@ QueryData genSnapPackages(QueryContext& context) {
     } else {
       r["channel"] = "";
       r["snap_id"] = "";
-    }
-
-    // Guarantee every schema column is present.
-    for (const auto* col : {"version",
-                            "summary",
-                            "description",
-                            "type",
-                            "confinement",
-                            "base",
-                            "license",
-                            "title",
-                            "grade",
-                            "architectures"}) {
-      if (r.count(col) == 0) {
-        r[col] = "";
-      }
     }
 
     results.push_back(std::move(r));

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ function(generateOsqueryTablesSystemLinuxTests)
     linux/extended_attributes_tests.cpp
     linux/md_tables_tests.cpp
     linux/pacman_packages_tests.cpp
+    linux/snap_packages_tests.cpp
     linux/pci_devices_tests.cpp
     linux/pcidb_tests.cpp
     linux/portage_tests.cpp

--- a/osquery/tables/system/tests/linux/snap_packages_tests.cpp
+++ b/osquery/tables/system/tests/linux/snap_packages_tests.cpp
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/core/tables.h>
+
+namespace osquery {
+namespace tables {
+
+Row parseSnapYaml(const std::string& content);
+
+class SnapPackagesTests : public testing::Test {};
+
+TEST_F(SnapPackagesTests, nested_name_does_not_overwrite_snap_name) {
+  // A 'name:' key nested inside slots/apps/etc. must not overwrite the
+  // top-level snap name.
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "version: 1.0\n"
+      "slots:\n"
+      "  dbus-service:\n"
+      "    interface: dbus\n"
+      "    bus: session\n"
+      "    name: com.example.mysnap\n"
+      "confinement: strict\n");
+
+  EXPECT_EQ(r["name"], "mysnap");
+  EXPECT_EQ(r["version"], "1.0");
+  EXPECT_EQ(r["confinement"], "strict");
+}
+
+TEST_F(SnapPackagesTests, parses_a_complete_snap_yaml) {
+  auto r = parseSnapYaml(
+      "name: hello-world\n"
+      "version: \"6.4\"\n"
+      "summary: Make your first snap\n"
+      "description: |\n"
+      "  The 'hello-world' snap shows how to use various\n"
+      "  Snapcraft features.\n"
+      "type: app\n"
+      "confinement: strict\n"
+      "grade: stable\n"
+      "base: core20\n"
+      "license: MIT\n"
+      "title: Hello World\n");
+
+  EXPECT_EQ(r["name"], "hello-world");
+  EXPECT_EQ(r["version"], "6.4");
+  EXPECT_EQ(r["summary"], "Make your first snap");
+  EXPECT_EQ(r["type"], "app");
+  EXPECT_EQ(r["confinement"], "strict");
+  EXPECT_EQ(r["grade"], "stable");
+  EXPECT_EQ(r["base"], "core20");
+  EXPECT_EQ(r["license"], "MIT");
+  EXPECT_EQ(r["title"], "Hello World");
+  // Description begins with the first line of the block scalar.
+  EXPECT_FALSE(r["description"].empty());
+  EXPECT_NE(r["description"].find("hello-world"), std::string::npos);
+}
+
+TEST_F(SnapPackagesTests, strips_double_quotes_from_version) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "version: \"2.0+git\"\n");
+
+  EXPECT_EQ(r["version"], "2.0+git");
+}
+
+TEST_F(SnapPackagesTests, strips_single_quotes_from_value) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "license: 'GPL-2.0'\n");
+
+  EXPECT_EQ(r["license"], "GPL-2.0");
+}
+
+TEST_F(SnapPackagesTests, parses_simple_architecture_list) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "architectures:\n"
+      "- amd64\n"
+      "- arm64\n");
+
+  EXPECT_EQ(r["architectures"], "amd64,arm64");
+}
+
+TEST_F(SnapPackagesTests, parses_inline_flow_sequence_architecture) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "architectures: [amd64]\n");
+
+  EXPECT_EQ(r["architectures"], "amd64");
+}
+
+TEST_F(SnapPackagesTests, parses_complex_architecture_objects) {
+  // build-on/run-on objects: only the run-on architecture is reported.
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "architectures:\n"
+      "- build-on: amd64\n"
+      "  run-on: amd64\n");
+
+  EXPECT_EQ(r["name"], "mysnap");
+  EXPECT_EQ(r["architectures"], "amd64");
+}
+
+TEST_F(SnapPackagesTests, ignores_comment_lines) {
+  auto r = parseSnapYaml(
+      "# This is a comment\n"
+      "name: mysnap\n"
+      "# version comment\n"
+      "version: 1.0\n");
+
+  EXPECT_EQ(r["name"], "mysnap");
+  EXPECT_EQ(r["version"], "1.0");
+}
+
+TEST_F(SnapPackagesTests, block_scalar_with_literal_style) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "description: |\n"
+      "  First line.\n"
+      "  Second line.\n"
+      "version: 1.0\n");
+
+  EXPECT_NE(r["description"].find("First line"), std::string::npos);
+  EXPECT_NE(r["description"].find("Second line"), std::string::npos);
+  EXPECT_EQ(r["version"], "1.0");
+}
+
+TEST_F(SnapPackagesTests, block_scalar_stripped_style) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "description: |-\n"
+      "  Stripped block.\n"
+      "version: 2.0\n");
+
+  EXPECT_NE(r["description"].find("Stripped block"), std::string::npos);
+  EXPECT_EQ(r["version"], "2.0");
+}
+
+TEST_F(SnapPackagesTests, unrecognized_keys_are_silently_ignored) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "version: 1.0\n"
+      "assumes:\n"
+      "- snapd2.38\n"
+      "confinement: strict\n");
+
+  EXPECT_EQ(r["name"], "mysnap");
+  EXPECT_EQ(r["version"], "1.0");
+  EXPECT_EQ(r["confinement"], "strict");
+  EXPECT_EQ(r.count("assumes"), 0u);
+}
+
+TEST_F(SnapPackagesTests, returns_empty_name_for_empty_input) {
+  auto r = parseSnapYaml("");
+  EXPECT_EQ(r.count("name"), 0u);
+}
+
+TEST_F(SnapPackagesTests, type_defaults_absent_when_not_in_yaml) {
+  auto r = parseSnapYaml(
+      "name: mysnap\n"
+      "version: 1.0\n");
+
+  // "type" is optional in snap.yaml; expect it to be absent from the Row.
+  EXPECT_EQ(r.count("type"), 0u);
+}
+
+TEST_F(SnapPackagesTests, parses_snapd_type_snap) {
+  auto r = parseSnapYaml(
+      "name: snapd\n"
+      "version: 2.60\n"
+      "type: snapd\n"
+      "confinement: strict\n");
+
+  EXPECT_EQ(r["type"], "snapd");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/linux/snap_packages_tests.cpp
+++ b/osquery/tables/system/tests/linux/snap_packages_tests.cpp
@@ -48,8 +48,7 @@ TEST_F(SnapPackagesTests, parses_a_complete_snap_yaml) {
       "confinement: strict\n"
       "grade: stable\n"
       "base: core20\n"
-      "license: MIT\n"
-      "title: Hello World\n");
+      "license: MIT\n");
 
   EXPECT_EQ(r["name"], "hello-world");
   EXPECT_EQ(r["version"], "6.4");
@@ -59,7 +58,6 @@ TEST_F(SnapPackagesTests, parses_a_complete_snap_yaml) {
   EXPECT_EQ(r["grade"], "stable");
   EXPECT_EQ(r["base"], "core20");
   EXPECT_EQ(r["license"], "MIT");
-  EXPECT_EQ(r["title"], "Hello World");
   // Description begins with the first line of the block scalar.
   EXPECT_FALSE(r["description"].empty());
   EXPECT_NE(r["description"].find("hello-world"), std::string::npos);

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -183,6 +183,7 @@ function(generateNativeTables)
     "linux/md_personalities.table:linux"
     "linux/msr.table:linux"
     "linux/pacman_packages.table:linux"
+    "linux/snap_packages.table:linux"
     "linux/portage_keywords.table:linux"
     "linux/portage_packages.table:linux"
     "linux/portage_use.table:linux"

--- a/specs/linux/snap_packages.table
+++ b/specs/linux/snap_packages.table
@@ -1,0 +1,23 @@
+table_name("snap_packages")
+description("Installed snap packages.")
+schema([
+    Column("name", TEXT, "Package name", index=True),
+    Column("version", TEXT, "Package version"),
+    Column("summary", TEXT, "One-line summary"),
+    Column("description", TEXT, "Long description"),
+    Column("type", TEXT, "Snap type (app, core, kernel, gadget, snapd)"),
+    Column("confinement", TEXT, "Confinement policy (strict, devmode, classic)"),
+    Column("base", TEXT, "Base snap this snap is built on"),
+    Column("license", TEXT, "SPDX license expression"),
+    Column("grade", TEXT, "Grade (stable, devel)"),
+    Column("architectures", TEXT, "Comma-separated list of supported architectures"),
+    Column("revision", TEXT, "Installed revision number"),
+    Column("channel", TEXT, "Tracking channel (e.g. stable, beta, edge)"),
+    Column("snap_id", TEXT, "Snap Store identifier"),
+])
+attributes(cacheable=True)
+implementation("system/snap_packages@genSnapPackages")
+fuzz_paths([
+    "/var/lib/snapd",
+    "/snap",
+])

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -174,6 +174,7 @@ function(generateTestsIntegrationTablesTestsTest)
       memory_map.cpp
       msr.cpp
       pacman_packages.cpp
+      snap_packages.cpp
       portage_keywords.cpp
       portage_packages.cpp
       portage_use.cpp

--- a/tests/integration/tables/snap_packages.cpp
+++ b/tests/integration/tables/snap_packages.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for snap_packages
+// Spec file: specs/linux/snap_packages.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class SnapPackages : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(SnapPackages, test_sanity) {
+  QueryData rows = execute_query("select * from snap_packages");
+  if (rows.size() == 0) {
+    GTEST_SKIP() << "No snap packages installed on this system";
+  }
+  ValidationMap row_map = {
+      {"name", NonEmptyString},
+      {"version", NormalType},
+      {"summary", NormalType},
+      {"description", NormalType},
+      {"type", NormalType},
+      {"confinement", NormalType},
+      {"base", NormalType},
+      {"license", NormalType},
+      {"grade", NormalType},
+      {"architectures", NormalType},
+      {"revision", NonEmptyString},
+      {"channel", NormalType},
+      {"snap_id", NormalType},
+  };
+
+  validate_rows(rows, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
YAML parsing is needed to read the snap package information. Alternatively a minimal parsing implementation could be added but it seemed messy and unreliable.