### PR TITLE
Add a macports_packages table

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -128,6 +128,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/firewall.mm
       darwin/gatekeeper.cpp
       darwin/homebrew_packages.cpp
+      darwin/macports_packages.cpp
       darwin/ibridge.cpp
       darwin/iokit_registry.cpp
       darwin/kernel_extensions.cpp

--- a/osquery/tables/system/darwin/macports_packages.cpp
+++ b/osquery/tables/system/darwin/macports_packages.cpp
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <set>
+#include <string>
+
+#include <boost/filesystem/path.hpp>
+
+#include <osquery/core/core.h>
+#include <osquery/core/tables.h>
+#include <osquery/filesystem/filesystem.h>
+#include <osquery/logger/logger.h>
+#include <osquery/sql/sqlite_util.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+/// genPortRow and portsFromPrefix are intentionally non-static so the unit
+/// test can drive them against a fixture registry.
+
+/// Default MacPorts install prefixes.
+///
+/// /opt/local is the documented default. A user may select another prefix at
+/// install time, in which case the `prefix` column can be constrained to it.
+const std::set<std::string> kMacPortsPrefixes = {
+    "/opt/local",
+};
+
+/// MacPorts records installed ports in a SQLite registry beneath the prefix.
+const std::string kMacPortsRegistryPath = "var/macports/registry/registry.db";
+
+/// MacPorts uses two states: 'installed' means activated, with the port's files
+/// linked into the prefix; 'imaged' means unpacked into the image directory but
+/// deactivated, so nothing is linked. Only 'installed' ports are usable, which
+/// is also what `port installed` reports.
+const std::string kMacPortsQuery =
+    "SELECT name, version, revision, variants, archs, requested, date "
+    "FROM ports WHERE state = 'installed';";
+
+void genPortRow(sqlite3_stmt* stmt, Row& r) {
+  for (int i = 0; i < sqlite3_column_count(stmt); i++) {
+    auto column_name = std::string(sqlite3_column_name(stmt, i));
+    auto column_type = sqlite3_column_type(stmt, i);
+
+    // The registry stores `archs`; the table exposes it as `arch`, matching the
+    // singular column name used elsewhere in osquery.
+    if (column_name == "archs") {
+      column_name = "arch";
+    }
+
+    if (column_type == SQLITE_TEXT) {
+      auto value = sqlite3_column_text(stmt, i);
+      if (value != nullptr) {
+        r[column_name] = std::string((const char*)value);
+      }
+    } else if (column_type == SQLITE_INTEGER) {
+      r[column_name] = INTEGER(sqlite3_column_int64(stmt, i));
+    }
+  }
+}
+
+void portsFromPrefix(QueryData& results,
+                     const std::string& prefix,
+                     bool userRequested) {
+  auto registry = (fs::path(prefix) / kMacPortsRegistryPath).string();
+
+  if (!pathExists(registry).ok()) {
+    if (userRequested) {
+      LOG(WARNING) << "Error reading MacPorts registry " << registry;
+    }
+    return;
+  }
+
+  sqlite3* db = nullptr;
+  auto rc = sqlite3_open_v2(
+      registry.c_str(),
+      &db,
+      (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
+      nullptr);
+  if (rc != SQLITE_OK || db == nullptr) {
+    VLOG(1) << "Cannot open " << registry << " read only: " << rc << " "
+            << getStringForSQLiteReturnCode(rc);
+    if (db != nullptr) {
+      sqlite3_close(db);
+    }
+    return;
+  }
+
+  sqlite3_stmt* stmt = nullptr;
+  rc = sqlite3_prepare_v2(db, kMacPortsQuery.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    VLOG(1) << "Cannot query " << registry << ": " << rc << " "
+            << getStringForSQLiteReturnCode(rc);
+    sqlite3_close(db);
+    return;
+  }
+
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    Row r;
+    genPortRow(stmt, r);
+    r["prefix"] = prefix;
+    results.push_back(r);
+  }
+
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+}
+
+QueryData genMacPortsPackages(QueryContext& context) {
+  QueryData results;
+
+  if (context.constraints.count("prefix") > 0 &&
+      context.constraints.at("prefix").exists(EQUALS)) {
+    std::set<std::string> prefixes =
+        context.constraints["prefix"].getAll(EQUALS);
+    for (const auto& prefix : prefixes) {
+      portsFromPrefix(results, prefix, true);
+    }
+  } else {
+    // No prefixes requested, fall back to the system ones.
+    for (const auto& prefix : kMacPortsPrefixes) {
+      portsFromPrefix(results, prefix, false);
+    }
+  }
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ function(generateOsqueryTablesSystemDarwinTests)
     darwin/extended_attributes_tests.cpp
     darwin/firewall_tests.cpp
     darwin/launchd_tests.cpp
+    darwin/macports_packages_tests.cpp
     darwin/mdfind_tests.cpp
     darwin/packages_tests.cpp
     darwin/processes_tests.cpp

--- a/osquery/tables/system/tests/darwin/macports_packages_tests.cpp
+++ b/osquery/tables/system/tests/darwin/macports_packages_tests.cpp
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <string>
+
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <gtest/gtest.h>
+
+#include <osquery/core/sql/query_data.h>
+#include <osquery/core/tables.h>
+#include <osquery/sql/sqlite_util.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+void portsFromPrefix(QueryData& results,
+                     const std::string& prefix,
+                     bool userRequested);
+
+class MacPortsPackagesTests : public testing::Test {
+ protected:
+  void SetUp() override {
+    prefix_ = fs::temp_directory_path() / fs::unique_path();
+    auto registry_dir = prefix_ / "var" / "macports" / "registry";
+    ASSERT_TRUE(fs::create_directories(registry_dir));
+    registry_ = (registry_dir / "registry.db").string();
+
+    sqlite3* db = nullptr;
+    ASSERT_EQ(sqlite3_open(registry_.c_str(), &db), SQLITE_OK);
+
+    // A cut-down copy of the MacPorts registry schema: only the columns the
+    // table reads, in the types MacPorts uses.
+    const char* schema =
+        "CREATE TABLE ports ("
+        "  name TEXT, version TEXT, revision INTEGER, variants TEXT,"
+        "  archs TEXT, requested INTEGER, date DATETIME, state TEXT);"
+        // An explicitly requested port.
+        "INSERT INTO ports VALUES"
+        "  ('jq', '1.8.2', 0, '', 'arm64', 1, 1757000000, 'installed');"
+        // A dependency, with variants, to check they survive verbatim.
+        "INSERT INTO ports VALUES"
+        "  ('cctools', '949.0.1', 3, '+xcode', 'arm64', 0, 1757000001,"
+        "   'installed');"
+        // Deactivated: unpacked into the image directory but not linked into
+        // the prefix, so the table must not report it.
+        "INSERT INTO ports VALUES"
+        "  ('ghosted', '1.0', 0, '', 'arm64', 1, 1757000002, 'imaged');";
+    char* err = nullptr;
+    ASSERT_EQ(sqlite3_exec(db, schema, nullptr, nullptr, &err), SQLITE_OK);
+    sqlite3_close(db);
+  }
+
+  void TearDown() override {
+    boost::system::error_code ec;
+    fs::remove_all(prefix_, ec);
+  }
+
+  fs::path prefix_;
+  std::string registry_;
+};
+
+TEST_F(MacPortsPackagesTests, test_only_installed_ports_are_returned) {
+  QueryData results;
+  portsFromPrefix(results, prefix_.string(), true);
+
+  ASSERT_EQ(results.size(), 2U);
+  for (const auto& row : results) {
+    EXPECT_NE(row.at("name"), "ghosted");
+  }
+}
+
+TEST_F(MacPortsPackagesTests, test_columns_are_mapped) {
+  QueryData results;
+  portsFromPrefix(results, prefix_.string(), true);
+  ASSERT_EQ(results.size(), 2U);
+
+  const Row* jq = nullptr;
+  for (const auto& row : results) {
+    if (row.at("name") == "jq") {
+      jq = &row;
+    }
+  }
+  ASSERT_NE(jq, nullptr);
+
+  EXPECT_EQ(jq->at("version"), "1.8.2");
+  EXPECT_EQ(jq->at("revision"), "0");
+  EXPECT_EQ(jq->at("requested"), "1");
+  // The registry column is `archs`; the table exposes `arch`.
+  EXPECT_EQ(jq->at("arch"), "arm64");
+  EXPECT_EQ(jq->count("archs"), 0U);
+  // Every row carries the prefix it was read from.
+  EXPECT_EQ(jq->at("prefix"), prefix_.string());
+}
+
+TEST_F(MacPortsPackagesTests, test_variants_survive_verbatim) {
+  QueryData results;
+  portsFromPrefix(results, prefix_.string(), true);
+
+  const Row* cctools = nullptr;
+  for (const auto& row : results) {
+    if (row.at("name") == "cctools") {
+      cctools = &row;
+    }
+  }
+  ASSERT_NE(cctools, nullptr);
+  EXPECT_EQ(cctools->at("variants"), "+xcode");
+  EXPECT_EQ(cctools->at("revision"), "3");
+  EXPECT_EQ(cctools->at("requested"), "0");
+}
+
+TEST_F(MacPortsPackagesTests, test_missing_registry_yields_no_rows) {
+  QueryData results;
+  auto absent = (fs::temp_directory_path() / fs::unique_path()).string();
+  portsFromPrefix(results, absent, false);
+  EXPECT_TRUE(results.empty());
+}
+
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -114,6 +114,7 @@ function(generateNativeTables)
     "darwin/gatekeeper.table:macos"
     "darwin/gatekeeper_approved_apps.table:macos"
     "darwin/homebrew_packages.table:macos"
