### PR TITLE
Scan the MacPorts prefix in npm_packages and python_packages

### DIFF
--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -40,6 +40,8 @@ const std::set<std::string> kNodeModulesPath = {
 #else
     "/usr/local/lib",
     "/opt/homebrew/lib",
+    // MacPorts
+    "/opt/local/lib",
     "/usr/lib",
     "/home/%/.npm-global/lib",
     "/home/%/.nvm/versions/node/%/lib",

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -54,6 +54,8 @@ const std::set<std::string> kPythonPath = {
 const std::set<std::string> kDarwinPythonPath = {
     "/System/Library/Frameworks/Python.framework/Versions",
     "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions",
+    // MacPorts
+    "/opt/local/Library/Frameworks/Python.framework/Versions",
 };
 // clang-format on
 


### PR DESCRIPTION
## Problem

`npm_packages` and `python_packages` both enumerate from a fixed list of default locations, and both lists know about Homebrew but not MacPorts. On a Mac using MacPorts, neither table reports anything installed under the MacPorts prefix.

- **`npm_packages`** — `kNodeModulesPath` lists `/usr/local/lib` and `/opt/homebrew/lib`, plus per-user directories for `.npm-global`, nvm, asdf, fnm, mise and Volta. `/opt/local/lib` is absent.
- **`python_packages`** — `kDarwinPythonPath` lists the system framework and the Command Line Tools framework. The MacPorts framework, `/opt/local/Library/Frameworks/Python.framework/Versions`, is absent.

## Evidence

Measured on an Apple Silicon machine running MacPorts. Both tables return **zero** rows from `/opt/local` today:

```sql
select (select count(*) from python_packages where path like '/opt/local/%') as py,
       (select count(*) from npm_packages) as npm;
-- {"npm":"0","py":"0"}
```

Present but unreported:

| Table | Installed under the MacPorts prefix |
| --- | --- |
| `npm_packages` | **13** packages (6 unscoped, 7 scoped) under `/opt/local/lib/node_modules` |
| `python_packages` | **730** distributions across eight of the ten installed framework versions, spanning 2.7 to 3.14 |

For `python_packages` the 4384 rows the table *does* return all come from virtualenvs (3514), `~/.local` (683), `~/Library` (180) and CommandLineTools (7) — the user-directory paths — so the MacPorts framework is the only system-wide Python on the host that goes unseen.

## Approach

Nothing beyond the two paths is needed.

`traverseVersions` already resolves `<version>/lib/python%/site-packages` beneath each `kDarwinPythonPath` entry, which is exactly the MacPorts layout, and it already skips symlinked version directories — so MacPorts' `Versions/Current` symlink does not produce duplicate rows. (Counting naively including `Current` gives 999 rather than 730; the existing skip is what makes the real figure correct.) `kDarwinPythonPath` is consumed inside `isPlatform(PlatformType::TYPE_OSX)`, so the addition is macOS-scoped by construction. The `npm_packages` entry sits in the existing non-Windows branch beside `/opt/homebrew/lib`.

The paths are hardcoded rather than derived at runtime, matching the existing entries in both lists and `kHomebrewPrefixes` in `homebrew_packages` — which documents in comments how the `brew` wrapper computes `HOMEBREW_PREFIX` and then deliberately does not do it.

## Notes

- No schema change; no test changes. `npm_packages_tests.cpp` drives explicit fixture directories rather than asserting on the default list.
- Both tables already expose a constrainable `directory` column (`index=True, optimized=True`), so a **non-default** MacPorts prefix stays reachable with an explicit constraint. That only helps someone who knows to write it, though — a scheduled query in a pack will not, so non-default prefixes remain unseen in practice. That is a general property of the defaults-plus-constraint pattern rather than something these two lines change.
- Related but independent: #9074 proposes a `macports_packages` table, and #9075 adds the MacPorts and Apple Silicon Homebrew prefixes to `suid_bin`. This PR depends on neither.
