### PR TITLE
Add `gpu_info` table for Linux, macOS, and Windows

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -94,6 +94,7 @@ function(generateOsqueryTablesSystemSystemtable)
       linux/apparmor_profiles.cpp
       linux/systemd_units.cpp
       linux/cpu_info.cpp
+      linux/gpu_info.cpp
       linux/yum_sources.cpp
     )
 
@@ -127,6 +128,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/extended_attributes.cpp
       darwin/firewall.mm
       darwin/gatekeeper.cpp
+      darwin/gpu_info.mm
       darwin/homebrew_packages.cpp
       darwin/ibridge.cpp
       darwin/iokit_registry.cpp
@@ -192,6 +194,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/dns_cache.cpp
       windows/drivers.cpp
       windows/groups.cpp
+      windows/gpu_info.cpp
       windows/ie_extensions.cpp
       windows/intel_me.cpp
       windows/kernel_info.cpp

--- a/osquery/tables/system/darwin/gpu_info.mm
+++ b/osquery/tables/system/darwin/gpu_info.mm
@@ -143,8 +143,7 @@ bool readPciIdsFromEntry(io_registry_entry_t entry,
 // Walk from the accelerator to its parent device node and read the PCI
 // vendor/device identity, falling back to the accelerator's own properties
 // (Apple Silicon accelerators publish vendor-id directly).
-void acceleratorPciIdentity(io_service_t accelerator,
-                            IOKitGpuInfo& info) {
+void acceleratorPciIdentity(io_service_t accelerator, IOKitGpuInfo& info) {
   io_registry_entry_t parent = 0;
   if (IORegistryEntryGetParentEntry(accelerator, "IOService", &parent) ==
           KERN_SUCCESS &&
@@ -222,14 +221,13 @@ IOKitGpuInfoList collectIOKitGpus() {
     }
 
     // driver: IOClass property.
-    info.driver = stringFromIOKitProperty(
-        CFDictionaryGetValue(props, CFSTR("IOClass")));
+    info.driver =
+        stringFromIOKitProperty(CFDictionaryGetValue(props, CFSTR("IOClass")));
 
     // model_id: IONameMatched (e.g. "gpu,t6000") identifies the SoC GPU
     // variant. On Apple Silicon there is no PCI device-id; this is the closest
     // hardware identifier.
-    auto name_matched =
-        CFDictionaryGetValue(props, CFSTR("IONameMatched"));
+    auto name_matched = CFDictionaryGetValue(props, CFSTR("IONameMatched"));
     info.model_id = stringFromIOKitProperty(name_matched);
 
     // cores: gpu-core-count (CFNumberRef).
@@ -259,11 +257,10 @@ IOKitGpuInfoList collectIOKitGpus() {
 // identity match (PCI vendor/device IDs), then fall back to model name. Each
 // accelerator is consumed at most once so two identical cards enrich two
 // different rows instead of the same node twice.
-IOKitGpuInfoList::iterator matchAccelerator(
-    const std::string& model_name,
-    const std::string& sp_vendor_id,
-    const std::string& sp_device_id,
-    IOKitGpuInfoList& gpus) {
+IOKitGpuInfoList::iterator matchAccelerator(const std::string& model_name,
+                                            const std::string& sp_vendor_id,
+                                            const std::string& sp_device_id,
+                                            IOKitGpuInfoList& gpus) {
   if (!sp_vendor_id.empty() && !sp_device_id.empty()) {
     for (auto it = gpus.begin(); it != gpus.end(); ++it) {
       if (it->pci_vendor_id == sp_vendor_id &&

--- a/osquery/tables/system/darwin/gpu_info.mm
+++ b/osquery/tables/system/darwin/gpu_info.mm
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#import <AppKit/NSDocument.h>
+#import <Foundation/Foundation.h>
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/IOKitKeys.h>
+
+#include <cstdio>
+#include <iomanip>
+#include <sstream>
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/darwin/cfdata.h>
+#include <osquery/utils/conversions/darwin/cfnumber.h>
+#include <osquery/utils/conversions/darwin/cfstring.h>
+#include <osquery/utils/darwin/iokit_helpers.h>
+#include <osquery/utils/darwin/system_profiler.h>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+
+const char* kIOAcceleratorClassName = "IOAccelerator";
+
+struct IOKitGpuInfo {
+  std::string vendor_id;
+  std::string model_id;
+  std::string model;
+  std::string driver;
+  std::uint64_t vram = 0;
+  std::uint32_t cores = 0;
+  bool found = false;
+};
+
+std::string cfDataToHexString(CFDataRef data) {
+  if (data == nullptr) {
+    return {};
+  }
+
+  auto length = CFDataGetLength(data);
+  if (length < 1) {
+    return {};
+  }
+
+  const UInt8* bytes = CFDataGetBytePtr(data);
+  std::stringstream ss;
+  ss << "0x" << std::hex << std::setfill('0');
+  // The vendor-id is stored little-endian; reverse for human-readable hex.
+  for (CFIndex i = length - 1; i >= 0; --i) {
+    ss << std::setw(2) << static_cast<int>(bytes[i]);
+  }
+  return ss.str();
+}
+
+std::uint64_t cfNumberToUint64(CFTypeRef value) {
+  if (value == nullptr || CFGetTypeID(value) != CFNumberGetTypeID()) {
+    return 0;
+  }
+  long long int n = 0;
+  CFNumberGetValue(static_cast<CFNumberRef>(value), kCFNumberLongLongType, &n);
+  return static_cast<std::uint64_t>(n);
+}
+
+// Enrich a row from the IOKit AGXAccelerator node matching the GPU model.
+void enrichFromIOKit(const std::string& model_name, IOKitGpuInfo& info) {
+  auto matching = IOServiceMatching(kIOAcceleratorClassName);
+  if (matching == nullptr) {
+    return;
+  }
+
+  io_iterator_t it = 0;
+  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
+  if (kr != KERN_SUCCESS) {
+    return;
+  }
+  UniqueIoIterator it_ptr(it);
+
+  io_service_t service = 0;
+  while ((service = IOIteratorNext(it_ptr.get())) != 0) {
+    UniqueIoService service_ptr(service);
+
+    CFMutableDictionaryRef props = nullptr;
+    kr = IORegistryEntryCreateCFProperties(
+        service, &props, kCFAllocatorDefault, kNilOptions);
+    if (kr != KERN_SUCCESS || props == nullptr) {
+      continue;
+    }
+    UniqueCFMutableDictionaryRef props_ptr(props);
+
+    // Match by model property.
+    auto model_cf =
+        static_cast<CFStringRef>(CFDictionaryGetValue(props, CFSTR("model")));
+    if (model_cf == nullptr) {
+      continue;
+    }
+    if (stringFromCFString(model_cf) != model_name) {
+      continue;
+    }
+
+    info.found = true;
+
+    // vendor-id: CFDataRef, 4 bytes, little-endian.
+    auto vendor_id_data =
+        static_cast<CFDataRef>(CFDictionaryGetValue(props, CFSTR("vendor-id")));
+    if (vendor_id_data != nullptr &&
+        CFGetTypeID(vendor_id_data) == CFDataGetTypeID()) {
+      info.vendor_id = cfDataToHexString(vendor_id_data);
+    }
+
+    // driver: IOClass property.
+    auto io_class =
+        static_cast<CFStringRef>(CFDictionaryGetValue(props, CFSTR("IOClass")));
+    if (io_class != nullptr) {
+      info.driver = stringFromCFString(io_class);
+    }
+
+    // model_id: IONameMatched (e.g. "gpu,t6000") identifies the SoC GPU
+    // variant. On Apple Silicon there is no PCI device-id; this is the closest
+    // hardware identifier.
+    auto name_matched = static_cast<CFStringRef>(
+        CFDictionaryGetValue(props, CFSTR("IONameMatched")));
+    if (name_matched != nullptr) {
+      info.model_id = stringFromCFString(name_matched);
+    }
+
+    // cores: gpu-core-count (CFNumberRef).
+    auto cores_cf = static_cast<CFTypeRef>(
+        CFDictionaryGetValue(props, CFSTR("gpu-core-count")));
+    if (cores_cf != nullptr) {
+      info.cores = static_cast<std::uint32_t>(cfNumberToUint64(cores_cf));
+    }
+
+    // vram: PerformanceStatistics -> "Alloc system memory" (CFNumberRef).
+    // On Apple Silicon the GPU uses unified memory; "Alloc system memory" is
+    // the amount of system memory currently allocated to the GPU and is the
+    // closest analog to dedicated VRAM.
+    auto perf_stats = static_cast<CFDictionaryRef>(
+        CFDictionaryGetValue(props, CFSTR("PerformanceStatistics")));
+    if (perf_stats != nullptr) {
+      auto alloc_mem = static_cast<CFTypeRef>(
+          CFDictionaryGetValue(perf_stats, CFSTR("Alloc system memory")));
+      if (alloc_mem != nullptr) {
+        info.vram = cfNumberToUint64(alloc_mem);
+      }
+    }
+
+    return;
+  }
+}
+
+std::uint64_t vramBytesFromDict(NSDictionary* item) {
+  id vram = [item valueForKey:@"spdisplays_vram"];
+  if (vram == nil) {
+    return 0;
+  }
+
+  if ([vram isKindOfClass:[NSNumber class]]) {
+    return [vram unsignedLongLongValue];
+  }
+
+  NSString* vram_str = [vram description];
+  std::string raw([vram_str UTF8String]);
+
+  double multiplier = 0;
+  if (raw.find("GB") != std::string::npos) {
+    multiplier = 1024.0 * 1024.0 * 1024.0;
+  } else if (raw.find("MB") != std::string::npos) {
+    multiplier = 1024.0 * 1024.0;
+  } else if (raw.find("KB") != std::string::npos) {
+    multiplier = 1024.0;
+  }
+
+  if (multiplier == 0) {
+    return 0;
+  }
+
+  try {
+    return static_cast<std::uint64_t>(std::stod(raw) * multiplier);
+  } catch (const std::exception&) {
+    return 0;
+  }
+}
+
+std::string stripPrefix(const std::string& str, const std::string& prefix) {
+  if (str.find(prefix) == 0) {
+    return str.substr(prefix.size());
+  }
+  return str;
+}
+
+} // namespace
+
+QueryData genGpuInfo(QueryContext& context) {
+  QueryData results;
+
+  @autoreleasepool {
+    NSDictionary* __autoreleasing result;
+    Status status = getSystemProfilerReport("SPDisplaysDataType", result);
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed to get GPU information: " << status.getMessage();
+      return results;
+    }
+
+    NSArray* items = [result objectForKey:@"_items"];
+    if (items == nil) {
+      return results;
+    }
+
+    std::int32_t device_id = 0;
+    for (NSDictionary* item in items) {
+      Row r;
+      r["device_id"] = "GPU" + std::to_string(device_id++);
+
+      std::string model_name;
+
+      if (id name = [item valueForKey:@"_name"]) {
+        r["name"] = SQL_TEXT([[name description] UTF8String]);
+        model_name = r["name"];
+      }
+
+      if (id model = [item valueForKey:@"sppci_model"]) {
+        if (r["name"].empty()) {
+          r["name"] = SQL_TEXT([[model description] UTF8String]);
+          model_name = r["name"];
+        }
+        r["model"] = SQL_TEXT([[model description] UTF8String]);
+        if (model_name.empty()) {
+          model_name = r["model"];
+        }
+      }
+
+      if (id vendor = [item valueForKey:@"spdisplays_vendor"]) {
+        std::string vendor_str([[vendor description] UTF8String]);
+        r["vendor"] = SQL_TEXT(stripPrefix(vendor_str, "sppci_vendor_"));
+      }
+
+      if (id driver = [item valueForKey:@"spdisplays_driver"]) {
+        r["driver"] = SQL_TEXT([[driver description] UTF8String]);
+      }
+
+      auto vram = vramBytesFromDict(item);
+      if (vram > 0) {
+        r["vram"] = BIGINT(vram);
+      }
+
+      if (id pci_slot = [item valueForKey:@"sppci_device_id"]) {
+        r["pci_slot"] = SQL_TEXT([[pci_slot description] UTF8String]);
+      } else if (id bus = [item valueForKey:@"sppci_bus"]) {
+        std::string bus_str([[bus description] UTF8String]);
+        if (bus_str != "spdisplays_builtin") {
+          r["pci_slot"] = SQL_TEXT(bus_str);
+        }
+      }
+
+      r["pci_class_id"] = "0x030000";
+
+      // Enrich from IOKit AGXAccelerator for Apple Silicon (and discrete GPUs
+      // that publish an IOAccelerator personality).
+      if (!model_name.empty()) {
+        IOKitGpuInfo iokit_info;
+        enrichFromIOKit(model_name, iokit_info);
+        if (iokit_info.found) {
+          if (r["vendor_id"].empty()) {
+            r["vendor_id"] = iokit_info.vendor_id;
+          }
+          if (r["model_id"].empty()) {
+            r["model_id"] = iokit_info.model_id;
+          }
+          if (r["driver"].empty()) {
+            r["driver"] = iokit_info.driver;
+          }
+          if (r["vram"].empty()) {
+            r["vram"] = BIGINT(iokit_info.vram);
+          }
+          if (iokit_info.cores > 0) {
+            r["cores"] = INTEGER(iokit_info.cores);
+          }
+        }
+      }
+
+      // metal_support from system_profiler.
+      if (id metal = [item valueForKey:@"spdisplays_mtlgpufamilysupport"]) {
+        r["metal_support"] =
+            SQL_TEXT(stripPrefix([[metal description] UTF8String],
+                                 "spdisplays_"));
+      }
+
+      results.push_back(r);
+    }
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/gpu_info.mm
+++ b/osquery/tables/system/darwin/gpu_info.mm
@@ -10,8 +10,8 @@
 #import <AppKit/NSDocument.h>
 #import <Foundation/Foundation.h>
 
-#include <IOKit/IOKitLib.h>
 #include <IOKit/IOKitKeys.h>
+#include <IOKit/IOKitLib.h>
 
 #include <cstdio>
 #include <iomanip>
@@ -291,9 +291,8 @@ QueryData genGpuInfo(QueryContext& context) {
 
       // metal_support from system_profiler.
       if (id metal = [item valueForKey:@"spdisplays_mtlgpufamilysupport"]) {
-        r["metal_support"] =
-            SQL_TEXT(stripPrefix([[metal description] UTF8String],
-                                 "spdisplays_"));
+        r["metal_support"] = SQL_TEXT(
+            stripPrefix([[metal description] UTF8String], "spdisplays_"));
       }
 
       results.push_back(r);

--- a/osquery/tables/system/darwin/gpu_info.mm
+++ b/osquery/tables/system/darwin/gpu_info.mm
@@ -7,15 +7,16 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#import <AppKit/NSDocument.h>
 #import <Foundation/Foundation.h>
 
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOKitLib.h>
 
 #include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
@@ -33,15 +34,21 @@ namespace {
 
 const char* kIOAcceleratorClassName = "IOAccelerator";
 
+// An IOKit accelerator node plus the hardware identity of the device it
+// drives, used to match accelerators to system_profiler rows.
 struct IOKitGpuInfo {
   std::string vendor_id;
   std::string model_id;
   std::string model;
   std::string driver;
-  std::uint64_t vram = 0;
   std::uint32_t cores = 0;
-  bool found = false;
+  // PCI vendor/device IDs published by the underlying device node (e.g.
+  // sgx@4000000 on Apple Silicon, IOPCIDevice for discrete GPUs), if any.
+  std::string pci_vendor_id;
+  std::string pci_device_id;
 };
+
+using IOKitGpuInfoList = std::vector<IOKitGpuInfo>;
 
 std::string cfDataToHexString(CFDataRef data) {
   if (data == nullptr) {
@@ -72,17 +79,119 @@ std::uint64_t cfNumberToUint64(CFTypeRef value) {
   return static_cast<std::uint64_t>(n);
 }
 
-// Enrich a row from the IOKit AGXAccelerator node matching the GPU model.
-void enrichFromIOKit(const std::string& model_name, IOKitGpuInfo& info) {
-  auto matching = IOServiceMatching(kIOAcceleratorClassName);
-  if (matching == nullptr) {
-    return;
+// Safely convert an IOKit property that may be either a CFString or a CFData
+// holding a (possibly unterminated) C string. IOKit does not guarantee property
+// types across vendors; on PCI device nodes, "model" is conventionally CFData.
+std::string stringFromIOKitProperty(CFTypeRef value) {
+  if (value == nullptr) {
+    return {};
   }
 
+  auto type_id = CFGetTypeID(value);
+  if (type_id == CFStringGetTypeID()) {
+    return stringFromCFString(static_cast<CFStringRef>(value));
+  }
+
+  if (type_id == CFDataGetTypeID()) {
+    auto data = static_cast<CFDataRef>(value);
+    auto length = CFDataGetLength(data);
+    if (length < 1) {
+      return {};
+    }
+    // The data bytes may not be null terminated; use strnlen against the
+    // CFDataGetLength bound.
+    auto bytes = CFDataGetBytePtr(data);
+    auto* begin = reinterpret_cast<const char*>(bytes);
+    auto str_length = strnlen(begin, static_cast<std::size_t>(length));
+    return std::string(begin, str_length);
+  }
+
+  return {};
+}
+
+// Read the PCI vendor-id / device-id properties of a device node. On Apple
+// Silicon the accelerator node itself carries vendor-id only; the device node
+// (e.g. sgx@4000000) has neither, in which case this returns false and callers
+// fall back to model-based matching.
+bool readPciIdsFromEntry(io_registry_entry_t entry,
+                         std::string& vendor_id,
+                         std::string& device_id) {
+  vendor_id.clear();
+  device_id.clear();
+
+  CFMutableDictionaryRef props = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      entry, &props, kCFAllocatorDefault, kNilOptions);
+  if (kr != KERN_SUCCESS || props == nullptr) {
+    return false;
+  }
+  UniqueCFMutableDictionaryRef props_ptr(props);
+
+  bool found = false;
+  auto vid = CFDictionaryGetValue(props, CFSTR("vendor-id"));
+  if (vid != nullptr && CFGetTypeID(vid) == CFDataGetTypeID()) {
+    vendor_id = cfDataToHexString(static_cast<CFDataRef>(vid));
+    found = !vendor_id.empty();
+  }
+  auto did = CFDictionaryGetValue(props, CFSTR("device-id"));
+  if (did != nullptr && CFGetTypeID(did) == CFDataGetTypeID()) {
+    device_id = cfDataToHexString(static_cast<CFDataRef>(did));
+  }
+  return found;
+}
+
+// Walk from the accelerator to its parent device node and read the PCI
+// vendor/device identity, falling back to the accelerator's own properties
+// (Apple Silicon accelerators publish vendor-id directly).
+void acceleratorPciIdentity(io_service_t accelerator,
+                            IOKitGpuInfo& info) {
+  io_registry_entry_t parent = 0;
+  if (IORegistryEntryGetParentEntry(accelerator, "IOService", &parent) ==
+          KERN_SUCCESS &&
+      parent != 0) {
+    UniqueIoService parent_ptr(parent);
+    readPciIdsFromEntry(parent, info.pci_vendor_id, info.pci_device_id);
+  }
+
+  if (info.pci_vendor_id.empty()) {
+    // Fall back to the accelerator's own vendor-id (e.g. Apple Silicon).
+    CFMutableDictionaryRef props = nullptr;
+    auto kr = IORegistryEntryCreateCFProperties(
+        accelerator, &props, kCFAllocatorDefault, kNilOptions);
+    if (kr == KERN_SUCCESS && props != nullptr) {
+      UniqueCFMutableDictionaryRef props_ptr(props);
+      auto vid = CFDictionaryGetValue(props, CFSTR("vendor-id"));
+      if (vid != nullptr && CFGetTypeID(vid) == CFDataGetTypeID()) {
+        info.pci_vendor_id = cfDataToHexString(static_cast<CFDataRef>(vid));
+      }
+    }
+  }
+}
+
+// Collect every IOAccelerator node with its properties, so rows can be
+// matched by hardware identity instead of by display name.
+IOKitGpuInfoList collectIOKitGpus() {
+  IOKitGpuInfoList gpus;
+
+  auto matching = IOServiceMatching(kIOAcceleratorClassName);
+  if (matching == nullptr) {
+    return gpus;
+  }
+
+  // kIOMasterPortDefault is deprecated since macOS 12; kIOMainPortDefault is
+  // unavailable before it. The deployment target is 10.15, so select at
+  // compile time and fall back to the deprecated constant on older systems.
+  mach_port_t main_port;
+#ifdef kIOMainPortDefault
+  main_port = kIOMainPortDefault;
+#else
+  main_port = kIOMasterPortDefault;
+#endif
+
   io_iterator_t it = 0;
-  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
+  auto kr = IOServiceGetMatchingServices(main_port, matching, &it);
   if (kr != KERN_SUCCESS) {
-    return;
+    return gpus;
   }
   UniqueIoIterator it_ptr(it);
 
@@ -98,17 +207,11 @@ void enrichFromIOKit(const std::string& model_name, IOKitGpuInfo& info) {
     }
     UniqueCFMutableDictionaryRef props_ptr(props);
 
-    // Match by model property.
-    auto model_cf =
-        static_cast<CFStringRef>(CFDictionaryGetValue(props, CFSTR("model")));
-    if (model_cf == nullptr) {
-      continue;
-    }
-    if (stringFromCFString(model_cf) != model_name) {
-      continue;
-    }
+    IOKitGpuInfo info;
 
-    info.found = true;
+    // model: matched against the row below; may be CFString or CFData.
+    auto model_cf = CFDictionaryGetValue(props, CFSTR("model"));
+    info.model = stringFromIOKitProperty(model_cf);
 
     // vendor-id: CFDataRef, 4 bytes, little-endian.
     auto vendor_id_data =
@@ -119,44 +222,68 @@ void enrichFromIOKit(const std::string& model_name, IOKitGpuInfo& info) {
     }
 
     // driver: IOClass property.
-    auto io_class =
-        static_cast<CFStringRef>(CFDictionaryGetValue(props, CFSTR("IOClass")));
-    if (io_class != nullptr) {
-      info.driver = stringFromCFString(io_class);
-    }
+    info.driver = stringFromIOKitProperty(
+        CFDictionaryGetValue(props, CFSTR("IOClass")));
 
     // model_id: IONameMatched (e.g. "gpu,t6000") identifies the SoC GPU
     // variant. On Apple Silicon there is no PCI device-id; this is the closest
     // hardware identifier.
-    auto name_matched = static_cast<CFStringRef>(
-        CFDictionaryGetValue(props, CFSTR("IONameMatched")));
-    if (name_matched != nullptr) {
-      info.model_id = stringFromCFString(name_matched);
-    }
+    auto name_matched =
+        CFDictionaryGetValue(props, CFSTR("IONameMatched"));
+    info.model_id = stringFromIOKitProperty(name_matched);
 
     // cores: gpu-core-count (CFNumberRef).
-    auto cores_cf = static_cast<CFTypeRef>(
-        CFDictionaryGetValue(props, CFSTR("gpu-core-count")));
+    auto cores_cf = CFDictionaryGetValue(props, CFSTR("gpu-core-count"));
     if (cores_cf != nullptr) {
       info.cores = static_cast<std::uint32_t>(cfNumberToUint64(cores_cf));
     }
 
-    // vram: PerformanceStatistics -> "Alloc system memory" (CFNumberRef).
-    // On Apple Silicon the GPU uses unified memory; "Alloc system memory" is
-    // the amount of system memory currently allocated to the GPU and is the
-    // closest analog to dedicated VRAM.
-    auto perf_stats = static_cast<CFDictionaryRef>(
-        CFDictionaryGetValue(props, CFSTR("PerformanceStatistics")));
-    if (perf_stats != nullptr) {
-      auto alloc_mem = static_cast<CFTypeRef>(
-          CFDictionaryGetValue(perf_stats, CFSTR("Alloc system memory")));
-      if (alloc_mem != nullptr) {
-        info.vram = cfNumberToUint64(alloc_mem);
+    // vram: deliberately not populated from PerformanceStatistics. The only
+    // candidate there, "Alloc system memory", is the memory *currently*
+    // allocated to the GPU and fluctuates with load (verified empirically:
+    // 7.26 GB vs 7.33 GB minutes apart on the same machine). Every other
+    // platform reports fixed capacity in this column; a dynamic value would
+    // surface as a row change on every poll and break diff-based monitoring.
+    // Apple Silicon has no dedicated VRAM, so the column stays empty here;
+    // system_profiler's spdisplays_vram still fills it for discrete GPUs.
+
+    acceleratorPciIdentity(service, info);
+
+    gpus.push_back(std::move(info));
+  }
+
+  return gpus;
+}
+
+// Find the best accelerator for a system_profiler row: prefer a hardware
+// identity match (PCI vendor/device IDs), then fall back to model name. Each
+// accelerator is consumed at most once so two identical cards enrich two
+// different rows instead of the same node twice.
+IOKitGpuInfoList::iterator matchAccelerator(
+    const std::string& model_name,
+    const std::string& sp_vendor_id,
+    const std::string& sp_device_id,
+    IOKitGpuInfoList& gpus) {
+  if (!sp_vendor_id.empty() && !sp_device_id.empty()) {
+    for (auto it = gpus.begin(); it != gpus.end(); ++it) {
+      if (it->pci_vendor_id == sp_vendor_id &&
+          it->pci_device_id == sp_device_id) {
+        return it;
       }
     }
-
-    return;
   }
+
+  if (model_name.empty()) {
+    return gpus.end();
+  }
+
+  for (auto it = gpus.begin(); it != gpus.end(); ++it) {
+    if (it->model == model_name) {
+      return it;
+    }
+  }
+
+  return gpus.end();
 }
 
 std::uint64_t vramBytesFromDict(NSDictionary* item) {
@@ -218,9 +345,13 @@ QueryData genGpuInfo(QueryContext& context) {
     }
 
     std::int32_t device_id = 0;
+
+    // Collect IOKit accelerators once; each row consumes at most one node so
+    // identical GPUs are enriched from distinct accelerators.
+    IOKitGpuInfoList iokit_gpus = collectIOKitGpus();
+
     for (NSDictionary* item in items) {
       Row r;
-      r["device_id"] = "GPU" + std::to_string(device_id++);
 
       std::string model_name;
 
@@ -263,30 +394,51 @@ QueryData genGpuInfo(QueryContext& context) {
         }
       }
 
+      // device_id: derived from the slot when present so it is stable across
+      // reboots; system_profiler enumeration order is not guaranteed. The
+      // counter is only a fallback for rows without one (e.g. Apple Silicon
+      // integrated GPUs).
+      if (r["pci_slot"].empty()) {
+        r["device_id"] = "GPU" + std::to_string(device_id++);
+      } else {
+        r["device_id"] = "GPU" + r["pci_slot"];
+      }
+
       r["pci_class_id"] = "0x030000";
 
+      // Hardware identity from system_profiler, used to match the row to its
+      // IOKit accelerator. Discrete GPUs report hex PCI ids (e.g.
+      // "0x1002" / "0x679e"); Apple Silicon does not report them.
+      std::string sp_vendor_id;
+      std::string sp_device_id;
+      if (id sp_vid = [item valueForKey:@"sppci_vendor_id"]) {
+        sp_vendor_id = [[sp_vid description] UTF8String];
+      }
+      if (id sp_did = [item valueForKey:@"sppci_device_id"]) {
+        sp_device_id = [[sp_did description] UTF8String];
+      }
+
       // Enrich from IOKit AGXAccelerator for Apple Silicon (and discrete GPUs
-      // that publish an IOAccelerator personality).
-      if (!model_name.empty()) {
-        IOKitGpuInfo iokit_info;
-        enrichFromIOKit(model_name, iokit_info);
-        if (iokit_info.found) {
-          if (r["vendor_id"].empty()) {
-            r["vendor_id"] = iokit_info.vendor_id;
-          }
-          if (r["model_id"].empty()) {
-            r["model_id"] = iokit_info.model_id;
-          }
-          if (r["driver"].empty()) {
-            r["driver"] = iokit_info.driver;
-          }
-          if (r["vram"].empty()) {
-            r["vram"] = BIGINT(iokit_info.vram);
-          }
-          if (iokit_info.cores > 0) {
-            r["cores"] = INTEGER(iokit_info.cores);
-          }
+      // that publish an IOAccelerator personality), matched by hardware
+      // identity when available.
+      auto accel_it =
+          matchAccelerator(model_name, sp_vendor_id, sp_device_id, iokit_gpus);
+      if (accel_it != iokit_gpus.end()) {
+        const auto& iokit_info = *accel_it;
+        if (r["vendor_id"].empty() && !iokit_info.vendor_id.empty()) {
+          r["vendor_id"] = iokit_info.vendor_id;
         }
+        if (r["model_id"].empty() && !iokit_info.model_id.empty()) {
+          r["model_id"] = iokit_info.model_id;
+        }
+        if (r["driver"].empty() && !iokit_info.driver.empty()) {
+          r["driver"] = iokit_info.driver;
+        }
+        if (iokit_info.cores > 0) {
+          r["cores"] = INTEGER(iokit_info.cores);
+        }
+        // Consume this accelerator so no other row matches it.
+        iokit_gpus.erase(accel_it);
       }
 
       // metal_support from system_profiler.

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -7,7 +7,9 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <cstring>
 #include <fstream>
+#include <string_view>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -60,7 +62,10 @@ void collectVramFromDrm(std::map<std::string, std::uint64_t>& vram_by_slot) {
   }
 
   for (const auto& entry : drm_entries) {
-    if (entry.find("card") == std::string::npos ||
+    // Select card0, card1, ... only: prefix-match "card" and exclude
+    // connector entries (card0-eDP-1) and other hyphenated names. The
+    // explicit render check excludes renderD* siblings.
+    if (entry.rfind("card", 0) != 0 ||
         entry.find("render") != std::string::npos ||
         entry.find("-") != std::string::npos) {
       continue;
@@ -92,7 +97,7 @@ void collectVramFromDrm(std::map<std::string, std::uint64_t>& vram_by_slot) {
     auto uevent = readSysFile(slot_path);
     for (const auto& line : split(uevent, "\n")) {
       if (line.find("PCI_SLOT_NAME=") == 0) {
-        slot = line.substr(strlen("PCI_SLOT_NAME="));
+        slot = line.substr(std::string_view("PCI_SLOT_NAME=").size());
         boost::trim(slot);
         break;
       }
@@ -207,8 +212,15 @@ QueryData genGpuInfo(QueryContext& context) {
     }
 
     Row r;
-    r["device_id"] = "GPU" + std::to_string(device_id++);
     r["pci_slot"] = UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
+    // device_id: derived from the PCI address so it is stable across reboots;
+    // udev enumeration order is not guaranteed. The counter is only a fallback
+    // for devices without a slot.
+    if (r["pci_slot"].empty()) {
+      r["device_id"] = "GPU" + std::to_string(device_id++);
+    } else {
+      r["device_id"] = "GPU" + r["pci_slot"];
+    }
     r["pci_class_id"] = "0x" + pci_class_attr;
     r["driver"] = UdevEventPublisher::getValue(device.get(), kPCIKeyDriver);
 

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -296,28 +296,33 @@ void enrichVramFromNvml(QueryData& results) {
 }
 
 bool isDisplayControllerClass(const std::string& pci_class_attr) {
+  // udev reports PCI_CLASS as the 24-bit class code, hex, WITHOUT the 0x
+  // prefix and with insignificant leading zeroes stripped (e.g. display is
+  // "30000" == 0x030000). The display controller base class is 0x03.
   std::string lowered = pci_class_attr;
   boost::algorithm::to_lower(lowered);
   boost::trim(lowered);
 
-  if (lowered.size() < 2) {
+  // Strip an optional 0x prefix.
+  if (lowered.rfind("0x", 0) == 0) {
+    lowered = lowered.substr(2);
+  }
+
+  if (lowered.empty()) {
     return false;
   }
 
-  std::string class_id;
-  switch (lowered.size()) {
-  case 5:
-    class_id = lowered.substr(0, 1);
-    break;
-  case 6:
-  case 7:
-    class_id = lowered.substr(0, 2);
-    break;
-  default:
-    return false;
+  // The class code is 0xRRCCSS: base class RR is the leading byte. With
+  // leading zeroes stripped, RR==0x03 appears as either "3" (id_len 5) or
+  // "03" (id_len 6).
+  std::string base;
+  if (lowered[0] == '0' && lowered.size() >= 2) {
+    base = lowered.substr(0, 2); // "03xxxx" -> "03"
+  } else {
+    base = lowered.substr(0, 1); // "3xxxx" -> "3"
   }
 
-  return class_id == "03";
+  return (base == "03" || base == "3");
 }
 
 } // namespace

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <fstream>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/events/linux/udev.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/linux/pci_devices.h>
+#include <osquery/utils/conversions/join.h>
+#include <osquery/utils/conversions/split.h>
+#include <osquery/utils/conversions/tryto.h>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+
+const std::string kDrmSysfsPath = "/sys/class/drm";
+
+std::string readSysFile(const std::string& path) {
+  std::string content;
+  if (!readFile(path, content).ok()) {
+    return {};
+  }
+  boost::trim(content);
+  return content;
+}
+
+std::string drmCardNameToDevicePath(const std::string& drm_dir,
+                                    const std::string& card_name) {
+  auto target = drm_dir + "/" + card_name + "/device";
+  boost::filesystem::path resolved;
+  if (!boost::filesystem::exists(target)) {
+    return {};
+  }
+  try {
+    resolved = boost::filesystem::canonical(target);
+  } catch (const boost::filesystem::filesystem_error&) {
+    return {};
+  }
+  return resolved.string();
+}
+
+void collectVramFromDrm(std::map<std::string, std::uint64_t>& vram_by_slot) {
+  std::vector<std::string> drm_entries;
+  if (!listDirectoriesInDirectory(kDrmSysfsPath, drm_entries).ok()) {
+    return;
+  }
+
+  for (const auto& entry : drm_entries) {
+    if (entry.find("card") == std::string::npos ||
+        entry.find("render") != std::string::npos ||
+        entry.find("-") != std::string::npos) {
+      continue;
+    }
+
+    auto device_path = drmCardNameToDevicePath(kDrmSysfsPath, entry);
+    if (device_path.empty()) {
+      continue;
+    }
+
+    std::string vram;
+    auto mem_info_vram_total = readSysFile(device_path + "/mem_info_vram_total");
+    if (!mem_info_vram_total.empty()) {
+      vram = mem_info_vram_total;
+    }
+
+    if (vram.empty()) {
+      continue;
+    }
+
+    auto vram_exp = tryTo<std::uint64_t>(vram, 10);
+    if (vram_exp.isError()) {
+      continue;
+    }
+
+    std::string slot;
+    auto slot_path = device_path + "/uevent";
+    auto uevent = readSysFile(slot_path);
+    for (const auto& line : split(uevent, "\n")) {
+      if (line.find("PCI_SLOT_NAME=") == 0) {
+        slot = line.substr(strlen("PCI_SLOT_NAME="));
+        boost::trim(slot);
+        break;
+      }
+    }
+
+    if (!slot.empty()) {
+      vram_by_slot[slot] = vram_exp.take();
+    }
+  }
+}
+
+void enrichVram(Row& row, const std::map<std::string, std::uint64_t>& vram_by_slot) {
+  auto slot_it = row.find("pci_slot");
+  if (slot_it == row.end() || slot_it->second.empty()) {
+    return;
+  }
+
+  auto vram_it = vram_by_slot.find(slot_it->second);
+  if (vram_it != vram_by_slot.end()) {
+    row["vram"] = BIGINT(vram_it->second);
+  }
+}
+
+bool isDisplayControllerClass(const std::string& pci_class_attr) {
+  std::string lowered = pci_class_attr;
+  boost::algorithm::to_lower(lowered);
+  boost::trim(lowered);
+
+  if (lowered.size() < 2) {
+    return false;
+  }
+
+  std::string class_id;
+  switch (lowered.size()) {
+  case 5:
+    class_id = lowered.substr(0, 1);
+    break;
+  case 6:
+  case 7:
+    class_id = lowered.substr(0, 2);
+    break;
+  default:
+    return false;
+  }
+
+  return class_id == "03";
+}
+
+} // namespace
+
+QueryData genGpuInfo(QueryContext& context) {
+  QueryData results;
+
+  auto del_udev = [](udev* u) { udev_unref(u); };
+  std::unique_ptr<udev, decltype(del_udev)> udev_handle(udev_new(), del_udev);
+  if (udev_handle.get() == nullptr) {
+    VLOG(1) << "Could not get udev handle";
+    return results;
+  }
+
+  auto del_udev_enum = [](udev_enumerate* e) { udev_enumerate_unref(e); };
+  std::unique_ptr<udev_enumerate, decltype(del_udev_enum)> enumerate(
+      udev_enumerate_new(udev_handle.get()), del_udev_enum);
+  if (enumerate.get() == nullptr) {
+    VLOG(1) << "Could not get udev_enumerate handle";
+    return results;
+  }
+
+  std::ifstream raw;
+  for (const std::string& pci_ids_path : kPciidsPathList) {
+    if (pathExists(pci_ids_path)) {
+      raw.open(pci_ids_path);
+      if (raw) {
+        break;
+      }
+    }
+  }
+
+  std::unique_ptr<PciDB> pcidb;
+  if (raw.is_open()) {
+    pcidb = std::make_unique<PciDB>(raw);
+  } else {
+    VLOG(1) << "Unexpected error attempting to read pci.ids at path: "
+            << osquery::join(kPciidsPathList, " ");
+  }
+
+  std::map<std::string, std::uint64_t> vram_by_slot;
+  collectVramFromDrm(vram_by_slot);
+
+  udev_enumerate_add_match_subsystem(enumerate.get(), "pci");
+  udev_enumerate_scan_devices(enumerate.get());
+
+  struct udev_list_entry *device_entries, *entry;
+  device_entries = udev_enumerate_get_list_entry(enumerate.get());
+
+  std::int32_t device_id = 0;
+  udev_list_entry_foreach(entry, device_entries) {
+    const char* path = udev_list_entry_get_name(entry);
+
+    std::unique_ptr<udev_device, decltype(&udev_device_unref)> device(
+        udev_device_new_from_syspath(udev_handle.get(), path),
+        udev_device_unref);
+    if (device.get() == nullptr) {
+      continue;
+    }
+
+    auto pci_class_attr =
+        UdevEventPublisher::getValue(device.get(), kPCIClassID);
+    if (!isDisplayControllerClass(pci_class_attr)) {
+      continue;
+    }
+
+    Row r;
+    r["device_id"] = "GPU" + std::to_string(device_id++);
+    r["pci_slot"] =
+        UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
+    r["pci_class_id"] = "0x" + pci_class_attr;
+    r["driver"] = UdevEventPublisher::getValue(device.get(), kPCIKeyDriver);
+
+    if (pcidb != nullptr) {
+      auto status = extractVendorModelFromPciDBIfPresent(
+          r,
+          UdevEventPublisher::getValue(device.get(), kPCIKeyID),
+          UdevEventPublisher::getValue(device.get(), kPCISubsysID),
+          *pcidb);
+      if (!status.ok()) {
+        VLOG(1) << "Unexpected error extracting GPU PCI info: "
+                << status.getMessage();
+      }
+    }
+
+    auto vendor_db = UdevEventPublisher::getValue(device.get(), kPCIKeyVendor);
+    auto model_db = UdevEventPublisher::getValue(device.get(), kPCIKeyModel);
+    if (r["vendor"].empty() && !vendor_db.empty()) {
+      r["vendor"] = vendor_db;
+    }
+    if (r["model"].empty() && !model_db.empty()) {
+      r["model"] = model_db;
+    }
+
+    if (!r["model"].empty()) {
+      r["name"] = r["model"];
+    }
+
+    enrichVram(r, vram_by_slot);
+
+    results.emplace_back(std::move(r));
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -72,7 +72,8 @@ void collectVramFromDrm(std::map<std::string, std::uint64_t>& vram_by_slot) {
     }
 
     std::string vram;
-    auto mem_info_vram_total = readSysFile(device_path + "/mem_info_vram_total");
+    auto mem_info_vram_total =
+        readSysFile(device_path + "/mem_info_vram_total");
     if (!mem_info_vram_total.empty()) {
       vram = mem_info_vram_total;
     }
@@ -103,7 +104,8 @@ void collectVramFromDrm(std::map<std::string, std::uint64_t>& vram_by_slot) {
   }
 }
 
-void enrichVram(Row& row, const std::map<std::string, std::uint64_t>& vram_by_slot) {
+void enrichVram(Row& row,
+                const std::map<std::string, std::uint64_t>& vram_by_slot) {
   auto slot_it = row.find("pci_slot");
   if (slot_it == row.end() || slot_it->second.empty()) {
     return;
@@ -206,8 +208,7 @@ QueryData genGpuInfo(QueryContext& context) {
 
     Row r;
     r["device_id"] = "GPU" + std::to_string(device_id++);
-    r["pci_slot"] =
-        UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
+    r["pci_slot"] = UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
     r["pci_class_id"] = "0x" + pci_class_attr;
     r["driver"] = UdevEventPublisher::getValue(device.get(), kPCIKeyDriver);
 

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -31,6 +31,22 @@ namespace {
 
 const std::string kDrmSysfsPath = "/sys/class/drm";
 
+// udev property names for PCI device attributes; these mirror the constants
+// in pci_devices.cpp, which are not exported through a header.
+const std::string kPCIClassID = "PCI_CLASS";
+const std::string kPCIKeySlot = "PCI_SLOT_NAME";
+const std::string kPCIKeyDriver = "DRIVER";
+const std::string kPCIKeyID = "PCI_ID";
+const std::string kPCISubsysID = "PCI_SUBSYS_ID";
+const std::string kPCIKeyVendor = "ID_VENDOR_FROM_DATABASE";
+const std::string kPCIKeyModel = "ID_MODEL_FROM_DATABASE";
+
+// Candidate locations of the pci.ids database; mirrors the constant in
+// pci_devices.cpp, which is not exported through a header.
+const std::vector<std::string> kPciidsPathList{"/usr/share/misc/pci.ids",
+                                               "/usr/share/hwdata/pci.ids",
+                                               "/usr/share/pci.ids"};
+
 std::string readSysFile(const std::string& path) {
   std::string content;
   if (!readFile(path, content).ok()) {

--- a/osquery/tables/system/linux/gpu_info.cpp
+++ b/osquery/tables/system/linux/gpu_info.cpp
@@ -7,8 +7,11 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <cstdint>
 #include <cstring>
+#include <dlfcn.h>
 #include <fstream>
+#include <memory>
 #include <string_view>
 
 #include <boost/algorithm/string.hpp>
@@ -136,6 +139,160 @@ void enrichVram(Row& row,
   if (vram_it != vram_by_slot.end()) {
     row["vram"] = BIGINT(vram_it->second);
   }
+}
+
+// NVML is the NVIDIA Management Library, the interface behind nvidia-smi.
+// The proprietary driver exposes no sysfs file with the video memory size, so
+// the fixed capacity of NVIDIA GPUs is read from NVML instead. The library is
+// part of the driver userland, ships with no stable header to build against
+// and is absent on non-NVIDIA systems, so it is opened dynamically at query
+// time and every failure is tolerated: the vram column stays empty.
+const std::vector<std::string> kNvmlLibraryNames{"libnvidia-ml.so.1",
+                                                 "libnvidia-ml.so"};
+
+// Mirrors nvmlMemory_t from NVIDIA's nvml.h. Only the layout matters, and
+// only the first field is consumed: total is the physical VRAM capacity.
+struct NvmlMemory {
+  std::uint64_t total;
+  std::uint64_t free;
+  std::uint64_t used;
+};
+
+// The two nvmlReturn_t values compared directly; every other result is only
+// passed to nvmlErrorString. NVML_SUCCESS has been 0 in every NVML release.
+enum NvmlResult {
+  kNvmlSuccess = 0,
+  kNvmlErrorNotFound = 6,
+};
+
+extern "C" {
+typedef int (*NvmlInitFn)();
+typedef int (*NvmlShutdownFn)();
+typedef const char* (*NvmlErrorStringFn)(int result);
+typedef int (*NvmlGetHandleByPciBusIdFn)(const char* pci_bus_id, void** device);
+typedef int (*NvmlGetMemoryInfoFn)(void* device, NvmlMemory* memory);
+}
+
+// The NVML symbols resolved from the dynamically opened library, plus the
+// dlopen handle they came from.
+struct NvmlApi {
+  void* library{nullptr};
+
+  NvmlInitFn init{nullptr};
+  NvmlShutdownFn shutdown{nullptr};
+  NvmlErrorStringFn error_string{nullptr};
+  NvmlGetHandleByPciBusIdFn get_handle_by_pci_bus_id{nullptr};
+  NvmlGetMemoryInfoFn get_memory_info{nullptr};
+};
+
+struct NvmlApiCloser {
+  void operator()(NvmlApi* api) const {
+    if (api != nullptr && api->library != nullptr) {
+      dlclose(api->library);
+    }
+    delete api;
+  }
+};
+
+using NvmlApiPtr = std::unique_ptr<NvmlApi, NvmlApiCloser>;
+
+NvmlApiPtr loadNvmlApi() {
+  for (const auto& library_name : kNvmlLibraryNames) {
+    auto library = dlopen(library_name.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (library == nullptr) {
+      VLOG(1) << "NVML is not available: " << dlerror();
+      continue;
+    }
+
+    auto api = NvmlApiPtr(new NvmlApi());
+    api->library = library;
+    api->init = reinterpret_cast<NvmlInitFn>(dlsym(library, "nvmlInit_v2"));
+    api->shutdown =
+        reinterpret_cast<NvmlShutdownFn>(dlsym(library, "nvmlShutdown"));
+    api->error_string =
+        reinterpret_cast<NvmlErrorStringFn>(dlsym(library, "nvmlErrorString"));
+    api->get_handle_by_pci_bus_id = reinterpret_cast<NvmlGetHandleByPciBusIdFn>(
+        dlsym(library, "nvmlDeviceGetHandleByPciBusId_v2"));
+    api->get_memory_info = reinterpret_cast<NvmlGetMemoryInfoFn>(
+        dlsym(library, "nvmlDeviceGetMemoryInfo"));
+
+    if (api->init == nullptr || api->shutdown == nullptr ||
+        api->error_string == nullptr ||
+        api->get_handle_by_pci_bus_id == nullptr ||
+        api->get_memory_info == nullptr) {
+      VLOG(1) << "NVML at " << library_name
+              << " is missing required symbols, NVIDIA GPUs cannot be queried";
+      continue;
+    }
+
+    return api;
+  }
+
+  return nullptr;
+}
+
+// Fills the vram column of the rows that could not be read from sysfs and
+// that have a PCI address NVML can be queried with. NVML addresses GPUs by
+// PCI bus id in the same domain:bus:device.function form udev reports in
+// PCI_SLOT_NAME, so each row is looked up by its own slot and identical GPUs
+// cannot be confused.
+void enrichVramFromNvml(QueryData& results) {
+  std::vector<Row*> gpus_without_vram;
+  for (auto& row : results) {
+    auto vram_it = row.find("vram");
+    bool has_vram = vram_it != row.end() && !vram_it->second.empty();
+    auto slot_it = row.find("pci_slot");
+    bool has_slot = slot_it != row.end() && !slot_it->second.empty();
+
+    if (!has_vram && has_slot) {
+      gpus_without_vram.push_back(&row);
+    }
+  }
+
+  if (gpus_without_vram.empty()) {
+    return;
+  }
+
+  auto nvml = loadNvmlApi();
+  if (nvml == nullptr) {
+    return;
+  }
+
+  auto result = nvml->init();
+  if (result != kNvmlSuccess) {
+    VLOG(1) << "Cannot initialize NVML: " << nvml->error_string(result);
+    return;
+  }
+
+  for (auto* row : gpus_without_vram) {
+    const auto& pci_slot = row->at("pci_slot");
+
+    void* device = nullptr;
+    result = nvml->get_handle_by_pci_bus_id(pci_slot.c_str(), &device);
+    if (result == kNvmlErrorNotFound) {
+      // No NVIDIA GPU at this slot.
+      continue;
+    }
+    if (result != kNvmlSuccess) {
+      VLOG(1) << "NVML cannot access the GPU at PCI slot " << pci_slot << ": "
+              << nvml->error_string(result);
+      continue;
+    }
+
+    NvmlMemory memory{};
+    result = nvml->get_memory_info(device, &memory);
+    if (result != kNvmlSuccess) {
+      VLOG(1) << "NVML cannot read the memory of the GPU at PCI slot "
+              << pci_slot << ": " << nvml->error_string(result);
+      continue;
+    }
+
+    if (memory.total > 0) {
+      (*row)["vram"] = BIGINT(memory.total);
+    }
+  }
+
+  nvml->shutdown();
 }
 
 bool isDisplayControllerClass(const std::string& pci_class_attr) {
@@ -269,6 +426,9 @@ QueryData genGpuInfo(QueryContext& context) {
 
     results.emplace_back(std::move(r));
   }
+
+  // The DRM sysfs files only cover AMD GPUs; NVML fills in NVIDIA ones.
+  enrichVramFromNvml(results);
 
   return results;
 }

--- a/osquery/tables/system/windows/gpu_info.cpp
+++ b/osquery/tables/system/windows/gpu_info.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <cstdio>
+#include <map>
+#include <string>
+
 #include <osquery/core/system.h>
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -32,23 +36,69 @@ void parsePnpDeviceId(const std::string& pnp_id,
   model_id.clear();
 
   // The PNPDeviceID is of the form: PCI\VEN_xxxx&DEV_xxxx&SUBSYS_...
+  // VEN_ and DEV_ values are fixed-width (4 hex digits), so read them directly
+  // rather than searching for a terminating '&', which fails when the ID ends
+  // the string.
   auto vpos = pnp_id.find("VEN_");
-  if (vpos != std::string::npos) {
-    auto start = vpos + 4;
-    auto end = pnp_id.find('&', start);
-    if (end != std::string::npos) {
-      vendor_id = "0x" + pnp_id.substr(start, end - start);
-    }
+  if (vpos != std::string::npos && vpos + 8 <= pnp_id.size()) {
+    vendor_id = "0x" + pnp_id.substr(vpos + 4, 4);
   }
 
   auto dpos = pnp_id.find("DEV_");
-  if (dpos != std::string::npos) {
-    auto start = dpos + 4;
-    auto end = pnp_id.find('&', start);
-    if (end != std::string::npos) {
-      model_id = "0x" + pnp_id.substr(start, end - start);
-    }
+  if (dpos != std::string::npos && dpos + 8 <= pnp_id.size()) {
+    model_id = "0x" + pnp_id.substr(dpos + 4, 4);
   }
+}
+
+// Build a map of PNPDeviceID -> PCI bus address ("0000:bb:dd.f") from
+// Win32_PnPEntity.LocationInformation, so pci_slot carries the same bus
+// address format as the Linux implementation instead of the full PNP string.
+std::map<std::string, std::string> pciAddressByPnpId() {
+  std::map<std::string, std::string> addresses;
+
+  const auto wmiReq = WmiRequest::CreateWmiRequest(
+      "SELECT PNPDeviceID, LocationInformation FROM Win32_PnPEntity");
+  if (!wmiReq) {
+    return addresses;
+  }
+
+  for (const auto& item : wmiReq->results()) {
+    std::string pnp_id;
+    if (!item.GetString("PNPDeviceID", pnp_id).ok() || pnp_id.empty()) {
+      continue;
+    }
+
+    // LocationInformation for PCI devices reads
+    // "PCI bus X, device Y, function Z"; non-PCI adapters report other
+    // strings ("Location Bus Number..." or empty), which are skipped.
+    std::string location;
+    if (!item.GetString("LocationInformation", location).ok() ||
+        location.empty()) {
+      continue;
+    }
+
+    unsigned long bus = 0;
+    unsigned long device = 0;
+    unsigned long function = 0;
+    if (std::sscanf(location.c_str(),
+                    "PCI bus %lu, device %lu, function %lu",
+                    &bus,
+                    &device,
+                    &function) != 3) {
+      continue;
+    }
+
+    char address[16];
+    std::snprintf(address,
+                  sizeof(address),
+                  "0000:%02lx:%02lx.%lu",
+                  bus,
+                  device,
+                  function);
+    addresses[pnp_id] = address;
+  }
+
+  return addresses;
 }
 
 } // namespace
@@ -63,10 +113,11 @@ QueryData genGpuInfo(QueryContext& context) {
     return results;
   }
 
+  const auto address_by_pnp_id = pciAddressByPnpId();
+
   std::int32_t device_id = 0;
   for (const auto& wmiResult : wmiReq->results()) {
     Row r;
-    r["device_id"] = "GPU" + std::to_string(device_id++);
 
     std::string pnp_device_id;
     wmiResult.GetString("PNPDeviceID", pnp_device_id);
@@ -82,9 +133,22 @@ QueryData genGpuInfo(QueryContext& context) {
       r["model_id"] = model_id;
     }
 
-    // pci_slot: use the PNPDeviceID location portion (e.g. PCI\VEN_...&BUS_...)
-    if (!pnp_device_id.empty()) {
-      r["pci_slot"] = pnp_device_id;
+    // pci_slot: the PCI bus address in the same format as Linux
+    // (e.g. "0000:01:00.0"), resolved via Win32_PnPEntity.LocationInformation.
+    // Non-PCI adapters (ROOT\BasicDisplay, virtual adapters) have no PCI
+    // location and leave the column empty.
+    auto slot_it = address_by_pnp_id.find(pnp_device_id);
+    if (slot_it != address_by_pnp_id.end()) {
+      r["pci_slot"] = slot_it->second;
+    }
+
+    // device_id: derived from the PCI address so it is stable across reboots;
+    // WMI enumeration order is not guaranteed. The counter is only a fallback
+    // for devices without a slot.
+    if (r["pci_slot"].empty()) {
+      r["device_id"] = "GPU" + std::to_string(device_id++);
+    } else {
+      r["device_id"] = "GPU" + r["pci_slot"];
     }
 
     wmiResult.GetString("Name", r["name"]);

--- a/osquery/tables/system/windows/gpu_info.cpp
+++ b/osquery/tables/system/windows/gpu_info.cpp
@@ -26,8 +26,8 @@ namespace {
 // Parse a PNPDeviceID like "PCI\VEN_10DE&DEV_1B81&SUBSYS_..." to extract the
 // vendor and device (model) IDs.
 void parsePnpDeviceId(const std::string& pnp_id,
-                       std::string& vendor_id,
-                       std::string& model_id) {
+                      std::string& vendor_id,
+                      std::string& model_id) {
   vendor_id.clear();
   model_id.clear();
 

--- a/osquery/tables/system/windows/gpu_info.cpp
+++ b/osquery/tables/system/windows/gpu_info.cpp
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <boost/algorithm/string.hpp>
+
+#include <osquery/core/system.h>
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/sql/sql.h>
+
+#include <osquery/core/windows/wmi.h>
+#include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/conversions/windows/strings.h>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+
+// Parse a PNPDeviceID like "PCI\VEN_10DE&DEV_1B81&SUBSYS_..." to extract the
+// vendor and device (model) IDs.
+void parsePnpDeviceId(const std::string& pnp_id,
+                       std::string& vendor_id,
+                       std::string& model_id) {
+  vendor_id.clear();
+  model_id.clear();
+
+  // The PNPDeviceID is of the form: PCI\VEN_xxxx&DEV_xxxx&SUBSYS_...
+  auto vpos = pnp_id.find("VEN_");
+  if (vpos != std::string::npos) {
+    auto start = vpos + 4;
+    auto end = pnp_id.find('&', start);
+    if (end != std::string::npos) {
+      vendor_id = "0x" + pnp_id.substr(start, end - start);
+    }
+  }
+
+  auto dpos = pnp_id.find("DEV_");
+  if (dpos != std::string::npos) {
+    auto start = dpos + 4;
+    auto end = pnp_id.find('&', start);
+    if (end != std::string::npos) {
+      model_id = "0x" + pnp_id.substr(start, end - start);
+    }
+  }
+}
+
+} // namespace
+
+QueryData genGpuInfo(QueryContext& context) {
+  QueryData results;
+
+  const auto wmiReq =
+      WmiRequest::CreateWmiRequest("SELECT * FROM Win32_VideoController");
+  if (!wmiReq || wmiReq->results().empty()) {
+    LOG(WARNING) << "Failed to retrieve GPU information";
+    return results;
+  }
+
+  std::int32_t device_id = 0;
+  for (const auto& wmiResult : wmiReq->results()) {
+    Row r;
+    r["device_id"] = "GPU" + std::to_string(device_id++);
+
+    std::string pnp_device_id;
+    wmiResult.GetString("PNPDeviceID", pnp_device_id);
+
+    std::string vendor_id;
+    std::string model_id;
+    parsePnpDeviceId(pnp_device_id, vendor_id, model_id);
+
+    if (!vendor_id.empty()) {
+      r["vendor_id"] = vendor_id;
+    }
+    if (!model_id.empty()) {
+      r["model_id"] = model_id;
+    }
+
+    // pci_slot: use the PNPDeviceID location portion (e.g. PCI\VEN_...&BUS_...)
+    if (!pnp_device_id.empty()) {
+      r["pci_slot"] = pnp_device_id;
+    }
+
+    wmiResult.GetString("Name", r["name"]);
+    wmiResult.GetString("AdapterCompatibility", r["vendor"]);
+    wmiResult.GetString("VideoProcessor", r["model"]);
+    wmiResult.GetString("InstalledDisplayDrivers", r["driver"]);
+
+    // VRAM: AdapterRAM is a uint32 and wraps at 4 GB. Try the registry-backed
+    // WMI property first; fall back to AdapterRAM.
+    unsigned long long adapter_ram = 0;
+    if (wmiResult.GetUnsignedLongLong("AdapterRAM", adapter_ram).ok() &&
+        adapter_ram > 0) {
+      r["vram"] = BIGINT(adapter_ram);
+    } else {
+      unsigned long ram = 0;
+      if (wmiResult.GetUnsignedLong("AdapterRAM", ram).ok() && ram > 0) {
+        r["vram"] = BIGINT(ram);
+      }
+    }
+
+    r["pci_class_id"] = "0x030000";
+
+    // Windows-specific extended schema columns.
+    wmiResult.GetString("DriverVersion", r["driver_version"]);
+    std::string cim_driver_date;
+    wmiResult.GetString("DriverDate", cim_driver_date);
+    if (!cim_driver_date.empty()) {
+      r["driver_date"] = BIGINT(cimDatetimeToUnixtime(cim_driver_date));
+    }
+
+    results.push_back(r);
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -244,6 +244,7 @@ function(generateNativeTables)
     "posix/memory_error_info.table:linux,macos"
     "posix/mounts.table:linux,macos"
     "posix/oem_strings.table:linux,macos"
+    "posix/gpu_info.table:linux,macos,windows"
     "posix/pci_devices.table:linux,macos"
     "posix/process_envs.table:linux,macos"
     "posix/process_events.table:linux,macos"

--- a/specs/posix/gpu_info.table
+++ b/specs/posix/gpu_info.table
@@ -1,0 +1,23 @@
+table_name("gpu_info")
+description("Retrieve GPU (graphics processing unit) information of the machine.")
+schema([
+    Column("device_id", TEXT, "The DeviceID of the GPU."),
+    Column("name", TEXT, "The name of the GPU."),
+    Column("vendor", TEXT, "The vendor of the GPU."),
+    Column("vendor_id", TEXT, "The hex encoded PCI vendor identifier of the GPU."),
+    Column("model", TEXT, "The model of the GPU."),
+    Column("model_id", TEXT, "The hex encoded PCI model identifier of the GPU."),
+    Column("driver", TEXT, "The driver in use by the GPU."),
+    Column("vram", BIGINT, "The total video memory of the GPU in bytes."),
+    Column("pci_slot", TEXT, "The PCI slot of the GPU."),
+    Column("pci_class_id", TEXT, "The PCI class identifier of the GPU in hex format."),
+])
+extended_schema(DARWIN, [
+    Column("cores", INTEGER, "The number of GPU cores. Only available on macOS."),
+    Column("metal_support", TEXT, "The Metal feature set supported by the GPU. Only available on macOS."),
+])
+extended_schema(WINDOWS, [
+    Column("driver_version", TEXT, "The version of the installed driver. Only available on Windows."),
+    Column("driver_date", BIGINT, "The date of the installed driver, as a Unix timestamp. Only available on Windows."),
+])
+implementation("gpu_info@genGpuInfo")

--- a/specs/posix/gpu_info.table
+++ b/specs/posix/gpu_info.table
@@ -8,7 +8,7 @@ schema([
     Column("model", TEXT, "The model of the GPU."),
     Column("model_id", TEXT, "The hex encoded PCI model identifier of the GPU."),
     Column("driver", TEXT, "The driver in use by the GPU."),
-    Column("vram", BIGINT, "The total video memory of the GPU in bytes. Fixed capacity only: on Linux only available for AMD GPUs (amdgpu driver, via mem_info_vram_total sysfs; NVIDIA and Intel drivers expose no equivalent); on macOS empty for unified-memory GPUs (Apple Silicon), which have no dedicated VRAM"),
+    Column("vram", BIGINT, "The total video memory of the GPU in bytes. Fixed capacity only: on Linux only available for AMD GPUs (amdgpu driver, via mem_info_vram_total sysfs) and for NVIDIA GPUs with the proprietary driver loaded (via NVML, the library behind nvidia-smi, which also requires the query to have permission to talk to the driver); Intel drivers expose no equivalent; on macOS empty for unified-memory GPUs (Apple Silicon), which have no dedicated VRAM"),
     Column("pci_slot", TEXT, "The PCI slot of the GPU, as a bus address (e.g. 0000:01:00.0 on Linux, 0000:bb:dd.f on Windows). Empty for non-PCI adapters."),
     Column("pci_class_id", TEXT, "The PCI class identifier of the GPU in hex format."),
 ])

--- a/specs/posix/gpu_info.table
+++ b/specs/posix/gpu_info.table
@@ -1,15 +1,15 @@
 table_name("gpu_info")
 description("Retrieve GPU (graphics processing unit) information of the machine.")
 schema([
-    Column("device_id", TEXT, "The DeviceID of the GPU."),
+    Column("device_id", TEXT, "The DeviceID of the GPU. Derived from the PCI slot when available (e.g. GPU0000:01:00.0) so it is stable across reboots; a positional GPU<n> counter is used only for devices without a slot."),
     Column("name", TEXT, "The name of the GPU."),
     Column("vendor", TEXT, "The vendor of the GPU."),
     Column("vendor_id", TEXT, "The hex encoded PCI vendor identifier of the GPU."),
     Column("model", TEXT, "The model of the GPU."),
     Column("model_id", TEXT, "The hex encoded PCI model identifier of the GPU."),
     Column("driver", TEXT, "The driver in use by the GPU."),
-    Column("vram", BIGINT, "The total video memory of the GPU in bytes."),
-    Column("pci_slot", TEXT, "The PCI slot of the GPU."),
+    Column("vram", BIGINT, "The total video memory of the GPU in bytes. Fixed capacity only: on Linux only available for AMD GPUs (amdgpu driver, via mem_info_vram_total sysfs; NVIDIA and Intel drivers expose no equivalent); on macOS empty for unified-memory GPUs (Apple Silicon), which have no dedicated VRAM"),
+    Column("pci_slot", TEXT, "The PCI slot of the GPU, as a bus address (e.g. 0000:01:00.0 on Linux, 0000:bb:dd.f on Windows). Empty for non-PCI adapters."),
     Column("pci_class_id", TEXT, "The PCI class identifier of the GPU in hex format."),
 ])
 extended_schema(DARWIN, [

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -121,6 +121,7 @@ function(generateTestsIntegrationTablesTestsTest)
       docker_volume_labels.cpp
       docker_volumes.cpp
       file_events.cpp
+      gpu_info.cpp
       hardware_events.cpp
       interface_ipv6.cpp
       known_hosts.cpp
@@ -303,6 +304,7 @@ function(generateTestsIntegrationTablesTestsTest)
       default_environment.cpp
       disk_info.cpp
       drivers.cpp
+      gpu_info.cpp
       ie_extensions.cpp
       intel_me_info.cpp
       logon_sessions.cpp

--- a/tests/integration/tables/gpu_info.cpp
+++ b/tests/integration/tables/gpu_info.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for gpu_info
+// Spec file: specs/posix/gpu_info.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class gpuInfo : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(gpuInfo, test_sanity) {
+  auto const data = execute_query("select * from gpu_info");
+  ValidationMap row_map = {
+      {"device_id", NormalType},
+      {"name", NormalType},
+      {"vendor", NormalType},
+      {"vendor_id", NormalType},
+      {"model", NormalType},
+      {"model_id", NormalType},
+      {"driver", NormalType},
+      {"vram", IntOrEmpty},
+      {"pci_slot", NormalType},
+      {"pci_class_id", NormalType},
+#ifdef __APPLE__
+      {"cores", IntOrEmpty},
+      {"metal_support", NormalType},
+#endif
+#ifdef WIN32
+      {"driver_version", NormalType},
+      {"driver_date", IntOrEmpty},
+#endif
+  };
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
New `gpu_info` table that lists GPUs on the host across all three platforms. It may complement well the table `gpu_metrics` from #9030

**Linux** enumerates PCI display controllers (class `0x03`) via udev and resolves vendor/model names through `pci.ids`, reusing the existing `PciDB` parser from `pci_devices`. VRAM is read from `/sys/class/drm/cardN/device/mem_info_vram_total` where the driver exposes it.

**macOS** pulls GPU info from `system_profiler`'s `SPDisplaysDataType` and enriches it with IOKit (`IOAccelerator`) to fill in vendor ID, driver class, core count, and memory. On Apple Silicon, where the GPU uses unified memory, `vram` reflects the system memory currently allocated to the GPU (`Alloc system memory` from `PerformanceStatistics`). The SoC GPU identifier (`IONameMatched`, e.g. `gpu,t6000`) is used as `model_id` since there's no PCI device ID on-die.

**Windows** queries `Win32_VideoController` via WMI and parses `PNPDeviceID` for vendor/model IDs. Note that `AdapterRAM` is a `uint32` in WMI and wraps at 4 GB, so VRAM values may be inaccurate for GPUs with more than 4 GB.

Platform-specific columns are gated with `extended_schema`:
- DARWIN: `cores`, `metal_support`
- WINDOWS: `driver_version`, `driver_date`

Includes integration tests for all platforms.