+    "darwin/macports_packages.table:macos"
     "darwin/ibridge_info.table:macos"
     "darwin/iokit_devicetree.table:macos"
     "darwin/iokit_registry.table:macos"

--- a/specs/darwin/macports_packages.table
+++ b/specs/darwin/macports_packages.table
@@ -1,0 +1,14 @@
+table_name("macports_packages")
+description("The installed MacPorts port database.")
+schema([
+    Column("name", TEXT, "Port name"),
+    Column("version", TEXT, "Port version", collate="version"),
+    Column("revision", INTEGER, "MacPorts revision of the port"),
+    Column("variants", TEXT, "Active variants, as recorded by MacPorts"),
+    Column("requested", INTEGER, "1 if explicitly requested, 0 if a dependency"),
+    Column("arch", TEXT, "Architectures the port was built for"),
+    Column("date", BIGINT, "Install time, in unix time"),
+    Column("prefix", TEXT, "MacPorts install prefix", hidden=True, additional=True, optimized=True),
+])
+attributes(cacheable=True)
+implementation("system/macports_packages@genMacPortsPackages")

--- a/tests/integration/tables/CMakeLists.txt
+++ b/tests/integration/tables/CMakeLists.txt
@@ -236,6 +236,7 @@ function(generateTestsIntegrationTablesTestsTest)
       gatekeeper.cpp
       gatekeeper_approved_apps.cpp
       homebrew_packages.cpp
