### PR TITLE
Add negotiated TLS version and cipher suite to curl_certificate

### DIFF
--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -408,7 +408,8 @@ Status getTLSCertificate(const std::string& hostname,
   SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
   auto cert_failure = Status::failure("No certificate");
   ret = SSL_connect(ssl);
-  if (ret != 1) {
+  const bool handshake_complete = (ret == 1);
+  if (!handshake_complete) {
     cert_failure = Status::failure("Failed to begin TLS handshake: " +
                                    std::to_string(ret));
   }
@@ -423,6 +424,30 @@ Status getTLSCertificate(const std::string& hostname,
   Row r;
   r["hostname"] = hostname;
   fillRow(r, cert.get(), dump_certificate, timeout);
+
+  // The negotiated cipher describes the connection rather than the
+  // certificate, and is only meaningful once the handshake has completed.
+  if (handshake_complete) {
+    auto tls_version = SSL_get_version(ssl);
+    if (tls_version != nullptr) {
+      r["tls_version"] = tls_version;
+    }
+
+    auto cipher = SSL_get_current_cipher(ssl);
+    if (cipher != nullptr) {
+      auto cipher_name = SSL_CIPHER_standard_name(cipher);
+      if (cipher_name == nullptr) {
+        cipher_name = SSL_CIPHER_get_name(cipher);
+      }
+
+      if (cipher_name != nullptr) {
+        r["cipher_suite"] = cipher_name;
+      }
+
+      r["cipher_bits"] = INTEGER(SSL_CIPHER_get_bits(cipher, nullptr));
+    }
+  }
+
   results.push_back(r);
   return Status::success();
 }

--- a/specs/curl_certificate.table
+++ b/specs/curl_certificate.table
@@ -35,7 +35,7 @@ schema([
     Column("pem", TEXT, "Certificate PEM format"),
     Column("tls_version", TEXT, "TLS protocol version negotiated for the connection; empty if the handshake did not complete"),
     Column("cipher_suite", TEXT, "IANA name of the cipher suite negotiated for the connection; empty if the handshake did not complete"),
-    Column("cipher_bits", INTEGER, "Bits of security provided by the negotiated cipher suite")
+    Column("cipher_bits", INTEGER, "Number of secret/key bits used by the negotiated cipher suite; NULL if the handshake did not complete")
 ])
 implementation("curl_certificate@genTLSCertificate")
 examples([

--- a/specs/curl_certificate.table
+++ b/specs/curl_certificate.table
@@ -32,7 +32,10 @@ schema([
     Column("policy_constraints", TEXT, "Policy Constraints"),
     Column("dump_certificate", INTEGER, "Set this value to '1' to dump certificate", additional=True, hidden=True),
     Column("timeout", INTEGER, "Set this value to the timeout in seconds to complete the TLS handshake (default 4s, use 0 for no timeout)", additional=True, hidden=True),
-    Column("pem", TEXT, "Certificate PEM format")
+    Column("pem", TEXT, "Certificate PEM format"),
+    Column("tls_version", TEXT, "TLS protocol version negotiated for the connection; empty if the handshake did not complete"),
+    Column("cipher_suite", TEXT, "IANA name of the cipher suite negotiated for the connection; empty if the handshake did not complete"),
+    Column("cipher_bits", INTEGER, "Bits of security provided by the negotiated cipher suite")
 ])
 implementation("curl_certificate@genTLSCertificate")
 examples([

--- a/tests/integration/tables/curl_certificate.cpp
+++ b/tests/integration/tables/curl_certificate.cpp
@@ -52,7 +52,10 @@ TEST_F(curlCertificate, test_sanity) {
                            {"basic_constraint", NormalType},
                            {"name_constraints", NormalType},
                            {"policy_constraints", NormalType},
-                           {"pem", NormalType}};
+                           {"pem", NormalType},
+                           {"tls_version", NormalType},
+                           {"cipher_suite", NormalType},
+                           {"cipher_bits", IntType}};
   validate_rows(data, row_map);
 }
 


### PR DESCRIPTION
`curl_certificate` exposes the peer certificate but nothing about the connection that delivered it. That means the table can tell you a listener's certificate is valid, but not whether it was handed over via TLS 1.0 or an export-grade cipher. Answering "which of my endpoints still negotiate a weak protocol or cipher" currently needs a separate tool.

This adds three columns, populated from the completed handshake:

| Column | Type | Source |
| --- | --- | --- |
| `tls_version` | TEXT | `SSL_get_version`, e.g. `TLSv1.3` |
| `cipher_suite` | TEXT | `SSL_CIPHER_standard_name`, e.g. `TLS_AES_128_GCM_SHA256` |
| `cipher_bits` | INTEGER | `SSL_CIPHER_get_bits` |

### Notes on the implementation

**These describe the connection, not the certificate.** `fillRow` only receives the `X509*`, so the new values are set in `getTLSCertificate` instead of being threaded into `fillRow`.

**They are only populated when the handshake completed.** Since #7349 the table deliberately still returns a peer certificate when the handshake does not complete. In that case no cipher was ever agreed, so a new `handshake_complete` flag gates the block and the columns are left empty rather than reporting a cipher that was not negotiated.

**`SSL_CIPHER_standard_name` is preferred over `SSL_CIPHER_get_name`** so the value is the IANA name rather than the OpenSSL one, falling back to the OpenSSL name if the standard name is unavailable. The two agree under TLS 1.3 but diverge under TLS 1.2, where the same suite is `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` versus `ECDHE-RSA-AES128-GCM-SHA256`. The IANA form is the more portable identifier for downstream consumers.

**The columns are appended after `pem`** rather than inserted next to `hostname`, so the existing `select *` column order is unchanged for current users.

No new includes are needed; `openssl/ssl.h` is already included.

### Testing

Built on Ubuntu 24 with the osquery toolchain and exercised through `osqueryi`:

```
                 hostname = www.github.com
              tls_version = TLSv1.3
             cipher_suite = TLS_AES_128_GCM_SHA256
              cipher_bits = 128

                 hostname = tls-v1-2.badssl.com:1012
              tls_version = TLSv1.2
             cipher_suite = TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
              cipher_bits = 256
```

`cipher_bits` reflects the negotiated suite (128 vs 256 above), and `expired.badssl.com` still reports `has_expired = 1` alongside its TLS 1.2 connection details.

The `ValidationMap` in `tests/integration/tables/curl_certificate.cpp` has been extended with the three columns, and `clang-format` reports no diff on either changed C++ file.
