### PR TITLE
Add --extensions_socket_group flag for extension socket permissions

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -186,6 +186,10 @@ Disable extension API. See the [SDK development](../development/osquery-sdk.md) 
 Path to the extensions UNIX domain socket.
 [Extensions](../deployment/extensions.md) use a UNIX domain socket for communication. It is very uncommon to change the location of the file. The osquery shell may use extensions, but the socket location is relative to the user invoking the shell and does not support concurrent shells.
 
+`--extensions_socket_group=osquery`
+
+Group name or numeric GID granted access to the extensions UNIX domain socket. When set, the socket is created with mode `0660` and assigned to the requested group. This allows extension processes to run as an unprivileged user and connect to a socket owned by root. The flag also applies to per-extension sockets. If the group cannot be resolved, osquery logs an error and continues to serve; the socket is still restricted to mode `0660`, so extensions running as another user will be unable to connect. This flag has no effect on Windows, where extensions use a named pipe.
+
 `--extensions_autoload=/etc/osquery/extensions.load`
 
 Optional path to a list of auto-loaded and managed extensions.

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -67,6 +67,12 @@ CLI_FLAG(string,
          "Path to the extensions UNIX domain socket");
 
 CLI_FLAG(string,
+         extensions_socket_group,
+         "",
+         "Group name or GID granted access to the extensions UNIX domain "
+         "socket. When set, the socket is created with mode 0660");
+
+CLI_FLAG(string,
          extensions_autoload,
          OSQUERY_HOME "extensions.load",
          "Optional path to a list of autoloaded & managed extensions");