+      macports_packages.cpp
       ibridge.cpp
       iokit_devicetree.cpp
       iokit_registry.cpp

--- a/tests/integration/tables/macports_packages.cpp
+++ b/tests/integration/tables/macports_packages.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+// Sanity check integration test for macports_packages
+// Spec file: specs/darwin/macports_packages.table
+
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+namespace table_tests {
+
+class macportsPackages : public testing::Test {
+ protected:
+  void SetUp() override {
+    setUpEnvironment();
+  }
+};
+
+TEST_F(macportsPackages, test_sanity) {
+  // The table is empty on a host without MacPorts, which is the common case on
+  // CI, so only the shape of any returned rows is asserted.
+  auto const data = execute_query("select * from macports_packages");
+  ValidationMap row_map = {
+      {"name", NonEmptyString},
+      {"version", NormalType},
+      {"revision", NonNegativeInt},
+      {"variants", NormalType},
+      // MacPorts records this as 0 or 1.
+      {"requested", Bool},
+      {"arch", NormalType},
+      // Install time, stored by MacPorts as a unix timestamp.
+      {"date", NonNegativeInt},
+      {"prefix", NonEmptyString},
+  };
+  validate_rows(data, row_map);
+}
+
+} // namespace table_tests
+} // namespace osquery


### PR DESCRIPTION
Adds a `macports_packages` table so macOS gets a MacPorts inventory alongside `homebrew_packages`. osquery currently has no MacPorts support at all — the string appears in no spec, source file or test.

MacPorts keeps its registry in a SQLite database under its prefix, so the table opens it read-only and follows the pattern `quicklook_cache` already uses for an external SQLite file.

**Two things I would like a call on before anyone reviews the details:**

1. **`archs` is exposed as `arch`.** The registry column is plural; I renamed it to match the singular naming used elsewhere in osquery. Happy to keep the source spelling if fidelity to the underlying database is preferred.

2. **Only `state = 'installed'` rows are returned.** MacPorts has two states, per `registry2.0/receipt_sqlite.tcl`: `installed` means activated, with the port's files linked into the prefix, and `imaged` means unpacked into the image directory but deactivated, so nothing is linked. Deactivated ports and superseded versions sit at `imaged` until uninstalled. Only `installed` ports are usable, and that is also what `port installed` reports by default — but exposing `imaged` rows would need a `state` column and a decision about the default.

A third, smaller one: `homebrew_packages` has no unit test, and only 15 of 72 darwin tables do, so a unit test was arguably optional here. I added one because the `archs`/`arch` rename is real logic worth pinning down.

## Verification

Against a live registry with 1659 installed ports, and on CI in my fork:

- compiles and links on macOS x86_64 and arm64, Linux (Debug/Release/RelWithDebInfo × x86_64/arm64) and Windows
- `check_code_style`, `check_source_code`, `check_libraries_manifest` and `check_genwebsitejson` all pass
- all four `MacPortsPackagesTests` cases pass on macOS arm64; 81 of 82 test suites pass
- the integration test runs and returns no rows on a CI host without MacPorts, as expected

The single red test on my fork is `SignatureTest.test_get_valid_signature` / `test_get_invalid_signature`, which needs a signed binary and is unrelated to this change.

The machine I verified against has 1659 `installed` ports and no `imaged` ones, so the `imaged` path is covered by the unit test fixture rather than observed in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)