### PR TITLE
Scan Homebrew and MacPorts prefixes in suid_bin

### DIFF
--- a/osquery/tables/system/posix/suid_bin.cpp
+++ b/osquery/tables/system/posix/suid_bin.cpp
@@ -33,6 +33,12 @@ std::vector<std::string> kBinarySearchPaths = {
     "/usr/sbin",
     "/usr/local/bin",
     "/usr/local/sbin",
+    // Homebrew on Apple Silicon, whose default prefix is not /usr/local
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    // MacPorts
+    "/opt/local/bin",
+    "/opt/local/sbin",
     "/tmp",
 };
 


### PR DESCRIPTION
## Problem

`kBinarySearchPaths` in `osquery/tables/system/posix/suid_bin.cpp` covers `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/usr/local/bin`, `/usr/local/sbin` and `/tmp`.

Homebrew on Intel Macs falls under `/usr/local` only incidentally, because that is a standard Unix location. **Homebrew's default prefix on Apple Silicon has been `/opt/homebrew` since 2020**, and MacPorts installs under `/opt/local`. Neither is searched, so setuid and setgid binaries shipped by either package manager do not appear in the table.

That matters more here than it would in an inventory table: `suid_bin` exists to enumerate privilege-escalation surface, so an unsearched prefix is a gap in precisely the thing the table reports.

## Evidence

Measured on an Apple Silicon machine running MacPorts, nine binaries under `/opt/local` are absent from `suid_bin` today:

| Binary | Owning port | Mode |
| --- | --- | --- |
| `pkexec` | policykit | setuid root |
| `ksu` | kerberos5 | setuid root |
| `gping`, `gping6`, `grcp`, `grlogin`, `grsh`, `gtraceroute` | inetutils | setuid root |
| `mutt_dotlock` | mutt | setgid mail |

I did **not** take an equivalent count under `/opt/homebrew`, because no Homebrew installation was available to me. The gap there follows from the prefix not being searched rather than from an observation, and I would rather say so than have it read as a measured claim.

## Approach

The paths are hardcoded rather than derived from the package managers at runtime, following `kHomebrewPrefixes` in `homebrew_packages`, `kNodeModulesPath` in `npm_packages` and `kPythonPath` in `python_packages`, each of which lists `/opt/homebrew` literally. `homebrew_packages` even documents how the `brew` wrapper computes `HOMEBREW_PREFIX` and then deliberately does not do it.

Deriving a prefix from host state would also mean letting that state decide the scan scope of a security table, which seems like the wrong trade for this table in particular.

A path that does not exist is skipped, so this costs one failed `stat` per entry on systems without either package manager.

## Notes

- No schema change, so `specs/posix/suid_bin.table` and the integration test are unaffected.
- Unlike `homebrew_packages` (`prefix`) or `npm_packages` (`directory`), `suid_bin` exposes no constrainable column, so a **non-default** prefix still cannot be reached from a query. Adding one would be a reasonable follow-up, but it is a larger change than this fix and I did not want to bundle a design question with it. Happy to do it separately if you would like it.
- Related but independent: #9074 proposes a `macports_packages` table. This PR does not depend on it, and stands on the Apple Silicon Homebrew case alone.
