### PR TITLE
Registry nocase path name

### DIFF
--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -283,14 +283,18 @@ TEST_F(RegistryTablesTest, test_registry_name_and_path_are_case_insensitive) {
       });
   ASSERT_NE(entry, baseline.rows().end());
   const auto loweredName = boost::to_lower_copy(entry->at("name"));
+  // A subkey and a value may share a name, and then also a path, so pin the
+  // row by type as well.
+  const auto typeClause = " and type = \"" + entry->at("type") + "\"";
 
   SQL nameResults("select * from registry where key = \"" + kCurrentVersionKey +
-                  "\" and name = \"" + loweredName + "\"");
+                  "\" and name = \"" + loweredName + "\"" + typeClause);
   ASSERT_EQ(nameResults.rows().size(), std::size_t{1});
   EXPECT_EQ(nameResults.rows()[0].at("name"), entry->at("name"));
 
   SQL pathResults("select * from registry where path = \"" +
-                  kCurrentVersionKey + kRegSep + loweredName + "\"");
+                  kCurrentVersionKey + kRegSep + loweredName + "\"" +
+                  typeClause);
   ASSERT_EQ(pathResults.rows().size(), std::size_t{1});
   EXPECT_EQ(pathResults.rows()[0].at("path"), entry->at("path"));
 }

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -7,6 +7,9 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <algorithm>
+
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <gtest/gtest.h>
 
@@ -260,6 +263,34 @@ TEST_F(RegistryTablesTest, test_populate_subkeys_invalid_middle_key) {
       std::any_of(keys.begin(), keys.end(), [&](const std::string& key) {
         return boost::starts_with(key, validKey2);
       }));
