### PR TITLE
Add a subject_alternative_names column to the certificates table

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -87,6 +87,9 @@ void genCertificate(X509* cert, const std::string& path, QueryData& results) {
   auto opt_cert_key_usage = getCertificateKeyUsage(cert);
   r["key_usage"] = opt_cert_key_usage.value_or("");
 
+  auto opt_subject_alt_names = getCertificateSubjectAltNames(cert);
+  r["subject_alternative_names"] = SQL_TEXT(opt_subject_alt_names.value_or(""));
+
   auto opt_authority_key_id = getCertificateAuthorityKeyID(cert);
   r["authority_key_id"] = SQL_TEXT(opt_authority_key_id.value_or(""));
 

--- a/osquery/tables/system/linux/certificates.cpp
+++ b/osquery/tables/system/linux/certificates.cpp
@@ -52,6 +52,7 @@ struct CertificateInformation final {
   std::string key_algorithm;
   std::string key_strength;
   std::string key_usage;
+  std::string subject_alternative_names;
   std::string subject_key_id;
   std::string authority_key_id;
   std::string sha1;
@@ -168,6 +169,11 @@ Expected<CertificateInformation, OpenSSLError> generateCertificateInformation(
   auto opt_cert_key_usage = getCertificateKeyUsage(x509);
   if (opt_cert_key_usage.has_value()) {
     cert_info.key_usage = opt_cert_key_usage.value();
+  }
+
+  auto opt_subject_alt_names = getCertificateSubjectAltNames(x509);
+  if (opt_subject_alt_names.has_value()) {
+    cert_info.subject_alternative_names = opt_subject_alt_names.value();
   }
 
   auto opt_authority_key_id = getCertificateAuthorityKeyID(x509);
@@ -289,6 +295,8 @@ QueryData genCerts(QueryContext& context) {
       row["key_algorithm"] = SQL_TEXT(cert_info.key_algorithm);
       row["key_strength"] = SQL_TEXT(cert_info.key_strength);
       row["key_usage"] = SQL_TEXT(cert_info.key_usage);
+      row["subject_alternative_names"] =
+          SQL_TEXT(cert_info.subject_alternative_names);
       row["subject_key_id"] = SQL_TEXT(cert_info.subject_key_id);
       row["authority_key_id"] = SQL_TEXT(cert_info.authority_key_id);
       row["sha1"] = SQL_TEXT(cert_info.sha1);

--- a/osquery/tables/system/posix/openssl_utils.cpp
+++ b/osquery/tables/system/posix/openssl_utils.cpp
@@ -188,6 +188,41 @@ boost::optional<std::string> getCertificateKeyUsage(X509* cert) {
   return output;
 }
 
+boost::optional<std::string> getCertificateSubjectAltNames(X509* cert) {
+  auto general_names = static_cast<GENERAL_NAMES*>(
+      X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr));
+
+  if (general_names == nullptr) {
+    return boost::none;
+  }
+
+  std::unique_ptr<GENERAL_NAMES, void (*)(GENERAL_NAMES*)> unique_general_names(
+      general_names, GENERAL_NAMES_free);
+
+  auto unique_mem_bio = createUniqueBIO();
+  if (unique_mem_bio == nullptr) {
+    return boost::none;
+  }
+
+  auto name_count = sk_GENERAL_NAME_num(general_names);
+  for (int i = 0; i < name_count; ++i) {
+    auto general_name = sk_GENERAL_NAME_value(general_names, i);
+    if (general_name == nullptr) {
+      continue;
+    }
+
+    // Separate on what has actually been written, so a name that could not be
+    // printed does not leave a stray separator behind
+    if (BIO_pending(unique_mem_bio.get()) != 0) {
+      BIO_puts(unique_mem_bio.get(), ", ");
+    }
+
+    GENERAL_NAME_print(unique_mem_bio.get(), general_name);
+  }
+
+  return getMemoryBackedBIOContentsAsString(unique_mem_bio.get());
+}
+
 boost::optional<std::string> getCertificateSerialNumber(X509* cert) {
   auto serial = X509_get_serialNumber(cert);
   if (serial == nullptr) {

--- a/osquery/tables/system/posix/openssl_utils.cpp
+++ b/osquery/tables/system/posix/openssl_utils.cpp
@@ -211,13 +211,25 @@ boost::optional<std::string> getCertificateSubjectAltNames(X509* cert) {
       continue;
     }
 
-    // Separate on what has actually been written, so a name that could not be
-    // printed does not leave a stray separator behind
+    auto unique_tmp_bio = createUniqueBIO();
+    if (unique_tmp_bio == nullptr) {
+      continue;
+    }
+
+    if (GENERAL_NAME_print(unique_tmp_bio.get(), general_name) == 0) {
+      continue;
+    }
+
+    auto opt_printed = getMemoryBackedBIOContentsAsString(unique_tmp_bio.get());
+    if (!opt_printed.has_value() || opt_printed->empty()) {
+      continue;
+    }
+
     if (BIO_pending(unique_mem_bio.get()) != 0) {
       BIO_puts(unique_mem_bio.get(), ", ");
     }
 
-    GENERAL_NAME_print(unique_mem_bio.get(), general_name);
+    BIO_puts(unique_mem_bio.get(), opt_printed->c_str());
   }
 
   return getMemoryBackedBIOContentsAsString(unique_mem_bio.get());

--- a/osquery/tables/system/posix/openssl_utils.h
+++ b/osquery/tables/system/posix/openssl_utils.h
@@ -20,6 +20,7 @@ namespace osquery::tables {
 boost::optional<std::string> generateCertificateSHA1Digest(X509* cert);
 void getCertificateAttributes(X509* cert, bool& is_ca, bool& is_self_signed);
 boost::optional<std::string> getCertificateKeyUsage(X509* cert);
+boost::optional<std::string> getCertificateSubjectAltNames(X509* cert);
 boost::optional<std::string> getCertificateSerialNumber(X509* cert);
 boost::optional<std::string> getCertificateAuthorityKeyID(X509* cert);
 boost::optional<std::string> getCertificateSubjectKeyID(X509* cert);

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -99,6 +99,162 @@ std::string getKeyUsage(const PCERT_INFO& certInfo) {
   return join(usages, ",");
 }
 
+/// Decode a certificate extension into the given buffer
+bool decodeCertExtension(LPCSTR structType,
+                         const CERT_EXTENSION* extension,
+                         std::vector<BYTE>& buffer) {
+  unsigned long structSize = 0;
+  auto ret = CryptDecodeObjectEx(CERT_ENCODING,
+                                 structType,
+                                 extension->Value.pbData,
+                                 extension->Value.cbData,
+                                 CRYPT_DECODE_NOCOPY_FLAG,
+                                 nullptr,
+                                 nullptr,
+                                 &structSize);
+  if (ret == 0) {
+    VLOG(1) << "Failed to size certificate extension with " << GetLastError();
+    return false;
+  }
+
+  buffer.resize(structSize, 0);
+  ret = CryptDecodeObjectEx(CERT_ENCODING,
+                            structType,
+                            extension->Value.pbData,
+                            extension->Value.cbData,
+                            CRYPT_DECODE_NOCOPY_FLAG,
+                            nullptr,
+                            buffer.data(),
+                            &structSize);
+  if (ret == 0) {
+    VLOG(1) << "Failed to decode certificate extension with " << GetLastError();
+    return false;
+  }
+
+  return true;
+}
+
+/// Render an alternate name IP address the way OpenSSL prints it, so the
+/// column reads the same across platforms
+std::string formatAltNameIpAddress(const CRYPT_DATA_BLOB& address) {
+  std::vector<std::string> parts;
+
+  if (address.cbData == 4) {
+    for (unsigned long i = 0; i < address.cbData; i++) {
+      parts.push_back(std::to_string(address.pbData[i]));
+    }
+
+    return join(parts, ".");
+  }
+
+  if (address.cbData == 16) {
+    constexpr char kHexDigits[] = "0123456789ABCDEF";
+
+    for (unsigned long i = 0; i < address.cbData; i += 2) {
+      // Match OpenSSL's ipaddr_to_asc, which prints each group as uppercase
+      // hex with no leading zeroes and no run compression
+      unsigned int group_value =
+          (address.pbData[i] << 8) | address.pbData[i + 1];
+      std::string group;
+
+      while (group_value != 0) {
+        group.insert(group.begin(), kHexDigits[group_value & 0x0F]);
+        group_value >>= 4;
+      }
+
+      parts.push_back(group.empty() ? "0" : group);
+    }
+
+    return join(parts, ":");
+  }
+
+  return "";
+}
+
+std::string getSubjectAltNames(const PCERT_INFO& certInfo) {
+  auto extension = CertFindExtension(
+      szOID_SUBJECT_ALT_NAME2, certInfo->cExtension, certInfo->rgExtension);
+
+  if (extension == nullptr) {
+    // Certificates predating RFC 3280 carry the alternate name under the
+    // obsolete OID
+    extension = CertFindExtension(
+        szOID_SUBJECT_ALT_NAME, certInfo->cExtension, certInfo->rgExtension);
+  }
+
+  if (extension == nullptr) {
+    return "";
+  }
+
+  std::vector<BYTE> buffer;
+  if (!decodeCertExtension(X509_ALTERNATE_NAME, extension, buffer)) {
+    return "";
+  }
+
+  auto altNameInfo = reinterpret_cast<PCERT_ALT_NAME_INFO>(buffer.data());
+  std::vector<std::string> names;
+
+  for (unsigned long i = 0; i < altNameInfo->cAltEntry; i++) {
+    auto& entry = altNameInfo->rgAltEntry[i];
+
+    switch (entry.dwAltNameChoice) {
+    case CERT_ALT_NAME_DNS_NAME:
+      names.push_back("DNS:" + wstringToString(entry.pwszDNSName));
+      break;
+
+    case CERT_ALT_NAME_RFC822_NAME:
+      names.push_back("email:" + wstringToString(entry.pwszRfc822Name));
+      break;
+
+    case CERT_ALT_NAME_URL:
+      names.push_back("URI:" + wstringToString(entry.pwszURL));
+      break;
+
+    case CERT_ALT_NAME_IP_ADDRESS: {
+      auto address = formatAltNameIpAddress(entry.IPAddress);
+      if (!address.empty()) {
+        names.push_back("IP Address:" + address);
+      }
+      break;
+    }
+
+    case CERT_ALT_NAME_REGISTERED_ID:
+      names.push_back(std::string("Registered ID:") + entry.pszRegisteredID);
+      break;
+
+    case CERT_ALT_NAME_DIRECTORY_NAME: {
+      auto size = CertNameToStr(
+          CERT_ENCODING, &entry.DirectoryName, CERT_X500_NAME_STR, nullptr, 0);
+      if (size == 0) {
+        break;
+      }
+
+      std::vector<WCHAR> nameBuff(size, 0);
+      size = CertNameToStr(CERT_ENCODING,
+                           &entry.DirectoryName,
+                           CERT_X500_NAME_STR,
+                           nameBuff.data(),
+                           size);
+      if (size != 0) {
+        names.push_back("DirName:" + wstringToString(nameBuff.data()));
+      }
+      break;
+    }
+
+    case CERT_ALT_NAME_OTHER_NAME:
+      if (entry.pOtherName != nullptr) {
+        names.push_back(std::string("othername:") + entry.pOtherName->pszObjId);
+      }
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  return join(names, ", ");
+}
+
 void getCertCtxProp(const PCCERT_CONTEXT& certContext,
                     unsigned long propId,
                     std::vector<BYTE>& dataBuff) {
@@ -475,6 +631,8 @@ void addCertRow(PCCERT_CONTEXT certContext,
       certContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId);
 
   r["key_usage"] = getKeyUsage(certContext->pCertInfo);
+
+  r["subject_alternative_names"] = getSubjectAltNames(certContext->pCertInfo);
 
   auto keyStrength = CertGetPublicKeyLength(
       CERT_ENCODING, &certContext->pCertInfo->SubjectPublicKeyInfo);

--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -19,6 +19,7 @@ schema([
     Column("sha1", TEXT, "SHA1 hash of the raw certificate contents", collate="nocase"),
     Column("path", TEXT, "Path to Keychain or PEM bundle", additional=True, optimized=True),
     Column("serial", TEXT, "Certificate serial number", collate="nocase"),
+    Column("subject_alternative_names", TEXT, "Subject Alternative Names, comma separated and prefixed with their type, e.g. 'DNS:example.com, IP Address:10.0.0.1'"),
 
 ])
 

--- a/tests/integration/tables/certificates.cpp
+++ b/tests/integration/tables/certificates.cpp
@@ -62,6 +62,7 @@ TEST_F(certificates, test_sanity) {
       {"sha1", NormalType},
       {"path", NormalType},
       {"serial", NormalType},
+      {"subject_alternative_names", NormalType},
   };
 
   if (isPlatform(PlatformType::TYPE_WINDOWS)) {


### PR DESCRIPTION
The `certificates` table reports who a certificate was issued to and by, but not the names it actually covers. In practice a certificate is identified by its subject alternative names rather than its common name, so a question as ordinary as "which certificate in this store covers this hostname" cannot be answered from this table today.

This adds a `subject_alternative_names` column on all platforms.

### Notes on the implementation

**POSIX** adds `getCertificateSubjectAltNames` to the shared OpenSSL helpers, printing through `GENERAL_NAME_print` and reusing the `createUniqueBIO` / `getMemoryBackedBIOContentsAsString` helpers already in that file. Both the Linux and macOS implementations pick it up from there.

That is the same representation `curl_certificate.subject_alternative_names` already produces, so two columns with the same name read the same way.

**Windows** has no OpenSSL available in this table, so the alternate name extension is decoded through CryptoAPI and its entries formatted to match. IP addresses are rendered the way OpenSSL's `ipaddr_to_asc` does, so an address reads identically on either platform:

```
IP Address:10.0.0.7
IP Address:2001:DB8:0:0:0:0:0:1
```

Both `szOID_SUBJECT_ALT_NAME2` and the obsolete `szOID_SUBJECT_ALT_NAME` are checked, so certificates predating RFC 3280 are still covered.

The separator is emitted based on what has actually been written to the BIO rather than the loop index, so an entry that cannot be printed does not leave a stray separator behind.

Existing columns and their order are unchanged.

### Testing

Built on Ubuntu 24 with the osquery toolchain. Against a certificate carrying every alternate name type:

```
              common_name = santest.example.com
subject_alternative_names = DNS:santest.example.com, DNS:*.example.com,
                            IP Address:10.0.0.7, IP Address:2001:DB8:0:0:0:0:0:1,
                            email:pki@example.com, URI:https://ca.example.com/crl
```

Against the system CA bundle, 121 certificates parse and the 3 carrying alternate names populate correctly, including a `DirName` entry.

The `ValidationMap` in `tests/integration/tables/certificates.cpp` has been extended, and `clang-format` reports no diff on any changed file.

I do not have a Windows build environment to hand, so the CryptoAPI path has been written and reviewed but not compiled locally, and I would appreciate CI or a reviewer confirming it. The one piece of custom logic in it, the IP address formatting, was extracted into a standalone harness and its output diffed against OpenSSL's for the same address bytes to confirm the two agree.