@@ -98,6 +104,7 @@ CLI_FLAG(string,
  * in the alias since we are already within the context of an extension.
  */
 EXTENSION_FLAG_ALIAS(socket, extensions_socket);
+EXTENSION_FLAG_ALIAS(socket_group, extensions_socket_group);
 EXTENSION_FLAG_ALIAS(timeout, extensions_timeout);
 EXTENSION_FLAG_ALIAS(interval, extensions_interval);
 

--- a/osquery/extensions/extensions.h
+++ b/osquery/extensions/extensions.h
@@ -17,6 +17,7 @@
 namespace osquery {
 
 DECLARE_string(extensions_socket);
+DECLARE_string(extensions_socket_group);
 DECLARE_string(extensions_autoload);
 DECLARE_string(extensions_timeout);
 DECLARE_bool(disable_extensions);

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -42,6 +42,7 @@
 
 #ifndef WIN32
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cctype>

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -24,6 +24,7 @@
 #include <thrift/transport/TPipeServer.h>
 
 #else
+#include <grp.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TSocket.h>
 #endif
@@ -33,8 +34,22 @@
 
 #include "osquery/extensions/interface.h"
 
+#include <osquery/extensions/extensions.h>
+#include <osquery/utils/conversions/tryto.h>
+
 #include <boost/chrono/include.hpp>
 #include <boost/thread/condition_variable.hpp>
+
+#ifndef WIN32
+#include <sys/stat.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+#endif
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/locks.hpp>
 
@@ -60,6 +75,61 @@ using TPlatformSocket = TPipe;
 #else
 using TPlatformServerSocket = TServerSocket;
 using TPlatformSocket = TSocket;
+#endif
+
+#ifndef WIN32
+namespace {
+
+bool resolveGroup(const std::string& group_str, gid_t& out_gid) {
+  if (group_str.empty()) {
+    return false;
+  }
+  if (std::all_of(group_str.begin(), group_str.end(), [](unsigned char c) {
+        return std::isdigit(c) != 0;
+      })) {
+    auto gid_exp = osquery::tryTo<std::uint64_t>(group_str, 10);
+    if (gid_exp.isError() ||
+        gid_exp.get() >=
+            static_cast<std::uint64_t>(std::numeric_limits<gid_t>::max())) {
+      return false;
+    }
+    out_gid = static_cast<gid_t>(gid_exp.get());
+    return true;
+  }
+
+  std::vector<char> buf(16384);
+  struct group grp;
+  struct group* result = nullptr;
+  int rc = getgrnam_r(group_str.c_str(), &grp, buf.data(), buf.size(), &result);
+  if (rc != 0) {
+    return false;
+  }
+  if (result == nullptr) {
+    return false;
+  }
+  out_gid = result->gr_gid;
+  return true;
+}
+
+void applySocketGroup(const std::string& path) {
+  // Restrict mode first. If the group cannot be resolved, the socket must not
+  // remain at its umask-derived default mode, which could be world-accessible.
+  if (chmod(path.c_str(), 0660) != 0) {
+    PLOG(ERROR) << "Failed to set mode 0660 on extensions socket " << path;
+  }
+
+  gid_t gid = 0;
+  if (!resolveGroup(osquery::FLAGS_extensions_socket_group, gid)) {
+    LOG(ERROR) << "Invalid extensions_socket_group: "
+               << osquery::FLAGS_extensions_socket_group;
+    return;
+  }
+  if (lchown(path.c_str(), static_cast<uid_t>(-1), gid) != 0) {
+    PLOG(ERROR) << "Failed to set group on extensions socket " << path;
+  }
+}
+
+} // namespace
 #endif
 
 class ThriftServerEventHandler : public TServerEventHandler,
@@ -348,7 +418,12 @@ void ExtensionRunnerInterface::connect() {
   server_->transport = std::make_shared<TPlatformServerSocket>(
       path_, bufsize, TPIPE_SERVER_MAX_CONNS_DEFAULT, securityDescriptor);
 #else
-  server_->transport = std::make_shared<TPlatformServerSocket>(path_);
+  auto transport_socket = std::make_shared<TPlatformServerSocket>(path_);
+  if (!osquery::FLAGS_extensions_socket_group.empty()) {
+    transport_socket->setListenCallback(
+        [path = path_](int /* fd */) { applySocketGroup(path); });
+  }
+  server_->transport = std::move(transport_socket);
 #endif
 
   // Construct the service's transport, protocol, thread pool.

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -29,11 +29,21 @@
 
 #include <boost/filesystem.hpp>
 
+#ifndef WIN32
+#include <grp.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <algorithm>
+#include <vector>
+
 namespace fs = boost::filesystem;
 
 namespace osquery {
 
 DECLARE_string(extensions_require);
+DECLARE_string(extensions_socket_group);
 
 const int kDelay = 20;
 const int kTimeout = 3000;
@@ -64,6 +74,8 @@ class ExtensionsTest : public testing::Test {
 
   void TearDown() override {
     resetDispatcher();
+
+    FLAGS_extensions_socket_group = "";
 
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
       fs::remove(fs::path(socket_path));
@@ -168,6 +180,54 @@ TEST_F(ExtensionsTest, test_extension_runnable) {
   // Test the extension manager API 'ping' call.
   EXPECT_TRUE(ping());
 }
+
+#ifndef WIN32
+TEST_F(ExtensionsTest, test_manager_socket_group) {
+  // Find a secondary group that differs from the effective GID so the
+  // assertion has power: the socket would not already have this group.
+  int ngroups = getgroups(0, nullptr);
+  if (ngroups <= 0) {
+    GTEST_SKIP() << "No supplemental groups available";
+  }
+  std::vector<gid_t> gids(ngroups);
+  if (getgroups(static_cast<int>(gids.size()), gids.data()) < 0) {
+    GTEST_SKIP() << "Failed to read supplemental groups";
+  }
+  auto it = std::find_if(
+      gids.begin(), gids.end(), [](gid_t g) { return g != getegid(); });
+  if (it == gids.end()) {
+    GTEST_SKIP() << "No secondary group available that differs from egid";
+  }
+  gid_t target_gid = *it;
+  auto group = getgrgid(target_gid);
+  if (group == nullptr || group->gr_name == nullptr) {
+    GTEST_SKIP() << "Cannot resolve secondary group name";
+  }
+
+  FLAGS_extensions_socket_group = group->gr_name;
+  auto status = startExtensionManager(socket_path);
+  ASSERT_TRUE(status.ok()) << " error " << status.what();
+  ASSERT_TRUE(ping(150));
+
+  struct stat sb;
+  ASSERT_EQ(stat(socket_path.c_str(), &sb), 0);
+  EXPECT_EQ(sb.st_mode & 0777, 0660u);
+  EXPECT_EQ(sb.st_gid, target_gid);
+}
+
+TEST_F(ExtensionsTest, test_manager_socket_group_unresolvable) {
+  // The flag is resolved at listen time and must not cause the server to fail.
+  // A typo'd group still leaves the socket at 0660, so it does not fail open.
+  FLAGS_extensions_socket_group = "osquery_nonexistent_group_zzz";
+  auto status = startExtensionManager(socket_path);
+  ASSERT_TRUE(status.ok()) << " error " << status.what();
+  ASSERT_TRUE(ping(150));
+
+  struct stat sb;
+  ASSERT_EQ(stat(socket_path.c_str(), &sb), 0);
+  EXPECT_EQ(sb.st_mode & 0777, 0660u);
+}
+#endif
 
 TEST_F(ExtensionsTest, test_extension_start) {
   auto status = startExtensionManager(socket_path);


### PR DESCRIPTION
This PR adds a CLI flag to set the group on the Unix domain socket used for Thrift extension IPC. This allows extension processes to run as an unprivileged/isolated user in the configured group. The change is POSIX-only and ignored on Windows. When the flag is unset, behavior is unchanged.


Running osquery without the proposed `--extensions_socket_group` flag specified to demonstrate backward compatbility:
```
sudo ./build/osquery/osqueryd \
  --pidfile=/tmp/osqueryd-test.pid \
  --database_path=/tmp/osqueryd-test.db \
  --extensions_socket=/tmp/osqueryd-test.em \
  --logger_plugin=stdout \
  --verbose
```

results in it being root owned:

```
smaerz@instance-20260823-221007:~/osquery/build$ ls -lahs /tmp/osqueryd-test.em
0 srwxr-xr-x 1 root root 0 Aug 25 10:48 /tmp/osqueryd-test.em
```


Running osquery with the new `--extensions_socket_group` flag:
```
sudo ./build/osquery/osqueryd \
  --pidfile=/tmp/osqueryd-test.pid \
  --database_path=/tmp/osqueryd-test.db \
  --extensions_socket=/tmp/osqueryd-test.em \
  --extensions_socket_group=smaerz \
  --logger_plugin=stdout \
  --verbose
```

Results in it being owned by me:

```
smaerz@instance-20260823-221007:~/osquery/build$ ls -lahs /tmp/osqueryd-test.em
0 srw-rw---- 1 root smaerz 0 Aug 25 10:48 /tmp/osqueryd-test.em
```