+}
+
+TEST_F(RegistryTablesTest, test_registry_name_and_path_are_case_insensitive) {
+  // Only the value name is lowercased; the hive is resolved separately.
+  const std::string kCurrentVersionKey =
+      "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion";
+
+  SQL baseline("select * from registry where key = \"" + kCurrentVersionKey +
+               "\"");
+  ASSERT_FALSE(baseline.rows().empty());
+
+  const auto entry = std::find_if(
+      baseline.rows().begin(), baseline.rows().end(), [](const auto& row) {
+        const auto& name = row.at("name");
+        return !name.empty() && boost::to_lower_copy(name) != name;
+      });
+  ASSERT_NE(entry, baseline.rows().end());
+  const auto loweredName = boost::to_lower_copy(entry->at("name"));
+
+  SQL nameResults("select * from registry where key = \"" + kCurrentVersionKey +
+                  "\" and name = \"" + loweredName + "\"");
+  ASSERT_EQ(nameResults.rows().size(), std::size_t{1});
+  EXPECT_EQ(nameResults.rows()[0].at("name"), entry->at("name"));
+
+  SQL pathResults("select * from registry where path = \"" +
+                  kCurrentVersionKey + kRegSep + loweredName + "\"");
+  ASSERT_EQ(pathResults.rows().size(), std::size_t{1});
+  EXPECT_EQ(pathResults.rows()[0].at("path"), entry->at("path"));
 }
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/windows/registry_tests.cpp
+++ b/osquery/tables/system/tests/windows/registry_tests.cpp
@@ -206,6 +206,8 @@ TEST_F(RegistryTablesTest, test_get_username_from_key) {
 
   status = getUsernameFromKey("HKEY_USERS\\S-1-5-19\\Some\\Key", username);
   EXPECT_TRUE(status.ok());
+  status = getUsernameFromKey("hkey_users\\S-1-5-19\\Some\\Key", username);
+  EXPECT_TRUE(status.ok());
   for (const auto& key : badKeys) {
     status = getUsernameFromKey(key, username);
     EXPECT_FALSE(status.ok());
@@ -291,6 +293,23 @@ TEST_F(RegistryTablesTest, test_registry_name_and_path_are_case_insensitive) {
                   kCurrentVersionKey + kRegSep + loweredName + "\"");
   ASSERT_EQ(pathResults.rows().size(), std::size_t{1});
   EXPECT_EQ(pathResults.rows()[0].at("path"), entry->at("path"));
+}
+
+TEST_F(RegistryTablesTest, test_registry_hive_is_case_insensitive) {
+  // The hive has its own lookup, so it needs its own coverage.
+  QueryData canonical;
+  auto ret = queryKey(kTestKey, canonical);
+  ASSERT_TRUE(ret.ok());
+  ASSERT_FALSE(canonical.empty());
+
+  QueryData lowercasedHive;
+  ret = queryKey("hkey_local_machine" + kRegSep + "SOFTWARE", lowercasedHive);
+  ASSERT_TRUE(ret.ok());
+  EXPECT_EQ(lowercasedHive.size(), canonical.size());
+
+  SQL results("select * from registry where key = \"hkey_local_machine" +
+              kRegSep + "SOFTWARE\"");
+  EXPECT_FALSE(results.rows().empty());
 }
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -51,7 +51,14 @@ using reg_handle_t = std::unique_ptr<HKEY__, decltype(closeRegHandle)>;
 const std::set<int> kRegistryStringTypes = {
     REG_SZ, REG_MULTI_SZ, REG_EXPAND_SZ};
 
-const std::map<std::string, HKEY> kRegistryHives = {
+/// Compare hive names the way Windows resolves them, case-insensitively.
+struct CaseInsensitiveLess {
+  bool operator()(const std::string& lhs, const std::string& rhs) const {
+    return boost::ilexicographical_compare(lhs, rhs);
+  }
+};
+
+const std::map<std::string, HKEY, CaseInsensitiveLess> kRegistryHives = {
     {"HKEY_CLASSES_ROOT", HKEY_CLASSES_ROOT},
     {"HKEY_CURRENT_CONFIG", HKEY_CURRENT_CONFIG},
     {"HKEY_CURRENT_USER", HKEY_CURRENT_USER},
@@ -172,7 +179,7 @@ Status getClassExecutables(const std::string& clsId,
 }
 
 Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
-  if (!boost::starts_with(key, "HKEY_USERS")) {
+  if (!boost::istarts_with(key, "HKEY_USERS")) {
     return Status(1, "Can not extract username from non-HKEY_USERS key");
   }
 
@@ -535,8 +542,8 @@ static inline void maybeWarnLocalUsers(const std::set<std::string>& rKeys) {
   std::string hive, _;
   for (const auto& key : rKeys) {
     explodeRegistryPath(key, hive, _);
-    if (hive == "HKEY_CURRENT_USER" ||
-        hive == "HKEY_CURRENT_USER_LOCAL_SETTINGS") {
+    if (boost::iequals(hive, "HKEY_CURRENT_USER") ||
+        boost::iequals(hive, "HKEY_CURRENT_USER_LOCAL_SETTINGS")) {
       LOG(WARNING) << "CURRENT_USER hives are not queryable by osqueryd; "
                       "query HKEY_USERS with the desired users SID instead";
       break;

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -2,8 +2,8 @@ table_name("registry")
 description("All of the Windows registry hives.")
 schema([
     Column("key", TEXT, "Name of the key to search for", additional=True, optimized=True, collate="nocase"),
-    Column("path", TEXT, "Full path to the value", index=True, optimized=True),
-    Column("name", TEXT, "Name of the registry value entry"),
+    Column("path", TEXT, "Full path to the value", index=True, optimized=True, collate="nocase"),
+    Column("name", TEXT, "Name of the registry value entry", collate="nocase"),
     Column("type", TEXT, "Type of the registry value, or 'subkey' if item is a subkey"),
     Column("data", TEXT, "Data content of registry value"),
     Column("mtime", BIGINT, "timestamp of the most recent registry write"),


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

In the `registry` table, made `path` and `name` case-insensitive to match Windows.
Fixes #9079 

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
